### PR TITLE
Require all commits to have a root node

### DIFF
--- a/lib/git/irmin_git.ml
+++ b/lib/git/irmin_git.ml
@@ -445,7 +445,7 @@ module Irmin_value_store
       let of_git g =
         let { Git.Commit.tree; parents; author; message; _ } = g in
         let parents = List.map commit_key_of_git parents in
-        let node = Some (node_key_of_git tree) in
+        let node = node_key_of_git tree in
         let task = task_of_git author message g in
         (task, node, parents)
 
@@ -467,13 +467,7 @@ module Irmin_value_store
           name, "irmin@openmirage.org"
 
       let to_git task node parents =
-        let tree = match node with
-          | None   ->
-            failwith
-              "Irmin.Git.Commit: a commit with an empty filesystem... \
-               this is not supported by Git!"
-          | Some n -> git_of_node_key n
-        in
+        let tree = git_of_node_key node in
         let parents = List.map git_of_commit_key parents in
         let parents = List.fast_sort Git.Hash.Commit.compare parents in
         let author =
@@ -485,9 +479,9 @@ module Irmin_value_store
         let message = String.concat "\n" (Irmin.Task.messages task) in
         { Git.Commit.tree; parents; author; committer = author; message }
 
-      let create task ?node ~parents = to_git task node parents
+      let create task ~node ~parents = to_git task node parents
       let xnode { Git.Commit.tree; _ } = node_key_of_git tree
-      let node t = Some (xnode t)
+      let node t = xnode t
       let parents { Git.Commit.parents; _ } = List.map commit_key_of_git parents
       let task g =
         let { Git.Commit.author; message; _ } = g in
@@ -499,7 +493,7 @@ module Irmin_value_store
 
       let to_c t =
         let task, node, parents = of_git t in
-        C.create task ?node ~parents
+        C.create task ~node ~parents
 
       let to_json t = C.to_json (to_c t)
       let of_json j = of_c (C.of_json j)

--- a/lib/ir_commit.mli
+++ b/lib/ir_commit.mli
@@ -39,8 +39,8 @@ module type HISTORY = sig
   type t
   type node
   type commit
-  val create: t -> ?node:node -> parents:commit list -> task:Ir_task.t -> commit Lwt.t
-  val node: t -> commit -> node option Lwt.t
+  val create: t -> node:node -> parents:commit list -> task:Ir_task.t -> commit Lwt.t
+  val node: t -> commit -> node Lwt.t
   val parents: t -> commit -> commit list Lwt.t
   val merge: t -> task:Ir_task.t -> commit Ir_merge.t
   val lcas: t -> ?max_depth:int -> ?n:int -> commit -> commit ->

--- a/lib/ir_dot.ml
+++ b/lib/ir_dot.ml
@@ -146,11 +146,8 @@ module Make (S: Ir_s.STORE_EXT) = struct
         List.iter (fun c ->
             add_edge (`Commit k) [`Style `Bold] (`Commit c)
           ) (Commit.Val.parents r);
-        match Commit.Val.node r with
-        | None      -> return_unit
-        | Some node ->
-          add_edge (`Commit k) [`Style `Dashed] (`Node node);
-          return_unit
+        add_edge (`Commit k) [`Style `Dashed] (`Node (Commit.Val.node r));
+        return_unit
       ) >>= fun () ->
     let ref_t = S.Private.Repo.ref_t (S.repo t) in
     Ref.iter ref_t (fun r k ->

--- a/lib/ir_s.mli
+++ b/lib/ir_s.mli
@@ -129,8 +129,8 @@ module type COMMIT = sig
   include Tc.S0
   type commit
   type node
-  val create: Ir_task.t -> ?node:node -> parents:commit list -> t
-  val node: t -> node option
+  val create: Ir_task.t -> node:node -> parents:commit list -> t
+  val node: t -> node
   val parents: t -> commit list
   val task: t -> Ir_task.t
 end

--- a/lib/ir_view.ml
+++ b/lib/ir_view.ml
@@ -821,11 +821,9 @@ module Make (S: Ir_s.STORE_EXT) = struct
         >>| function
         | None   -> ok None
         | Some c ->
-          History.node (history_t repo) c >>= function
-          | None   -> ok None
-          | Some n ->
-            Graph.read_node (graph_t repo) n path >>= fun n ->
-            ok (Some n)
+          History.node (history_t repo) c >>= fun n ->
+          Graph.read_node (graph_t repo) n path >>= fun n ->
+          ok (Some n)
     in
     P.Node.(merge Path.empty) (graph_t repo) ~old current_node (Some view_node)
     >>| fun merge_node ->

--- a/lib/irmin.mli
+++ b/lib/irmin.mli
@@ -1546,10 +1546,10 @@ module Private: sig
       type node
       (** Type for node keys. *)
 
-      val create: task -> ?node:node -> parents:commit list -> t
+      val create: task -> node:node -> parents:commit list -> t
       (** Create a commit. *)
 
-      val node: t -> node option
+      val node: t -> node
       (** The underlying node. *)
 
       val parents: t -> commit list
@@ -1621,10 +1621,10 @@ module Private: sig
       type commit
       (** The type for commit values. *)
 
-      val create: t -> ?node:node -> parents:commit list -> task:task -> commit Lwt.t
+      val create: t -> node:node -> parents:commit list -> task:task -> commit Lwt.t
       (** Create a new commit. *)
 
-      val node: t -> commit -> node option Lwt.t
+      val node: t -> commit -> node Lwt.t
       (** Get the commit node.
 
           A commit might contain a graph

--- a/lib_test/test_store.ml
+++ b/lib_test/test_store.ml
@@ -1040,10 +1040,7 @@ module Make (S: Test_S) = struct
       View.update_path (t "empty view") (p []) v1 >>= fun () ->
       S.head_exn (t "empty view") >>= fun head   ->
       Commit.read_exn (ct repo) head >>= fun commit ->
-      let node = match Commit.Val.node commit with
-        | None -> failwith "empty node"
-        | Some n -> n
-      in
+      let node = Commit.Val.node commit in
       Node.read_exn (n repo) node >>= fun node ->
       assert_equal (module Node.Val) "empty view" Node.Val.empty node;
 


### PR DESCRIPTION
Since we already require a Node.empty, there's no need to make nodes optional too.

Note: `HISTORY.node` previously returned None if the node was missing from the store. It now throws an exception. I believe this is the correct behaviour, rather than pretending the node was empty.

Fixes #349 by ensuring that Git always has a valid node to commit.