### PR TITLE
Remove task from internal stores

### DIFF
--- a/lib/http/irmin_http_common.mli
+++ b/lib/http/irmin_http_common.mli
@@ -52,7 +52,7 @@ val ct_of_contents: contents option -> ct
 val contents: 'a Tc.t -> contents -> 'a
 
 module Request: sig
-  type t = Irmin.task * contents option
+  type t = Irmin.task option * contents option
 
   val to_body: ct -> t -> Cohttp_lwt_body.t
   val of_body: meth:string -> ct -> Cohttp_lwt_body.t -> t option Lwt.t

--- a/lib/http/irmin_http_server.ml
+++ b/lib/http/irmin_http_server.ml
@@ -805,11 +805,10 @@ module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S) = struct
       | _       -> Lwt.fail Invalid
     end >>= fun body ->
     let task, params = match meth, body with
-      (* FIXME: we currently don't have the client's task for GET
-         queries. See similar comment in [Irmin_http]. *)
       | `GET, None   -> Irmin.Task.empty, None
-      | _   , None   -> err_no_task ()
-      | _   , Some t -> t
+      | _   , None   -> err_no_task ()    (* Wrong error message? Params missing too! *)
+      | _   , Some (Some t, params) -> t, params
+      | _   , Some (None, params) -> Irmin.Task.empty, params  (* Should be an error, but reads arrive here too! *)
     in
     (* FIXME: validate the client task *)
     let request path = { t; task; ct; path; params; query } in

--- a/lib/ir_ao.ml
+++ b/lib/ir_ao.ml
@@ -18,6 +18,7 @@ module Log = Log.Make(struct let section = "AO" end)
 
 module type STORE = sig
   include Ir_ro.STORE
+  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_ao.ml
+++ b/lib/ir_ao.ml
@@ -18,7 +18,7 @@ module Log = Log.Make(struct let section = "AO" end)
 
 module type STORE = sig
   include Ir_ro.STORE
-  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  val create: Ir_conf.t -> t Lwt.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_ao.mli
+++ b/lib/ir_ao.mli
@@ -18,6 +18,7 @@
 
 module type STORE = sig
   include Ir_ro.STORE
+  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_ao.mli
+++ b/lib/ir_ao.mli
@@ -18,7 +18,7 @@
 
 module type STORE = sig
   include Ir_ro.STORE
-  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  val create: Ir_conf.t -> t Lwt.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_bc.ml
+++ b/lib/ir_bc.ml
@@ -489,7 +489,7 @@ module Make_ext (P: PRIVATE) = struct
         compare_and_set_head_unsafe t ~test:head ~set:(Some c1) >>=
         ok
       | Some c2 ->
-        three_way_merge t ?max_depth ?n c1 c2 >>| fun c3 ->
+        three_way_merge t ~task:t.task ?max_depth ?n c1 c2 >>| fun c3 ->
         compare_and_set_head_unsafe t ~test:head ~set:(Some c3) >>=
         ok
     in

--- a/lib/ir_bc.ml
+++ b/lib/ir_bc.ml
@@ -24,6 +24,7 @@ module StringMap = Map.Make(String)
 
 module type STORE = sig
   include Ir_rw.HIERARCHICAL
+  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   type branch_id
   val of_branch_id: Ir_conf.t -> 'a Ir_task.f -> branch_id -> ('a -> t) Lwt.t
   val name: t -> branch_id option Lwt.t

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -19,6 +19,7 @@
 
 module type STORE = sig
   include Ir_rw.HIERARCHICAL
+  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   type branch_id
   val of_branch_id: Ir_conf.t -> 'a Ir_task.f -> branch_id -> ('a -> t) Lwt.t
   val name: t -> branch_id option Lwt.t

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -20,6 +20,7 @@
 module type STORE = sig
   include Ir_rw.HIERARCHICAL
   val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  val task: t -> Ir_task.t
   type branch_id
   val of_branch_id: Ir_conf.t -> 'a Ir_task.f -> branch_id -> ('a -> t) Lwt.t
   val name: t -> branch_id option Lwt.t

--- a/lib/ir_commit.ml
+++ b/lib/ir_commit.ml
@@ -94,13 +94,17 @@ module type HISTORY = sig
   val create: t -> ?node:node -> parents:commit list -> commit Lwt.t
   val node: t -> commit -> node option Lwt.t
   val parents: t -> commit -> commit list Lwt.t
-  val merge: t -> commit Ir_merge.t
+  val merge: t -> task:Ir_task.t -> commit Ir_merge.t
   val lcas: t -> ?max_depth:int -> ?n:int -> commit -> commit ->
     [`Ok of commit list | `Max_depth_reached | `Too_many_lcas] Lwt.t
