### PR TITLE
Add fold to RO

### DIFF
--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -237,6 +237,11 @@ module RO (Client: Cohttp_lwt.Client) (K: Irmin.Hum.S) (V: Tc.S0) = struct
     let fn key = fn key (read_exn t key) in
     get_stream t ["iter"] (module K) >>= Lwt_stream.iter_p fn
 
+  let fold t fn acc =
+    let fn key acc = fn key (read_exn t key) acc in
+    get_stream t ["fold"] (module K) >>= fun stream ->
+    Lwt_stream.fold_s fn stream acc
+
 end
 
 module AO (Client: Cohttp_lwt.Client) (K: Irmin.Hash.S) (V: Tc.S0) = struct
@@ -281,6 +286,7 @@ module RW (Client: Cohttp_lwt.Client) (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let read_exn t = RO.read_exn t.t
   let mem t = RO.mem t.t
   let iter t = RO.iter t.t
+  let fold t = RO.fold t.t
 
   let update t key value =
     post t ["update"; K.to_hum key] ~body:(v, value) Tc.unit
@@ -640,6 +646,11 @@ struct
   let iter t fn =
     let fn key = fn key (read_exn t key) in
     get_stream t ["iter"] (module Key) >>= Lwt_stream.iter_p fn
+
+  let fold t fn acc =
+    let fn key acc = fn key (read_exn t key) acc in
+    get_stream t ["fold"] (module Key) >>= fun stream ->
+    Lwt_stream.fold_s fn stream acc
 
   let update t key value =
     post t ["update"; Key.to_hum key] ~body:(v, value) head_tc >>= fun h ->

--- a/lib/ir_commit.ml
+++ b/lib/ir_commit.ml
@@ -137,6 +137,8 @@ struct
 
     let iter (_, t) fn = S.iter t fn
 
+    let fold (_, t) fn acc = S.fold t fn acc
+
     module Key = S.Key
     module Val = struct
       include S.Val

--- a/lib/ir_node.ml
+++ b/lib/ir_node.ml
@@ -286,6 +286,8 @@ struct
 
     let iter (_, t) fn = S.iter t fn
 
+    let fold (_, t) fn acc = S.fold t fn acc
+
     module Key = S.Key
     module Val = struct
       include S.Val

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -49,6 +49,7 @@ module type RO_STORE = sig
   val read_exn: t -> key -> value Lwt.t
   val mem: t -> key -> bool Lwt.t
   val iter: t -> (key -> value Lwt.t -> unit Lwt.t) -> unit Lwt.t
+  val fold: t -> (key -> value Lwt.t -> 'a -> 'a Lwt.t) -> 'a -> 'a Lwt.t
 end
 
 module type RO_MAKER =

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -355,6 +355,8 @@ module type RO = sig
   (** [iter t fn] call the function [fn] on all [t]'s keys and
       values. *)
 
+  val fold: t -> (key -> value Lwt.t -> 'a -> 'a Lwt.t) -> 'a -> 'a Lwt.t
+
 end
 
 (** Append-only store. *)

--- a/lib/mem/irmin_mem.ml
+++ b/lib/mem/irmin_mem.ml
@@ -57,6 +57,11 @@ module RO (K: Irmin.Hum.S) (V: Tc.S0) = struct
     KHashtbl.iter (fun k v -> todo := (fn k (Lwt.return v)) :: !todo) t;
     Lwt_list.iter_p (fun x -> x) !todo
 
+  let fold { t; _ } fn acc =
+    Log.debug "fold";
+    KHashtbl.fold (fun k v acc ->
+		   acc >>= fun acc ->
+		   fn k (Lwt.return v) acc) t (Lwt.return acc)
 end
 
 module AO (K: Irmin.Hash.S) (V: Tc.S0) = struct
@@ -104,6 +109,7 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let read_exn t = RO.read_exn t.t
   let mem t = RO.mem t.t
   let iter t = RO.iter t.t
+  let fold t = RO.fold t.t
   let watch_key t = W.watch_key t.w
   let watch t = W.watch t.w
   let unwatch t = W.unwatch t.w


### PR DESCRIPTION
Hi,

This pull request isn't there to be actually merged but more like to understand how it is possible to simply fold the content of an Irmin store.

My first idea was to implement a fold function alongside iter in RO, but this might not be the best solution since it introduce some changes in Irmin's API and might break a few third party backends.

I might have missed a few things, I mostly started implementing this since it looked simple enough and allowed me to understand a bit better Irmin's codebase, but if there is a simpler solution to do a fold on an Irmin store (other than relying on iter, which sounds like a bad idea since most iter implementations within Irmin use `fold_p`)

Thank you for your time :)
