### PR TITLE
Move BC operations that ignore the branch to BC.Repo

### DIFF
--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -25,4 +25,4 @@ module Make (P: Ir_s.PRIVATE): Ir_s.STORE_EXT
    and type slice = P.Slice.t
    and module Key = P.Contents.Path
    and module Private.Contents = P.Contents
-   and module Repo = P.Repo
+   and type Repo.t = P.Repo.t

--- a/lib/ir_dot.ml
+++ b/lib/ir_dot.ml
@@ -42,7 +42,7 @@ module Make (S: Ir_s.STORE_EXT) = struct
       (match depth with None -> "<none>" | Some d -> string_of_int d)
       html
       (match full with None -> "<none>" | Some b -> string_of_bool b);
-    S.export ?full ?depth t >>= fun slice ->
+    S.Repo.export ?full ?depth (S.repo t) >>= fun slice ->
     let vertex = Hashtbl.create 102 in
     let add_vertex v l = Hashtbl.add vertex v l in
     let mem_vertex v = Hashtbl.mem vertex v in

--- a/lib/mirage/irmin_mirage.ml
+++ b/lib/mirage/irmin_mirage.ml
@@ -57,7 +57,7 @@ module KV_RO (C: CONTEXT) (I: Git.Inflate.S) = struct
     S.head t.t >>= function
     | None   -> Lwt.return "empty HEAD"
     | Some h ->
-      S.task_of_head t.t h >|= fun task ->
+      S.Repo.task_of_head (S.repo t.t) h >|= fun task ->
       Printf.sprintf
         "commit: %s\n\
          Author: %s\n\

--- a/lib_test/test_memory.ml
+++ b/lib_test/test_memory.ml
@@ -18,9 +18,8 @@ open Test_common
 let (>>=) = Lwt.(>>=)
 
 let clean config (module S: Test_S) () =
-  S.Repo.create config >>= S.empty Irmin.Task.none >>= fun t ->
-  S.branches (t ()) >>= fun branches ->
-  Lwt_list.iter_p (S.remove_branch (t ())) branches
+  S.Repo.create config >>= fun repo ->
+  S.Repo.branches repo >>= Lwt_list.iter_p (S.Repo.remove_branch repo)
 
 let suite k =
   let config = Irmin_mem.config () in

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -493,7 +493,7 @@ module Make (S: Test_S) = struct
       let v2 = string x "X2" in
 
       S.update (t1 "update") (p ["a";"b"]) v1 >>= fun () ->
-      S.remove_branch (t1 "remove-tag") Ref.Key.master >>= fun () ->
+      S.Repo.remove_branch repo Ref.Key.master >>= fun () ->
       State.check "init" (0, 0) (0, 0, 0) state >>= fun () ->
 
       watch 100 >>= fun () ->
@@ -506,7 +506,7 @@ module Make (S: Test_S) = struct
       S.update (t2 "update") (p ["a";"c"]) v1 >>= fun () ->
       State.check "watches updates" (1, 2) (100, 100, 0) state >>= fun () ->
 
-      S.remove_branch (t1 "remove-tag") Ref.Key.master >>= fun () ->
+      S.Repo.remove_branch repo Ref.Key.master >>= fun () ->
       State.check "watches removes" (1, 2) (100, 100, 100) state >>= fun () ->
 
       Lwt_list.iter_s (fun f -> f ()) !stops_0 >>= fun () ->
@@ -531,7 +531,7 @@ module Make (S: Test_S) = struct
           S.Private.Ref.remove (S.Private.Repo.ref_t repo) tag
         ) in
 
-      S.watch_branches (t1 "watch-tags") (fun _ -> State.process state)
+      S.Repo.watch_branches repo (fun _ -> State.process state)
       >>= fun unwatch ->
 
       add    true (0,  0, 0) 10 ~first:true >>= fun () ->
@@ -871,7 +871,7 @@ module Make (S: Test_S) = struct
       let b = string x "haha" in
       S.update (t "slice") (p ["x";"a"]) a >>= fun () ->
       S.update (t "slice") (p ["x";"b"]) b >>= fun () ->
-      S.export (t "export") >>= fun slice ->
+      S.Repo.export repo >>= fun slice ->
       let str = Tc.write_string (module S.Private.Slice) slice in
       let slice' = Tc.read_string (module S.Private.Slice) str in
       assert_equal (module S.Private.Slice) "slices" slice slice';
@@ -912,7 +912,7 @@ module Make (S: Test_S) = struct
           wait 10
         | `Empty_head -> Alcotest.fail "empty head"
       in
-      S.remove_branch (t "prepare") (S.Ref.of_hum "test") >>= fun () ->
+      S.Repo.remove_branch repo (S.Ref.of_hum "test") >>= fun () ->
       Lwt.join [clone (); clone (); clone (); clone ()] >>= fun () ->
       let t = get_result () in
 
@@ -1002,8 +1002,8 @@ module Make (S: Test_S) = struct
       let vx = string x "VX" in
       S.of_branch_id Irmin_unix.task tagx repo >>= fun tx ->
       S.of_branch_id Irmin_unix.task tagy repo >>= fun ty ->
-      S.remove_branch (tx "?") tagx >>= fun () ->
-      S.remove_branch (tx "?") tagy >>= fun () ->
+      S.Repo.remove_branch repo tagx >>= fun () ->
+      S.Repo.remove_branch repo tagy >>= fun () ->
 
       S.update (tx "update") xy vx >>= fun () ->
       S.update_branch (ty "update-tag") tagx >>= fun () ->
@@ -1170,7 +1170,7 @@ module Make (S: Test_S) = struct
       let ta = Irmin.Task.empty in
       View.make_head (t "mk-head") ta ~parents:[r1;r2] ~contents:v3 >>= fun h ->
 
-      S.task_of_head (t "task") h >>= fun ta' ->
+      S.Repo.task_of_head repo h >>= fun ta' ->
       assert_equal (module Irmin.Task) "task" ta ta';
 
       S.of_head Irmin_unix.task h repo >>= fun tt ->


### PR DESCRIPTION
These are: `branches`, `remove_branch`, `heads`, `watch_branches`, `import`, `export`, and `task_of_head`.

This should make the API clearer, by making it obvious whether the current branch is or isn't used. Callers of the APIs have been updated in the obvious way (e.g. calling `S.Repo.branches (S.repo t)`), but in future some refactoring may simplify this. For example, the HTTP server currently opens a branch for each request, but ignores it for repo operations.

Note that `heads` used to ensure that the current branch's head was included in the returned set (which made a difference for anonymous branches). This feature has been removed. Ideally, we should use OCaml's GC to track which anonymous branches are still being used and return all of them.