-  val lca: t -> ?max_depth:int -> ?n:int -> commit list -> commit option Ir_merge.result Lwt.t
-  val three_way_merge: t -> ?max_depth:int -> ?n:int -> commit -> commit -> commit Ir_merge.result Lwt.t
+  val lca: t -> task:Ir_task.t -> ?max_depth:int -> ?n:int -> commit list -> commit option Ir_merge.result Lwt.t
+  val three_way_merge: t -> task:Ir_task.t -> ?max_depth:int -> ?n:int -> commit -> commit -> commit Ir_merge.result Lwt.t
   val closure: t -> min:commit list -> max:commit list -> commit list Lwt.t
-  module Store: Ir_contents.STORE with type t = t and type key = commit
+  module Store: sig
+    include STORE with type t = t and type key = commit
+    module Path: Ir_path.S
+    val merge: Path.t -> t -> task:Ir_task.t -> key option Ir_merge.t
+  end
 end
 
 module History (N: Ir_contents.STORE) (S: STORE with type Val.node = N.key) =
@@ -128,7 +132,7 @@ struct
     let read_exn (_, t) = S.read_exn t
     let merge_node path (n, _) = N.merge path n
 
-    let merge_commit path t ~old k1 k2 =
+    let merge_commit path t ~task ~old k1 k2 =
       read_exn t k1  >>= fun v1   ->
       read_exn t k2  >>= fun v2   ->
       if List.mem k1 (S.Val.parents v2) then ok k2
@@ -156,11 +160,11 @@ struct
         merge_node path t ~old (S.Val.node v1) (S.Val.node v2)
         >>| fun node ->
         let parents = [k1; k2] in
-        let commit = S.Val.create ?node ~parents (task t) in
+        let commit = S.Val.create ?node ~parents task in
         add t commit >>= fun key ->
         ok key
 
-    let merge path t = Ir_merge.option (module S.Key) (merge_commit path t)
+    let merge path t ~task = Ir_merge.option (module S.Key) (merge_commit path t ~task)
 
     let iter (_, t) fn = S.iter t fn
 
@@ -406,7 +410,7 @@ struct
            Lwt.return_unit)
     )
 
-  let rec three_way_merge t ?max_depth ?n c1 c2 =
+  let rec three_way_merge t ~task ?max_depth ?n c1 c2 =
     Log.debug "3-way merge between %a and %a"
       force (show (module S.Key) c1)
       force (show (module S.Key) c2);
@@ -421,17 +425,17 @@ struct
         let rec aux acc = function
           | []        -> ok (Some acc)
           | old::olds ->
-            three_way_merge t acc old >>| fun acc ->
+            three_way_merge t ~task acc old >>| fun acc ->
             aux acc olds
         in
         aux old olds
       in
-      try merge t ~old c1 c2
+      try merge t ~task ~old c1 c2
       with Ir_merge.Conflict msg ->
         conflict "Recursive merging of common ancestors: %s" msg
     )
 
-  let lca_aux t ?max_depth ?n c1 c2 =
+  let lca_aux t ~task ?max_depth ?n c1 c2 =
     if S.Key.equal c1 c2 then ok (Some c1)
     else (
       lcas t ?max_depth ?n c1 c2 >>= function
@@ -443,19 +447,19 @@ struct
         let rec aux acc = function
           | []    -> ok (Some acc)
           | c::cs ->
-            three_way_merge t ?max_depth ?n acc c >>= function
+            three_way_merge t ~task ?max_depth ?n acc c >>= function
             | `Conflict _ -> ok None
             | `Ok acc     -> aux acc cs
         in
         aux c cs
     )
 
-  let rec lca t ?max_depth ?n = function
+  let rec lca t ~task ?max_depth ?n = function
     | []  -> conflict "History.lca: empty"
     | [c] -> ok (Some c)
     | c1::c2::cs ->
-      lca_aux t ?max_depth ?n c1 c2 >>| function
+      lca_aux t ~task ?max_depth ?n c1 c2 >>| function
       | None   -> ok None
-      | Some c -> lca t ?max_depth ?n (c::cs)
+      | Some c -> lca t ~task ?max_depth ?n (c::cs)
 
 end

--- a/lib/ir_commit.mli
+++ b/lib/ir_commit.mli
@@ -45,13 +45,17 @@ module type HISTORY = sig
   val create: t -> ?node:node -> parents:commit list -> commit Lwt.t
   val node: t -> commit -> node option Lwt.t
   val parents: t -> commit -> commit list Lwt.t
