### PR TITLE
Rename 'tag' to 'branch_id'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - ALCOTEST_SHOW_ERRORS=1
   - REVDEPS="irmin-indexeddb"
   - PACKAGE=irmin.0.9.9
+  - PINS="irmin-indexeddb:https://github.com/talex5/irmin-indexeddb.git#branch_id"
   matrix:
   - OCAML_VERSION=4.01
   - OCAML_VERSION=4.02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
   same offset in the `Cstruct.t` value, which is obviously not
   always the case. Apply the same fix to `Hash.SHA1.compare` and
   `Hash.SHA1.hash`.
+* Renamed "tag" to "branch" in the API, as "tag" is confusing for Git
+  users. `BC.tag` is now `BC.name` and `BC.branch` is now `BC.head_ref`.
+  Note: The remote HTTP protocol still uses "tag".
 
 ### 0.9.10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
   `Hash.SHA1.hash`.
 * Renamed "tag" to "branch" in the API, as "tag" is confusing for Git
   users. `BC.tag` is now `BC.name` and `BC.branch` is now `BC.head_ref`.
+  The various "Tag" modules are now called "Ref" ("Branch" would be
+  confusing here since they only store references to commits, not the
+  branch contents).
   Note: The remote HTTP protocol still uses "tag".
 
 ### 0.9.10

