### PR TITLE
 Remove Irmin_http_server.listen

### DIFF
--- a/lib/http/irmin_http_server.mli
+++ b/lib/http/irmin_http_server.mli
@@ -25,30 +25,24 @@ module type S = sig
   type t
   (** Database type. *)
 
-  val listen:
-    ?timeout:int -> ?strict:bool -> ?hooks:hooks -> t -> Uri.t -> unit Lwt.t
-  (** [start_server t uri] start a server serving the contents of [t]
-      at the address [uri]. If [strict] is set, incoming connections
-      will fail if they do not have the right {i X-IrminVersion}
-      headers. *)
+  type spec
+  (** HTTP configuration. *)
+
+  val http_spec: ?strict:bool -> ?hooks:hooks -> t -> spec
+  (** [http_spec t] returns the configuration for a server serving the contents of [t].
+      If [strict] is set, incoming connections will fail if they do not have the right
+      {i X-IrminVersion} headers. *)
 
 end
 
 (** {2 Constructor} *)
-
-module type SERVER = sig
-
-  include Cohttp_lwt.Server
-
-  val listen: t -> ?timeout:int -> Uri.t -> unit Lwt.t
-  (** Start the server, listening at the given adress. *)
-
-end
 
 module type DATE = sig
   val pretty: int64 -> string
   (** Pretty print a raw date format. *)
 end
 
-module Make (HTTP: SERVER) (D: DATE) (S: Irmin.S): S with type t = S.t
+module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S): S with
+  type t = S.t and
+  type spec = HTTP.t
 (** Create an HTTP server, serving the contents of an Irmin database. *)

--- a/lib/unix/irmin_unix.ml
+++ b/lib/unix/irmin_unix.ml
@@ -108,14 +108,6 @@ module Irmin_http = struct
 end
 
 module Irmin_http_server = struct
-  module X = struct
-    include Cohttp_lwt_unix.Server
-    let listen t ?timeout uri =
-      let port = match Uri.port uri with
-        | None   -> 8080
-        | Some p -> p in
-      create ?timeout ~mode:(`TCP (`Port port)) t
-  end
   module Y = struct
     let pretty d =
       let tm = Unix.localtime (Int64.to_float d) in
@@ -124,7 +116,7 @@ module Irmin_http_server = struct
   end
   type hooks = Irmin_http_server.hooks = { update: unit -> unit Lwt.t }
   module type S = Irmin_http_server.S
-  module Make = Irmin_http_server.Make (X)(Y)
+  module Make = Irmin_http_server.Make (Cohttp_lwt_unix.Server)(Y)
 end
 
 module S = struct

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -204,23 +204,9 @@ module Irmin_http_server: sig
   }
   (** Server hooks. *)
 
-  (** Server Signature. *)
-  module type S = sig
-
-    type t
-    (** The type for store handles. *)
-
-    val listen:
-      ?timeout:int -> ?strict:bool -> ?hooks:hooks -> t -> Uri.t -> unit Lwt.t
-    (** [listen t uri] start a server serving the contents of
-        [t] at the address [uri]. Close clients' connections after
-        [timeout] seconds of inactivity. If [strict] is set (by
-        default it is not), incoming connections will fail if they do
-        not have the right {i X-IrminVersion} headers. *)
-
-  end
-
-  module Make (S: Irmin.S): S with type t = S.t
+  module Make (S: Irmin.S): Irmin_http_server.S with
+    type t = S.t and
+    type spec = Cohttp_lwt_unix.Server.t
   (** [Make] exposes an Irmin store as a REST API for HTTP
       {{!module:Irmin_http}clients}. *)
 

--- a/lib_test/test_http.ml
+++ b/lib_test/test_http.ml
@@ -49,7 +49,8 @@ let suite ?(content_type=`Raw) server =
         server.init () >>= fun () ->
         Server.create server.config task >>= fun t  ->
         signal () >>= fun () ->
-        HTTP.listen (t "server") ~strict:true uri
+        let spec = HTTP.http_spec (t "server") ~strict:true in
+        Cohttp_lwt_unix.Server.create ~mode:(`TCP (`Port 8080)) spec
       in
       let () =
         try Unix.unlink file


### PR DESCRIPTION
Instead, return the Cohttp configuration for the server and let the user perform the listen. The resulting API is simpler (removes "timeout" and "uri" parameters), more flexible, and easier to use from Mirage.

Here's the diff for irmin-www to switch to the new API: https://github.com/talex5/irmin-www/commit/ff8a4e68e46abc11e698746ab407715caf4caf0e