### PR TITLE
git versions < 1.7.1 conflict with irmin 0.9.10

### DIFF
--- a/opam
+++ b/opam
@@ -49,6 +49,6 @@ depopts: [
 ]
 conflicts: [
   "cohttp" {< "0.18.3"}
-  "git"    {< "1.7.0"}
+  "git"    {< "1.7.1"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
Attempting to compile irmin with git 1.7.0 fails:

```
# File "lib/git/irmin_git.ml", line 676, characters 36-37:
# Error: Signature mismatch:
#        ...
#        The value `length' is required but not provided
#        The value `string' is required but not provided
#        The value `cstruct' is required but not provided
```

Express this in `opam`.