### PR TITLE
Remove Irmin.Basic

### DIFF
--- a/bin/ir_resolver.ml
+++ b/bin/ir_resolver.ml
@@ -22,7 +22,7 @@ type contents = (module Irmin.Contents.S)
 
 let create: (module Irmin.S_MAKER) -> contents -> (module Irmin.S) =
   fun (module B) (module C) ->
-    let module S = Irmin.Basic(B)(C) in (module S)
+    let module S = B(C)(Irmin.Ref.String)(Irmin.Hash.SHA1) in (module S)
 
 let mem_store = create (module Irmin_mem.Make)
 let irf_store = create (module Irmin_fs.Make)

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -152,7 +152,7 @@ end = struct
 
 end
 
-module Store = Irmin.Basic (Irmin_git.FS) (Log)
+module Store = Irmin_git.FS(Log)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 let config = Irmin_git.config ~root:Config.root ~bare:true ()
 
 let log_file = [ "local"; "debug" ]

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -4,7 +4,7 @@ open Irmin_unix
 (* Install the polling thread for FS notification to work. *)
 let () = install_dir_polling_listener 0.5
 
-module Store = Irmin.Basic(Irmin_git.FS)(Irmin.Contents.String)
+module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 module View = Irmin.View(Store)
 
 let config =

--- a/examples/git_store.ml
+++ b/examples/git_store.ml
@@ -3,7 +3,7 @@ open Lwt
 open Irmin_unix
 open Printf
 
-module Store = Irmin.Basic (Irmin_git.FS) (Irmin.Contents.String)
+module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 
 let update t k v =
   let msg = sprintf "Updating /%s" (String.concat "/" k) in

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -70,7 +70,7 @@ let branch image =
 
 let images = [| (*ubuntu; *) wordpress; mysql |]
 
-module Store = Irmin.Basic (Irmin_git.FS) (Irmin.Contents.String)
+module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 let config = Irmin_git.config
     ~root:Config.root
     ~bare:true

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -7,7 +7,7 @@ let path =
   else
     "git://github.com/mirage/ocaml-git.git"
 
-module Store = Irmin.Basic (Irmin_git.FS) (Irmin.Contents.String)
+module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 module Sync = Irmin.Sync(Store)
 module View = Irmin.View(Store)
 

--- a/examples/views.ml
+++ b/examples/views.ml
@@ -1,7 +1,7 @@
 open Lwt
 open Irmin_unix
 
-module Store = Irmin.Basic (Irmin_git.FS) (Irmin.Contents.String)
+module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)
 module View = Irmin.View(Store)
 
 let fmt t x = Printf.ksprintf (fun str -> t str) x

--- a/lib/ir_bc.ml
+++ b/lib/ir_bc.ml
@@ -793,38 +793,3 @@ module type MAKER =
            and type value = C.t
            and type head = H.t
            and type branch_id = R.t
-
-module Make
-    (AO: Ir_ao.MAKER)
-    (RW: Ir_rw.MAKER)
-    (C: Ir_contents.S)
-    (R: Ir_tag.S)
-    (H: Ir_hash.S) =
-struct
-  module X = struct
-    module Contents = Ir_contents.Make(struct
-        include AO(H)(C)
-        module Key = H
-        module Val = C
-      end)
-    module Node = struct
-      module Key = H
-      module Val = Ir_node.Make (H)(H)(C.Path)
-      module Path = C.Path
-      include AO (Key)(Val)
-    end
-    module Commit = struct
-      module Key = H
-      module Val = Ir_commit.Make (H)(H)
-      include AO (Key)(Val)
-    end
-    module Ref = struct
-      module Key = R
-      module Val = H
-      include RW (Key)(Val)
-    end
-    module Slice = Ir_slice.Make(Contents)(Node)(Commit)
-    module Sync = Ir_sync.None(H)(R)
-  end
-  include Make_ext(X)
-end

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -75,15 +75,6 @@ module type STORE = sig
   val import: t -> slice -> [`Ok | `Error] Lwt.t
 end
 
-module type MAKER =
-  functor (C: Ir_contents.S) ->
-  functor (R: Ir_tag.S) ->
-  functor (H: Ir_hash.S) ->
-    STORE with type key = C.Path.t
-           and type value = C.t
-           and type head = H.t
-           and type branch_id = R.t
-
 module type PRIVATE = sig
   module Contents: Ir_contents.STORE
   module Node: Ir_node.STORE
