### PR TITLE
Do not fail silently when a synchronisation fails.

### DIFF
--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -269,8 +269,9 @@ let clone = {
         store >>= fun t ->
         remote >>= fun remote ->
         Sync.fetch (t "Cloning.") ?depth remote >>= function
-        | Some d -> S.update_head (t "update head after clone") d
-        | None   -> return_unit
+        | `Head d  -> S.update_head (t "update head after clone") d
+        | `No_head -> return_unit
+        | `Error   -> Printf.eprintf "Error!\n"; exit 1
       end
     in
     Term.(mk clone $ store $ remote $ depth);

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -623,8 +623,8 @@ module Make (IO: Git.Sync.IO) (L: LOCK) (G: Git.Store.S)
     let head_of_git key = H.of_raw (GK.to_raw (Git.SHA.of_commit key))
 
     let o_head_of_git = function
-      | None   -> return_none
-      | Some k -> return (Some (`Local (head_of_git k)))
+      | None   -> Lwt.return `No_head
+      | Some k -> Lwt.return (`Head (head_of_git k))
 
     let create config =
       let root = Irmin.Private.Conf.get config Conf.root in

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -751,8 +751,25 @@ struct
 
   module I = Tc.List(Tag)
 
+  module Ok_or_error = struct
+    type t  = [`Ok | `Error]
+    let hash = Hashtbl.hash
+    let compare = Pervasives.compare
+    let equal = (=)
+    let of_json = function
+      | `String "ok"    -> `Ok
+      | `String "error" -> `Error
+      | j -> Ezjsonm.parse_error j "Ok_or_error"
+
+    let to_json _ = failwith "TODO"
+    let read _ = failwith "TODO"
+    let write _ = failwith "TODO"
+    let size_of _ = failwith "TODO"
+  end
+  let ok_or_error = (module Ok_or_error: Tc.S0 with type t = Ok_or_error.t)
+
   let import t slice =
-    post t ["import"] (some @@ Slice.to_json slice) Tc.unit
+    post t ["import"] (some @@ Slice.to_json slice) ok_or_error
 
   let remove_rec t dir =
     delete t ["remove-rec"; Key.to_hum dir] (module Head) >>= fun h ->

--- a/lib/http/irmin_http_server.ml
+++ b/lib/http/irmin_http_server.ml
@@ -560,6 +560,21 @@ module Make (HTTP: SERVER) (D: DATE) (S: Irmin.S) = struct
   end
   module HTC = Tc.Biject (G)(Conv)
 
+  module Ok_or_error = struct
+    type t  = [`Ok | `Error]
+    let hash = Hashtbl.hash
+    let compare = Pervasives.compare
+    let equal = (=)
+    let to_json = function
+      | `Ok    -> `String "ok"
+      | `Error -> `String "error"
+    let of_json _ = failwith "TODO"
+    let read _ = failwith "TODO"
+    let write _ = failwith "TODO"
+    let size_of _ = failwith "TODO"
+  end
+  let ok_or_error = (module Ok_or_error: Tc.S0 with type t = Ok_or_error.t)
+
   let mk_task t = function
     | None   -> S.task t
     | Some t -> t
@@ -667,7 +682,7 @@ module Make (HTTP: SERVER) (D: DATE) (S: Irmin.S) = struct
       mk1p0bf "clone"       s_clone t tag' ok_or_duplicated_tag;
       mk1p0bf "clone-force" s_clone_force t tag' Tc.unit;
       mk0p1bfq "export"     s_export t export slice;
-      mk0p1bf "import"      S.import t slice Tc.unit;
+      mk0p1bf "import"      S.import t slice ok_or_error;
       mk0p1bfq "history"    s_history t min_max (module HTC);
 
       (* lca *)

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -64,7 +64,7 @@ module type STORE = sig
   type slice
   val export: ?full:bool -> ?depth:int -> ?min:head list -> ?max:head list ->
     t -> slice Lwt.t
-  val import: t -> slice -> unit Lwt.t
+  val import: t -> slice -> [`Ok | `Error] Lwt.t
 end
 
 module type MAKER =

--- a/lib/ir_sync.ml
+++ b/lib/ir_sync.ml
@@ -21,7 +21,8 @@ module type S = sig
   type head
   type tag
   val create: Ir_conf.t -> t Lwt.t