--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -288,8 +288,8 @@ let fetch = {
       run begin
         store >>= fun t ->
         remote >>= fun r ->
-        let tag = S.Tag.of_hum "import" in
-        S.of_tag (S.Private.config (t "config")) task tag >>= fun t ->
+        let branch_id = S.Ref.of_hum "import" in
+        S.of_branch_id (S.Private.config (t "config")) task branch_id >>= fun t ->
         Sync.pull_exn (t "Fetching.")  r `Update
       end
     in

--- a/bin/ir_resolver.ml
+++ b/bin/ir_resolver.ml
@@ -155,7 +155,7 @@ let read_config_file (): t option =
       mk_store kind contents
     in
     let module S = (val store) in
-    let branch = assoc "branch" (fun x -> S.Tag.of_hum x) in
+    let branch = assoc "branch" (fun x -> S.Ref.of_hum x) in
     let config =
       let root = assoc "root" (fun x -> x) in
       let bare = match assoc "bare" bool_of_string with
@@ -173,7 +173,7 @@ let read_config_file (): t option =
     in
     match branch with
     | None   -> Some (S ((module S), S.create config task))
-    | Some b -> Some (S ((module S), S.of_tag config task b))
+    | Some b -> Some (S ((module S), S.of_branch_id config task b))
 
 let store =
   let branch =
@@ -191,7 +191,7 @@ let store =
       (* first look at the command-line options *)
       let t = match branch with
         | None   -> S.create config task
-        | Some t -> S.of_tag config task (S.Tag.of_hum t)
+        | Some t -> S.of_branch_id config task (S.Ref.of_hum t)
       in
       S ((module S), t)
     | None ->

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -21,7 +21,7 @@ let provision () =
   Config.init ();
   let provision = task ~user:"Automatic VM provisioning" in
 
-  Store.of_tag config provision "upstream" >>= fun t ->
+  Store.of_branch_id config provision "upstream" >>= fun t ->
 
   View.empty () >>= fun v ->
   View.update v ["etc"; "manpath"]
@@ -36,7 +36,7 @@ let provision () =
 (* 2. VM configuration. *)
 let sysadmin = task ~user:"Bob the sysadmin"
 let configure () =
-  Store.of_tag config sysadmin "upstream" >>= fun t ->
+  Store.of_branch_id config sysadmin "upstream" >>= fun t ->
 
   Lwt_unix.sleep 2.  >>= fun () ->
   Store.clone_force sysadmin (t "Cloning upstream") "dev" >>= fun t ->
@@ -53,7 +53,7 @@ let attack () =
   let task = task ~user:"Remote connection from 132.443.12.444" in
 
   (* 3. Attacker. *)
-  Store.of_tag config task "prod" >>= fun t ->
+  Store.of_branch_id config task "prod" >>= fun t ->
 
   Lwt_unix.sleep 2. >>= fun () ->
   Store.update (t "$ vim /etc/resolv.conf")
@@ -68,8 +68,8 @@ let attack () =
     "�����XpNx ������� H__PAGEZERO(__TEXT__text__TEXT [...]"
 
 let revert () =
-  Store.of_tag config sysadmin "prod" >>= fun prod ->
-  Store.of_tag config sysadmin "dev"  >>= fun dev ->
+  Store.of_branch_id config sysadmin "prod" >>= fun prod ->
+  Store.of_branch_id config sysadmin "dev"  >>= fun dev ->
 
   Store.head_exn (prod "head") >>= fun h1 ->
   Store.head_exn (dev  "head") >>= fun h2 ->

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -86,7 +86,7 @@ let master = branch images.(0)
 
 let init () =
   Config.init ();
-  Store.of_tag config (task images.(0)) master >>= fun t ->
+  Store.of_branch_id config (task images.(0)) master >>= fun t ->
   Store.update (t "init") ["0"] "0" >>= fun () ->
   Lwt_list.iter_s (fun i ->
       Store.clone_force (task images.(0)) (t "Cloning") (branch i) >>= fun _ ->
@@ -106,14 +106,14 @@ let rec process image =
     try random_list actions.files
     with _ -> ["log"; id; "0"], fun () -> id ^ string_of_int (Random.int 10)
   in
-  Store.of_tag config (task image) id >>= fun t ->
+  Store.of_branch_id config (task image) id >>= fun t ->
   Store.update (t actions.message) key (value ()) >>= fun () ->
 
   begin if Random.int 3 = 0 then
     let branch = branch (random_array images) in
     if branch <> id then (
       Printf.printf "Merging ...%!";
-      Store.merge_tag_exn (fmt t "Merging with %s" branch) branch >>= fun () ->
+      Store.merge_branch_exn (fmt t "Merging with %s" branch) branch >>= fun () ->
       Printf.printf "ok!\n%!";
       Lwt.return_unit
     ) else

--- a/lib/fs/irmin_fs.ml
+++ b/lib/fs/irmin_fs.ml
@@ -251,12 +251,12 @@ end
 
 module Make_ext (IO: IO) (L: LOCK) (Obj: Config) (Ref: Config)
     (C: Ir_contents.S)
-    (T: Ir_tag.S)
+    (R: Ir_tag.S)
     (H: Ir_hash.S)
 = struct
   module AO = AO_ext(IO)(Obj)
   module RW = RW_ext(IO)(L)(Ref)
-  include Irmin.Make(AO)(RW)(C)(T)(H)
+  include Irmin.Make(AO)(RW)(C)(R)(H)
 end
 
 let string_chop_prefix ~prefix str =

--- a/lib/git/irmin_git.mli
+++ b/lib/git/irmin_git.mli
@@ -73,7 +73,7 @@ end
 
 module AO (G: Git.Store.S): Irmin.AO_MAKER
 
-module RW (L: LOCK) (G: Git.Store.S) (K: Irmin.Tag.S) (V: Irmin.Hash.S):
+module RW (L: LOCK) (G: Git.Store.S) (K: Irmin.Ref.S) (V: Irmin.Hash.S):
   Irmin.RW with type key = K.t and type value = V.t
 
 module Memory (IO: Git.Sync.IO) (I: Git.Inflate.S):

--- a/lib/http/irmin_http_common.ml
+++ b/lib/http/irmin_http_common.ml
@@ -18,21 +18,21 @@ open Lwt.Infix
 
 module Log = Log.Make(struct let section = "HTTP" end)
 
-let ok_or_duplicated_tag =
+let ok_or_duplicated_branch_id =
   let module M = struct
-    type t = [ `Ok | `Duplicated_tag | `Empty_head ]
+    type t = [ `Ok | `Duplicated_branch | `Empty_head ]
     let compare = Pervasives.compare
     let equal = (=)
     let hash = Hashtbl.hash
 
     let to_string = function
       | `Ok -> "ok"
-      | `Duplicated_tag -> "duplicated-tag"
+      | `Duplicated_branch -> "duplicated-tag"
       | `Empty_head -> "empty-head"
 
     let of_string = function
       | "ok" -> `Ok
-      | "duplicated-tag" -> `Duplicated_tag
+      | "duplicated-tag" -> `Duplicated_branch
       | "empty-head" -> `Empty_head
       | s -> failwith ("parse error: " ^ s)
 

--- a/lib/http/irmin_http_common.mli
+++ b/lib/http/irmin_http_common.mli
@@ -19,7 +19,7 @@
 val truncate: string -> int -> string
 
 val ok_or_error: [`Ok | `Error] Tc.t
-val ok_or_duplicated_tag: [`Ok | `Duplicated_tag | `Empty_head] Tc.t
+val ok_or_duplicated_branch_id: [`Ok | `Duplicated_branch | `Empty_head] Tc.t
 val lca: 'a Tc.t -> [`Ok of 'a list | `Max_depth_reached | `Too_many_lcas] Tc.t
 
 val start_stream: string

--- a/lib/ir_dot.ml
+++ b/lib/ir_dot.ml
@@ -30,12 +30,12 @@ module Make (S: Ir_s.STORE) = struct
 
   type db = S.t
 
-  module Tag = S.Private.Tag
+  module Ref = S.Private.Ref
   module Contents = S.Private.Contents
   module Node = S.Private.Node
   module Commit = S.Private.Commit
   module Slice = S.Private.Slice
-  module Graph = Ir_graph.Make(Contents.Key)(Node.Key)(Commit.Key)(Tag.Key)
+  module Graph = Ir_graph.Make(Contents.Key)(Node.Key)(Commit.Key)(Ref.Key)
 
   let fprintf (t:db) ?depth ?(html=false) ?full ~date name =
     Log.debug "fprintf depth=%s html=%b full=%s"
@@ -115,9 +115,9 @@ module Make (S: Ir_s.STORE) = struct
     let label_of_tag t =
       let s =
         if html then
-          sprintf "<div class='tag'>%s</div>" (Tag.Key.to_hum t)
+          sprintf "<div class='tag'>%s</div>" (Ref.Key.to_hum t)
         else
-          Tag.Key.to_hum t
+          Ref.Key.to_hum t
       in
       `Label s in
     Slice.iter_contents slice (fun (k, b) ->
@@ -151,11 +151,11 @@ module Make (S: Ir_s.STORE) = struct
           add_edge (`Commit k) [`Style `Dashed] (`Node node);
           return_unit
       ) >>= fun () ->
-    let tag_t = S.Private.tag_t t in
-    Tag.iter tag_t (fun r k ->
+    let ref_t = S.Private.ref_t t in
+    Ref.iter ref_t (fun r k ->
         k >>= fun k ->
-        add_vertex (`Tag r) [`Shape `Plaintext; label_of_tag r; `Style `Filled];
-        add_edge (`Tag r) [`Style `Bold] (`Commit k);
+        add_vertex (`Branch r) [`Shape `Plaintext; label_of_tag r; `Style `Filled];
+        add_edge (`Branch r) [`Style `Bold] (`Commit k);
         return_unit
       ) >>= fun () ->
     let vertex = Hashtbl.fold (fun k v acc -> (k, v) :: acc) vertex [] in

--- a/lib/ir_graph.ml
+++ b/lib/ir_graph.ml
@@ -50,7 +50,7 @@ module Make
     (Contents: Ir_hum.S)
     (Node: Ir_hum.S)
     (Commit: Ir_hum.S)
-    (Tag: Ir_hum.S)
+    (Ref: Ir_hum.S)
 = struct
 
   module X = struct
@@ -59,7 +59,7 @@ module Make
       [ `Contents of Contents.t
       | `Node of Node.t
       | `Commit of Commit.t
-      | `Tag of Tag.t ]
+      | `Branch of Ref.t ]
 
     let hash = Hashtbl.hash
 