@@ -99,8 +90,6 @@ module type PRIVATE = sig
   module Sync: Ir_sync.S
     with type head = Commit.key and type branch_id = Ref.key
 end
-
-module Make (X: Ir_ao.MAKER) (Y: Ir_rw.MAKER): MAKER
 
 (** {1 Extended API} *)
 

--- a/lib/ir_s.ml
+++ b/lib/ir_s.ml
@@ -106,5 +106,3 @@ struct
   end
   include Make_ext(X)
 end
-
-module Default (S: MAKER) (C: Ir_contents.S) = S(C)(Ir_tag.String)(Ir_hash.SHA1)

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -61,9 +61,3 @@ module Make_ext (P: Ir_bc.PRIVATE): STORE
    and type branch_id = P.Ref.key
    and type head = P.Ref.value
    and type Key.step = P.Contents.Path.step
-
-module Default (S: MAKER) (C: Ir_contents.S): STORE
-  with type key = C.Path.t
-   and type value = C.t
-   and type branch_id = string
-   and type head = Ir_hash.SHA1.t

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -84,8 +84,6 @@ let remote_uri = Ir_sync_ext.remote_uri
 
 module type BASIC = S with type branch_id = string and type head = Hash.SHA1.t
 
-module Basic = Ir_s.Default
-
 module type T = S with type branch_id = string and type head = Hash.SHA1.t
 
 let with_hrw_view (type store) (type path) (type view)

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -54,7 +54,6 @@ module type AO_MAKER_RAW =
   AO with type key = K.t and type value = V.t
 
 module type RW_MAKER = Ir_rw.MAKER
-module type BC_MAKER = Ir_bc.MAKER
 module type S_MAKER = Ir_s.MAKER
 
 module Private = struct
@@ -62,7 +61,6 @@ module Private = struct
   module Node = Ir_node
   module Commit = Ir_commit
   module Slice = Ir_slice
-  module Make = Ir_bc.Make
   module Sync = Ir_sync
   module type S = Ir_bc.PRIVATE
   module Watch = Ir_watch

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1822,12 +1822,13 @@ module type S_MAKER =
 
 
 module type BASIC = S with type branch_id = string and type head = Hash.SHA1.t
-(** The signature of basic stores. *)
+(** The signature of basic stores.
+ 
+    Branch names (refs) are strings and the hash is SHA1.
+    To generate a basic store from a backend, use e.g.
 
-module Basic (R: S_MAKER) (C: Contents.S):
-  BASIC with type key = C.Path.t and type value = C.t
-(** Generate a basic store using [R] as backend and [C] as
-    user-provided contents. *)
+    [module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)]
+*)
 
 (** {2 Synchronization} *)
 

--- a/lib/mirage/irmin_mirage.ml
+++ b/lib/mirage/irmin_mirage.ml
@@ -40,7 +40,7 @@ module KV_RO (C: CONTEXT) (I: Git.Inflate.S) = struct
 
   open Lwt.Infix
 
-  module S = Irmin.Basic(Irmin_git.Memory(C)(I))(Irmin.Contents.Cstruct)
+  module S = Irmin_git.Memory(C)(I)(Irmin.Contents.Cstruct)(Irmin.Ref.String)(Irmin.Hash.SHA1)
   module Sync = Irmin.Sync(S)
   let config = Irmin_mem.config ()
 

--- a/lib/mirage/irmin_mirage.mli
+++ b/lib/mirage/irmin_mirage.mli
@@ -53,7 +53,7 @@ module Irmin_git: sig
       be written in {i .git/objects/} and might be cleaned-up if you
       run {i git gc} manually. *)
 
-  module Memory (C: CONTEXT) (I: Git.Inflate.S): Irmin.S_MAKER
+  module Memory (C: CONTEXT) (I: Git.Inflate.S): Irmin_git.S_MAKER
   (** Embed an Irmin store into an in-memory Git repository. *)
 
 end

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -140,10 +140,10 @@ module Irmin_git: sig
   (** Embed a read-write store into a Git repository. Contents will be
       written in {i .git/refs}. *)
 
-  module Memory: Irmin.S_MAKER
+  module Memory: Irmin_git.S_MAKER
   (** Embed an Irmin store into an in-memory Git repository. *)
 
