### PR TITLE
V1.Kv_ro is gone, use mirage-kv instead

### DIFF
--- a/_tags
+++ b/_tags
@@ -20,7 +20,7 @@ true: package(fmt)
 <src/git/*>: package(git)
 
 <src/unix/*>: package(irmin-watcher git.unix), thread
-<src/mirage/*>: package(git.mirage ptime mirage-runtime)
+<src/mirage/*>: package(git.mirage ptime mirage-kv)
 
 <bin/*>: package(irmin-watcher), thread
 <bin/*>: package(cmdliner git.unix fmt.cli logs.fmt fmt.tty ezjsonm.lwt)

--- a/opam
+++ b/opam
@@ -12,14 +12,14 @@ build: [
       "--with-http"   "%{cohttp:installed}%"
       "--with-git"    "%{git:installed}%"
       "--with-unix"   "%{irmin-watcher+git-unix:installed}%"
-      "--with-mirage" "%{git-mirage+mirage-runtime:installed}%"
+      "--with-mirage" "%{git-mirage+mirage-kv:installed}%"
 ]
 build-test: [
   ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
       "--with-http"   "%{cohttp:installed}%"
       "--with-git"    "%{git:installed}%"
       "--with-unix"   "%{irmin-watcher+git-unix:installed}%"
-      "--with-mirage" "%{git-mirage+mirage-runtime:installed}%"]
+      "--with-mirage" "%{git-mirage+mirage-kv:installed}%"]
   ["ocaml" "pkg/pkg.ml" "test"]
 ]
 
@@ -48,7 +48,6 @@ depends: [
   "cohttp"        {test}
   "alcotest"      {test & >="0.4.1"}
   "irmin-watcher" {test & >= "0.2.0"}
-  "mirage-runtime"{test}
 ]
 depopts: [
   "git"
@@ -56,7 +55,7 @@ depopts: [
   "cohttp"
   "git-mirage"
   "irmin-watcher"
-  "mirage-runtime"
+  "mirage-kv"
 ]
 conflicts: [
   "cohttp"        {< "0.18.3"}

--- a/pkg/META
+++ b/pkg/META
@@ -42,7 +42,7 @@ package "unix" (
 package "mirage" (
  description = "MirageOS backend for Irmin"
  version = "%%VERSION_NUM%%"
- requires = "irmin irmin.mem irmin.git irmin.fs irmin.http cohttp.lwt git.mirage ptime"
+ requires = "irmin irmin.mem irmin.git irmin.fs irmin.http cohttp.lwt git.mirage ptime mirage-kv"
  archive(byte)   = "irmin-mirage.cma"
  archive(native) = "irmin-mirage.cmxa"
  plugin(byte)    = "irmin-mirage.cma"

--- a/src/mirage/irmin_mirage.ml
+++ b/src/mirage/irmin_mirage.ml
@@ -55,8 +55,8 @@ module KV_RO (C: CONTEXT) (I: Git.Inflate.S) = struct
   type page_aligned_buffer = Cstruct.t
   let unknown_key k = Lwt.return (Error (`Unknown_key k))
   let ok x = Lwt.return (Ok x)
-  type error = V1.Kv_ro.error
-  let pp_error = Mirage_pp.pp_kv_ro_error
+  type error = Mirage_kv.error
+  let pp_error = Mirage_kv.pp_error
 
   let read_head t =
     S.head t.t >>= function


### PR DESCRIPTION
mirage-runtime is superfluous now here