### PR TITLE
CLI: Add support for launchd

### DIFF
--- a/examples/org.mirage.irmind.plist
+++ b/examples/org.mirage.irmind.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.mirage.irmind</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/path/to/irmin</string>
+		<string>init</string>
+		<string>--root</string>
+		<string>/tmp/foo</string>
+		<string>-d</string>
+		<string>--address</string>
+		<string>launchd://Listener</string>
+	</array>
+	<key>Sockets</key>
+	<dict>
+
+		<key>Listener</key>
+		<dict>
+			<key>SockServiceName</key>
+			<string>8081</string>
+			<key>SockType</key>
+			<string>stream</string>
+			<key>SockFamily</key>
+			<string>IPv4</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/opam
+++ b/opam
@@ -50,5 +50,6 @@ depopts: [
 conflicts: [
   "cohttp" {< "0.18.3"}
   "git"    {< "1.7.1"}
+  "conduit" {< "0.9.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
The `--address` argument of the CLI now supports a URI
`launchd://<name>` where `<name>` corresponds to the section in
the property list file (see examples/org.mirage.irmind.plist).

To make the example work:

1. edit the .plist to contain the full path to the binary, and customise
   the program arguments
2. install the .plist somewhere sensible (e.g. ~/Library/LaunchAgents)
3. `launchctl load <.plist path>`
4. connect to port 8080

This requires [mirage/ocaml-conduit#96]

Signed-off-by: David Scott <dave.scott@unikernel.com>