### PR TITLE
Remove Lwt_unix.fork in the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ clean:
 	rm -rf _build lib_test/_tests lib_test/test-db lib_test/test_db_git
 	ocaml pkg/pkg.ml clean
 
-
 test:
 	ocaml pkg/pkg.ml build ${OPTIONS}
-	ocaml pkg/pkg.ml test
+	ocaml pkg/pkg.ml test -- -e

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -33,7 +33,7 @@ let () =
     Pkg.mllib ~cond:http   "lib/http/irmin-http.mllib";
     Pkg.mllib ~cond:unix   "lib/unix/irmin-unix.mllib";
     Pkg.bin   ~cond:unix   "bin/main" ~dst:"irmin";
-    Pkg.test  ~cond:tool ~dir:"lib_test" "lib_test/test" ~args:Cmd.(v "-e");
+    Pkg.test  ~cond:tool ~dir:"lib_test" "lib_test/test" ~args:Cmd.(v "-e" % "-q");
     example "deploy";
     example "custom_merge";
     example "process";


### PR DESCRIPTION
Use exec to respawn the same binary but with different command-line
argument, eg. `test.native serve 3` which will run a webserver
using the 3rd configuration.

This avoids the scary message:

 __THE_PROCESS_HAS_FORKED_AND_YOU_CANNOT_USE_THIS_COREFOUNDATION_FUNCTIONALITY___YOU_MUST_EXEC__()

and should make the tests work on Windows (yay).