### PR TITLE
Fix slice-based HTTP synchronization

### DIFF
--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -727,13 +727,13 @@ struct
     LP.Commit.read_exn t.commit_t head >>= fun commit ->
     Lwt.return (LP.Commit.Val.task commit)
 
-  module E = Tc.Pair (Tc.List(Head)) (Tc.List(Head))
+  module E = Tc.Pair (Tc.List(Head)) (Tc.Option(Tc.List(Head)))
 
   type slice = L.slice
 
   module Slice = L.Private.Slice
 
-  let export ?full ?depth ?(min=[]) ?(max=[]) t =
+  let export ?full ?depth ?(min=[]) ?max t =
     let query =
       let full = match full with
         | None   -> []

--- a/lib/http/irmin_http_server.ml
+++ b/lib/http/irmin_http_server.ml
@@ -500,7 +500,7 @@ module Make (HTTP: SERVER) (D: DATE) (S: Irmin.S) = struct
   let key: S.key Tc.t = (module S.Key)
   let head: S.head Tc.t = (module S.Head)
 
-  let export = Tc.pair (Tc.list head) (Tc.list head)
+  let export = Tc.pair (Tc.list head) (Tc.option (Tc.list head))
 
   let merge (type x) (x:x Tc.t): x Irmin.Merge.result Tc.t =
     let module X = (val x: Tc.S0 with type t = x) in
@@ -576,7 +576,8 @@ module Make (HTTP: SERVER) (D: DATE) (S: Irmin.S) = struct
     in
     let s_export t (min, max) query =
       let full, depth = mk_export_query query in
-      S.export ?full ?depth ~min ~max t
+      S.export ?full ?depth ~min ?max t
+
     in
     let s_history t (min, max) query =
       let depth = mk_history_query query in

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -86,14 +86,14 @@ module Make (S: Ir_s.STORE) = struct
       Log.debug "fetch store";
       S.heads t >>= fun min ->
       let min = List.map (conv (module S.Head) (module R.Head) ) min in
-      R.export r ?depth ~min >>= fun r_slice ->
-      convert_slice (module R.Private) (module S.Private) r_slice
-      >>= fun s_slice -> S.import t s_slice >>= fun () ->
       R.head r >>= function
       | None   -> return_none
       | Some h ->
-        let h = conv (module R.Head) (module S.Head) h in
-        return (Some h)
+         R.export r ?depth ~min ~max:[h] >>= fun r_slice ->
+         convert_slice (module R.Private) (module S.Private) r_slice >>= fun s_slice ->
+         S.import t s_slice >>= fun () ->
+         let h = conv (module R.Head) (module S.Head) h in
+         return (Some h)
 
   let fetch_exn t ?depth remote =
     fetch t ?depth remote >>= function


### PR DESCRIPTION
I have recently experimented with synchronizing different Irmin backends via HTTP and ran into a couple of problems.

Slice-based HTTP sync is not working because parameters for /export API handle are serialized in such a way that max parameter is set to an empty list resulting in empty slice. The first patch fixes this problem by serializing max parameter as optional list.

The second patch fixes a potential race condition in HTTP fetch protocol - the /export is called first and then /head. If after exporting slice remote head is advanced by concurrent process, local repository is left in inconsistent state. I think it is better to fetch remote head first and then ask for slice up to that point.