### PR TITLE
Fix step type

### DIFF
--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -813,6 +813,7 @@ module type S_MAKER =
   functor (R: Irmin.Ref.S) ->
   functor (H: Irmin.Hash.S) ->
     S with type key = C.Path.t
+       and module Key = C.Path
        and type value = C.t
        and type branch_id = R.t
        and type commit_id = H.t

--- a/lib/git/irmin_git.mli
+++ b/lib/git/irmin_git.mli
@@ -98,6 +98,7 @@ module type S_MAKER =
   functor (R: Irmin.Ref.S) ->
   functor (H: Irmin.Hash.S) ->
     S with type key = C.Path.t
+       and module Key = C.Path
        and type value = C.t
        and type branch_id = R.t
        and type commit_id = H.t

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -325,6 +325,7 @@ module type MAKER =
   functor (H: HASH) ->
     STORE_EXT
       with type key = C.Path.t
+       and module Key = C.Path
        and type value = C.t
        and type branch_id = R.t
        and type commit_id = H.t

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -432,7 +432,6 @@ end
 
 module Make (S: Ir_s.STORE_EXT) = struct
 
-  module B = Ir_bc.Make(S.Private)
   module P = S.Private
 
   module Graph = Ir_node.Graph(P.Contents)(P.Node)
@@ -443,12 +442,12 @@ module Make (S: Ir_s.STORE_EXT) = struct
 
   module Contents = struct
 
-    type key = S.t * B.Private.Contents.key
+    type key = S.t * S.Private.Contents.key
 
     type contents_or_key =
       | Key of key
-      | Contents of B.value
-      | Both of key * B.value
+      | Contents of S.value
+      | Both of key * S.value
 
     type t = contents_or_key ref
     (* Same as [Contents.t] but can either be a raw contents or a key

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1795,6 +1795,7 @@ module type S_MAKER =
   functor (R: Ref.S) ->
   functor (H: Hash.S) ->
     S with type key = C.Path.t
+       and module Key = C.Path
        and type value = C.t
        and type branch_id = R.t
        and type commit_id = H.t


### PR DESCRIPTION
Expose `Store.Key = Contents.Path` in `Irmin.Maker`. Otherwise, the type of steps is abstract.

Also, I included a couple of minor clean-up patches in this PR that I've been too lazy to submit on their own. Let me know if you want them split out into their own PR.