-  val merge: t -> commit Ir_merge.t
+  val merge: t -> task:Ir_task.t -> commit Ir_merge.t
   val lcas: t -> ?max_depth:int -> ?n:int -> commit -> commit ->
     [`Ok of commit list | `Max_depth_reached | `Too_many_lcas ] Lwt.t
-  val lca: t -> ?max_depth:int -> ?n:int -> commit list -> commit option Ir_merge.result Lwt.t
-  val three_way_merge: t -> ?max_depth:int -> ?n:int -> commit -> commit -> commit Ir_merge.result Lwt.t
+  val lca: t -> task:Ir_task.t -> ?max_depth:int -> ?n:int -> commit list -> commit option Ir_merge.result Lwt.t
+  val three_way_merge: t -> task:Ir_task.t -> ?max_depth:int -> ?n:int -> commit -> commit -> commit Ir_merge.result Lwt.t
   val closure: t -> min:commit list -> max:commit list -> commit list Lwt.t
-  module Store: Ir_contents.STORE with type t = t and type key = commit
+  module Store: sig
+    include STORE with type t = t and type key = commit
+    module Path: Ir_path.S
+    val merge: Path.t -> t -> task:Ir_task.t -> key option Ir_merge.t
+  end
 end
 
 module History (N: Ir_contents.STORE) (S: STORE with type Val.node = N.key):

--- a/lib/ir_commit.mli
+++ b/lib/ir_commit.mli
@@ -42,7 +42,7 @@ module type HISTORY = sig
   type t
   type node
   type commit
-  val create: t -> ?node:node -> parents:commit list -> commit Lwt.t
+  val create: t -> ?node:node -> parents:commit list -> task:Ir_task.t -> commit Lwt.t
   val node: t -> commit -> node option Lwt.t
   val parents: t -> commit -> commit list Lwt.t
   val merge: t -> task:Ir_task.t -> commit Ir_merge.t

--- a/lib/ir_node.ml
+++ b/lib/ir_node.ml
@@ -255,15 +255,14 @@ struct
 
     type t = C.t * S.t
 
-    let create config task =
-      C.create config task >>= fun c ->
-      S.create config task >>= fun s ->
-      Lwt.return (fun a -> c a, s a)
+    let create config =
+      C.create config >>= fun c ->
+      S.create config >>= fun s ->
+      Lwt.return (c, s)
 
     type key = S.key
     type value = S.value
     let config (c, s) = Ir_conf.union (C.config c) (S.config s)
-    let task (_, t) = S.task t
     let mem (_, t) = S.mem t
     let read (_, t) = S.read t
     let read_exn (_, t) = S.read_exn t

--- a/lib/ir_ro.ml
+++ b/lib/ir_ro.ml
@@ -20,7 +20,6 @@ module type STORE = sig
   type t
   type key
   type value
-  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   val config: t -> Ir_conf.t
   val task: t -> Ir_task.t
   val read: t -> key -> value option Lwt.t

--- a/lib/ir_ro.ml
+++ b/lib/ir_ro.ml
@@ -21,7 +21,6 @@ module type STORE = sig
   type key
   type value
   val config: t -> Ir_conf.t
-  val task: t -> Ir_task.t
   val read: t -> key -> value option Lwt.t
   val read_exn: t -> key -> value Lwt.t
   val mem: t -> key -> bool Lwt.t

--- a/lib/ir_ro.mli
+++ b/lib/ir_ro.mli
@@ -20,7 +20,6 @@ module type STORE = sig
   type t
   type key
   type value
-  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   val config: t -> Ir_conf.t
   val task: t -> Ir_task.t
   val read: t -> key -> value option Lwt.t

--- a/lib/ir_ro.mli
+++ b/lib/ir_ro.mli
@@ -21,7 +21,6 @@ module type STORE = sig
   type key
   type value
   val config: t -> Ir_conf.t
-  val task: t -> Ir_task.t
   val read: t -> key -> value option Lwt.t
   val read_exn: t -> key -> value Lwt.t
   val mem: t -> key -> bool Lwt.t

--- a/lib/ir_rw.ml
+++ b/lib/ir_rw.ml
@@ -39,5 +39,7 @@ end
 
 module type MAKER =
   functor (K: Ir_hum.S) ->
-  functor (V: Tc.S0) ->
-    REACTIVE with type key = K.t and type value = V.t
+  functor (V: Tc.S0) -> sig
+    include REACTIVE with type key = K.t and type value = V.t
+    val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  end

--- a/lib/ir_rw.ml
+++ b/lib/ir_rw.ml
@@ -41,5 +41,5 @@ module type MAKER =
   functor (K: Ir_hum.S) ->
   functor (V: Tc.S0) -> sig
     include REACTIVE with type key = K.t and type value = V.t
-    val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+    val create: Ir_conf.t -> t Lwt.t
   end

--- a/lib/ir_rw.mli
+++ b/lib/ir_rw.mli
@@ -41,5 +41,7 @@ end
 
 module type MAKER =
   functor (K: Ir_hum.S) ->
-  functor (V: Tc.S0) ->
-    REACTIVE with type key = K.t and type value = V.t
+  functor (V: Tc.S0) -> sig
+    include REACTIVE with type key = K.t and type value = V.t
+    val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  end

--- a/lib/ir_rw.mli
+++ b/lib/ir_rw.mli
@@ -43,5 +43,5 @@ module type MAKER =
   functor (K: Ir_hum.S) ->
   functor (V: Tc.S0) -> sig
     include REACTIVE with type key = K.t and type value = V.t
-    val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+    val create: Ir_conf.t -> t Lwt.t
   end

--- a/lib/ir_tag.ml
+++ b/lib/ir_tag.ml
@@ -43,6 +43,7 @@ end
 
 module type STORE = sig
   include Ir_rw.REACTIVE
+  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   module Key: S with type t = key
   module Val: Ir_hash.S with type t = value
 end

--- a/lib/ir_tag.ml
+++ b/lib/ir_tag.ml
@@ -43,7 +43,7 @@ end
 
 module type STORE = sig
   include Ir_rw.REACTIVE
-  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  val create: Ir_conf.t -> t Lwt.t
   module Key: S with type t = key
   module Val: Ir_hash.S with type t = value
 end

--- a/lib/ir_tag.mli
+++ b/lib/ir_tag.mli
@@ -26,6 +26,7 @@ module String: S with type t = string
 
 module type STORE = sig
   include Ir_rw.REACTIVE
+  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
   module Key: S with type t = key
   module Val: Ir_hash.S with type t = value
 end

--- a/lib/ir_tag.mli
+++ b/lib/ir_tag.mli
@@ -26,7 +26,7 @@ module String: S with type t = string
 
 module type STORE = sig
   include Ir_rw.REACTIVE
-  val create: Ir_conf.t -> ('a -> Ir_task.t) -> ('a -> t) Lwt.t
+  val create: Ir_conf.t -> t Lwt.t
   module Key: S with type t = key
   module Val: Ir_hash.S with type t = value
 end

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -175,11 +175,6 @@ module Internal (Node: NODE) = struct
     let lock = Lwt_mutex.create () in
     Lwt.return { parents; view; ops; lock }
 
-  let create _conf _task =
-    Log.debug "create";
-    empty () >>= fun t ->
-    Lwt.return (fun _ -> t)
-
   let task = `Views_do_not_have_task
   let config _ = Ir_conf.empty
 

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -806,12 +806,13 @@ module Make (S: Ir_s.STORE) = struct
     rebase_path db path view >>= Ir_merge.exn
 
   let merge_node db ?max_depth ?n path view head_node view_node =
+    let task = S.task db in
     (* Create a commit with the contents of the view *)
     Graph.read_node (graph_t db) head_node path >>= fun current_node ->
     let old () = match !(view.parents) with
       | []      -> ok None
       | parents ->
-        History.lca (history_t db) ~task:(S.task db) ?max_depth ?n parents
+        History.lca (history_t db) ~task ?max_depth ?n parents
         >>| function
         | None   -> ok None
         | Some c ->
@@ -832,7 +833,7 @@ module Make (S: Ir_s.STORE) = struct
       end >>= fun new_head_node ->
       S.head_exn db >>= fun head ->
       let parents = head :: !(view.parents) in
-      History.create (history_t db) ~node:new_head_node ~parents >>= fun h ->
+      History.create (history_t db) ~node:new_head_node ~parents ~task >>= fun h ->
       ok (`Changed h)
     )
 

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -811,7 +811,7 @@ module Make (S: Ir_s.STORE) = struct
     let old () = match !(view.parents) with
       | []      -> ok None
       | parents ->
-        History.lca (history_t db) ?max_depth ?n parents
+        History.lca (history_t db) ~task:(S.task db) ?max_depth ?n parents
         >>| function
         | None   -> ok None
         | Some c ->

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -175,7 +175,6 @@ module Internal (Node: NODE) = struct
     let lock = Lwt_mutex.create () in
     Lwt.return { parents; view; ops; lock }
 
-  let task = `Views_do_not_have_task
   let config _ = Ir_conf.empty
 
   let sub t path =
@@ -966,5 +965,4 @@ module type S = sig
   val make_head: db -> Ir_task.t -> parents:head list -> contents:t -> head Lwt.t
   val watch_path: db -> key -> ?init:(head * t) ->
     ((head * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
-  val task: [`Views_do_not_have_task]
 end

--- a/lib/ir_view.mli
+++ b/lib/ir_view.mli
@@ -45,7 +45,6 @@ module type S = sig
   val make_head: db -> Ir_task.t -> parents:head list -> contents:t -> head Lwt.t
   val watch_path: db -> key -> ?init:(head * t) ->
     ((head * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
-  val task: [`Views_do_not_have_task]
 end
 
 module Make (S: Ir_s.STORE):

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -2178,9 +2178,6 @@ module type VIEW = sig
   (** [watch_head t p f] calls [f] every time a subpath of [p] is
       updated in the branch [t]. The callback parameters contain the
       branch's current head and the corresponding view. *)
-
-  val task: [`Views_do_not_have_task]
-  (** Views do not have tasks. *)
 end
 
 module View (S: S): VIEW with type db = S.t

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1574,7 +1574,7 @@ module Private: sig
           data-structure: every commit carries the list of its
           immediate predecessors. *)
 
-      val merge: t -> commit Merge.t
+      val merge: t -> task:task -> commit Merge.t
       (** [merge t] is the 3-way merge function for commit.  *)
 
       val lcas: t -> ?max_depth:int -> ?n:int -> commit -> commit ->
@@ -1583,7 +1583,7 @@ module Private: sig
           {{:http://en.wikipedia.org/wiki/Lowest_common_ancestor}lca}
           between two commits. *)
 
-      val lca: t -> ?max_depth:int -> ?n:int -> commit list ->
+      val lca: t -> task:task -> ?max_depth:int -> ?n:int -> commit list ->
         commit option Merge.result Lwt.t
       (** Compute the lowest common ancestors ancestor of a list of
           commits by recursively calling {!lcas} and merging the
@@ -1593,7 +1593,7 @@ module Private: sig
           {!lcas} returns either [`Max_depth_reached] or
           [`Too_many_lcas] then the function returns [None]. *)
 
-      val three_way_merge: t -> ?max_depth:int -> ?n:int -> commit -> commit ->
+      val three_way_merge: t -> task:task -> ?max_depth:int -> ?n:int -> commit -> commit ->
         commit Merge.result Lwt.t
       (** Compute the {!lcas} of the two commit and 3-way merge the
           result. *)
@@ -1602,8 +1602,12 @@ module Private: sig
       (** Same as {{!Private.Node.GRAPH.closure}GRAPH.closure} but for
           the history graph. *)
 
-      module Store: Contents.STORE with type t = t and type key = commit
-      (** An history forms a {{!Contents.STORE}contents store}. *)
+      (** A history forms a {{!STORE}store} of commits. *)
+      module Store: sig
+        include STORE with type t = t and type key = commit
+        module Path: Ir_path.S
+        val merge: Path.t -> t -> task:task -> key option Merge.t
+      end
 
     end
 

--- a/lib/mem/irmin_mem.ml
+++ b/lib/mem/irmin_mem.ml
@@ -30,14 +30,13 @@ module RO (K: Irmin.Hum.S) (V: Tc.S0) = struct
 
   type value = V.t
 
-  type t = { t: value KHashtbl.t; task: Irmin.task; config: Irmin.config }
+  type t = { t: value KHashtbl.t; config: Irmin.config }
 
-  let task t = t.task
   let config t = t.config
   let table = KHashtbl.create 23
 
-  let create config task =
-    Lwt.return (fun a -> { t = table; task = task a; config })
+  let create config =
+    Lwt.return { t = table; config }
 
   let read { t; _ } key =
     Log.debug "read";
@@ -98,14 +97,13 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let watches = W.create ()
   let lock = L.create ()
 
-  let create config task =
-    RO.create config task >>= fun t ->
-    Lwt.return (fun a -> { t = t a; w = watches; lock })
+  let create config =
+    RO.create config >>= fun t ->
+    Lwt.return { t; w = watches; lock }
 
   let read t = RO.read t.t
   let read_exn t = RO.read_exn t.t
   let mem t = RO.mem t.t
-  let task t = RO.task t.t
   let config t = RO.config t.t
   let iter t = RO.iter t.t
   let watch_key t = W.watch_key t.w

--- a/lib_test/test_link.ml
+++ b/lib_test/test_link.ml
@@ -23,17 +23,17 @@ end
 
 module type S = sig
   include Irmin.LINK with type key = Hash.t and type value = Hash.t
-  val create: unit -> (unit -> t) Lwt.t
+  val create: unit -> t Lwt.t
 end
 
 module Mem: S = struct
   include Irmin_mem.Link(Hash)
-  let create () = create (Irmin_mem.config ()) Irmin.Task.none
+  let create () = create (Irmin_mem.config ())
 end
 
 module FS:S = struct
   include Irmin_unix.Irmin_fs.Link(Hash)
-  let create () = create Test_fs.config Irmin.Task.none
+  let create () = create Test_fs.config
 end
 
 let key x = Hash.digest (Cstruct.of_string x)
@@ -44,24 +44,24 @@ let test (module M: S) () =
   let k2 = key "bar" in
   let k3 = key "toto" in
   M.create () >>= fun t ->
-  M.add (t ()) k1 k2 >>= fun () ->
-  M.read (t ()) k1 >>= fun k2' ->
+  M.add t k1 k2 >>= fun () ->
+  M.read t k1 >>= fun k2' ->
   Alcotest.(check @@ option key_t) "k1 -> k2" (Some k2) k2';
   begin Lwt.catch
-    (fun () -> M.add (t ()) k1 k3 >>= fun () -> Alcotest.fail "already linked")
+    (fun () -> M.add t k1 k3 >>= fun () -> Alcotest.fail "already linked")
     (fun _e -> Lwt.return_unit)
   end >>= fun () ->
-  M.add (t ()) k2 k3 >>= fun () ->
-  M.read (t ()) k2 >>= fun k3' ->
+  M.add t k2 k3 >>= fun () ->
+  M.read t k2 >>= fun k3' ->
   Alcotest.(check @@ option key_t) "k2 -> k3" (Some k3) k3';
-  M.mem (t ()) k1 >>= fun m1 ->
+  M.mem t k1 >>= fun m1 ->
   Alcotest.(check bool) "mem k1" true m1;
-  M.mem (t ()) k2 >>= fun m2 ->
+  M.mem t k2 >>= fun m2 ->
   Alcotest.(check bool) "mem k2" true m2;
-  M.mem (t ()) k3 >>= fun m3 ->
+  M.mem t k3 >>= fun m3 ->
   Alcotest.(check bool) "mem k3" false m3;
   let all = ref [] in
-  M.iter (t ()) (fun k _ -> all := k :: !all; Lwt.return_unit) >>= fun () ->
+  M.iter t (fun k _ -> all := k :: !all; Lwt.return_unit) >>= fun () ->
   Alcotest.(check @@ slist key_t Hash.compare) "all keys" !all [k1; k2];
   Lwt.return_unit
 

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -713,14 +713,14 @@ module Make (S: Irmin.S) = struct
       History.create (h 0) ~node:k0 ~parents:[] >>= fun kr0 ->
       History.create (h 1) ~node:k2 ~parents:[kr0] >>= fun kr1 ->
       History.create (h 2) ~node:k3 ~parents:[kr0] >>= fun kr2 ->
-      History.merge (h 3) ~old:(old kr0) kr1 kr2 >>= fun kr3 ->
+      History.merge (h 3) ~task:(task 3) ~old:(old kr0) kr1 kr2 >>= fun kr3 ->
       Irmin.Merge.exn kr3 >>= fun kr3 ->
 
-      History.merge (h 4) ~old:(old kr2) kr2 kr3 >>= fun kr3_id' ->
+      History.merge (h 4) ~task:(task 4) ~old:(old kr2) kr2 kr3 >>= fun kr3_id' ->
       Irmin.Merge.exn kr3_id' >>= fun kr3_id' ->
       assert_equal (module KC) "kr3 id with immediate parent'" kr3 kr3_id';
 
-      History.merge (h 5) ~old:(old kr0) kr0 kr3 >>= fun kr3_id ->
+      History.merge (h 5) ~task:(task 4) ~old:(old kr0) kr0 kr3 >>= fun kr3_id ->
       Irmin.Merge.exn kr3_id >>= fun kr3_id ->
       assert_equal (module KC) "kr3 id with old parent" kr3 kr3_id;
 

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -114,13 +114,13 @@ module Make (S: Irmin.S) = struct
   let r1 x =
     n2 x >>= fun kn2 ->
     create_dummy x >>= fun t ->
-    History.create (h t ()) ~node:kn2 ~parents:[]
+    History.create (h t ()) ~node:kn2 ~parents:[] ~task:Irmin.Task.empty
 
   let r2 x =
     n3 x >>= fun kn3 ->
     r1 x >>= fun kr1 ->
     create_dummy x >>= fun t ->
-    History.create (h t ()) ~node:kn3 ~parents:[kr1]
+    History.create (h t ()) ~node:kn3 ~parents:[kr1] ~task:Irmin.Task.empty
 
   let run x test =
     try Lwt_unix.run (x.init () >>= test >>= x.clean)
@@ -315,16 +315,18 @@ module Make (S: Irmin.S) = struct
       Graph.create (g 2) [l "b", `Node kt2] >>= fun kt3 ->
 
       (* r1 : t2 *)
-      History.create (h 3) ~node:kt2 ~parents:[] >>= fun kr1 ->
-      History.create (h 3) ~node:kt2 ~parents:[] >>= fun kr1' ->
+      let with_task n fn =
+        fn (h n) ~task:(task n) in
+      with_task 3 @@ History.create ~node:kt2 ~parents:[] >>= fun kr1 ->
+      with_task 3 @@ History.create ~node:kt2 ~parents:[] >>= fun kr1' ->
       Commit.read_exn (c 0) kr1  >>= fun t1 ->
       Commit.read_exn (c 0) kr1' >>= fun t1' ->
       assert_equal (module C) "t1" t1 t1';
       assert_equal (module KC) "kr1" kr1 kr1';
 
       (* r1 -> r2 : t3 *)
-      History.create (h 4) ~node:kt3 ~parents:[kr1] >>= fun kr2 ->
-      History.create (h 4) ~node:kt3 ~parents:[kr1] >>= fun kr2' ->
+      with_task 4 @@ History.create ~node:kt3 ~parents:[kr1] >>= fun kr2 ->
+      with_task 4 @@ History.create ~node:kt3 ~parents:[kr1] >>= fun kr2' ->
       assert_equal (module KC) "kr2" kr2 kr2';
 
       History.closure (h 5) ~min:[] ~max:[kr1] >>= fun kr1s ->
@@ -709,22 +711,24 @@ module Make (S: Irmin.S) = struct
       S.create x.config task >>= fun t ->
 
       let h = h t and c a = S.Private.commit_t (t a) in
+      let with_task n fn =
+        fn (h n) ~task:(task n) in
 
-      History.create (h 0) ~node:k0 ~parents:[] >>= fun kr0 ->
-      History.create (h 1) ~node:k2 ~parents:[kr0] >>= fun kr1 ->
-      History.create (h 2) ~node:k3 ~parents:[kr0] >>= fun kr2 ->
-      History.merge (h 3) ~task:(task 3) ~old:(old kr0) kr1 kr2 >>= fun kr3 ->
+      with_task 0 @@ History.create ~node:k0 ~parents:[] >>= fun kr0 ->
+      with_task 1 @@ History.create ~node:k2 ~parents:[kr0] >>= fun kr1 ->
+      with_task 2 @@ History.create ~node:k3 ~parents:[kr0] >>= fun kr2 ->
+      with_task 3 History.merge ~old:(old kr0) kr1 kr2 >>= fun kr3 ->
       Irmin.Merge.exn kr3 >>= fun kr3 ->
 
-      History.merge (h 4) ~task:(task 4) ~old:(old kr2) kr2 kr3 >>= fun kr3_id' ->
+      with_task 4 History.merge ~old:(old kr2) kr2 kr3 >>= fun kr3_id' ->
       Irmin.Merge.exn kr3_id' >>= fun kr3_id' ->
       assert_equal (module KC) "kr3 id with immediate parent'" kr3 kr3_id';
 
-      History.merge (h 5) ~task:(task 4) ~old:(old kr0) kr0 kr3 >>= fun kr3_id ->
+      with_task 5 History.merge ~old:(old kr0) kr0 kr3 >>= fun kr3_id ->
       Irmin.Merge.exn kr3_id >>= fun kr3_id ->
       assert_equal (module KC) "kr3 id with old parent" kr3 kr3_id;
 
-      History.create (h 3) ~node:k4 ~parents:[kr1; kr2] >>= fun kr3' ->
+      with_task 3 @@ History.create ~node:k4 ~parents:[kr1; kr2] >>= fun kr3' ->
 
       Commit.read_exn (c 0) kr3 >>= fun r3 ->
       Commit.read_exn (c 0) kr3' >>= fun r3' ->
@@ -772,17 +776,19 @@ module Make (S: Irmin.S) = struct
         assert_lcas_err msg `Max_depth_reached lcas;
         Lwt.return_unit
       in
+      let with_task n fn =
+        fn (h n) ~task:(task n) in
 
       (* test that we don't compute too many lcas
 
          0->1->2->3->4
 
       *)
-      History.create (h 0) ~node ~parents:[]   >>= fun k0 ->
-      History.create (h 1) ~node ~parents:[k0] >>= fun k1 ->
-      History.create (h 2) ~node ~parents:[k1] >>= fun k2 ->
-      History.create (h 3) ~node ~parents:[k2] >>= fun k3 ->
-      History.create (h 4) ~node ~parents:[k3] >>= fun k4 ->
+      with_task 0 @@ History.create ~node ~parents:[]   >>= fun k0 ->
+      with_task 1 @@ History.create ~node ~parents:[k0] >>= fun k1 ->
+      with_task 2 @@ History.create ~node ~parents:[k1] >>= fun k2 ->
+      with_task 3 @@ History.create ~node ~parents:[k2] >>= fun k3 ->
+      with_task 4 @@ History.create ~node ~parents:[k3] >>= fun k4 ->
 
       assert_lcas "line lcas 1" ~max_depth:0 3 k3 k4 [k3] >>= fun () ->
       assert_lcas "line lcas 2" ~max_depth:1 3 k2 k4 [k2] >>= fun () ->
@@ -797,14 +803,14 @@ module Make (S: Irmin.S) = struct
              \--->12-->14-->16-->17
 
       *)
-      History.create (h 10) ~node ~parents:[k4]       >>= fun k10 ->
-      History.create (h 11) ~node ~parents:[k10]      >>= fun k11 ->
-      History.create (h 12) ~node ~parents:[k10]      >>= fun k12 ->
-      History.create (h 13) ~node ~parents:[k11]      >>= fun k13 ->
-      History.create (h 14) ~node ~parents:[k12]      >>= fun k14 ->
-      History.create (h 15) ~node ~parents:[k12; k13] >>= fun k15 ->
-      History.create (h 16) ~node ~parents:[k14]      >>= fun k16 ->
-      History.create (h 17) ~node ~parents:[k11; k16] >>= fun k17 ->
+      with_task 10 @@ History.create ~node ~parents:[k4]       >>= fun k10 ->
+      with_task 11 @@ History.create ~node ~parents:[k10]      >>= fun k11 ->
+      with_task 12 @@ History.create ~node ~parents:[k10]      >>= fun k12 ->
+      with_task 13 @@ History.create ~node ~parents:[k11]      >>= fun k13 ->
+      with_task 14 @@ History.create ~node ~parents:[k12]      >>= fun k14 ->
+      with_task 15 @@ History.create ~node ~parents:[k12; k13] >>= fun k15 ->
+      with_task 16 @@ History.create ~node ~parents:[k14]      >>= fun k16 ->
+      with_task 17 @@ History.create ~node ~parents:[k11; k16] >>= fun k17 ->
 
       assert_lcas "x lcas 0" ~max_depth:0 5 k10 k10 [k10]      >>= fun () ->
       assert_lcas "x lcas 1" ~max_depth:0 5 k14 k14 [k14]      >>= fun () ->
@@ -823,13 +829,13 @@ module Make (S: Irmin.S) = struct
                  |        \--|--/
                  \-----------/
       *)
-      History.create (h 10) ~node ~parents:[k4]      >>= fun k10 ->
-      History.create (h 11) ~node ~parents:[k10]     >>= fun k11 ->
-      History.create (h 12) ~node ~parents:[k11]     >>= fun k12 ->
-      History.create (h 13) ~node ~parents:[k12]     >>= fun k13 ->
-      History.create (h 14) ~node ~parents:[k11;k13] >>= fun k14 ->
-      History.create (h 15) ~node ~parents:[k13;k14] >>= fun k15 ->
-      History.create (h 16) ~node ~parents:[k11]     >>= fun k16 ->
+      with_task 10 @@ History.create ~node ~parents:[k4]      >>= fun k10 ->
+      with_task 11 @@ History.create ~node ~parents:[k10]     >>= fun k11 ->
+      with_task 12 @@ History.create ~node ~parents:[k11]     >>= fun k12 ->
+      with_task 13 @@ History.create ~node ~parents:[k12]     >>= fun k13 ->
+      with_task 14 @@ History.create ~node ~parents:[k11;k13] >>= fun k14 ->
+      with_task 15 @@ History.create ~node ~parents:[k13;k14] >>= fun k15 ->
+      with_task 16 @@ History.create ~node ~parents:[k11]     >>= fun k16 ->
 
       assert_lcas "weird lcas 1" ~max_depth:0 3 k14 k15 [k14] >>= fun () ->
       assert_lcas "weird lcas 2" ~max_depth:0 3 k13 k15 [k13] >>= fun () ->


### PR DESCRIPTION
Irmin's store interface requires passing a task to every store. However, most stores don't need this for anything. This branch removes them from most places. The `BC` interface is unchanged, so users of the public interface should be unaffected.

Backend providers no longer deal with tasks at all.

Apart from simplifying the code, this change is necessary for adding a separate repository type. This will allow connecting to a database once and then reusing that state for multiple branches. This isn't possible if the backend stores must be recreated for each new commit message.

Notes:

- We might still want to change the `BC` interface, but I think this branch can be merged without that, as it is useful on its own.

- It is now explicit which operations create commits. In particular, the API now makes it clear that `lcas` doesn't change anything, while `lca` requires a task because it may create commits.

- `HISTORY.Store` was previously a `Contents.STORE`. Now, contents can be merged without a task, but merging commits needs one, so they cannot share the same interface. I have made a new one to hold the new `HISTORY.Store.merge` function. However, this function appears to be unused.

- `View.task` is gone (it never did anything).

- `View.create` is gone (it ignored both its arguments and called `View.empty`).

- There were plans for an auditing API using the tasks. I think this can be achieved in other ways; for the discussion, see http://lists.xenproject.org/archives/html/mirageos-devel/2015-10/msg00006.html