### PR TITLE
Add directory metadata

### DIFF
--- a/bin/ir_resolver.ml
+++ b/bin/ir_resolver.ml
@@ -26,7 +26,7 @@ let create: (module Irmin.S_MAKER) -> contents -> (module Irmin.S) =
 
 let mem_store = create (module Irmin_mem.Make)
 let irf_store = create (module Irmin_fs.Make)
-let http_store = create (module Irmin_http.Make)
+let http_store = create (module Irmin_http.Make(Irmin.Metadata.None))
 let git_store = create (module Irmin_git.FS)
 
 let mk_store = function

--- a/lib/git/irmin_git.mli
+++ b/lib/git/irmin_git.mli
@@ -18,6 +18,8 @@
 
 (* Discard the hash implementation passed in parameter of the functors. *)
 
+module Metadata: Irmin.Metadata.S with type t = [`Normal | `Exec | `Link]
+
 val config:
   ?config:Irmin.config ->
   ?root:string -> ?head:Git.Reference.t -> ?bare:bool -> ?level:int -> unit ->
@@ -57,9 +59,10 @@ module Irmin_value_store
 
   module Node: Irmin.Private.Node.STORE
     with type key = H.t
-     and type Val.contents = Contents.key
+     and type Val.raw_contents = Contents.key
      and module Key = H
      and module Path = Contents.Val.Path
+     and module Val.Metadata = Metadata
 
   module Commit: Irmin.Private.Commit.STORE
     with type key = H.t
@@ -103,6 +106,7 @@ module type S_MAKER =
        and type value = C.t
        and type branch_id = R.t
        and type commit_id = H.t
+       and module Private.Node.Val.Metadata = Metadata
 
 module Memory (IO: Git.Sync.IO) (I: Git.Inflate.S):
   S_MAKER

--- a/lib/http/irmin_http.ml
+++ b/lib/http/irmin_http.ml
@@ -352,6 +352,7 @@ module RW (Client: Cohttp_lwt.Client) (K: Irmin.Hum.S) (V: Tc.S0) = struct
 end
 
 module Low (Client: Cohttp_lwt.Client)
+    (M: Irmin.Metadata.S)
     (C: Irmin.Contents.S)
     (R: Irmin.Ref.S)
     (H: Irmin.Hash.S) =
@@ -370,7 +371,7 @@ struct
       module X = struct
         module Key = H
         module Path = C.Path
-        module Val = Irmin.Private.Node.Make(H)(H)(C.Path)
+        module Val = Irmin.Private.Node.Make(H)(H)(C.Path)(M)
         include AO(Client)(Key)(Val)
       end
       include Irmin.Private.Node.Store(Contents)(X)
@@ -430,6 +431,7 @@ struct
 end
 
 module Make (Client: Cohttp_lwt.Client)
+    (M: Irmin.Metadata.S)
     (C: Irmin.Contents.S)
     (R: Irmin.Ref.S)
     (H: Irmin.Hash.S) =
@@ -473,7 +475,7 @@ struct
   (* The high-level bindings: every high-level operation is simply
      forwarded to the HTTP server. *much* more efficient than using
      [L]. *)
-  module L = Low(Client)(Val)(Ref)(Hash)
+  module L = Low(Client)(M)(Val)(Ref)(Hash)
   module LP = L.Private
   module S  = RW(Client)(Key)(Val)
 

--- a/lib/http/irmin_http.mli
+++ b/lib/http/irmin_http.mli
@@ -26,5 +26,5 @@ val content_type: string option Irmin.Private.Conf.key
 module AO (C: Cohttp_lwt.Client): Irmin.AO_MAKER
 module RW (C: Cohttp_lwt.Client): Irmin.RW_MAKER
 
-module Make (C: Cohttp_lwt.Client): Irmin.S_MAKER
-module Low (C: Cohttp_lwt.Client): Irmin.S_MAKER
+module Make (C: Cohttp_lwt.Client) (M: Irmin.Metadata.S): Irmin.S_MAKER
+module Low (C: Cohttp_lwt.Client) (M: Irmin.Metadata.S): Irmin.S_MAKER

--- a/lib/http/irmin_http_server.ml
+++ b/lib/http/irmin_http_server.ml
@@ -577,7 +577,7 @@ module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S) = struct
            let node = Node.Key.of_hum node in
            let read =
              let aux (c, n) path =
-               Graph.read_contents_exn n node path >>= fun k ->
+               Graph.read_contents_exn n node path >>= fun (k, _meta) ->
                Contents.read_exn c k
              in
              list aux
@@ -585,7 +585,7 @@ module Make (HTTP: Cohttp_lwt.Server) (D: DATE) (S: Irmin.S) = struct
            let update =
              let aux (c, n) path value =
                Contents.add c value >>= fun k ->
-               Graph.add_contents n node path k
+               Graph.add_contents n node path (k, Node.Val.Metadata.default)
              in
              list aux
            in

--- a/lib/ir_bc.mli
+++ b/lib/ir_bc.mli
@@ -25,4 +25,5 @@ module Make (P: Ir_s.PRIVATE): Ir_s.STORE_EXT
    and type slice = P.Slice.t
    and module Key = P.Contents.Path
    and module Private.Contents = P.Contents
+   and module Private.Node.Val.Metadata = P.Node.Val.Metadata
    and type Repo.t = P.Repo.t

--- a/lib/ir_dot.ml
+++ b/lib/ir_dot.ml
@@ -134,7 +134,7 @@ module Make (S: Ir_s.STORE_EXT) = struct
         return_unit
       ) >>= fun () ->
     Slice.iter_nodes slice (fun (k, t) ->
-        Node.Val.iter_contents t (fun l v ->
+        Node.Val.iter_contents t (fun l (v, _meta) ->
             add_edge (`Node k) [`Style `Dotted; label_of_step l] (`Contents v)
           );
         Node.Val.iter_succ t (fun l n ->

--- a/lib/ir_node.mli
+++ b/lib/ir_node.mli
@@ -18,10 +18,13 @@
 (** Nodes represent structured values serialized in the block
     store. *)
 
-module Make (C: Tc.S0) (N: Tc.S0) (P: Ir_s.PATH):
-  Ir_s.NODE with type contents = C.t
+module No_metadata: Ir_s.METADATA with type t = unit
+
+module Make (C: Tc.S0) (N: Tc.S0) (P: Ir_s.PATH) (M: Ir_s.METADATA):
+  Ir_s.NODE with type raw_contents = C.t
              and type node = N.t
              and type step = P.step
+             and module Metadata = M
 
 module Store
     (C: Ir_s.CONTENTS_STORE)
@@ -30,7 +33,7 @@ module Store
        module Key: Ir_s.HASH with type t = key
        module Val: Ir_s.NODE with type t = value
                               and type node = key
-                              and type contents = C.key
+                              and type raw_contents = C.key
                               and type step = C.Path.step
      end):
   Ir_s.NODE_STORE
@@ -75,7 +78,7 @@ end
 
 module Graph (S: Ir_s.NODE_STORE):
   GRAPH with type t = S.t
-         and type contents = S.Contents.key
+         and type contents = S.Contents.key * S.Val.Metadata.t
          and type node = S.key
          and type step = S.Path.step
          and type path = S.Path.t

--- a/lib/irmin.ml
+++ b/lib/irmin.ml
@@ -59,7 +59,7 @@ struct
     module Node = struct
       module AO = struct
         module Key = H
-        module Val = Ir_node.Make (H)(H)(C.Path)
+        module Val = Ir_node.Make (H)(H)(C.Path)(Ir_node.No_metadata)
         module Path = C.Path
         include AO (Key)(Val)
       end
@@ -186,3 +186,8 @@ let with_hrw_view (type store) (type path) (type view)
   | `Update -> V.update_path t path view >>= fun () -> Merge.OP.ok ()
   | `Rebase -> V.rebase_path t path view
   | `Merge  -> V.merge_path t path view
+
+module Metadata = struct
+  module type S = Ir_s.METADATA
+  module None = Ir_node.No_metadata
+end

--- a/lib/unix/irmin_unix.mli
+++ b/lib/unix/irmin_unix.mli
@@ -176,7 +176,7 @@ module Irmin_http: sig
   module RW: Irmin.RW_MAKER
   (** An HTTP client using a REST API for a read-write store. *)
 
-  module Make: Irmin.S_MAKER
+  module Make (M:Irmin.Metadata.S): Irmin.S_MAKER
   (** [Make] provides high-level bindings to the remote HTTP server.
 
       Most of the computation are done on the server, the client is
@@ -187,7 +187,7 @@ module Irmin_http: sig
       All of the low-level and high-level operations take only one
       RTT. *)
 
-  module Low: Irmin.S_MAKER
+  module Low (M:Irmin.Metadata.S): Irmin.S_MAKER
   (** [Low] provides low-level bindings to the remote HTTP server.
 
       Only the {{!Irmin.S.Private}low-level operations} are forwarded

--- a/lib_test/test_common.ml
+++ b/lib_test/test_common.ml
@@ -147,7 +147,7 @@ let (/) = Filename.concat
 
 let mem_store = create (module Irmin_mem.Make)
 let irf_store = create (module Irmin_fs.Make)
-let http_store = create (module Irmin_http.Make)
+let http_store = create (module Irmin_http.Make(Irmin.Metadata.None))
 let git_store c =
   let (module C: Irmin.Contents.S) = match c with
     | `String -> (module Irmin.Contents.String)


### PR DESCRIPTION
A Node implementation can now expose additional metadata for each content item. The Git backend uses this to give the type of the file (normal, executable or symlink). This information is stored in the tree object, not the blob, so changing the content type doesn't work well.

Currently, this is only exposed via the private interfaces (not Irmin.BC/VIEW).