@@ -67,7 +67,7 @@ module Make
       | `Contents x, `Contents y -> Contents.compare x y
       | `Node x, `Node y -> Node.compare x y
       | `Commit x, `Commit y -> Commit.compare x y
-      | `Tag x, `Tag y -> Tag.compare x y
+      | `Branch x, `Branch y -> Ref.compare x y
       | `Contents _, _ -> 1
       | _, `Contents _ -> -1
       | `Node _, _ -> 1
@@ -79,46 +79,46 @@ module Make
       | `Contents x, `Contents y -> Contents.equal x y
       | `Node x, `Node y -> Node.equal x y
       | `Commit x, `Commit y -> Commit.equal x y
-      | `Tag x, `Tag y -> Tag.equal x y
+      | `Branch x, `Branch y -> Ref.equal x y
       | _ -> false
 
     let to_json = function
       | `Contents x -> `O [ "contents", Contents.to_json x ]
       | `Node x -> `O [ "node", Node.to_json x ]
       | `Commit x -> `O [ "commit", Commit.to_json x ]
-      | `Tag x -> `O [ "tag", Tag.to_json x ]
+      | `Branch x -> `O [ "tag", Ref.to_json x ]
 
     let of_json = function
       | `O [ "contents", x ] -> `Contents (Contents.of_json x)
       | `O [ "node", x ] -> `Node (Node.of_json x)
       | `O [ "commit", x ] -> `Commit (Commit.of_json x)
-      | `O [ "tag", x ] -> `Tag (Tag.of_json x)
+      | `O [ "tag", x ] -> `Branch (Ref.of_json x)
       | j -> Ezjsonm.parse_error j "Vertex.of_json"
 
     let write t buf = match t with
       | `Contents x -> Contents.write x (Ir_misc.tag buf 0)
       | `Node x -> Node.write x (Ir_misc.tag buf 1)
       | `Commit x -> Commit.write x (Ir_misc.tag buf 2)
