### PR TITLE
ptime is used by the mirage backend only, so moving it to depopts

### DIFF
--- a/opam
+++ b/opam
@@ -42,7 +42,6 @@ depends: [
   "re"
   "cmdliner"
   "crunch"
-  "ptime"
   "git-unix"  {test}
   "cohttp"    {test}
   "alcotest"  {test & >="0.4.1"}
@@ -52,6 +51,7 @@ depopts: [
   "git-unix"
   "cohttp"
   "mirage-git"
+  "ptime"
 ]
 conflicts: [
   "cohttp" {< "0.18.3"}


### PR DESCRIPTION
@yomimono Not sure why you removed from depopts in 33022a5cd7237bba6e3dfb89b9d8274dbc355e42 but let's see if the CI complain :-)