### PR TITLE
Watches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.01   DEPOPTS="git cohttp" EXTRA_DEPS="conf-gmp"
-  - OCAML_VERSION=latest DEPOPTS="git cohttp" EXTRA_DEPS="conf-gmp"
+  - OCAML_VERSION=4.01   EXTRA_DEPS="conf-gmp"
+  - OCAML_VERSION=latest EXTRA_DEPS="conf-gmp"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,15 @@
 ## 0.9.5
+* Add `Task.empty` (the empty task) and `Task.none` (the empty task constructor)
+* Completely rewrite the notification mechanism. All the watch functions now
+  take a callback as argument and return a de-allocation function. The callbacks
+  receive a heads values (the last and current ones) and diff values. (#187)
+  - Add `Irmin.watch_head` to watch for the changes of the current branch's head
+  - Add `Irmin.watch_tags` to watch for the changes of all the tags in the store
+  - Add `Irmin.watch_key` to watch for the changes of the values associated to a
+    given key (this is not recursive anymore).
+  - Add `View.watch_path` to watch for the changes in a subtree. The function
+    return views and the user can use `View.diff` to compute differences between
+    views if needed.
 * Transfer the HTTP client task to the server to make the commit messages
   relative to the client state (and not the server's) (#136)
 * Fix `View.remove` to clean-up empty directories (#190)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,4 @@
 ## 0.9.5
-* Change `View.empty` return type to not mention `Lwt` anymore.
 * Add `Task.empty` (the empty task) and `Task.none` (the empty task constructor)
 * Completely rewrite the notification mechanism. All the watch functions now
   take a callback as argument and return a de-allocation function. The callbacks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## 0.9.5
+* Change `View.empty` return type to not mention `Lwt` anymore.
 * Add `Task.empty` (the empty task) and `Task.none` (the empty task constructor)
 * Completely rewrite the notification mechanism. All the watch functions now
   take a callback as argument and return a de-allocation function. The callbacks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ## 0.9.5
+* Transfer the HTTP client task to the server to make the commit messages
+  relative to the client state (and not the server's) (#136)
 * Fix `View.remove` to clean-up empty directories (#190)
 * Fix the ordering of tree entries in the Git backend (#190)
 * Allow to create a new head from a view and a list of parents with

--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -386,10 +386,11 @@ let watch = {
               printf "%s%s\n%!" v k
             in
             let x, y = match d with
-              | `Updated (x, y) -> snd x, snd y
-              | `Added x        -> View.empty (), snd x
-              | `Removed x      -> snd x, View.empty ()
+              | `Updated (x, y) -> Lwt.return (snd x), Lwt.return (snd y)
+              | `Added x        -> View.empty (), Lwt.return (snd x)
+              | `Removed x      -> Lwt.return (snd x), View.empty ()
             in
+            x >>= fun x -> y >>= fun y ->
             View.diff x y >>= fun diff ->
             List.iter pr diff;
             return_unit

--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -383,7 +383,7 @@ let watch = {
                 | `Added _   -> "+"
                 | `Removed _ -> "-"
               in
-              printf "%s%s" v k
+              printf "%s%s\n%!" v k
             in
             let x, y = match d with
               | `Updated (x, y) -> snd x, snd y

--- a/examples/contacts.ml
+++ b/examples/contacts.ml
@@ -95,7 +95,7 @@ module Contact = struct
   let view_of_t t =
     let name = Contents.String t.name in
     let phones = Contents.Set t.phones in
-    let v = View.empty () in
+    View.empty () >>= fun v ->
     View.update v [t.id; "name"  ] name >>= fun () ->
     View.update v [t.id; "phones"] phones >>= fun () ->
     return v

--- a/examples/contacts.ml
+++ b/examples/contacts.ml
@@ -95,7 +95,7 @@ module Contact = struct
   let view_of_t t =
     let name = Contents.String t.name in
     let phones = Contents.Set t.phones in
-    View.empty () >>= fun v ->
+    let v = View.empty () in
     View.update v [t.id; "name"  ] name >>= fun () ->
     View.update v [t.id; "phones"] phones >>= fun () ->
     return v

--- a/examples/intrusion.ml
+++ b/examples/intrusion.ml
@@ -35,7 +35,7 @@ let provision () =
 
   Store.of_tag config task "upstream" >>= fun t ->
 
-  let v = View.empty () in
+  View.empty () >>= fun v ->
   View.update v ["etc"; "manpath"]
     "/usr/share/man\n\
      /usr/local/share/man"
@@ -52,7 +52,7 @@ let configure () =
   Lwt_unix.sleep 2.                >>= fun () ->
 
   Store.clone_force task (t "Switching to upstream") "upstream" >>= fun t ->
-  let v = View.empty () in
+  View.empty () >>= fun v ->
 
 (*
   Store.View.update v ["etc";"passwd"]

--- a/examples/intrusion.ml
+++ b/examples/intrusion.ml
@@ -35,7 +35,7 @@ let provision () =
 
   Store.of_tag config task "upstream" >>= fun t ->
 
-  View.empty () >>= fun v ->
+  let v = View.empty () in
   View.update v ["etc"; "manpath"]
     "/usr/share/man\n\
      /usr/local/share/man"
@@ -52,7 +52,7 @@ let configure () =
   Lwt_unix.sleep 2.                >>= fun () ->
 
   Store.clone_force task (t "Switching to upstream") "upstream" >>= fun t ->
-  View.empty ()                    >>= fun v ->
+  let v = View.empty () in
 
 (*
   Store.View.update v ["etc";"passwd"]

--- a/examples/views.ml
+++ b/examples/views.ml
@@ -36,7 +36,7 @@ type t = t2 list
 
 let view_of_t t =
   Log.debug "view_of_t";
-  let v = View.empty () in
+  View.empty () >>= fun v ->
   Lwt_list.iteri_s (fun i t2 ->
       let i = string_of_int i in
       View.update v [i;"x"] t2.x >>= fun () ->

--- a/examples/views.ml
+++ b/examples/views.ml
@@ -36,7 +36,7 @@ type t = t2 list
 
 let view_of_t t =
   Log.debug "view_of_t";
-  View.empty () >>= fun v ->
+  let v = View.empty () in
   Lwt_list.iteri_s (fun i t2 ->
       let i = string_of_int i in
       View.update v [i;"x"] t2.x >>= fun () ->

--- a/lib/fs/irmin_fs.mli
+++ b/lib/fs/irmin_fs.mli
@@ -71,7 +71,7 @@ module type Config = sig
   val file_of_key: string -> string
   (** Convert a key to a filename. *)
 
-  val key_of_file: root:string -> string -> string
+  val key_of_file: string -> string
     (** Convert a filename to a key. *)
 
 end

--- a/lib/fs/irmin_fs.mli
+++ b/lib/fs/irmin_fs.mli
@@ -71,7 +71,7 @@ module type Config = sig
   val file_of_key: string -> string
   (** Convert a key to a filename. *)
 
-  val key_of_file: string -> string
+  val key_of_file: root:string -> string -> string
     (** Convert a filename to a key. *)
 
 end

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -239,13 +239,13 @@ module Make (IO: Git.Sync.IO) (L: LOCK) (G: Git.Store.S)
 
       let err_file_is_dir n =
         let str = sprintf
-            "Cannot add the file %s as it is already a directory name." n
+            "Cannot add the file '%s' as it is already a directory name." n
         in
         raise (Invalid_argument str)
 
       let err_dir_is_file n =
         let str = sprintf
-            "Cannot add the directory %s as it is already a filename." n
+            "Cannot add the directory '%s' as it is already a filename." n
         in
         raise (Invalid_argument str)
 

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -521,7 +521,7 @@ module Make (IO: Git.Sync.IO) (L: LOCK) (G: Git.Store.S)
       Lwt.return (w, stop)
 
     let unwatch t (w, stop) =
-      stop;
+      stop ();
       W.unwatch t.w w
 
     let create config task =

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -618,6 +618,10 @@ struct
   let watch_head t = L.watch_head t.l
   let watch_tags t = L.watch_tags t.l
 
+  (* FIXME: this could be improved quite a bit by having a separate
+     stream per path. *)
+  let watch_key t = L.watch_key t.l
+
   let clone task t tag =
     post t ["clone"; T.to_hum tag] None Tc.string >>= function
     | "ok" -> of_tag t.config task tag >|= fun t -> `Ok t

--- a/lib/ir_bc.ml
+++ b/lib/ir_bc.ml
@@ -501,7 +501,6 @@ module Make_ext (P: PRIVATE) = struct
     merge a ?max_depth ?n t ~into >>= Ir_merge.exn
 
   let watch_head t ?init fn =
-    Log.debug "watch-head";
     tag t >>= function
     | None       ->
       (* FIXME: start a local watcher on the detached branch *)
@@ -517,7 +516,6 @@ module Make_ext (P: PRIVATE) = struct
       Lwt.return (fun () -> Tag.unwatch (tag_t t) id)
 
   let watch_tags t ?init fn =
-    Log.debug "watch-tags";
     Tag.watch (tag_t t) ?init fn >>= fun id ->
     Lwt.return (fun () -> Tag.unwatch (tag_t t) id)
 

--- a/lib/ir_bc.ml
+++ b/lib/ir_bc.ml
@@ -543,13 +543,16 @@ module Make_ext (P: PRIVATE) = struct
             | Some v -> fn @@ `Added (x, v)
           end
         | `Updated (x, y) ->
+          assert (not (Head.equal x y));
           value_of_head x >>= fun vx ->
           value_of_head y >>= fun vy ->
           match vx, vy with
           | None   ,  None   -> Lwt.return_unit
           | Some vx, None    -> fn @@ `Removed (x, vx)
           | None   , Some vy -> fn @@ `Added (y, vy)
-          | Some vx, Some vy -> fn @@ `Updated ( (x, vx), (y, vy) )
+          | Some vx, Some vy ->
+            if Val.equal vx vy then Lwt.return_unit
+            else fn @@ `Updated ( (x, vx), (y, vy) )
       )
 
   type slice = P.Slice.t

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -44,6 +44,8 @@ module type STORE = sig
     (unit -> unit Lwt.t) Lwt.t
   val watch_tags: t -> ?init:(tag * head) list ->
     (tag -> head Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+  val watch_key: t -> key -> ?init:(head * value) ->
+    ((head * value) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
   val clone: 'a Ir_task.f -> t -> tag -> [`Ok of ('a -> t) | `Duplicated_tag] Lwt.t
   val clone_force: 'a Ir_task.f -> t -> tag -> ('a -> t) Lwt.t
   val merge: 'a -> ?max_depth:int -> ?n:int -> ('a -> t) -> into:('a -> t) ->

--- a/lib/ir_task.ml
+++ b/lib/ir_task.ml
@@ -76,8 +76,6 @@ let uid t = t.uid
 let owner t = t.owner
 let messages t = List.rev t.msgs
 
-let empty = create ~date:0L ~owner:"<none>" "None"
-
 let add t msg =
   if t = empty then ()
   else t.msgs <- msg :: t.msgs

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -169,11 +169,11 @@ module Internal (Node: NODE) = struct
     let ops = ref [] in
     let parents = ref [] in
     let lock = Lwt_mutex.create () in
-    { parents; view; ops; lock }
+    Lwt.return { parents; view; ops; lock }
 
   let create _conf _task =
     Log.debug "create";
-    let t = empty () in
+    empty () >>= fun t ->
     Lwt.return (fun _ -> t)
 
   let task _ = failwith "Not task for views"
@@ -864,7 +864,7 @@ end
 
 module type S = sig
   include Ir_rw.HIERARCHICAL
-  val empty: unit -> t
+  val empty: unit -> t Lwt.t
   val rebase: t -> into:t -> unit Ir_merge.result Lwt.t
   val rebase_exn: t -> into:t -> unit Lwt.t
   type db

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -169,11 +169,11 @@ module Internal (Node: NODE) = struct
     let ops = ref [] in
     let parents = ref [] in
     let lock = Lwt_mutex.create () in
-    Lwt.return { parents; view; ops; lock }
+    { parents; view; ops; lock }
 
   let create _conf _task =
     Log.debug "create";
-    empty () >>= fun t ->
+    let t = empty () in
     Lwt.return (fun _ -> t)
 
   let task _ = failwith "Not task for views"
@@ -864,7 +864,7 @@ end
 
 module type S = sig
   include Ir_rw.HIERARCHICAL
-  val empty: unit -> t Lwt.t
+  val empty: unit -> t
   val rebase: t -> into:t -> unit Ir_merge.result Lwt.t
   val rebase_exn: t -> into:t -> unit Lwt.t
   type db

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -115,6 +115,7 @@ module type NODE = sig
   module Contents: Tc.S0 with type t = contents
   module Path: Ir_path.S
 
+  val equal: t -> t -> bool
   val empty: unit -> t
   val is_empty: t -> bool Lwt.t
 
@@ -155,6 +156,7 @@ module Internal (Node: NODE) = struct
     lock: Lwt_mutex.t;
   }
 
+  let equal x y = Node.equal x.view y.view
   type head = Node.commit
   let parents t = !(t.parents)
 
@@ -359,6 +361,54 @@ module Internal (Node: NODE) = struct
         conflict "list %s: got %s, expecting %s" (one l) (many r') (many r)
 
   let actions t = List.rev !(t.ops)
+
+  module KV = Ir_misc.Set(Tc.Pair(Path)(Node.Contents))
+
+  module PathMap = Ir_misc.Map(Path)
+
+  let diff x y =
+    let set t =
+      let acc = ref KV.empty in
+      iter t (fun k v ->
+          v >>= fun v ->
+          acc := KV.add (k, v) !acc;
+          Lwt.return_unit
+        ) >>= fun () ->
+      Lwt.return !acc
+    in
+    (* FIXME very dumb and slow *)
+    set x >>= fun sx ->
+    set y >>= fun sy ->
+    let added     = KV.diff sy sx in
+    let removed   = KV.diff sx sy in
+    let added_l   = KV.elements added in
+    let removed_l = KV.elements removed in
+    let added_m   = PathMap.of_alist added_l in
+    let removed_m = PathMap.of_alist removed_l in
+    let added_p   = PathSet.of_list (List.map fst added_l) in
+    let removed_p = PathSet.of_list (List.map fst removed_l) in
+
+    let updated_p = PathSet.inter added_p removed_p in
+    let added_p   = PathSet.diff added_p updated_p in
+    let removed_p = PathSet.diff removed_p updated_p in
+    let added =
+      PathSet.fold (fun path acc ->
+          (path, `Added (PathMap.find path added_m)) :: acc
+        ) added_p []
+    in
+    let removed =
+      PathSet.fold (fun path acc ->
+          (path, `Removed (PathMap.find path removed_m)) :: acc
+        ) removed_p []
+    in
+    let updated =
+      PathSet.fold (fun path acc ->
+          let x = PathMap.find path removed_m in
+          let y = PathMap.find path added_m in
+          (path, `Updated (x, y)) :: acc
+        ) updated_p []
+    in
+    Lwt.return (added @ updated @ removed)
 
   let rebase t1 ~into =
     Ir_merge.iter (apply into) (actions t1) >>| fun () ->
@@ -786,6 +836,30 @@ module Make (S: Ir_s.STORE) = struct
     let commit = S.Private.Commit.Val.create task ~parents ~node in
     S.Private.Commit.add (S.Private.commit_t db) commit
 
+  let watch_path db key ?init fn =
+    let view_of_head h =
+        S.of_head (S.Private.config db) (fun () -> S.task db) h >>= fun db ->
+        of_path (db ()) key
+    in
+    let init = match init with
+      | None        -> None
+      | Some (h, _) -> Some h
+    in
+    S.watch_head db ?init (function
+        | `Removed h ->
+          view_of_head h >>= fun v ->
+          fn @@ `Removed (h, v)
+        | `Added h ->
+          view_of_head h >>= fun v ->
+          fn @@ `Added (h, v)
+        | `Updated (x, y) ->
+          assert (not (S.Head.equal x y));
+          view_of_head x >>= fun vx ->
+          view_of_head y >>= fun vy ->
+          if equal vx vy then Lwt.return_unit
+          else fn @@ `Updated ( (x, vx), (y, vy) )
+      )
+
 end
 
 module type S = sig
@@ -812,7 +886,10 @@ module type S = sig
     val prettys: t list -> string
   end
   val actions: t -> Action.t list
+  val diff: t -> t -> (key * value Ir_watch.diff) list Lwt.t
   type head
   val parents: t -> head list
   val make_head: db -> Ir_task.t -> parents:head list -> contents:t -> head Lwt.t
+  val watch_path: db -> key -> ?init:(head * t) ->
+    ((head * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
 end

--- a/lib/ir_view.mli
+++ b/lib/ir_view.mli
@@ -18,7 +18,7 @@
 
 module type S = sig
   include Ir_rw.HIERARCHICAL
-  val empty: unit -> t
+  val empty: unit -> t Lwt.t
   val rebase: t -> into:t -> unit Ir_merge.result Lwt.t
   val rebase_exn: t -> into:t -> unit Lwt.t
   type db

--- a/lib/ir_view.mli
+++ b/lib/ir_view.mli
@@ -18,7 +18,7 @@
 
 module type S = sig
   include Ir_rw.HIERARCHICAL
-  val empty: unit -> t Lwt.t
+  val empty: unit -> t
   val rebase: t -> into:t -> unit Ir_merge.result Lwt.t
   val rebase_exn: t -> into:t -> unit Lwt.t
   type db

--- a/lib/ir_view.mli
+++ b/lib/ir_view.mli
@@ -39,9 +39,12 @@ module type S = sig
     val prettys: t list -> string
   end
   val actions: t -> Action.t list
+  val diff: t -> t -> (key * value Ir_watch.diff) list Lwt.t
   type head
   val parents: t -> head list
   val make_head: db -> Ir_task.t -> parents:head list -> contents:t -> head Lwt.t
+  val watch_path: db -> key -> ?init:(head * t) ->
+    ((head * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
 end
 
 module Make (S: Ir_s.STORE):

--- a/lib/ir_watch.ml
+++ b/lib/ir_watch.ml
@@ -213,6 +213,7 @@ module Make (K: Tc.S0) (V: Tc.S0) = struct
 
   let listen_dir t dir ~key ~value =
     if t.listeners = 0 then (
+      Log.debug "%s: start listening to %s" (to_string t) dir;
       t.stop_listening <-
         !listen_dir_hook t.id dir (fun file ->
             match key file with
@@ -222,7 +223,10 @@ module Make (K: Tc.S0) (V: Tc.S0) = struct
     );
     t.listeners <- t.listeners + 1;
     function () ->
-      t.listeners <- t.listeners - 1;
-      t.stop_listening ()
+      if t.listeners > 0 then t.listeners <- t.listeners - 1;
+      if t.listeners = 0 then (
+        Log.debug "%s: stop listening to %s" (to_string t) dir;
+        t.stop_listening ();
+      )
 
 end

--- a/lib/ir_watch.mli
+++ b/lib/ir_watch.mli
@@ -34,12 +34,10 @@ module type S = sig
   val listen_dir: t -> string
     -> key:(string -> key option)
     -> value:(key -> value option Lwt.t)
-    -> unit
-  (** Register a fsevents/inotify thread to look for changes in the
-      given directory. *)
+    -> (unit -> unit)
 end
 
 module Make(K: Tc.S0) (V: Tc.S0): S with type key = K.t and type value = V.t
 
-val set_listen_dir_hook: (int -> string -> (string -> unit Lwt.t) -> unit) -> unit
+val set_listen_dir_hook: (int -> string -> (string -> unit Lwt.t) -> (unit -> unit)) -> unit
 val workers: unit -> int

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -2210,7 +2210,7 @@ module type VIEW = sig
   (** A view is a read-write temporary store, mirroring the main
       store. *)
 
-  val empty: unit -> t
+  val empty: unit -> t Lwt.t
   (** Create an empty view. Empty views do not have associated backend
       configuration values, as they can perform in-memory operation,
       independently of any given backend. *)

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -2210,7 +2210,7 @@ module type VIEW = sig
   (** A view is a read-write temporary store, mirroring the main
       store. *)
 
-  val empty: unit -> t Lwt.t
+  val empty: unit -> t
   (** Create an empty view. Empty views do not have associated backend
       configuration values, as they can perform in-memory operation,
       independently of any given backend. *)

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -2304,6 +2304,9 @@ module type VIEW = sig
   (** Return the list of actions performed on this view since its
       creation. *)
 
+  val diff: t -> t -> (key * value diff) list Lwt.t
+  (** Compute the diff between two views. *)
+
   (** {2 Heads} *)
 
   type head
@@ -2313,10 +2316,17 @@ module type VIEW = sig
   (** [parents t] are [t]'s parent commits. *)
 
   val make_head: db -> task -> parents:head list -> contents:t -> head Lwt.t
-  (** [make_head db t ~parents ~contents] creates a new commit into
-      the store [db] and return its id (of type {!head}). The new
-      commit has [t] as task and the given [parents] and
-      [contents]. The actual parents of [contents] are not used. *)
+  (** [make_head t task ~parents ~contents] creates a new commit into
+      the store where the branch [t] is stored and return its id (of
+      type {!head}). The new commit has [task] as task and the given
+      [parents] and [contents]. The actual parents of [contents] are
+      not used. *)
+
+  val watch_path: db -> key -> ?init:(head * t) ->
+    ((head * t) diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+  (** [watch_head t p f] calls [f] every time subpaths of [p] are
+      updated in the branch [t]. The callback parameters contains
+      branch's current head and the corresponding view. *)
 
 end
 

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1890,6 +1890,10 @@ val watch_tags: ([`BC],'k,'v) t -> ?init:(string * Hash.SHA1.t) list ->
   (unit -> unit Lwt.t) Lwt.t
 (** See {!BC.watch_tags}. *)
 
+val watch_key: ([`BC],'k,'v) t -> 'k -> ?init:(Hash.SHA1.t * 'v) ->
+  ((Hash.SHA1.t * 'v) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+(** See {!BC.watch_key}. *)
+
 (** {2 Clones and Merges} *)
 
 val clone: 'm Task.f -> ([`BC],'k,'v) t -> string

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1165,9 +1165,10 @@ module Private: sig
       val listen_dir: t -> string
         -> key:(string -> key option)
         -> value:(key -> value option Lwt.t)
-        -> unit
-        (** Register a fsevents/inotify thread to look for changes in
-            the given directory. *)
+        -> (unit -> unit)
+      (** Register a thread looking for changes in the given directory
+          and return a function to stop watching and free up
+          resources. *)
 
     end
 
@@ -1175,10 +1176,12 @@ module Private: sig
     (** [workers ()] is the number of background worker threads
         managing event notification currently active. *)
 
-    val set_listen_dir_hook: (int -> string -> (string -> unit Lwt.t) -> unit) -> unit
+    val set_listen_dir_hook:
+      (int -> string -> (string -> unit Lwt.t) -> (unit -> unit)) -> unit
     (** Register a function which looks for file changes in a
-        directory. Could use [inotify] when available, or use an active
-        stats file polling.*)
+        directory and return a function to stop watching. Could use
+        [inotify] when available or {!Irmin_unix.set_listen_dir_hook}
+        to use active file polling. *)
 
     (** [Make] builds an implementation of watch helpers. *)
     module Make(K: Tc.S0) (V: Tc.S0): S with type key = K.t and type value = V.t

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -2200,7 +2200,7 @@ module type VIEW = sig
   (** {1 Views} *)
 
   type db
-  (** The type for store handles. *)
+  (** The type for branch handles. *)
 
   include HRW
   (** A view is a read-write temporary store, mirroring the main
@@ -2221,22 +2221,22 @@ module type VIEW = sig
       conflict. *)
 
   val of_path: db -> key -> t Lwt.t
-  (** Read a view from a path in the store. This is a cheap operation,
-      all the real reads operation will be done on-demand when the
-      view is used. *)
+  (** [of_path t p] reads the view from a path [p] in the branch
+      [t]. This is a cheap operation, all the real reads operation
+      will be done on-demand when the view is used. *)
 
   val update_path: db -> key -> t -> unit Lwt.t
-  (** [update_path x t path v] {e replaces} the sub-tree under [path]
-      in the store [t x] by the contents of the view [v x]. See
-      {!merge_path} for more details. *)
+  (** [update_path t p v] {e replaces} the sub-tree under [p] in the
+      branch [t] by the contents of the view [v]. See {!merge_path}
+      for more details. *)
 
   val rebase_path: db -> key -> t -> unit Merge.result Lwt.t
-  (** [rebase_path x t path v] {e rebases} the view [v x] on top of
-      the contents of [t x]'s sub-tree pointed by the path
-      [path]. Rebasing means re-applying every {{!Action.t}actions}
-      stored in [t], including the {e reads}. Return {!Merge.Conflict}
-      if one of the action cannot apply cleanly. See {!merge_path} for
-      more details.  *)
+  (** [rebase_path t p v] {e rebases} the view [v] on top of the
+      contents of the sub-tree under [p] in the branch [t]. Rebasing
+      means re-applying every {{!Action.t}actions} stored in [v],
+      including the {e reads}. Return {!Merge.Conflict} if one of the
+      action cannot apply cleanly. See {!merge_path} for more
+      details.  *)
 
   val rebase_path_exn: db -> key -> t -> unit Lwt.t
   (** Same as {!rebase_path} but raise {!Merge.Conflict} in case of
@@ -2244,10 +2244,10 @@ module type VIEW = sig
 
   val merge_path: db -> ?max_depth:int -> ?n:int -> key -> t ->
     unit Merge.result Lwt.t
-  (** [merge_path x t path v] {e merges} the view [v x] with the
-      contents of [t x]'s sub-tree pointed by the path [path]. Merging
-      means applying the {{!Merge.Map}merge function for map} between
-      the view's contents and [t]'s sub-tree.
+  (** [merge_path t path v] {e merges} the view [v] with the contents
+      of the sub-tree under [p] in the branch [t]. Merging means
+      applying the {{!Merge.Map}merge function for map} between the
+      view's contents and [t]'s sub-tree.
 
       {ul
       {- {!VIEW.update_path} discards any preexisting sub-tree.}
@@ -2257,7 +2257,7 @@ module type VIEW = sig
       preexisting sub-tree.}
       {- {!VIEW.merge_path} is state based. Is is an efficient 3-way merge
       operators between prefix trees, based on {!Merge.Map.merge}.}
-     } *)
+      } *)
 
   val merge_path_exn: db -> ?max_depth:int -> ?n:int -> key -> t -> unit Lwt.t
   (** Same as {!merge_path} but raise {!Merge.Conflict} in case of

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -609,7 +609,7 @@ module type BC = sig
 
   val watch_head: t -> ?init:head -> (head diff -> unit Lwt.t) ->
     (unit -> unit Lwt.t) Lwt.t
-  (** [watch_tag t f] calls [f] everytime the contents of [t]'s tag is
+  (** [watch_tag t f] calls [f] every time the contents of [t]'s tag is
       updated. Do nothing if [t] is not persistent. Return a clean-up
       function to remove the watch handler.
 
@@ -620,9 +620,14 @@ module type BC = sig
 
   val watch_tags: t -> ?init:(tag * head) list ->
     (tag -> head diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
-  (** [watch_tags t f] calls [f] to the watch handlers of {b all} tag
-      changes in the local store. Return a function to remove the
+  (** [watch_tags t f] calls [f] every time a tag is added, removed or
+      updated in the local store. Return a function to remove the
       handler. *)
+
+  val watch_key: t -> key -> ?init:(head * value) ->
+    ((head * value) diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+  (** [watch_key t key f] calls [f] every time the [key]'s value is
+      added, removed or updated. *)
 
   (** {2 Clones and Merges} *)
 

--- a/lib/unix/irmin_unix.ml
+++ b/lib/unix/irmin_unix.ml
@@ -252,6 +252,8 @@ let install_dir_polling_listener delay =
   in
   Irmin.Private.Watch.set_listen_dir_hook listen_dir
 
+let polling_threads () = Hashtbl.length watchdogs
+
 let task msg =
   let date = Int64.of_float (Unix.gettimeofday ()) in
   let owner =

--- a/lib/unix/irmin_unix.ml
+++ b/lib/unix/irmin_unix.ml
@@ -137,6 +137,7 @@ let stop = ref (fun () -> ())
 
 let install_dir_polling_listener delay =
   let s, u = Lwt.task () in
+  !stop ();
   stop := Lwt.wakeup u;
 
   Irmin.Private.Watch.set_listen_dir_hook (fun id dir fn ->

--- a/lib/unix/irmin_unix.ml
+++ b/lib/unix/irmin_unix.ml
@@ -138,9 +138,26 @@ let stop = ref (fun () -> ())
 
 let to_string set = Tc.show (module S) set
 
+let string_chop_prefix t ~prefix =
+  let lt = String.length t in
+  let lp = String.length prefix in
+  if lt < lp then None else
+    let p = String.sub t 0 lp in
+    if String.compare p prefix <> 0 then None
+    else Some (String.sub t lp (lt - lp))
+
+let string_chop_prefix_exn t ~prefix = match string_chop_prefix t ~prefix with
+  | None   -> failwith "string_chop_prefix"
+  | Some s -> s
+
+let (/) = Filename.concat
+
 let read_files dir =
   IO.rec_files dir >>= fun new_files ->
-  let new_files = List.map (fun f -> f, Digest.file f) new_files in
+  let prefix = dir / "" in
+  let new_files =
+    List.map (fun f -> string_chop_prefix_exn f ~prefix, Digest.file f) new_files
+  in
   return (S.of_list new_files)
 
 let with_cancel t =

--- a/lib/unix/irmin_unix.ml
+++ b/lib/unix/irmin_unix.ml
@@ -204,6 +204,8 @@ let callback dir file =
   let fns = try Hashtbl.find listeners dir with Not_found -> [] in
   Lwt_list.iter_p (fun (id, f) -> Log.debug "callback %d" id; f file) fns
 
+let realdir dir = if Filename.is_relative dir then Sys.getcwd () / dir else dir
+
 let start_watchdog ~delay dir =
   match watchdog dir with
   | Some _ -> assert (nb_listeners dir <> 0)
@@ -241,6 +243,7 @@ let uninstall_dir_polling_listener () =
 let install_dir_polling_listener delay =
   uninstall_dir_polling_listener ();
   let listen_dir id dir fn =
+    let dir = realdir dir in
     start_watchdog ~delay dir;
     add_listener id dir fn;
     function () ->

--- a/lib/unix/irmin_unix.ml
+++ b/lib/unix/irmin_unix.ml
@@ -134,7 +134,10 @@ module S = struct
   include Tc.As_L0 (X)
 end
 
-module StringSet = Set.Make(Tc.String)
+module StringSet = struct
+  include Set.Make(Tc.String)
+  let of_list l = List.fold_left (fun acc e -> add e acc) empty l
+end
 
 let to_string set = Tc.show (module S) set
 

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -74,7 +74,7 @@ module Irmin_fs: sig
     val file_of_key: string -> string
     (** Convert a key to a filename. *)
 
-    val key_of_file: root:string -> string -> string
+    val key_of_file: string -> string
     (** Convert a filename to a key. *)
 
   end

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -214,6 +214,9 @@ val install_dir_polling_listener: float -> unit
 val uninstall_dir_polling_listener: unit -> unit
 (** Stop the thread started by {!install_dir_polling_listener}. *)
 
+val polling_threads: unit -> int
+(** The number of polling threads. *)
+
 module type LOCK = sig
 
   (** {1 Filesystem {i dotlocking}} *)

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -74,7 +74,7 @@ module Irmin_fs: sig
     val file_of_key: string -> string
     (** Convert a key to a filename. *)
 
-    val key_of_file: string -> string
+    val key_of_file: root:string -> string -> string
     (** Convert a filename to a key. *)
 
   end

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -211,6 +211,9 @@ val install_dir_polling_listener: float -> unit
     {{:https://opam.ocaml.org/packages/inotify/inotify.2.0/}inotify}
     if it works on your system. *)
 
+val uninstall_dir_polling_listener: unit -> unit
+(** Stop the thread started by {!install_dir_polling_listener}. *)
+
 module type LOCK = sig
 
   (** {1 Filesystem {i dotlocking}} *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -19,8 +19,8 @@ let () =
     `Quick, Test_memory.suite k;
     `Quick, Test_fs.suite k;
     `Quick, Test_git.suite k;
-    `Quick, Test_http.suite k (Test_memory.suite k);
-    `Slow , Test_http.suite k (Test_fs.suite k);
-    `Slow , Test_http.suite k (Test_git.suite k);
+    `Quick, Test_http.suite (Test_memory.suite k);
+    `Slow , Test_http.suite (Test_fs.suite k);
+    `Slow , Test_http.suite (Test_git.suite k);
   ] in
   Test_store.run "irmin" (suite `String @ suite `Json)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -19,7 +19,7 @@ let () =
     `Quick, Test_memory.suite k;
     `Quick, Test_fs.suite k;
     `Quick, Test_git.suite k;
-    `Slow , Test_http.suite k (Test_memory.suite k);
+    `Quick, Test_http.suite k (Test_memory.suite k);
     `Slow , Test_http.suite k (Test_fs.suite k);
     `Slow , Test_http.suite k (Test_git.suite k);
   ] in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -15,12 +15,14 @@
  *)
 
 let () =
-  let suite k = [
-    `Quick, Test_memory.suite k;
-    `Quick, Test_fs.suite k;
-    `Quick, Test_git.suite k;
-    `Quick, Test_http.suite (Test_memory.suite k);
-    `Slow , Test_http.suite (Test_fs.suite k);
-    `Slow , Test_http.suite (Test_git.suite k);
-  ] in
+  let suite k =
+    let depends = if k = `String then `Quick else `Slow in
+    [
+      `Quick , Test_memory.suite k;
+      `Quick , Test_fs.suite k;
+      `Quick , Test_git.suite k;
+      depends, Test_http.suite (Test_memory.suite k);
+      `Slow  , Test_http.suite (Test_fs.suite k);
+      `Slow  , Test_http.suite (Test_git.suite k);
+    ] in
   Test_store.run "irmin" (suite `String @ suite `Json)

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -113,6 +113,7 @@ let create: (module Irmin.S_MAKER) -> [`String | `Json] -> (module Irmin.S) =
 type t = {
   name  : string;
   kind  : [`Json | `String];
+  disk  : bool;
   init  : unit -> unit Lwt.t;
   clean : unit -> unit Lwt.t;
   config: Irmin.config;

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -110,10 +110,12 @@ let create: (module Irmin.S_MAKER) -> [`String | `Json] -> (module Irmin.S) =
     in
     let module S = Irmin.Basic(B)(C) in (module S)
 
+type kind = [`Mem | `Fs | `Git | `Http of kind]
+
 type t = {
   name  : string;
-  kind  : [`Json | `String];
-  disk  : bool;
+  kind  : kind;
+  cont  : [`Json | `String];
   init  : unit -> unit Lwt.t;
   clean : unit -> unit Lwt.t;
   config: Irmin.config;
@@ -123,7 +125,7 @@ type t = {
 let none () =
   return_unit
 
-let string_of_kind = function
+let string_of_contents = function
   | `Json   -> "-json"
   | `String -> ""
 

--- a/lib_test/test_fs.ml
+++ b/lib_test/test_fs.ml
@@ -18,7 +18,9 @@ open Test_common
 
 let test_db = "test-db"
 
-let polling = 0.01
+let polling =
+  try float_of_string (Sys.getenv "IRMIN_FS_POLLING")
+  with Not_found | Failure _ -> 0.01
 
 let init () =
   Irmin_unix.install_dir_polling_listener polling;

--- a/lib_test/test_fs.ml
+++ b/lib_test/test_fs.ml
@@ -34,9 +34,9 @@ let clean () =
 
 let suite k =
   {
-    name = "FS" ^ string_of_kind k;
-    kind = k;
-    disk = true;
+    name = "FS" ^ string_of_contents k;
+    kind = `Fs;
+    cont = k;
     init; clean;
     config = Irmin_fs.config ~root:test_db ();
     store  =  irf_store k;

--- a/lib_test/test_fs.ml
+++ b/lib_test/test_fs.ml
@@ -18,8 +18,10 @@ open Test_common
 
 let test_db = "test-db"
 
+let polling = 0.01
+
 let init () =
-  Irmin_unix.install_dir_polling_listener 0.1;
+  Irmin_unix.install_dir_polling_listener polling;
   if Sys.file_exists test_db then begin
     let cmd = Printf.sprintf "rm -rf %s" test_db in
     let _ = Sys.command cmd in ()

--- a/lib_test/test_fs.ml
+++ b/lib_test/test_fs.ml
@@ -14,24 +14,28 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt
 open Test_common
 
 let test_db = "test-db"
 
 let init () =
+  Irmin_unix.install_dir_polling_listener 0.1;
   if Sys.file_exists test_db then begin
     let cmd = Printf.sprintf "rm -rf %s" test_db in
     let _ = Sys.command cmd in ()
   end;
-  return_unit
+  Lwt.return_unit
+
+let clean () =
+  Irmin_unix.uninstall_dir_polling_listener ();
+  Lwt.return_unit
 
 let suite k =
   {
     name = "FS" ^ string_of_kind k;
     kind = k;
-    init;
-    clean  = none;
+    disk = true;
+    init; clean;
     config = Irmin_fs.config ~root:test_db ();
     store  =  irf_store k;
   }

--- a/lib_test/test_git.ml
+++ b/lib_test/test_git.ml
@@ -32,6 +32,7 @@ let suite k =
   {
     name   = "GIT" ^ string_of_kind k;
     kind   = k;
+    disk   = true;
     init   = init_disk;
     clean  = none;
     store  = git_store k;

--- a/lib_test/test_git.ml
+++ b/lib_test/test_git.ml
@@ -24,9 +24,14 @@ let init_disk () =
     failwith "The Git test should be run in the lib_test/ directory."
   else if Sys.file_exists test_db then
     Git_unix.FS.create ~root:test_db () >>= fun t ->
+    Irmin_unix.install_dir_polling_listener Test_fs.polling;
     Git_unix.FS.clear t
   else
     return_unit
+
+let clean () =
+  Irmin_unix.uninstall_dir_polling_listener ();
+  Lwt.return_unit
 
 let suite k =
   {
@@ -34,7 +39,7 @@ let suite k =
     kind   = k;
     disk   = true;
     init   = init_disk;
-    clean  = none;
+    clean  = clean;
     store  = git_store k;
     config =
       let head = Git.Reference.of_raw "refs/heads/test" in

--- a/lib_test/test_git.ml
+++ b/lib_test/test_git.ml
@@ -35,9 +35,9 @@ let clean () =
 
 let suite k =
   {
-    name   = "GIT" ^ string_of_kind k;
-    kind   = k;
-    disk   = true;
+    name   = "GIT" ^ string_of_contents k;
+    cont   = k;
+    kind   = `Git;
     init   = init_disk;
     clean  = clean;
     store  = git_store k;

--- a/lib_test/test_http.ml
+++ b/lib_test/test_http.ml
@@ -37,7 +37,7 @@ let rec wait_for_the_server_to_start () =
     Lwt_unix.sleep 0.1 >>= fun () ->
     wait_for_the_server_to_start ()
 
-let suite k server =
+let suite server =
   let server_pid = ref 0 in
   { name = Printf.sprintf "HTTP.%s" server.name;
 
@@ -63,8 +63,8 @@ let suite k server =
         wait_for_the_server_to_start ()
     end;
 
-    kind = k;
-    disk = server.disk;
+    cont = server.cont;
+    kind = `Http server.kind;
 
     clean = begin fun () ->
       Unix.kill !server_pid 9;
@@ -75,5 +75,5 @@ let suite k server =
     end;
 
     config = Irmin_http.config uri;
-    store = http_store k;
+    store = http_store server.cont;
   }

--- a/lib_test/test_http.ml
+++ b/lib_test/test_http.ml
@@ -64,6 +64,7 @@ let suite k server =
     end;
 
     kind = k;
+    disk = server.disk;
 
     clean = begin fun () ->
       Unix.kill !server_pid 9;

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -20,6 +20,7 @@ let suite k =
   {
     name   = "MEM" ^ string_of_kind k;
     kind   = k;
+    disk   = false;
     init   = none;
     clean  = none;
     config = Irmin_mem.config ();

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -15,14 +15,21 @@
  *)
 
 open Test_common
+let (>>=) = Lwt.(>>=)
+
+let clean config (module S: Irmin.S) () =
+  S.empty config Irmin.Task.none  >>= fun t ->
+  S.tags (t ()) >>= fun tags ->
+  Lwt_list.iter_p (S.remove_tag (t ())) tags
 
 let suite k =
+  let config = Irmin_mem.config () in
+  let store = mem_store k in
   {
     name   = "MEM" ^ string_of_kind k;
     kind   = k;
     disk   = false;
     init   = none;
-    clean  = none;
-    config = Irmin_mem.config ();
-    store  = mem_store k;
+    clean  = clean config store;
+    config; store;
 }

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -26,9 +26,9 @@ let suite k =
   let config = Irmin_mem.config () in
   let store = mem_store k in
   {
-    name   = "MEM" ^ string_of_kind k;
-    kind   = k;
-    disk   = false;
+    name   = "MEM" ^ string_of_contents k;
+    kind   = `Mem;
+    cont   = k;
     init   = none;
     clean  = clean config store;
     config; store;

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -321,7 +321,9 @@ module Make (S: Irmin.S) = struct
       let adds    = ref 0 in
       let updates = ref 0 in
       let removes = ref 0 in
+      let sleep_t = 0.02 in
       let process head =
+        Lwt_unix.sleep sleep_t >>= fun () ->
         let () = match head with
           | `Added _h  -> adds    := !adds + 1
           | `Updated _ -> updates := !updates + 1
@@ -342,7 +344,8 @@ module Make (S: Irmin.S) = struct
       in
       let sleep () =
         (* sleep duration is arbiratry set to 2 * polling time. *)
-        if x.disk then Lwt_unix.sleep (2. *. Test_fs.polling) else Lwt.return_unit
+        if x.disk then Lwt_unix.sleep (2. *. (max sleep_t Test_fs.polling))
+        else Lwt.return_unit
       in
       let check msg w a b =
         let printer (a, u, r) =

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -866,7 +866,7 @@ module Make (S: Irmin.S) = struct
 
       (* Testing [View.remove] *)
 
-      View.empty () >>= fun v1 ->
+      let v1 = View.empty () in
 
       View.update v1 (p ["foo";"1"]) foo1 >>= fun () ->
       View.update v1 (p ["foo";"2"]) foo2 >>= fun () ->
@@ -908,9 +908,9 @@ module Make (S: Irmin.S) = struct
         if not (cmp x y) then error msg (printer x) (printer y)
       in
 
-      View.empty () >>= fun v0 ->
-      View.empty () >>= fun v1 ->
-      View.empty () >>= fun v2 ->
+      let v0 = View.empty () in
+      let v1 = View.empty () in
+      let v2 = View.empty () in
       View.update v1 (p ["foo";"1"]) foo1 >>= fun () ->
       View.update v2 (p ["foo";"1"]) foo2 >>= fun () ->
       View.update v2 (p ["foo";"2"]) foo1 >>= fun () ->
@@ -927,7 +927,7 @@ module Make (S: Irmin.S) = struct
 
       (* Testing other View operations. *)
 
-      View.empty () >>= fun v0 ->
+      let v0 = View.empty () in
 
       View.update v0 (p []) foo1 >>= fun () ->
       View.read   v0 (p []) >>= fun foo1' ->

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -354,7 +354,6 @@ module Make (S: Irmin.S) = struct
       S.remove_tag (t "remove-tag") Tag.Key.master >>= fun () ->
       sleep () >>= fun () ->
       check "init" 0 (0, 0, 0) (state ());
-      S.head_exn (t "head") >>= fun _ ->
 
       loop 100 >>= fun () ->
 

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -566,7 +566,8 @@ module Make (S: Irmin.S) = struct
       S.remove_rec (t1 "fresh") (p ["a"]) >>= fun () ->
 
       S.head_exn (t1 "head") >>= fun h ->
-      let init = h, View.empty () in
+      View.empty () >>= fun v ->
+      let init = h, v in
 
       View.watch_path (t2 "wath-path") ~init (p ["a";"b"]) (State.process state)
       >>= fun unwatch ->
@@ -912,7 +913,7 @@ module Make (S: Irmin.S) = struct
 
       (* Testing [View.remove] *)
 
-      let v1 = View.empty () in
+      View.empty () >>= fun v1 ->
 
       View.update v1 (p ["foo";"1"]) foo1 >>= fun () ->
       View.update v1 (p ["foo";"2"]) foo2 >>= fun () ->
@@ -954,9 +955,9 @@ module Make (S: Irmin.S) = struct
         if not (cmp x y) then error msg (printer x) (printer y)
       in
 
-      let v0 = View.empty () in
-      let v1 = View.empty () in
-      let v2 = View.empty () in
+      View.empty () >>= fun v0 ->
+      View.empty () >>= fun v1 ->
+      View.empty () >>= fun v2 ->
       View.update v1 (p ["foo";"1"]) foo1 >>= fun () ->
       View.update v2 (p ["foo";"1"]) foo2 >>= fun () ->
       View.update v2 (p ["foo";"2"]) foo1 >>= fun () ->
@@ -973,7 +974,7 @@ module Make (S: Irmin.S) = struct
 
       (* Testing other View operations. *)
 
-      let v0 = View.empty () in
+      View.empty () >>= fun v0 ->
 
       View.update v0 (p []) foo1 >>= fun () ->
       View.read   v0 (p []) >>= fun foo1' ->

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -337,7 +337,7 @@ module Make (S: Irmin.S) = struct
       in
       let sleep () =
         (* sleep duration is arbiratry set to 2 * polling time. *)
-        if x.disk then Lwt_unix.sleep 1. else Lwt.return_unit in
+        if x.disk then Lwt_unix.sleep Test_fs.polling else Lwt.return_unit in
       let check msg w x y =
         let printer (a, u, r) =
           Printf.sprintf "{ adds=%d; updates=%d; removes=%d }" a u r
@@ -930,7 +930,6 @@ module Make (S: Irmin.S) = struct
       return_unit
     in
     run x test
-
 
   let rec write fn = function
     | 0 -> return_unit

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -345,7 +345,7 @@ module Make (S: Irmin.S) = struct
       let sleep () =
         let sleep_t =
           (* sleep duration is 2*max(polling time, callback sleep time) *)
-          2. *. if x.disk then (max sleep_t Test_fs.polling) else sleep_t
+          3. *. if x.disk then (max sleep_t Test_fs.polling) else sleep_t
         in
         Lwt_unix.sleep sleep_t
       in

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -343,9 +343,11 @@ module Make (S: Irmin.S) = struct
           loop (n-1)
       in
       let sleep () =
-        (* sleep duration is arbiratry set to 2 * polling time. *)
-        if x.disk then Lwt_unix.sleep (2. *. (max sleep_t Test_fs.polling))
-        else Lwt.return_unit
+        let sleep_t =
+          (* sleep duration is 2*max(polling time, callback sleep time) *)
+          2. *. if x.disk then (max sleep_t Test_fs.polling) else sleep_t
+        in
+        Lwt_unix.sleep sleep_t
       in
       let check msg w a b =
         let printer (a, u, r) =

--- a/opam
+++ b/opam
@@ -49,5 +49,6 @@ depopts: [
 conflicts: [
   "git"    {< "1.4.10"}
   "cohttp" {< "0.14.0"}
+  "cohttp" {= "0.16.1"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
Not ready to merge yet. Here is the current status:

- the code compiles but is totally untested (so assume it is broken)

- there is no unit-tests at all for the notification code (the old one as well as the new one). I'll add extensive tests before envisaging merging.

- the new API is much simpler than the previous one, with explicit de-allocation and clearer concurrency semantics. Basically you now only have:
    ```ocaml
  type 'a diff = [ `Updated of 'a * 'a | `Added of 'a | `Removed of 'a ]

  val watch_head: t -> ?init:head -> (head diff -> unit Lwt.t) ->
    (unit -> unit Lwt.t) Lwt.t
  (** [watch_tag t f] calls [f] everytime the contents of [t]'s tag is
      updated. Do nothing if [t] is not persistent. Return a clean-up
      function to remove the watch handler.

      {b Note:} even [f] might skip some head updates, it will never
      be called concurrently: all consecutive calls to [f] are done in
      sequence, so we ensure that the previous one ended before
      calling the next one. *)

  val watch_tags: t -> ?init:(tag * head) list ->
    (tag -> head diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
  (** [watch_tags t f] calls [f] to the watch handlers of {b all} tag
      changes in the local store. Return a function to remove the
      handler. *)
    ```
     I'm not totally convinced about the function names yet, but the types are ok now I think. Basically, you register a callback which is called on every update. If multiple callbacks are registered, they are called in sequence, and they won't overloap with each other. 

- There is not (yet?) an optimisation to clean-up the callback calls in case the waiting queue become too big and starts to lag. I'm not sure it is necessary, I plan to run some stress-tests to see how it works under load with lots of long-running callback function.

- The previous API which let you watch for changes in sub-path has been completely removed. This was designed first to look like xenstore watches, but with subtle semantic differences so not really useful as they were. I plan to maybe add back something similar later if people needs it, but for now I prefer relying on fewer well-tested functions.