### PR TITLE
Add BC.repo type

### DIFF
--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -298,7 +298,7 @@ let fetch = {
         store >>= fun t ->
         remote >>= fun r ->
         let branch_id = S.Ref.of_hum "import" in
-        S.of_branch_id (S.Private.config (t "config")) task branch_id >>= fun t ->
+        S.of_branch_id task branch_id (S.repo (t "config")) >>= fun t ->
         Sync.pull_exn (t "Fetching.")  r `Update
       end
     in

--- a/bin/ir_resolver.ml
+++ b/bin/ir_resolver.ml
@@ -172,8 +172,8 @@ let read_config_file (): t option =
       |> add Irmin_http.uri uri
     in
     match branch with
-    | None   -> Some (S ((module S), S.create config task))
-    | Some b -> Some (S ((module S), S.of_branch_id config task b))
+    | None   -> Some (S ((module S), S.Repo.create config >>= S.master task))
+    | Some b -> Some (S ((module S), S.Repo.create config >>= S.of_branch_id task b))
 
 let store =
   let branch =
@@ -190,8 +190,8 @@ let store =
       let module S = (val s: Irmin.S) in
       (* first look at the command-line options *)
       let t = match branch with
-        | None   -> S.create config task
-        | Some t -> S.of_branch_id config task (S.Ref.of_hum t)
+        | None   -> S.Repo.create config >>= S.master task
+        | Some t -> S.Repo.create config >>= S.of_branch_id task (S.Ref.of_hum t)
       in
       S ((module S), t)
     | None ->
@@ -201,7 +201,7 @@ let store =
       | None   ->
         let s = mk_store `Git (mk_contents `String) in
         let module S = (val s: Irmin.S) in
-        let t = S.create config task in
+        let t = S.Repo.create config >>= S.master task in
         S ((module S), t)
   in
   Term.(pure create $ store_term $ config_term $ branch)
@@ -226,7 +226,7 @@ let infer_remote contents str =
       |> add Irmin_http.uri (Some (Uri.of_string str))
       |> add Irmin.Private.Conf.root (Some str)
     in
-    R.create config task >>= fun r ->
+    R.Repo.create config >>= R.master task >>= fun r ->
       return (Irmin.remote_store (module R) (r "Clone %s."))
     ) else
       return (Irmin.remote_uri str)

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -178,7 +178,7 @@ let print_logs name t =
 
 let main () =
   Config.init ();
-  Store.create config task >>= fun t ->
+  Store.Repo.create config >>= Store.master task >>= fun t ->
 
   (* populate the log with some random messages *)
   Lwt_list.iter_s (fun msg ->

--- a/examples/git_store.ml
+++ b/examples/git_store.ml
@@ -18,7 +18,7 @@ let read_exn t k =
 let main () =
   Config.init ();
   let config = Irmin_git.config ~root:Config.root ~bare:true () in
-  Store.create config task >>= fun t ->
+  Store.Repo.create config >>= Store.master task >>= fun t ->
 
   update t ["root";"misc";"1.txt"] "Hello world!" >>= fun () ->
   update t ["root";"misc";"2.txt"] "Hi!" >>= fun () ->

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -86,7 +86,7 @@ let master = branch images.(0)
 
 let init () =
   Config.init ();
-  Store.of_branch_id config (task images.(0)) master >>= fun t ->
+  Store.Repo.create config >>= Store.of_branch_id (task images.(0)) master >>= fun t ->
   Store.update (t "init") ["0"] "0" >>= fun () ->
   Lwt_list.iter_s (fun i ->
       Store.clone_force (task images.(0)) (t "Cloning") (branch i) >>= fun _ ->
@@ -106,7 +106,7 @@ let rec process image =
     try random_list actions.files
     with _ -> ["log"; id; "0"], fun () -> id ^ string_of_int (Random.int 10)
   in
-  Store.of_branch_id config (task image) id >>= fun t ->
+  Store.Repo.create config >>= Store.of_branch_id (task image) id >>= fun t ->
   Store.update (t actions.message) key (value ()) >>= fun () ->
 
   begin if Random.int 3 = 0 then

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -16,7 +16,7 @@ let upstream = Irmin.remote_uri path
 let test () =
   Config.init ();
   let config = Irmin_git.config ~root:Config.root () in
-  Store.create config task >>= fun t ->
+  Store.Repo.create config >>= Store.master task >>= fun t ->
   Sync.pull_exn (t "Syncing with upstream store") upstream `Update >>= fun () ->
   Store.read_exn (t "get the README") ["README.md"]>>= fun readme ->
   Irmin.with_hrw_view (module View) (t "Updating BAR and FOO") `Merge ~path:[] (fun view ->

--- a/examples/views.ml
+++ b/examples/views.ml
@@ -50,7 +50,7 @@ let main () =
   ] in
   view_of_t t >>= fun v ->
 
-  Store.create config task >>= fun t ->
+  Store.Repo.create config >>= Store.master task >>= fun t ->
   View.update_path (t "update a/b") ["a";"b"] v >>= fun () ->
   View.of_path (t "of-path a/b") ["a";"b"] >>= fun v ->
   t_of_view v >>= fun tt ->

--- a/lib/fs/irmin_fs.ml
+++ b/lib/fs/irmin_fs.ml
@@ -174,7 +174,6 @@ module RW_ext (IO: IO) (L: LOCK)(S: Config) (K: Irmin.Hum.S) (V: Tc.S0) = struct
     let w = W.create () in
     Lwt.return { t; w }
 
-  let config t = RO.config t.t
   let read t = RO.read t.t
   let read_exn t = RO.read_exn t.t
   let mem t = RO.mem t.t

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -512,7 +512,6 @@ module Make_ext
     type key = Key.t
     type value = Val.t
     type watch = W.watch * (unit -> unit)
-    let config t = t.config
 
     let tag_of_git r =
       let str = String.trim @@ Git.Reference.to_raw r in

--- a/lib/ir_ao.ml
+++ b/lib/ir_ao.ml
@@ -19,6 +19,7 @@ module Log = Log.Make(struct let section = "AO" end)
 module type STORE = sig
   include Ir_ro.STORE
   val create: Ir_conf.t -> t Lwt.t
+  val config: t -> Ir_conf.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_ao.mli
+++ b/lib/ir_ao.mli
@@ -19,6 +19,7 @@
 module type STORE = sig
   include Ir_ro.STORE
   val create: Ir_conf.t -> t Lwt.t
+  val config: t -> Ir_conf.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_ro.ml
+++ b/lib/ir_ro.ml
@@ -20,7 +20,6 @@ module type STORE = sig
   type t
   type key
   type value
-  val config: t -> Ir_conf.t
   val read: t -> key -> value option Lwt.t
   val read_exn: t -> key -> value Lwt.t
   val mem: t -> key -> bool Lwt.t

--- a/lib/ir_ro.mli
+++ b/lib/ir_ro.mli
@@ -20,7 +20,6 @@ module type STORE = sig
   type t
   type key
   type value
-  val config: t -> Ir_conf.t
   val read: t -> key -> value option Lwt.t
   val read_exn: t -> key -> value Lwt.t
   val mem: t -> key -> bool Lwt.t

--- a/lib/ir_s.ml
+++ b/lib/ir_s.ml
@@ -27,7 +27,7 @@ module type STORE = sig
        and type Commit.key = head
        and type Slice.t = slice
        and type Ref.key = branch_id
-    val config: t -> Ir_conf.t
+    val repo: t -> Repo.t
     val contents_t: t -> Contents.t
     val node_t: t -> Node.t
     val commit_t: t -> Commit.t
@@ -58,7 +58,7 @@ module Make_ext (P: Ir_bc.PRIVATE) = struct
   module Head = P.Private.Commit.Key
   module Private = struct
     include P.Private
-    let config = P.config
+    let repo = P.repo
     let contents_t = P.contents_t
     let node_t = P.node_t
     let commit_t = P.commit_t

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -29,7 +29,7 @@ module type STORE = sig
        and type Ref.key = branch_id
        and type Slice.t = slice
        and module Contents.Path = Key
-    val config: t -> Ir_conf.t
+    val repo: t -> Repo.t
     val contents_t: t -> Contents.t
     val node_t: t -> Node.t
     val commit_t: t -> Commit.t

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -79,7 +79,7 @@ module Make (S: Ir_s.STORE) = struct
       begin S.name t >>= function
         | None     -> Lwt.return `No_head
         | Some branch_id ->
-          B.create (S.Private.config t) >>= fun g ->
+          B.create (S.Repo.config (S.repo t)) >>= fun g ->
           B.fetch g ?depth ~uri branch_id
       end
     | Store ((module R), r) ->
@@ -126,7 +126,7 @@ module Make (S: Ir_s.STORE) = struct
       begin S.name t >>= function
         | None     -> return `Error
         | Some branch_id ->
-          B.create (S.Private.config t) >>= fun g ->
+          B.create (S.Repo.config (S.repo t)) >>= fun g ->
           B.push g ?depth ~uri branch_id
       end
     | Store ((module R), r) ->

--- a/lib/mem/irmin_mem.ml
+++ b/lib/mem/irmin_mem.ml
@@ -104,7 +104,6 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let read t = RO.read t.t
   let read_exn t = RO.read_exn t.t
   let mem t = RO.mem t.t
-  let config t = RO.config t.t
   let iter t = RO.iter t.t
   let watch_key t = W.watch_key t.w
   let watch t = W.watch t.w

--- a/lib/mirage/irmin_mirage.ml
+++ b/lib/mirage/irmin_mirage.ml
@@ -110,7 +110,7 @@ module KV_RO (C: CONTEXT) (I: Git.Inflate.S) = struct
       | None -> []
       | Some s -> List.filter ((<>)"") @@ Stringext.split s ~on:'/'
     in
-    S.of_branch_id config Irmin.Task.none branch_id >>= fun t ->
+    S.Repo.create config >>= S.of_branch_id Irmin.Task.none branch_id >>= fun t ->
     Sync.pull_exn (t ()) ~depth uri `Update >|= fun () ->
     { t = t (); path }
 

--- a/lib_test/test_git.ml
+++ b/lib_test/test_git.ml
@@ -51,7 +51,7 @@ let test_non_bare () =
   init_disk () >>= fun () ->
   let module Store = Irmin.Basic (Irmin_git.FS) (Irmin.Contents.String) in
   let config = Irmin_git.config ~root:test_db ~bare:false () in
-  Store.create config task >>= fun t ->
+  Store.Repo.create config >>= Store.master task >>= fun t ->
   Store.update (t "fst one") ["fst"] "ok" >>= fun () ->
   Store.update (t "snd one") ["fst"; "snd"] "maybe?" >>= fun () ->
   Store.update (t "fst one") ["fst"] "hoho"

--- a/lib_test/test_http.ml
+++ b/lib_test/test_http.ml
@@ -47,7 +47,7 @@ let suite ?(content_type=`Raw) server =
       let module HTTP = Irmin_http_server.Make(Server) in
       let server () =
         server.init () >>= fun () ->
-        Server.create server.config task >>= fun t  ->
+        Server.Repo.create server.config >>= Server.master task >>= fun t  ->
         signal () >>= fun () ->
         let spec = HTTP.http_spec (t "server") ~strict:true in
         Cohttp_lwt_unix.Server.create ~mode:(`TCP (`Port 8080)) spec

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -18,7 +18,7 @@ open Test_common
 let (>>=) = Lwt.(>>=)
 
 let clean config (module S: Irmin.S) () =
-  S.empty config Irmin.Task.none  >>= fun t ->
+  S.Repo.create config >>= S.empty Irmin.Task.none >>= fun t ->
   S.branches (t ()) >>= fun branches ->
   Lwt_list.iter_p (S.remove_branch (t ())) branches
 


### PR DESCRIPTION
Before, `BC.create` and similar took a `config` argument. Now, they take a `repo` argument, which can be obtained by calling `BC.connect config`.

The main goal here is to allow state to be shared between branches. For example, an Irmin repository backed by a database could open a connection in `connect` once, where currently it must open one connection for every branch or head store created.

A memory store could use this to keep the state (rather than using a global) and an HTTP-backed store could use this for the connection pool.

In fact, the old code didn't open one connection per branch, but 4, because the content, node, commit and tag stores each also open a connection. Ideally, I'd like to share the `repo` with these backing stores to get the number of required connections down to 1, but that isn't done yet.

Also, the terminology isn't very good:
- `connect` may be confusing for HTTP stores, since it might not make an HTTP connection at that point
- there should probably be separate modules for `Repository` and `Branch`, rather than bundling everything in `Store`.

Does this look like a reasonable approach?