-      | `Tag x -> Tag.write x (Ir_misc.tag buf 3)
+      | `Branch x -> Ref.write x (Ir_misc.tag buf 3)
 
     let size_of t = 1 + match t with
       | `Contents x -> Contents.size_of x
       | `Node x -> Node.size_of x
       | `Commit x -> Commit.size_of x
-      | `Tag x -> Tag.size_of x
+      | `Branch x -> Ref.size_of x
 
     let read buf = match Ir_misc.untag buf with
       | 0 -> `Contents (Contents.read buf)
       | 1 -> `Node (Node.read buf)
       | 2 -> `Commit (Commit.read buf)
-      | 3 -> `Tag (Tag.read buf)
+      | 3 -> `Branch (Ref.read buf)
       | n -> Tc.Reader.error "Vertex.read parse error (tag=%d)" n
 
     let to_hum = function
       | `Contents x -> Contents.to_hum x
       | `Node x -> Node.to_hum x
       | `Commit x -> Commit.to_hum x
-      | `Tag x -> Tag.to_hum x
+      | `Branch x -> Ref.to_hum x
 
   end
 

--- a/lib/ir_graph.mli
+++ b/lib/ir_graph.mli
@@ -81,9 +81,9 @@ module Make
     (Contents: Ir_hum.S)
     (Node: Ir_hum.S)
     (Commit: Ir_hum.S)
-    (Tag: Ir_hum.S):
+    (Ref: Ir_hum.S):
   S with type V.t =
   [ `Contents of Contents.t
   | `Node of Node.t
   | `Commit of Commit.t
