### PR TITLE
Change the JSON stream API

### DIFF
--- a/lib/http/irmin_http_common.ml
+++ b/lib/http/irmin_http_common.ml
@@ -118,7 +118,8 @@ let lca (type a) (head: a Tc.t) =
   end in
   (module M: Tc.S0 with type t = M.t)
 
-let start_stream = "¡start!"
+let start_stream = "start"
+let stop_stream = "stop"
 let irmin_version = "X-IrminVersion"
 let content_type_header = "Content-type"
 let application_json = "application/json"

--- a/lib/http/irmin_http_common.mli
+++ b/lib/http/irmin_http_common.mli
@@ -23,6 +23,7 @@ val ok_or_duplicated_tag: [`Ok | `Duplicated_tag | `Empty_head] Tc.t
 val lca: 'a Tc.t -> [`Ok of 'a list | `Max_depth_reached | `Too_many_lcas] Tc.t
 
 val start_stream: string
+val stop_stream: string
 val irmin_version: string
 
 val content_type_header: string

--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ remove: ["ocamlfind" "remove" "irmin"]
 
 depends: [
   "ocamlfind" {build}
-  "ezjsonm" {>= "0.4.0"}
+  "ezjsonm" {>= "0.4.2"}
   "ocamlgraph"
   "lwt" {>= "2.4.7"}
   "dolog" {>= "0.4"}


### PR DESCRIPTION
The previous API was hard to parse (#266) and wrong (#269). This commit tries to
fix that.

Now the stream is an (almost valid) JSON array which looks like:

[ {"stream":"start"}, {"version":"..."}, {"result":..},..,{"result":..},{"stream":"end"}]

almost valid as the spec doesn't allow multiple fields with the same name; but
most of existing implementation don't really care.

This needs a special release of ezjsonm (0.4.2)