### PR TITLE
Change "type head" to "type commit_id"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,13 @@
   `Repo.config` to be removed and allowing sharing of the back-end's
   internal state with the sync code. For example, the Git back-end
   no longer needs to create a new Git store object for sync.
+* Change `type head` to `type commit_id`. `head` was confusing because
+  it applied to all commits, not just branch heads. Putting `id` in the
+  name makes it clear that this is just data and (for example) holding
+  an ID will not prevent the corresponding commit from being GC'd (once
+  we have GC). `of_head` is now `of_commit_id`, `task_of_head` is now
+  `task_of_commit_id`, `Internals.commit_of_head` is now
+  `Internals.commit_of_id` and `BC.Head` is now `BC.Hash`.
 
 
 ### 0.9.10

--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -349,7 +349,7 @@ let snapshot = {
       run begin
         store >>= fun t ->
         S.head_exn (t "Snapshot") >>= fun k ->
-        print "%s" (S.Head.to_hum k);
+        print "%s" (S.Hash.to_hum k);
         return_unit
       end
     in
@@ -368,7 +368,7 @@ let revert = {
     let revert (S ((module S), store)) snapshot =
       run begin
         store >>= fun t ->
-        let s = S.Head.of_hum snapshot in
+        let s = S.Hash.of_hum snapshot in
         S.update_head (t "Revert") s
       end
     in

--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -650,7 +650,7 @@ module Make_ext
     module Sync = Git.Sync.Make(IO)(G)
 
     type t = G.t
-    type head = X.Commit.key
+    type commit_id = X.Commit.key
     type branch_id = XRef.key
 
     let head_of_git key = H.of_raw (X.GK.to_raw (Git.SHA.of_commit key))
@@ -723,8 +723,8 @@ module Make_ext
   include Irmin.Make_ext(P)
 
   module Internals = struct
-    let commit_of_head repo h =
-      let h = Head.to_raw h |> Cstruct.to_string |> Git.SHA.of_raw in
+    let commit_of_id repo h =
+      let h = Hash.to_raw h |> Cstruct.to_string |> Git.SHA.of_raw in
       Git_store.read repo.g h >|= function
       | Some Git.Value.Commit c -> Some c
       | _ -> None
@@ -804,13 +804,7 @@ module type S = sig
   include Irmin.S
 
   module Internals: sig
-
-    (** {1 Access to the Git objects} *)
-
-    val commit_of_head: Repo.t -> head -> Git.Commit.t option Lwt.t
-    (** [commit_of_head repo h] is the commit corresponding to [h] in the
-        repository [repo]. *)
-
+    val commit_of_id: Repo.t -> commit_id -> Git.Commit.t option Lwt.t
   end
 end
 
@@ -821,6 +815,6 @@ module type S_MAKER =
     S with type key = C.Path.t
        and type value = C.t
        and type branch_id = R.t
-       and type head = H.t
+       and type commit_id = H.t
 
 include Conf

--- a/lib/git/irmin_git.mli
+++ b/lib/git/irmin_git.mli
@@ -86,8 +86,8 @@ module type S = sig
 
     (** {1 Access to the Git objects} *)
 
-    val commit_of_head: Repo.t -> head -> Git.Commit.t option Lwt.t
-    (** [commit_of_head repo h] is the commit corresponding to [h] in the
+    val commit_of_id: Repo.t -> commit_id -> Git.Commit.t option Lwt.t
+    (** [commit_of_id repo h] is the commit corresponding to [h] in the
         repository [repo]. *)
 
   end
@@ -100,7 +100,7 @@ module type S_MAKER =
     S with type key = C.Path.t
        and type value = C.t
        and type branch_id = R.t
-       and type head = H.t
+       and type commit_id = H.t
 
 module Memory (IO: Git.Sync.IO) (I: Git.Inflate.S):
   S_MAKER

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -21,7 +21,7 @@ module Make (P: Ir_s.PRIVATE): Ir_s.STORE_EXT
   with type key = P.Contents.Path.t
    and type value = P.Contents.value
    and type branch_id = P.Ref.key
-   and type head = P.Commit.key
+   and type commit_id = P.Commit.key
    and type slice = P.Slice.t
    and module Key = P.Contents.Path
    and module Private.Contents = P.Contents

--- a/lib/ir_sync.ml
+++ b/lib/ir_sync.ml
@@ -18,7 +18,7 @@ open Lwt
 
 module None (H: Tc.S0) (R: Tc.S0) = struct
   type t = unit
-  type head = H.t
+  type commit_id = H.t
   type branch_id = R.t
   let create _ = return_unit
   let fetch () ?depth:_ ~uri:_ _tag = return `Error

--- a/lib/ir_sync.mli
+++ b/lib/ir_sync.mli
@@ -17,6 +17,6 @@
 (** Store Synchronisation signatures. *)
 
 module None (H: Tc.S0) (R: Tc.S0): sig
-  include Ir_s.SYNC with type head = H.t and type branch_id = R.t
+  include Ir_s.SYNC with type commit_id = H.t and type branch_id = R.t
   val create: 'a -> t Lwt.t
 end

--- a/lib/ir_sync_ext.mli
+++ b/lib/ir_sync_ext.mli
@@ -22,10 +22,10 @@ val remote_store: (module Ir_s.STORE_EXT with type t = 'a) -> 'a -> remote
 
 module type STORE = sig
   type db
-  type head
+  type commit_id
   val fetch: db -> ?depth:int -> remote ->
-    [`Head of head | `No_head | `Error] Lwt.t
-  val fetch_exn: db -> ?depth:int -> remote -> head Lwt.t
+    [`Head of commit_id | `No_head | `Error] Lwt.t
+  val fetch_exn: db -> ?depth:int -> remote -> commit_id Lwt.t
   val pull: db -> ?depth:int -> remote -> [`Merge|`Update] ->
     [`Ok | `No_head | `Error] Ir_merge.result Lwt.t
   val pull_exn: db -> ?depth:int -> remote -> [`Merge|`Update] -> unit Lwt.t
@@ -34,4 +34,4 @@ module type STORE = sig
 end
 
 module Make (S: Ir_s.STORE_EXT): STORE
-  with type db = S.t and type head = S.head
+  with type db = S.t and type commit_id = S.commit_id

--- a/lib/ir_view.mli
+++ b/lib/ir_view.mli
@@ -40,15 +40,15 @@ module type S = sig
   end
   val actions: t -> Action.t list
   val diff: t -> t -> (key * value Ir_watch.diff) list Lwt.t
-  type head
-  val parents: t -> head list
-  val make_head: db -> Ir_task.t -> parents:head list -> contents:t -> head Lwt.t
-  val watch_path: db -> key -> ?init:(head * t) ->
-    ((head * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
+  type commit_id
+  val parents: t -> commit_id list
+  val make_head: db -> Ir_task.t -> parents:commit_id list -> contents:t -> commit_id Lwt.t
+  val watch_path: db -> key -> ?init:(commit_id * t) ->
+    ((commit_id * t) Ir_watch.diff -> unit Lwt.t) -> (unit -> unit Lwt.t) Lwt.t
 end
 
 module Make (S: Ir_s.STORE_EXT):
   S with type db = S.t
      and type key = S.key
      and type value = S.value
-     and type head = S.head
+     and type commit_id = S.commit_id

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -171,9 +171,9 @@ let remote_store (type t) (module M: S with type t = t) (t:t) =
 
 let remote_uri = Ir_sync_ext.remote_uri
 
-module type BASIC = S with type branch_id = string and type head = Hash.SHA1.t
+module type BASIC = S with type branch_id = string and type commit_id = Hash.SHA1.t
 
-module type T = S with type branch_id = string and type head = Hash.SHA1.t
+module type T = S with type branch_id = string and type commit_id = Hash.SHA1.t
 
 let with_hrw_view (type store) (type path) (type view)
   (module V : VIEW with type t = view and type db = store and type key = path)

--- a/lib/mirage/irmin_mirage.ml
+++ b/lib/mirage/irmin_mirage.ml
@@ -57,14 +57,14 @@ module KV_RO (C: CONTEXT) (I: Git.Inflate.S) = struct
     S.head t.t >>= function
     | None   -> Lwt.return "empty HEAD"
     | Some h ->
-      S.Repo.task_of_head (S.repo t.t) h >|= fun task ->
+      S.Repo.task_of_commit_id (S.repo t.t) h >|= fun task ->
       Printf.sprintf
         "commit: %s\n\
          Author: %s\n\
          Date: %Ld\n\
          \n\
          %s\n"
-        (S.Head.to_hum h)
+        (S.Hash.to_hum h)
         (Irmin.Task.owner task)
         (Irmin.Task.date task)
         (String.concat "\n" @@ Irmin.Task.messages task)

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -21,7 +21,7 @@ open Irmin_unix
 module type Test_S = sig
   include Irmin.S
   module Internals: sig
-    val commit_of_head: Repo.t -> head -> Git.Commit.t option Lwt.t
+    val commit_of_id: Repo.t -> commit_id -> Git.Commit.t option Lwt.t
   end
 end
 
@@ -89,7 +89,7 @@ module Make (S: Irmin.S) = struct
 
   module KV = S.Private.Contents.Key
   module KN = S.Private.Node.Key
-  module KC = S.Head
+  module KC = S.Hash
 
   module RV = Tc.App1(Irmin.Merge.Result)(Tc.Option(KV))
   module RN = Tc.App1(Irmin.Merge.Result)(KN)
@@ -120,7 +120,7 @@ let create: (module Irmin.S_MAKER) -> [`String | `Json] -> (module Test_S) =
     let module S = struct
       include B(C)(Irmin.Ref.String)(Irmin.Hash.SHA1)
       module Internals = struct
-        let commit_of_head _t _head = failwith "Only used for testing Git stores"
+        let commit_of_id _t _id = failwith "Only used for testing Git stores"
       end
     end
     in (module S)


### PR DESCRIPTION
Change `type head` to `type commit_id`. `head` was confusing because it applied to all commits, not just branch heads. Putting `id` in the name makes it clear that this is just data and (for example) holding
an ID will not prevent the corresponding commit from being GC'd (once we have GC). `of_head` is now `of_commit_id`, `task_of_head` is now `task_of_commit_id`, `Internals.commit_of_head` is now `Internals.commit_of_id` and `BC.Head` is now `BC.Hash`.

(on top of #319)