### PR TITLE
Allow back-ends to create their own internal stores

### DIFF
--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -642,6 +642,12 @@ module Make_ext
 
   end
 
+  type repo = {
+    config: Irmin.config;
+    g: Git_store.t;
+    ref_store: XRef.t;
+  }
+
   module XSync = struct
 
     (* FIXME: should not need to pass G.Digest and G.Inflate... *)
@@ -657,9 +663,7 @@ module Make_ext
       | None   -> Lwt.return `No_head
       | Some k -> Lwt.return (`Head (head_of_git k))
 
-    let create config =
-      let root = Irmin.Private.Conf.get config Conf.root in
-      G.create ?root ()
+    let create repo = return repo.g
 
     let fetch t ?depth ~uri tag =
       Log.debug "fetch %s" uri;
@@ -702,11 +706,7 @@ module Make_ext
     module Slice = Irmin.Private.Slice.Make(Contents)(Node)(Commit)
     module Sync = XSync
     module Repo = struct
-      type t = {
-        config: Irmin.config;
-        g: Git_store.t;
-        ref_store: Ref.t;
-      }
+      type t = repo
       let ref_t t = t.ref_store
       let commit_t t = t.g
       let node_t t = t.g

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -711,7 +711,6 @@ module Make_ext
       let commit_t t = t.g
       let node_t t = t.g
       let contents_t t = t.g
-      let config t = t.config
 
       let create config =
         Git_store.create config >>= fun g ->
@@ -726,10 +725,9 @@ module Make_ext
   include Irmin.Make_ext(P)
 
   module Internals = struct
-    let commit_of_head t h =
+    let commit_of_head repo h =
       let h = Head.to_raw h |> Cstruct.to_string |> Git.SHA.of_raw in
-      Git_store.create (Repo.config (repo t)) >>= fun g ->
-      Git_store.read g h >|= function
+      Git_store.read repo.g h >|= function
       | Some Git.Value.Commit c -> Some c
       | _ -> None
 
@@ -811,9 +809,9 @@ module type S = sig
 
     (** {1 Access to the Git objects} *)
 
-    val commit_of_head: t -> head -> Git.Commit.t option Lwt.t
-    (** [commit_of_head t h] is the commit corresponding to [h] in the
-        store [t]. *)
+    val commit_of_head: Repo.t -> head -> Git.Commit.t option Lwt.t
+    (** [commit_of_head repo h] is the commit corresponding to [h] in the
+        repository [repo]. *)
 
   end
 end

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -722,10 +722,10 @@ module Make_ext
       let config t = t.config
 
       let create config =