-  module FS: Irmin.S_MAKER
+  module FS: Irmin_git.S_MAKER
   (** Embed an Irmin store into a local Git repository. *)
 
 end

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -108,7 +108,7 @@ let create: (module Irmin.S_MAKER) -> [`String | `Json] -> (module Irmin.S) =
       | `String -> (module Irmin.Contents.String)
       | `Json   -> (module Irmin.Contents.Json)
     in
-    let module S = Irmin.Basic(B)(C) in (module S)
+    let module S = B(C)(Irmin.Ref.String)(Irmin.Hash.SHA1) in (module S)
 
 type kind = [`Mem | `Fs | `Git | `Http of kind]
 

--- a/lib_test/test_git.ml
+++ b/lib_test/test_git.ml
@@ -49,7 +49,7 @@ let suite k =
 let test_non_bare () =
   let open Irmin_unix in
   init_disk () >>= fun () ->
-  let module Store = Irmin.Basic (Irmin_git.FS) (Irmin.Contents.String) in
+  let module Store = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1) in
   let config = Irmin_git.config ~root:test_db ~bare:false () in
   Store.Repo.create config >>= Store.master task >>= fun t ->
   Store.update (t "fst one") ["fst"] "ok" >>= fun () ->

--- a/lib_test/test_git.ml
+++ b/lib_test/test_git.ml
@@ -34,13 +34,14 @@ let clean () =
   Lwt.return_unit
 
 let suite k =
+  let module S = (val git_store k) in
   {
     name   = "GIT" ^ string_of_contents k;
     cont   = k;
     kind   = `Git;
     init   = init_disk;
     clean  = clean;
-    store  = git_store k;
+    store  = (module S: Test_S);
     config =
       let head = Git.Reference.of_raw "refs/heads/test" in
       Irmin_git.config ~root:test_db ~head ~bare:true ()

--- a/lib_test/test_http.ml
+++ b/lib_test/test_http.ml
@@ -43,7 +43,7 @@ let suite ?(content_type=`Raw) server =
   { name = Printf.sprintf "HTTP.%s.%s" server.name ct_str;
 
     init = begin fun () ->
-      let (module Server) = server.store in
+      let (module Server: Test_S) = server.store in
       let module HTTP = Irmin_http_server.Make(Server) in
       let server () =
         server.init () >>= fun () ->

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -17,7 +17,7 @@
 open Test_common
 let (>>=) = Lwt.(>>=)
 
-let clean config (module S: Irmin.S) () =
+let clean config (module S: Test_S) () =
   S.Repo.create config >>= S.empty Irmin.Task.none >>= fun t ->
   S.branches (t ()) >>= fun branches ->
   Lwt_list.iter_p (S.remove_branch (t ())) branches

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -34,7 +34,7 @@ let random_string n = String.init n (fun _i -> random_char ())
 let long_random_string = random_string 1024_000
 let fail fmt = Printf.ksprintf Alcotest.fail fmt
 
-module Make (S: Irmin.S) = struct
+module Make (S: Test_S) = struct
 
   module Common = Make(S)
   open Common
@@ -336,8 +336,7 @@ module Make (S: Irmin.S) = struct
       assert_equal (module Set(KC)) "g2" [kr1; kr2] kr2s;
 
       if x.kind = `Git then (
-        let module I = Irmin_git.Internals(S) in
-        I.commit_of_head (t 0) kr1 >|= function
+        S.Internals.commit_of_head (t 0) kr1 >|= function
         | None   -> Alcotest.fail "cannot read the Git internals"
         | Some c ->
           let name = c.Git.Commit.author.Git.User.name in


### PR DESCRIPTION
The `Basic` functor makes things confusing for users by hiding what's going on, and restricts all back-ends to providing only the base API.

This branch removes it, changing the examples to use the more explicit form. As back-ends can now provide additional functions, `Irmin_git.Internals` is moved inside the store and the hacks removed (or, at least, moved to just the unit-tests). i.e. you can now only ask for a Git commit object from a Git store.

I also deleted `Ir_bc.Make` and `Ir_bc.MAKER` because a) they were confusing me, b) they aren't used within Irmin, and c) they are not exposed to users of the API.

Code needs to be updated from e.g.
    
    module S = Irmin.Basic(Irmin_git.FS)(Irmin.Contents.String)
    
to
    
    module S = Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Irmin.Hash.SHA1)