-  val fetch: t -> ?depth:int -> uri:string -> tag -> [`Local of head] option Lwt.t
+  val fetch: t -> ?depth:int -> uri:string -> tag ->
+    [`Head of head | `No_head | `Error] Lwt.t
   val push : t -> ?depth:int -> uri:string -> tag -> [`Ok | `Error] Lwt.t
 end
 
@@ -30,6 +31,6 @@ module None (H: Tc.S0) (T: Tc.S0) = struct
   type head = H.t
   type tag = T.t
   let create _ = return_unit
-  let fetch () ?depth:_ ~uri:_ _tag = return_none
+  let fetch () ?depth:_ ~uri:_ _tag = return `Error
   let push () ?depth:_ ~uri:_ _tag = return `Error
 end

--- a/lib/ir_sync.mli
+++ b/lib/ir_sync.mli
@@ -21,7 +21,8 @@ module type S = sig
   type head
   type tag
   val create: Ir_conf.t -> t Lwt.t
-  val fetch: t -> ?depth:int -> uri:string -> tag -> [`Local of head] option Lwt.t
+  val fetch: t -> ?depth:int -> uri:string -> tag ->
+    [`Head of head | `No_head | `Error] Lwt.t
   val push : t -> ?depth:int -> uri:string -> tag -> [`Ok | `Error] Lwt.t
 end
 

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -28,9 +28,11 @@ let remote_uri s = URI s
 module type STORE = sig
   type db
   type head
-  val fetch: db -> ?depth:int -> remote -> head option Lwt.t
+  val fetch: db -> ?depth:int -> remote ->
+    [`Head of head | `No_head | `Error] Lwt.t
   val fetch_exn: db -> ?depth:int -> remote -> head Lwt.t
-  val pull: db -> ?depth:int -> remote -> [`Merge|`Update] -> unit Ir_merge.result Lwt.t
+  val pull: db -> ?depth:int -> remote -> [`Merge|`Update] ->
+    [`Ok | `No_head | `Error] Ir_merge.result Lwt.t
   val pull_exn: db -> ?depth:int -> remote -> [`Merge|`Update] -> unit Lwt.t
   val push: db -> ?depth:int -> remote -> [`Ok | `Error] Lwt.t
   val push_exn: db -> ?depth:int -> remote -> unit Lwt.t
@@ -75,45 +77,47 @@ module Make (S: Ir_s.STORE) = struct
     | URI uri ->
       Log.debug "fetch URI %s" uri;
       begin S.tag t >>= function
-        | None     -> return_none
+        | None     -> Lwt.return `No_head
         | Some tag ->
           B.create (S.Private.config t) >>= fun g ->
-          B.fetch g ?depth ~uri tag >>= function
-          | None  -> return_none
-          | Some (`Local h) -> return (Some h)
+          B.fetch g ?depth ~uri tag
       end
     | Store ((module R), r) ->
       Log.debug "fetch store";
       S.heads t >>= fun min ->
       let min = List.map (conv (module S.Head) (module R.Head) ) min in
       R.head r >>= function