-  | `Tag of Tag.t ]
+  | `Branch of Ref.t ]

--- a/lib/ir_sync.ml
+++ b/lib/ir_sync.ml
@@ -19,17 +19,17 @@ open Lwt
 module type S = sig
   type t
   type head
-  type tag
+  type branch_id
   val create: Ir_conf.t -> t Lwt.t
-  val fetch: t -> ?depth:int -> uri:string -> tag ->
+  val fetch: t -> ?depth:int -> uri:string -> branch_id ->
     [`Head of head | `No_head | `Error] Lwt.t
-  val push : t -> ?depth:int -> uri:string -> tag -> [`Ok | `Error] Lwt.t
+  val push : t -> ?depth:int -> uri:string -> branch_id -> [`Ok | `Error] Lwt.t
 end
 
-module None (H: Tc.S0) (T: Tc.S0) = struct
+module None (H: Tc.S0) (R: Tc.S0) = struct
   type t = unit
   type head = H.t
-  type tag = T.t
+  type branch_id = R.t
   let create _ = return_unit
   let fetch () ?depth:_ ~uri:_ _tag = return `Error
   let push () ?depth:_ ~uri:_ _tag = return `Error

--- a/lib/ir_sync.mli
+++ b/lib/ir_sync.mli
@@ -19,11 +19,11 @@
 module type S = sig
   type t
   type head
-  type tag
+  type branch_id
   val create: Ir_conf.t -> t Lwt.t
-  val fetch: t -> ?depth:int -> uri:string -> tag ->
+  val fetch: t -> ?depth:int -> uri:string -> branch_id ->
     [`Head of head | `No_head | `Error] Lwt.t
-  val push : t -> ?depth:int -> uri:string -> tag -> [`Ok | `Error] Lwt.t
+  val push : t -> ?depth:int -> uri:string -> branch_id -> [`Ok | `Error] Lwt.t
 end
 
-module None (H: Tc.S0) (T: Tc.S0): S with type head = H.t and type tag = T.t
+module None (H: Tc.S0) (R: Tc.S0): S with type head = H.t and type branch_id = R.t

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -76,11 +76,11 @@ module Make (S: Ir_s.STORE) = struct
     match remote with
     | URI uri ->
       Log.debug "fetch URI %s" uri;
-      begin S.tag t >>= function
+      begin S.name t >>= function
         | None     -> Lwt.return `No_head
-        | Some tag ->
+        | Some branch_id ->
           B.create (S.Private.config t) >>= fun g ->
-          B.fetch g ?depth ~uri tag
+          B.fetch g ?depth ~uri branch_id
       end
     | Store ((module R), r) ->
       Log.debug "fetch store";
@@ -123,11 +123,11 @@ module Make (S: Ir_s.STORE) = struct
     Log.debug "push";
     match remote with
     | URI uri ->
-      begin S.tag t >>= function
+      begin S.name t >>= function
         | None     -> return `Error
-        | Some tag ->
+        | Some branch_id ->
           B.create (S.Private.config t) >>= fun g ->
-          B.push g ?depth ~uri tag
+          B.push g ?depth ~uri branch_id
       end
     | Store ((module R), r) ->
       S.head t >>= function

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -18,7 +18,7 @@ open Lwt
 
 module Contents = Ir_contents
 module Merge = Ir_merge
-module Tag = Ir_tag
+module Ref = Ir_tag
 module Task = Ir_task
 module View = Ir_view.Make
 module type VIEW = Ir_view.S
@@ -84,11 +84,11 @@ let remote_store (type t) (module M: S with type t = t) (t:t) =
 
 let remote_uri = Ir_sync_ext.remote_uri
 
