### PR TITLE
Combine Ir_bc.STORE_EXT and Ir_s.STORE

### DIFF
--- a/lib/fs/irmin_fs.ml
+++ b/lib/fs/irmin_fs.ml
@@ -53,10 +53,7 @@ module RO_ext (IO: IO) (S: Config) (K: Irmin.Hum.S) (V: Tc.S0) = struct
 
   type t = {
     path: string;
-    config: Irmin.config;
   }
-
-  let config t = t.config
 
   let get_path config =
     match Irmin.Private.Conf.get config root_key with
@@ -66,7 +63,7 @@ module RO_ext (IO: IO) (S: Config) (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let create config =
     get_path config >>= fun path ->
     IO.mkdir path >>= fun () ->
-    Lwt.return { config; path }
+    Lwt.return { path }
 
   let file_of_key { path; _ } key =
     path / S.file_of_key (K.to_hum key)

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -133,18 +133,16 @@ module Irmin_value_store
 
     type t = {
       t: G.t;
-      config: Irmin.config;
     }
 
     type key = K.t
     type value = V.t
-    let config t = t.config
     let git_of_key k = GK.of_raw (K.to_raw k)
     let key_of_git k = K.of_raw (GK.to_raw k)
 
     let create config =
       G.create config >>= fun t ->
-      return { config; t }
+      return { t }
 
     let mem { t; _ } key =
       let key = git_of_key key in

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -204,13 +204,12 @@ module RO (Client: Cohttp_lwt.Client) (K: Irmin.Hum.S) (V: Tc.S0) = struct
   include Helper (Client)
 
   type t = {
-    mutable uri: Uri.t; config: Irmin.config; ct: ct;
+    mutable uri: Uri.t; ct: ct;
   }
 
   type key = K.t
   type value = V.t
 
-  let config t = t.config
   let uri t = t.uri
   let ct t = t.ct
 
@@ -220,7 +219,7 @@ module RO (Client: Cohttp_lwt.Client) (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let create config =
     let uri = get_uri config in
     let ct  = get_ct config in
-    Lwt.return { config; uri; ct; }
+    Lwt.return { uri; ct; }
 
   let read t key = get t ["read"; K.to_hum key] (module Tc.Option(V))
 

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -847,7 +847,6 @@ struct
   module Private = struct
     include L.Private
     module Repo = Repo
-    let repo t = t.repo
     let contents_t t = t.contents_t
     let node_t t = t.node_t
     let commit_t t = t.commit_t

--- a/lib/ir_ao.ml
+++ b/lib/ir_ao.ml
@@ -19,7 +19,6 @@ module Log = Log.Make(struct let section = "AO" end)
 module type STORE = sig
   include Ir_ro.STORE
   val create: Ir_conf.t -> t Lwt.t
-  val config: t -> Ir_conf.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_ao.mli
+++ b/lib/ir_ao.mli
@@ -19,7 +19,6 @@
 module type STORE = sig
   include Ir_ro.STORE
   val create: Ir_conf.t -> t Lwt.t
-  val config: t -> Ir_conf.t
   val add: t -> value -> key Lwt.t
 end
 

--- a/lib/ir_commit.ml
+++ b/lib/ir_commit.ml
@@ -124,7 +124,6 @@ struct
       S.create config >>= fun s ->
       return (n, s)
 
-    let config (s, t) = Ir_conf.union (N.config s) (S.config t)
     let add (_, t) = S.add t
     let mem (_, t) = S.mem t
     let read (_, t) = S.read t

--- a/lib/ir_dot.ml
+++ b/lib/ir_dot.ml
@@ -26,7 +26,7 @@ module type S = sig
     Buffer.t -> unit Lwt.t
 end
 
-module Make (S: Ir_s.STORE) = struct
+module Make (S: Ir_bc.STORE_EXT) = struct
 
   type db = S.t
 

--- a/lib/ir_dot.mli
+++ b/lib/ir_dot.mli
@@ -23,4 +23,4 @@ module type S = sig
     -> Buffer.t -> unit Lwt.t
 end
 
-module Make (S: Ir_s.STORE): S with type db = S.t
+module Make (S: Ir_bc.STORE_EXT): S with type db = S.t

--- a/lib/ir_node.ml
+++ b/lib/ir_node.ml
@@ -262,7 +262,6 @@ struct
 
     type key = S.key
     type value = S.value
-    let config (c, s) = Ir_conf.union (C.config c) (S.config s)
     let mem (_, t) = S.mem t
     let read (_, t) = S.read t
     let read_exn (_, t) = S.read_exn t

--- a/lib/ir_s.ml
+++ b/lib/ir_s.ml
@@ -14,63 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type STORE = sig
-  include Ir_bc.STORE
-  module Key: Ir_path.S with type t = key
-  module Val: Ir_contents.S with type t = value
-  module Ref: Ir_tag.S with type t = branch_id
-  module Head: Ir_hash.S with type t = head
-  module Private: sig
-    include Ir_bc.PRIVATE
-      with type Contents.value = value
-       and module Contents.Path = Key
-       and type Commit.key = head
-       and type Slice.t = slice
-       and type Ref.key = branch_id
-    val repo: t -> Repo.t
-    val contents_t: t -> Contents.t
-    val node_t: t -> Node.t
-    val commit_t: t -> Commit.t
-    val ref_t: t -> Ref.t
-    val read_node: t -> key -> Node.key option Lwt.t
-    val mem_node: t -> key -> bool Lwt.t
-    val update_node: t -> key -> Node.key -> unit Lwt.t
-    val merge_node: t -> key -> (head * Node.key) -> unit Ir_merge.result Lwt.t
-    val remove_node: t -> key -> unit Lwt.t
-    val iter_node: t -> Node.key ->
-      (key -> value Lwt.t -> unit Lwt.t) -> unit Lwt.t
-  end
-end
-
 module type MAKER =
   functor (C: Ir_contents.S) ->
   functor (R: Ir_tag.S) ->
   functor (H: Ir_hash.S) ->
-    STORE with type key = C.Path.t
-           and type value = C.t
-           and type branch_id = R.t
-           and type head = H.t
-
-module Make_ext (P: Ir_bc.PRIVATE) = struct
-  module P = Ir_bc.Make_ext(P)
-  include (P: module type of P with module Private := P.Private)
-  module Ref = P.Private.Ref.Key
-  module Head = P.Private.Commit.Key
-  module Private = struct
-    include P.Private
-    let repo = P.repo
-    let contents_t = P.contents_t
-    let node_t = P.node_t
-    let commit_t = P.commit_t
-    let ref_t = P.ref_t
-    let update_node = P.update_node
-    let merge_node = P.merge_node
-    let remove_node = P.remove_node
-    let mem_node = P.mem_node
-    let read_node = P.read_node
-    let iter_node = P.iter_node
-  end
-end
+    Ir_bc.STORE_EXT
+      with type key = C.Path.t
+       and type value = C.t
+       and type branch_id = R.t
+       and type head = H.t
 
 module Make
     (AO: Ir_ao.MAKER)
@@ -104,5 +56,5 @@ struct
     module Slice = Ir_slice.Make(Contents)(Node)(Commit)
     module Sync = Ir_sync.None(H)(R)
   end
-  include Make_ext(X)
+  include Ir_bc.Make_ext(X)
 end

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -16,48 +16,14 @@
 
 (** Irmin stores *)
 
-module type STORE = sig
-  include Ir_bc.STORE
-  module Key: Ir_path.S with type t = key
-  module Val: Ir_contents.S with type t = value
-  module Ref: Ir_tag.S with type t = branch_id
-  module Head: Ir_hash.S with type t = head
-  module Private: sig
-    include Ir_bc.PRIVATE
-      with type Contents.value = value
-       and type Commit.key = head
-       and type Ref.key = branch_id
-       and type Slice.t = slice
-       and module Contents.Path = Key
-    val repo: t -> Repo.t
-    val contents_t: t -> Contents.t
-    val node_t: t -> Node.t
-    val commit_t: t -> Commit.t
-    val ref_t: t -> Ref.t
-    val read_node: t -> key -> Node.key option Lwt.t
-    val mem_node: t -> key -> bool Lwt.t
-    val update_node: t -> key -> Node.key -> unit Lwt.t
-    val merge_node: t -> key -> (head * Node.key) -> unit Ir_merge.result Lwt.t
-    val remove_node: t -> key -> unit Lwt.t
-    val iter_node: t -> Node.key ->
-      (key -> value Lwt.t -> unit Lwt.t) -> unit Lwt.t
-  end
-end
-
 module type MAKER =
   functor (C: Ir_contents.S) ->
   functor (R: Ir_tag.S) ->
   functor (H: Ir_hash.S) ->
-    STORE with type key = C.Path.t
-           and type value = C.t
-           and type branch_id = R.t
-           and type head = H.t
+    Ir_bc.STORE_EXT
+      with type key = C.Path.t
+       and type value = C.t
+       and type branch_id = R.t
+       and type head = H.t
 
 module Make (AO: Ir_ao.MAKER) (RW: Ir_rw.MAKER): MAKER
-
-module Make_ext (P: Ir_bc.PRIVATE): STORE
-  with type key = P.Contents.Path.t
-   and type value = P.Contents.value
-   and type branch_id = P.Ref.key
-   and type head = P.Ref.value
-   and type Key.step = P.Contents.Path.step

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -19,7 +19,7 @@ open Lwt
 module Log = Log.Make(struct let section = "SYNC" end)
 
 type remote =
-  | Store: (module Ir_s.STORE with type t = 'a) * 'a -> remote
+  | Store: (module Ir_bc.STORE_EXT with type t = 'a) * 'a -> remote
   | URI of string
 
 let remote_store m x = Store (m, x)
@@ -38,7 +38,7 @@ module type STORE = sig
   val push_exn: db -> ?depth:int -> remote -> unit Lwt.t
 end
 
-module Make (S: Ir_s.STORE) = struct
+module Make (S: Ir_bc.STORE_EXT) = struct
 
   module B = S.Private.Sync
   type db = S.t

--- a/lib/ir_sync_ext.mli
+++ b/lib/ir_sync_ext.mli
@@ -18,7 +18,7 @@
 
 type remote
 val remote_uri: string -> remote
-val remote_store: (module Ir_s.STORE with type t = 'a) -> 'a -> remote
+val remote_store: (module Ir_bc.STORE_EXT with type t = 'a) -> 'a -> remote
 
 module type STORE = sig
   type db
@@ -33,5 +33,5 @@ module type STORE = sig
   val push_exn: db -> ?depth:int -> remote -> unit Lwt.t
 end
 
-module Make (S: Ir_s.STORE): STORE
+module Make (S: Ir_bc.STORE_EXT): STORE
   with type db = S.t and type head = S.head

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -430,7 +430,7 @@ module Internal (Node: NODE) = struct
 
 end
 
-module Make (S: Ir_s.STORE) = struct
+module Make (S: Ir_bc.STORE_EXT) = struct
 
   module B = Ir_bc.Make_ext(S.Private)
   module P = S.Private

--- a/lib/ir_view.mli
+++ b/lib/ir_view.mli
@@ -47,7 +47,7 @@ module type S = sig
     ((head * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
 end
 
-module Make (S: Ir_s.STORE):
+module Make (S: Ir_bc.STORE_EXT):
   S with type db = S.t
      and type key = S.key
      and type value = S.value

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -23,12 +23,12 @@ module Task = Ir_task
 module View = Ir_view.Make
 module type VIEW = Ir_view.S
 module Dot = Ir_dot.Make
-module type S = Ir_s.STORE
+module type S = Ir_bc.STORE_EXT
 
 module Hash = Ir_hash
 module Path = Ir_path
 module Make = Ir_s.Make
-module Make_ext = Ir_s.Make_ext
+module Make_ext = Ir_bc.Make_ext
 
 module type RO = Ir_ro.STORE
 module type AO = Ir_ao.STORE
@@ -77,7 +77,7 @@ module Sync = Ir_sync_ext.Make
 type remote = Ir_sync_ext.remote
 
 let remote_store (type t) (module M: S with type t = t) (t:t) =
-  let module X = (M: Ir_s.STORE with type t = t) in
+  let module X = (M: Ir_bc.STORE_EXT with type t = t) in
   Ir_sync_ext.remote_store (module X) t
 
 let remote_uri = Ir_sync_ext.remote_uri

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -370,9 +370,6 @@ module type AO = sig
       provided by the backend. The operation might be blocking,
       depending on the backend. *)
 
-  val config: t -> config
-  (** [config t] is [t]'s config. *)
-
   val add: t -> value -> key Lwt.t
   (** Write the contents of a value to the store. It's the
       responsibility of the append-only store to generate a
@@ -396,9 +393,6 @@ module type LINK = sig
   include RO
 
   val create: config -> t Lwt.t
-
-  val config: t -> config
-  (** [config t] is [t]'s config. *)
 
   val add: t -> key -> value -> unit Lwt.t
   (** [add t src dst] add a link between the key [src] and the value

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1773,7 +1773,6 @@ module type S = sig
        and type Commit.key = head
        and type Ref.key = branch_id
        and type Slice.t = slice
-    val repo: t -> Repo.t
     val contents_t: t -> Contents.t
     val node_t: t -> Node.t
     val commit_t: t -> Commit.t

--- a/lib/mem/irmin_mem.ml
+++ b/lib/mem/irmin_mem.ml
@@ -30,13 +30,12 @@ module RO (K: Irmin.Hum.S) (V: Tc.S0) = struct
 
   type value = V.t
 
-  type t = { t: value KHashtbl.t; config: Irmin.config }
+  type t = { t: value KHashtbl.t }
 
-  let config t = t.config
   let table = KHashtbl.create 23
 
-  let create config =
-    Lwt.return { t = table; config }
+  let create _config =
+    Lwt.return { t = table }
 
   let read { t; _ } key =
     Log.debug "read";


### PR DESCRIPTION
`Ir_s` was the only consumer of the `Ir_bc.STORE_EXT` interface, and all it did was repack the values to match its own interface. Now, `Ir_bc` exports the final public API directly. This should make the code easier to work with.

I also removed `AO.config`, as the previous change to `Irmin_git.Internals` meant it was no longer needed (my eventual goal is that internal stores will not take config objects at all).