-      | None   -> return_none
+      | None   -> Lwt.return `No_head
       | Some h ->
          R.export r ?depth ~min ~max:[h] >>= fun r_slice ->
          convert_slice (module R.Private) (module S.Private) r_slice >>= fun s_slice ->
-         S.import t s_slice >>= fun () ->
-         let h = conv (module R.Head) (module S.Head) h in
-         return (Some h)
+         S.import t s_slice >>= function
+         | `Error -> Lwt.return `Error
+         | `Ok    ->
+           let h = conv (module R.Head) (module S.Head) h in
+           return (`Head h)
 
   let fetch_exn t ?depth remote =
     fetch t ?depth remote >>= function
-    | Some h -> return h
-    | None   -> fail (Failure "Sync.fetch_exn")
+    | `Head h  -> Lwt.return h
+    | `No_head -> Lwt.fail (Failure "Sync.fetch_exn: no head!")
+    | `Error   -> Lwt.fail (Failure "Sync.fetch_exn: fetch error!")
 
   let pull t ?depth remote kind =
     let open Ir_merge.OP in
     fetch t ?depth remote >>= function
-    | None -> ok () (* XXX ? *)
-    | Some k ->
+    | `Error   -> ok `Error
+    | `No_head -> ok `No_head
+    | `Head k  ->
       match kind with
-      | `Merge  -> S.merge_head t k
-      | `Update ->
-        S.update_head t k >>= fun () ->
-        ok ()
+      | `Merge  -> S.merge_head t k  >>| fun () -> ok `Ok
+      | `Update -> S.update_head t k >>= fun () -> ok `Ok
 
   let pull_exn t ?depth remote kind =
-    pull t ?depth remote kind >>=
-    Ir_merge.exn
+    pull t ?depth remote kind >>= Ir_merge.exn >>= function
+    | `Ok      -> Lwt.return_unit
+    | `No_head -> Lwt.fail (Failure "Sync.pull_exn: no head!")
+    | `Error   -> Lwt.fail (Failure "Sync.pull_exn: pull error!")
 
   let push t ?depth remote =
     Log.debug "push";
@@ -134,10 +138,12 @@ module Make (S: Ir_s.STORE) = struct
         let min = List.map (conv (module R.Head) (module S.Head)) min in
         S.export t ?depth ~min >>= fun s_slice ->
         convert_slice (module S.Private) (module R.Private) s_slice
-        >>= fun r_slice -> R.import r r_slice >>= fun () ->
-        let h = conv (module S.Head) (module R.Head) h in
-        R.update_head r h >>= fun () ->
-        return `Ok
+        >>= fun r_slice -> R.import r r_slice >>= function
+        | `Error -> Lwt.return `Error
+        | `Ok    ->
+          let h = conv (module S.Head) (module R.Head) h in
+          R.update_head r h >>= fun () ->
+          Lwt.return `Ok
 
   let push_exn t ?depth remote =
     push t ?depth remote >>= function

--- a/lib/ir_sync_ext.mli
+++ b/lib/ir_sync_ext.mli
@@ -23,9 +23,11 @@ val remote_store: (module Ir_s.STORE with type t = 'a) -> 'a -> remote
 module type STORE = sig
   type db
   type head
-  val fetch: db -> ?depth:int -> remote -> head option Lwt.t
+  val fetch: db -> ?depth:int -> remote ->
+    [`Head of head | `No_head | `Error] Lwt.t
   val fetch_exn: db -> ?depth:int -> remote -> head Lwt.t
-  val pull: db -> ?depth:int -> remote -> [`Merge|`Update] -> unit Ir_merge.result Lwt.t
+  val pull: db -> ?depth:int -> remote -> [`Merge|`Update] ->
+    [`Ok | `No_head | `Error] Ir_merge.result Lwt.t
   val pull_exn: db -> ?depth:int -> remote -> [`Merge|`Update] -> unit Lwt.t
   val push: db -> ?depth:int -> remote -> [`Ok | `Error] Lwt.t
   val push_exn: db -> ?depth:int -> remote -> unit Lwt.t

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -154,9 +154,10 @@ and ('k, 'v) bc = {
     unit -> History.t Lwt.t;
   task_of_head: Hash.SHA1.t -> Task.t Lwt.t;
   remote_basic: unit -> remote;
-  fetch: ?depth:int -> remote -> Hash.SHA1.t option Lwt.t;
+  fetch: ?depth:int -> remote -> [`Head of Hash.SHA1.t | `No_head | `Error] Lwt.t;
   fetch_exn: ?depth:int -> remote -> Hash.SHA1.t Lwt.t;
-  pull: ?depth:int -> remote -> [`Merge | `Update] -> unit Merge.result Lwt.t;
+  pull: ?depth:int -> remote -> [`Merge | `Update] ->
+    [`Ok | `No_head | `Error] Merge.result Lwt.t;
   pull_exn: ?depth:int -> remote -> [`Merge | `Update] -> unit Lwt.t;
   push: ?depth:int -> remote -> [`Ok | `Error] Lwt.t;
   push_exn: ?depth:int -> remote -> unit Lwt.t;


### PR DESCRIPTION
Would be maybe better to carry the error along as a string instead of just
printing it once and forgetting about it. Not sure the error string would
be very useful for the users still.

Fix #202