-module type BASIC = S with type tag = string and type head = Hash.SHA1.t
+module type BASIC = S with type branch_id = string and type head = Hash.SHA1.t
 
 module Basic = Ir_s.Default
 
-module type T = S with type tag = string and type head = Hash.SHA1.t
+module type T = S with type branch_id = string and type head = Hash.SHA1.t
 
 let with_hrw_view (type store) (type path) (type view)
   (module V : VIEW with type t = view and type db = store and type key = path)

--- a/lib/mem/irmin_mem.ml
+++ b/lib/mem/irmin_mem.ml
@@ -148,5 +148,5 @@ end
 
 let config () = Irmin.Private.Conf.empty
 
-module Make (C: Irmin.Contents.S) (T: Irmin.Tag.S) (H: Irmin.Hash.S) =
-  Irmin.Make(AO)(RW)(C)(T)(H)
+module Make (C: Irmin.Contents.S) (R: Irmin.Ref.S) (H: Irmin.Hash.S) =
+  Irmin.Make(AO)(RW)(C)(R)(H)

--- a/lib/mirage/irmin_mirage.ml
+++ b/lib/mirage/irmin_mirage.ml
@@ -105,12 +105,12 @@ module KV_RO (C: CONTEXT) (I: Git.Inflate.S) = struct
 
   let connect ?(depth = 1) ?(branch = "master") ?path uri =
     let uri = Irmin.remote_uri (Uri.to_string uri) in
-    let tag = S.Tag.of_hum branch in
+    let branch_id = S.Ref.of_hum branch in
     let path = match path with
       | None -> []
       | Some s -> List.filter ((<>)"") @@ Stringext.split s ~on:'/'
     in
-    S.of_tag config Irmin.Task.none tag >>= fun t ->
+    S.of_branch_id config Irmin.Task.none branch_id >>= fun t ->
     Sync.pull_exn (t ()) ~depth uri `Update >|= fun () ->
     { t = t (); path }
 

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -135,7 +135,7 @@ module Irmin_git: sig
       be written in {i .git/objects/} and might be cleaned-up if you
       run {i git gc} manually. *)
 
-  module RW (G: Git.Store.S) (K: Irmin.Tag.S) (V: Irmin.Hash.S): Irmin.RW
+  module RW (G: Git.Store.S) (K: Irmin.Ref.S) (V: Irmin.Hash.S): Irmin.RW
     with type key = K.t and type value = V.t
   (** Embed a read-write store into a Git repository. Contents will be
       written in {i .git/refs}. *)
@@ -178,7 +178,7 @@ module Irmin_http: sig
 
       Most of the computation are done on the server, the client is
       (almost) stateless. The only thing that the client needs to
-      remember is the tag of the current branch or the current head if
+      remember is the ID of the current branch or the current head if
       the branch is detached.
 
       All of the low-level and high-level operations take only one

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -90,7 +90,7 @@ module Make (S: Irmin.S) = struct
   module Node = S.Private.Node
   module Commit = S.Private.Commit
 
-  module T = S.Tag
+  module T = S.Ref
   module K = S.Key
   module V = S.Val
   module N = Node.Val

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -19,8 +19,8 @@ let (>>=) = Lwt.(>>=)
 
 let clean config (module S: Irmin.S) () =
   S.empty config Irmin.Task.none  >>= fun t ->
-  S.tags (t ()) >>= fun tags ->
-  Lwt_list.iter_p (S.remove_tag (t ())) tags
+  S.branches (t ()) >>= fun branches ->
+  Lwt_list.iter_p (S.remove_branch (t ())) branches
 
 let suite k =
   let config = Irmin_mem.config () in


### PR DESCRIPTION
Using 'tag' to mean branch name is really confusing, because Git uses 'tag' to mean a named pointer that is *not* a branch.

BC.tag is now BC.name and BC.branch is now BC.head_ref.

The remote HTTP protocol still uses "tag".

This API change will break most users of Irmin.