### PR TITLE
Add HTTP client and server version checks

### DIFF
--- a/lib/http/irmin_http_common.ml
+++ b/lib/http/irmin_http_common.ml
@@ -91,3 +91,4 @@ let lca (type a) (head: a Tc.t) =
   (module M: Tc.S0 with type t = M.t)
 
 let start_stream = "¡start!"
+let irmin_header = "X-IrminVersion"

--- a/lib/http/irmin_http_common.mli
+++ b/lib/http/irmin_http_common.mli
@@ -21,3 +21,4 @@ val ok_or_duplicated_tag: [`Ok | `Duplicated_tag] Tc.t
 val lca: 'a Tc.t -> [`Ok of 'a list | `Max_depth_reached | `Too_many_lcas] Tc.t
 
 val start_stream: string
+val irmin_header: string

--- a/lib/http/irmin_http_server.mli
+++ b/lib/http/irmin_http_server.mli
@@ -25,9 +25,11 @@ module type S = sig
   type t
   (** Database type. *)
 
-  val listen: t -> ?timeout:int -> ?hooks:hooks -> Uri.t -> unit Lwt.t
+  val listen: t -> ?timeout:int -> ?strict:bool -> ?hooks:hooks -> Uri.t -> unit Lwt.t
   (** [start_server t uri] start a server serving the contents of [t]
-      at the address [uri]. *)
+      at the address [uri]. If [strict] is set, incoming connections
+      will fail if they do not have the right {i X-IrminVersion}
+      headers. *)
 
 end
 

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -139,8 +139,9 @@ module Make (S: Ir_s.STORE) = struct
         S.export t ?depth ~min >>= fun s_slice ->
         convert_slice (module S.Private) (module R.Private) s_slice
         >>= fun r_slice -> R.import r r_slice >>= function
-        | `Error -> Lwt.return `Error
+        | `Error -> Log.debug "ERROR!"; Lwt.return `Error
         | `Ok    ->
+          Log.debug "OK!";
           let h = conv (module S.Head) (module R.Head) h in
           R.update_head r h >>= fun () ->
           Lwt.return `Ok

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -192,10 +192,13 @@ module Irmin_http_server: sig
     type t
     (** The type for store handles. *)
 
-    val listen: t -> ?timeout:int -> ?hooks:hooks -> Uri.t -> unit Lwt.t
+    val listen: t -> ?timeout:int -> ?strict:bool -> ?hooks:hooks ->
+      Uri.t -> unit Lwt.t
     (** [start_server t uri] start a server serving the contents of
         [t] at the address [uri]. Close clients' connections after
-        [timeout] seconds of inactivity. *)
+        [timeout] seconds of inactivity. If [strict] is set (by
+        default it is not), incoming connections will fail if they do
+        not have the right {i X-IrminVersion} headers. *)
 
   end
 


### PR DESCRIPTION
The client puts its version in the X-IrminVersion header of the request.
By default, the server will serve the request anyway if the header is not
set, as we still want default browser connections to work fine.

The server puts its version in the `versions` field of the JSON objects that
it returns. The client can deal with that and print the correct error message
instead of failing miserably in case of API mismatch.

Fix #167