-        Contents.create config >>= fun contents ->
-        Node.create config     >>= fun node ->
-        Commit.create config   >>= fun commit ->
-        Ref.create config      >>= fun ref_store ->
+        X.Contents.create config >>= fun contents ->
+        Node.create config       >>= fun node ->
+        Commit.create config     >>= fun commit ->
+        Ref.create config        >>= fun ref_store ->
         return
           { contents     = contents;
             node         = node;

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -707,6 +707,33 @@ module Make_ext
     module Ref = XRef
     module Slice = Irmin.Private.Slice.Make(Contents)(Node)(Commit)
     module Sync = XSync
+    module Repo = struct
+      type t = {
+        config: Irmin.config;
+        contents: Contents.t;
+        node: Node.t;
+        commit: Commit.t;
+        ref_store: Ref.t;
+      }
+      let ref_t t = t.ref_store
+      let commit_t t = t.commit
+      let node_t t = t.node
+      let contents_t t = t.contents
+      let config t = t.config
+
+      let create config =
+        Contents.create config >>= fun contents ->
+        Node.create config     >>= fun node ->
+        Commit.create config   >>= fun commit ->
+        Ref.create config      >>= fun ref_store ->
+        return
+          { contents     = contents;
+            node         = node;
+            commit       = commit;
+            ref_store    = ref_store;
+            config       = config;
+          }
+    end
   end
   include Irmin.Make_ext(P)
 

--- a/lib/git/irmin_git.mli
+++ b/lib/git/irmin_git.mli
@@ -86,9 +86,9 @@ module type S = sig
 
     (** {1 Access to the Git objects} *)
 
-    val commit_of_head: t -> head -> Git.Commit.t option Lwt.t
-    (** [commit_of_head t h] is the commit corresponding to [h] in the
-        store [t]. *)
+    val commit_of_head: Repo.t -> head -> Git.Commit.t option Lwt.t
+    (** [commit_of_head repo h] is the commit corresponding to [h] in the
+        repository [repo]. *)
 
   end
 end

--- a/lib/git/irmin_git.mli
+++ b/lib/git/irmin_git.mli
@@ -71,7 +71,10 @@ module type LOCK = sig
   val with_lock: string -> (unit -> 'a Lwt.t) -> 'a Lwt.t
 end
 
-module AO (G: Git.Store.S): Irmin.AO_MAKER
+module AO (G: Git.Store.S) (K: Irmin.Hash.S) (V: Tc.S0) : Irmin.AO
+  with type t = G.t
+   and type key = K.t
+   and type value = V.t
 
 module RW (L: LOCK) (G: Git.Store.S) (K: Irmin.Ref.S) (V: Irmin.Hash.S):
   Irmin.RW with type key = K.t and type value = V.t

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -869,8 +869,14 @@ struct
     get t ?query ["history"] (module HTC)
 
   module Private = struct
-    include (L.Private: module type of L.Private with module Repo := L.Private.Repo)
+    include (L.Private: module type of L.Private
+      with module Repo := L.Private.Repo
+       and module Sync := L.Private.Sync)
     module Repo = Repo
+    module Sync = struct
+      include L.Private.Sync
+      let create t = create t.Repo.l
+    end
     let update_node t = t.update_node
     let merge_node t = t.merge_node
     let remove_node t = t.remove_node

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -402,7 +402,6 @@ struct
       let commit_t t = t.commit
       let node_t t = t.node
       let contents_t t = t.contents
-      let config t = t.config
 
       let create config =
         XContents.create config >>= fun contents ->
@@ -484,8 +483,6 @@ struct
     let commit_t t = LP.Repo.commit_t t.l
     let node_t t = LP.Repo.node_t t.l
     let contents_t t = LP.Repo.contents_t t.l
-
-    let config t = t.config
   end
 
   (* [t.s.uri] always point to the right location:

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -390,6 +390,33 @@ struct
     end
     module Slice = Irmin.Private.Slice.Make(Contents)(Node)(Commit)
     module Sync = Irmin.Private.Sync.None(H)(R)
+    module Repo = struct
+      type t = {
+        config: Irmin.config;
+        contents: Contents.t;
+        node: Node.t;
+        commit: Commit.t;
+        ref_store: Ref.t;
+      }
+      let ref_t t = t.ref_store
+      let commit_t t = t.commit
+      let node_t t = t.node
+      let contents_t t = t.contents
+      let config t = t.config
+
+      let create config =
+        Contents.create config >>= fun contents ->
+        Node.create config     >>= fun node ->
+        Commit.create config   >>= fun commit ->
+        Ref.create config      >>= fun ref_store ->
+        Lwt.return
+          { contents     = contents;
+            node         = node;
+            commit       = commit;
+            ref_store    = ref_store;
+            config       = config;
+          }
+    end
   end
   include Irmin.Make_ext(X)
 end
@@ -453,6 +480,11 @@ struct
       L.Repo.create config >>= fun l ->
       Lwt.return {config; h; l}
 
+    let ref_t t = LP.Repo.ref_t t.l
+    let commit_t t = LP.Repo.commit_t t.l
+    let node_t t = LP.Repo.node_t t.l
+    let contents_t t = LP.Repo.contents_t t.l
+
     let config t = t.config
   end
 
@@ -464,10 +496,6 @@ struct
     head_ref: [`Branch of Ref.t | `Head of Head.t | `Empty] ref;
     l: L.t;
     repo: Repo.t;
-    contents_t: LP.Contents.t;
-    node_t: LP.Node.t;
-    commit_t: LP.Commit.t;
-    ref_t: LP.Ref.t;
     read_node: L.key -> LP.Node.key option Lwt.t;
     mem_node: L.key -> bool Lwt.t;
     update_node: L.key -> LP.Node.key -> unit Lwt.t;
@@ -507,10 +535,6 @@ struct
   let create_aux head_ref repo l =
     let fn a =
       let l = l a in
-      let contents_t = LP.contents_t l in
-      let node_t = LP.node_t l in
-      let commit_t = LP.commit_t l in
-      let ref_t = LP.ref_t l in
       let read_node = LP.read_node l in
       let mem_node = LP.mem_node l in
       let update_node = LP.update_node l in
@@ -518,7 +542,7 @@ struct
       let merge_node = LP.merge_node l in
       let iter_node = LP.iter_node l in
       let lock = Lwt_mutex.create () in
-      { l; head_ref; contents_t; node_t; commit_t; ref_t;
+      { l; head_ref;
         read_node; mem_node; update_node; remove_node; merge_node;
         repo; lock; iter_node; }
     in
@@ -771,7 +795,7 @@ struct
     | `Empty     -> Lwt.return (`Ok [])
 
   let task_of_head t head =
-    LP.Commit.read_exn t.commit_t head >>= fun commit ->
+    LP.Commit.read_exn (Repo.commit_t t.repo) head >>= fun commit ->
     Lwt.return (LP.Commit.Val.task commit)
 
   module E = Tc.Pair (Tc.List(Head)) (Tc.Option(Tc.List(Head)))
@@ -845,12 +869,8 @@ struct
     get t ?query ["history"] (module HTC)
 
   module Private = struct
-    include L.Private
+    include (L.Private: module type of L.Private with module Repo := L.Private.Repo)
     module Repo = Repo
-    let contents_t t = t.contents_t
-    let node_t t = t.node_t
-    let commit_t t = t.commit_t
-    let ref_t t = t.ref_t
     let update_node t = t.update_node
     let merge_node t = t.merge_node
     let remove_node t = t.remove_node

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -356,15 +356,15 @@ module Low (Client: Cohttp_lwt.Client)
     (H: Irmin.Hash.S) =
 struct
   module X = struct
-    module Contents =
-      Irmin.Contents.Make(struct
-        module Key = H
-        module Val = C
-        include AO(Client)(H)(C)
-        let create config =
-          let config = Conf.add config content_type (Some "json") in
-          create (add_uri_suffix "contents" config)
-      end)
+    module XContents = struct
+      module Key = H
+      module Val = C
+      include AO(Client)(H)(C)
+      let create config =
+        let config = Conf.add config content_type (Some "json") in
+        create (add_uri_suffix "contents" config)
+    end
+    module Contents = Irmin.Contents.Make(XContents)
     module Node = struct
       module Key = H
       module Path = C.Path
@@ -405,10 +405,10 @@ struct
       let config t = t.config
 
       let create config =
-        Contents.create config >>= fun contents ->
-        Node.create config     >>= fun node ->
-        Commit.create config   >>= fun commit ->
-        Ref.create config      >>= fun ref_store ->
+        XContents.create config >>= fun contents ->
+        Node.create config      >>= fun node ->
+        Commit.create config    >>= fun commit ->
+        Ref.create config       >>= fun ref_store ->
         Lwt.return
           { contents     = contents;
             node         = node;

--- a/lib/http/irmin_http_server.ml
+++ b/lib/http/irmin_http_server.ml
@@ -413,19 +413,19 @@ module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S) = struct
       (module S.Private.Contents)
       (module S.Private.Contents.Key)
       (module S.Private.Contents.Val)
-      (fun t -> Lwt.return (S.Private.contents_t t))
+      (fun t -> Lwt.return (S.Private.Repo.contents_t (S.repo t)))
 
   let node_store = ao_store
       (module S.Private.Node)
       (module S.Private.Node.Key)
       (module S.Private.Node.Val)
-      (fun t -> Lwt.return (S.Private.node_t t))
+      (fun t -> Lwt.return (S.Private.Repo.node_t (S.repo t)))
 
   let commit_store = ao_store
       (module S.Private.Commit)
       (module S.Private.Commit.Key)
       (module S.Private.Commit.Val)
-      (fun t -> Lwt.return (S.Private.commit_t t))
+      (fun t -> Lwt.return (S.Private.Repo.commit_t (S.repo t)))
 
   let stream fn t =
     let stream, push = Lwt_stream.create () in
@@ -440,7 +440,7 @@ module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S) = struct
 
   let tag_store =
     let module T = S.Private.Ref in
-    let ref_t t _ = Lwt.return (S.Private.ref_t t) in
+    let ref_t t _ = Lwt.return (S.Private.Repo.ref_t (S.repo t)) in
     let lock3 (_, tag, _) = Lwt.return (Some tag) in
     let lock2 (_, tag) = Lwt.return (Some tag) in
     let tag': S.branch_id Irmin.Hum.t = (module S.Ref) in
@@ -545,8 +545,9 @@ module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S) = struct
     let module Graph = Irmin.Private.Node.Graph(Contents)(Node) in
     let t x _ = Lwt.return x in
     let g x _ =
-      let c = S.Private.contents_t x in
-      let n = S.Private.node_t x in
+      let repo = S.repo x in
+      let c = S.Private.Repo.contents_t repo in
+      let n = S.Private.Repo.node_t repo in
       Lwt.return (c, n)
     in
     dyn_node

--- a/lib/ir_bc.ml
+++ b/lib/ir_bc.ml
@@ -47,30 +47,7 @@ module Make (P: Ir_s.PRIVATE) = struct
   module KGraph =
     Ir_graph.Make(P.Contents.Key)(P.Node.Key)(P.Commit.Key)(Ref_store.Key)
 
-  module Repo = struct
-    type t = {
-      config: Ir_conf.t;
-      contents: P.Contents.t;
-      node: P.Node.t;
-      commit: P.Commit.t;
-      ref_store: Ref_store.t;
-    }
-
-    let create config =
-      P.Contents.create config >>= fun contents ->
-      P.Node.create config     >>= fun node ->
-      P.Commit.create config   >>= fun commit ->
-      Ref_store.create config  >>= fun ref_store ->
-      return
-        { contents     = contents;
-          node         = node;
-          commit       = commit;
-          ref_store    = ref_store;
-          config       = config;
-        }
-
-    let config t = t.config
-  end
+  module Repo = P.Repo
 
   type t = {
     repo: Repo.t;
@@ -81,10 +58,10 @@ module Make (P: Ir_s.PRIVATE) = struct
 
   let repo t = t.repo
   let task t = t.task
-  let ref_t t = t.repo.Repo.ref_store
-  let commit_t t = t.repo.Repo.commit
-  let node_t t = t.repo.Repo.node
-  let contents_t t = t.repo.Repo.contents
+  let ref_t t = Repo.ref_t t.repo
+  let commit_t t = Repo.commit_t t.repo
+  let node_t t = Repo.node_t t.repo
+  let contents_t t = Repo.contents_t t.repo
   let graph_t t = contents_t t, node_t t
   let history_t t = graph_t t, commit_t t
   let head_ref t = match t.head_ref with
@@ -364,11 +341,6 @@ module Make (P: Ir_s.PRIVATE) = struct
 
   module Private = struct
     include P
-
-    let ref_t = ref_t
-    let commit_t = commit_t
-    let contents_t = contents_t
-    let node_t = node_t
 
     let read_node t path =
       read_head_node t >>= function

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -25,3 +25,4 @@ module Make (P: Ir_s.PRIVATE): Ir_s.STORE_EXT
    and type slice = P.Slice.t
    and module Key = P.Contents.Path
    and module Private.Contents = P.Contents
+   and module Repo = P.Repo

--- a/lib/ir_commit.ml
+++ b/lib/ir_commit.ml
@@ -95,11 +95,6 @@ struct
     type key = S.key
     type value = S.value
 
-    let create config =
-      N.create config >>= fun n ->
-      S.create config >>= fun s ->
-      return (n, s)
-
     let add (_, t) = S.add t
     let mem (_, t) = S.mem t
     let read (_, t) = S.read t

--- a/lib/ir_dot.ml
+++ b/lib/ir_dot.ml
@@ -151,7 +151,7 @@ module Make (S: Ir_s.STORE_EXT) = struct
           add_edge (`Commit k) [`Style `Dashed] (`Node node);
           return_unit
       ) >>= fun () ->
-    let ref_t = S.Private.ref_t t in
+    let ref_t = S.Private.Repo.ref_t (S.repo t) in
     Ref.iter ref_t (fun r k ->
         k >>= fun k ->
         add_vertex (`Branch r) [`Shape `Plaintext; label_of_tag r; `Style `Filled];

--- a/lib/ir_node.ml
+++ b/lib/ir_node.ml
@@ -224,11 +224,6 @@ struct
 
     type t = C.t * S.t
 
-    let create config =
-      C.create config >>= fun c ->
-      S.create config >>= fun s ->
-      Lwt.return (c, s)
-
     type key = S.key
     type value = S.value
     let mem (_, t) = S.mem t

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -59,14 +59,15 @@ module type RO_MAKER =
 
 module type AO_STORE = sig
   include RO_STORE
-  val create: Ir_conf.t -> t Lwt.t
   val add: t -> value -> key Lwt.t
 end
 
 module type AO_MAKER =
   functor (K: HASH) ->
-  functor (V: Tc.S0) ->
-    AO_STORE with type key = K.t and type value = V.t
+  functor (V: Tc.S0) -> sig
+    include AO_STORE with type key = K.t and type value = V.t
+    val create: Ir_conf.t -> t Lwt.t
+  end
 
 module type CONTENTS = sig
   include Tc.S0
@@ -137,7 +138,10 @@ module type LINK_STORE = sig
 end
 
 module type LINK_MAKER =
-  functor (K: HASH) -> LINK_STORE with type key = K.t and type value = K.t
+  functor (K: HASH) -> sig
+    include LINK_STORE with type key = K.t and type value = K.t
+    val create: Ir_conf.t -> t Lwt.t
+  end
 
 module type SLICE = sig
   include Tc.S0

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -204,7 +204,6 @@ module type SYNC = sig
   type t
   type head
   type branch_id
-  val create: Ir_conf.t -> t Lwt.t
   val fetch: t -> ?depth:int -> uri:string -> branch_id ->
     [`Head of head | `No_head | `Error] Lwt.t
   val push : t -> ?depth:int -> uri:string -> branch_id -> [`Ok | `Error] Lwt.t
@@ -280,8 +279,6 @@ module type PRIVATE = sig
     with type contents = Contents.key * Contents.value
      and type node = Node.key * Node.value
      and type commit = Commit.key * Commit.value
-  module Sync: SYNC
-    with type head = Commit.key and type branch_id = Ref.key
   module Repo: sig
     type t
     val create: Ir_conf.t -> t Lwt.t
@@ -290,6 +287,11 @@ module type PRIVATE = sig
     val node_t: t -> Node.t
     val commit_t: t -> Commit.t
     val ref_t: t -> Ref.t
+  end
+  module Sync: sig
+    include SYNC
+      with type head = Commit.key and type branch_id = Ref.key
+    val create: Repo.t -> t Lwt.t
   end
 end
 

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -189,7 +189,6 @@ module type RW_MAKER =
 
 module type REF_STORE = sig
   include REACTIVE
-  val create: Ir_conf.t -> t Lwt.t
   module Key: REF with type t = key
   module Val: HASH with type t = value
 end

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -213,7 +213,6 @@ module type STORE = sig
   module Repo: sig
     type t
     val create: Ir_conf.t -> t Lwt.t
-    val config: t -> Ir_conf.t
   end
   include HIERARCHICAL
   val master: ('a -> Ir_task.t) -> Repo.t -> ('a -> t) Lwt.t
@@ -282,7 +281,6 @@ module type PRIVATE = sig
   module Repo: sig
     type t
     val create: Ir_conf.t -> t Lwt.t
-    val config: t -> Ir_conf.t
     val contents_t: t -> Contents.t
     val node_t: t -> Node.t
     val commit_t: t -> Commit.t

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -278,6 +278,15 @@ module type PRIVATE = sig
      and type commit = Commit.key * Commit.value
   module Sync: SYNC
     with type head = Commit.key and type branch_id = Ref.key
+  module Repo: sig
+    type t
+    val create: Ir_conf.t -> t Lwt.t
+    val config: t -> Ir_conf.t
+    val contents_t: t -> Contents.t
+    val node_t: t -> Node.t
+    val commit_t: t -> Commit.t
+    val ref_t: t -> Ref.t
+  end
 end
 
 module type STORE_EXT = sig
@@ -295,10 +304,7 @@ module type STORE_EXT = sig
        and type Commit.key = head
        and type Ref.key = branch_id
        and type Slice.t = slice
-    val contents_t: t -> Contents.t
-    val node_t: t -> Node.t
-    val commit_t: t -> Commit.t
-    val ref_t: t -> Ref.t
+       and type Repo.t = Repo.t
     val read_node: t -> key -> Node.key option Lwt.t
     val mem_node: t -> key -> bool Lwt.t
     val update_node: t -> key -> Node.key -> unit Lwt.t

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -319,5 +319,3 @@ module type MAKER =
        and type value = C.t
        and type branch_id = R.t
        and type head = H.t
-
-module Make (AO: AO_MAKER) (RW: RW_MAKER): MAKER

--- a/lib/ir_sync.mli
+++ b/lib/ir_sync.mli
@@ -16,4 +16,7 @@
 
 (** Store Synchronisation signatures. *)
 
-module None (H: Tc.S0) (R: Tc.S0): Ir_s.SYNC with type head = H.t and type branch_id = R.t
+module None (H: Tc.S0) (R: Tc.S0): sig
+  include Ir_s.SYNC with type head = H.t and type branch_id = R.t
+  val create: 'a -> t Lwt.t
+end

--- a/lib/ir_sync_ext.ml
+++ b/lib/ir_sync_ext.ml
@@ -79,7 +79,7 @@ module Make (S: Ir_s.STORE_EXT) = struct
       begin S.name t >>= function
         | None     -> Lwt.return `No_head
         | Some branch_id ->
-          B.create (S.Repo.config (S.repo t)) >>= fun g ->
+          B.create (S.repo t) >>= fun g ->
           B.fetch g ?depth ~uri branch_id
       end
     | Store ((module R), r) ->
@@ -126,7 +126,7 @@ module Make (S: Ir_s.STORE_EXT) = struct
       begin S.name t >>= function
         | None     -> return `Error
         | Some branch_id ->
-          B.create (S.Repo.config (S.repo t)) >>= fun g ->
+          B.create (S.repo t) >>= fun g ->
           B.push g ?depth ~uri branch_id
       end
     | Store ((module R), r) ->

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -73,6 +73,33 @@ struct
     end
     module Slice = Ir_slice.Make(Contents)(Node)(Commit)
     module Sync = Ir_sync.None(H)(R)
+    module Repo = struct
+      type t = {
+        config: Ir_conf.t;
+        contents: Contents.t;
+        node: Node.t;
+        commit: Commit.t;
+        ref_store: Ref.t;
+      }
+      let ref_t t = t.ref_store
+      let commit_t t = t.commit
+      let node_t t = t.node
+      let contents_t t = t.contents
+      let config t = t.config
+
+      let create config =
+        Contents.create config >>= fun contents ->
+        Node.create config     >>= fun node ->
+        Commit.create config   >>= fun commit ->
+        Ref.create config      >>= fun ref_store ->
+        return
+          { contents     = contents;
+            node         = node;
+            commit       = commit;
+            ref_store    = ref_store;
+            config       = config;
+          }
+    end
   end
   include Ir_bc.Make(X)
 end

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -50,11 +50,12 @@ module Make
     (H: Ir_s.HASH) =
 struct
   module X = struct
-    module Contents = Ir_contents.Make(struct
-        include AO(H)(C)
-        module Key = H
-        module Val = C
-      end)
+    module XContents = struct
+      include AO(H)(C)
+      module Key = H
+      module Val = C
+    end
+    module Contents = Ir_contents.Make(XContents)
     module Node = struct
       module Key = H
       module Val = Ir_node.Make (H)(H)(C.Path)
@@ -88,10 +89,10 @@ struct
       let config t = t.config
 
       let create config =
-        Contents.create config >>= fun contents ->
-        Node.create config     >>= fun node ->
-        Commit.create config   >>= fun commit ->
-        Ref.create config      >>= fun ref_store ->
+        XContents.create config >>= fun contents ->
+        Node.create config      >>= fun node ->
+        Commit.create config    >>= fun commit ->
+        Ref.create config       >>= fun ref_store ->
         return
           { contents     = contents;
             node         = node;

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -86,7 +86,6 @@ struct
       let commit_t t = t.commit
       let node_t t = t.node
       let contents_t t = t.contents
-      let config t = t.config
 
       let create config =
         XContents.create config >>= fun contents ->

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -506,10 +506,6 @@ module type BC = sig
 
     val create: config -> t Lwt.t
     (** [create config] connects to a repository in a backend-specific manner. *)
-
-    val config: t -> config
-    (** Recover the config passed to [create].
-     * todo: would be good to remove this, but Ir_sync_ext needs it for now. *)
   end
 
   include HRW
@@ -1737,7 +1733,6 @@ module Private: sig
     module Repo: sig
       type t
       val create: config -> t Lwt.t
-      val config: t -> config
       val contents_t: t -> Contents.t
       val node_t: t -> Node.t
       val commit_t: t -> Commit.t
@@ -2317,3 +2312,4 @@ module Make_ext (P: Private.S): S
    and type branch_id = P.Ref.key
    and type head = P.Ref.value
    and type Key.step = P.Contents.Path.step
+   and module Repo = P.Repo

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1741,6 +1741,16 @@ module Private: sig
 
     module Sync: Sync.S with type head = Commit.key and type branch_id = Ref.key
 
+    (** Private repositories. *)
+    module Repo: sig
+      type t
+      val create: config -> t Lwt.t
+      val config: t -> config
+      val contents_t: t -> Contents.t
+      val node_t: t -> Node.t
+      val commit_t: t -> Commit.t
+      val ref_t: t -> Ref.t
+    end
   end
 
 end
@@ -1773,10 +1783,7 @@ module type S = sig
        and type Commit.key = head
        and type Ref.key = branch_id
        and type Slice.t = slice
-    val contents_t: t -> Contents.t
-    val node_t: t -> Node.t
-    val commit_t: t -> Commit.t
-    val ref_t: t -> Ref.t
+       and type Repo.t = Repo.t
     val read_node: t -> key -> Node.key option Lwt.t
     val mem_node: t -> key -> bool Lwt.t
     val update_node: t -> key -> Node.key -> unit Lwt.t

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -993,8 +993,6 @@ module Ref: sig
 
     include RRW
 
-    val create: config -> t Lwt.t
-
     module Key: S with type t = key
     (** Base functions on keys. *)
 

--- a/lib/mirage/irmin_mirage.mli
+++ b/lib/mirage/irmin_mirage.mli
@@ -48,7 +48,10 @@ module Irmin_git: sig
   (** The configuration key to set the local Git repository's bare
       attribute. See {!Irmin_git.config}.*)
 
-  module AO (G: Git.Store.S): Irmin.AO_MAKER
+  module AO (G: Git.Store.S) (K: Irmin.Hash.S) (V: Tc.S0) : Irmin.AO
+    with type t = G.t
+     and type key = K.t
+     and type value = V.t
   (** Embed an append-only store into a Git repository. Contents will
       be written in {i .git/objects/} and might be cleaned-up if you
       run {i git gc} manually. *)

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -130,7 +130,10 @@ module Irmin_git: sig
   (** [level] is the Zlib compression level used to compress
       persisting values. *)
 
-  module AO (G: Git.Store.S): Irmin.AO_MAKER
+  module AO (G: Git.Store.S) (K: Irmin.Hash.S) (V: Tc.S0) : Irmin.AO
+    with type t = G.t
+     and type key = K.t
+     and type value = V.t
   (** Embed an append-only store into a Git repository. Contents will
       be written in {i .git/objects/} and might be cleaned-up if you
       run {i git gc} manually. *)

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -21,7 +21,7 @@ open Irmin_unix
 module type Test_S = sig
   include Irmin.S
   module Internals: sig
-    val commit_of_head: t -> head -> Git.Commit.t option Lwt.t
+    val commit_of_head: Repo.t -> head -> Git.Commit.t option Lwt.t
   end
 end
 

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -291,7 +291,6 @@ module Make (S: Test_S) = struct
         let i = Int64.of_int date in
         Irmin.Task.create ~date:i ~owner:"test" "Test commit" ~uid:i
       in
-      S.master task repo >>= fun t ->
 
       kv1 ~repo x >>= fun kv1 ->
       let g = g repo and h = h repo and c = S.Private.Repo.commit_t repo in
@@ -323,7 +322,7 @@ module Make (S: Test_S) = struct
       assert_equal (module Set(KC)) "g2" [kr1; kr2] kr2s;
 
       if x.kind = `Git then (
-        S.Internals.commit_of_head (t 0) kr1 >|= function
+        S.Internals.commit_of_head repo kr1 >|= function
         | None   -> Alcotest.fail "cannot read the Git internals"
         | Some c ->
           let name = c.Git.Commit.author.Git.User.name in


### PR DESCRIPTION
Private.Repo is now provided by each back-end, allowing them to share state between their internal stores. For example, `Irmin_git` now creates a single underlying `G.t` store.

There are lots of changes to the unit tests because using `Private.Repo.ref_t` and similar no longer need a task.

`AO` stores are no longer required to provide `create`, so the dummy `Ir_node.Graph.Store.create` and `Ir_commit.History.Store.create` functions are gone.

`Sync.create` now takes a `Repo.t`, not a `config`, allowing `Repo.config` to be removed (and allowing sharing of state with the sync code).