### PR TITLE
final fixes for MirageOS3

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,7 @@
 PKG lwt dolog ezjsonm bin_prot cstruct re uri git tc hex topkg
 PKG nocrypto cohttp.lwt-core cmdliner ocamlgraph oUnit alcotest mstruct
-PKG mirage-http git.mirage logs irmin-watcher mtime.os mirage-runtime
+PKG mirage-http git-mirage logs irmin-watcher mtime.os
+PKG mirage-kv-lwt mirage-clock ptime
 B _build/**
 S src
 S src-git

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
   - PINS="irmin.1.0.0:. irmin-http.1.0.0:. irmin-git.1.0.0:. irmin-mirage.1.0.0:. irmin-unix.1.0.0:."
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
-  - OCAML_VERSION=4.02 PACKAGE="irmin-mirage"
   - OCAML_VERSION=4.03 PACKAGE="irmin-unix" TESTS=true EXTRA_DEPS=inotify
   - OCAML_VERSION=4.03 PACKAGE="irmin-git"
   - OCAML_VERSION=4.03 PACKAGE="irmin-mirage"
   - OCAML_VERSION=4.04 PACKAGE="irmin-http"
   - OCAML_VERSION=4.04 PACKAGE="irmin-unix" TESTS=true EXTRA_DEPS=inotify
+  - OCAML_VERSION=4.04 PACKAGE="irmin-mirage"

--- a/_tags
+++ b/_tags
@@ -13,7 +13,7 @@ true: package(fmt)
 
 <src-http/*>: package(irmin cohttp crunch ezjsonm)
 <src-unix/*>: package(irmin irmin-git irmin-http irmin-watcher git-unix), thread
-<src-mirage/*>: package(irmin ptime mirage-kv git-mirage irmin-git result)
+<src-mirage/*>: package(irmin ptime mirage-kv-lwt mirage-clock git-mirage irmin-git result)
 
 <src-unix>: include
 <bin/*>: package(irmin irmin-git irmin-http irmin-watcher), thread

--- a/irmin-mirage.opam
+++ b/irmin-mirage.opam
@@ -17,5 +17,6 @@ depends: [
   "git-mirage" {>= "2.0.0"}
   "ptime"
   "mirage-kv-lwt"
+  "mirage-clock"
   "result"
 ]

--- a/pkg/META.mirage
+++ b/pkg/META.mirage
@@ -1,6 +1,6 @@
 description = "MirageOS backend for Irmin"
 version = "%%VERSION_NUM%%"
-requires = "irmin irmin-git irmin-http cohttp.lwt git-mirage ptime mirage-kv"
+requires = "irmin irmin-git irmin-http cohttp.lwt git-mirage ptime mirage-kv-lwt mirage-clock"
 archive(byte)   = "irmin-mirage.cma"
 archive(native) = "irmin-mirage.cmxa"
 plugin(byte)    = "irmin-mirage.cma"

--- a/src-mirage/irmin_mirage.ml
+++ b/src-mirage/irmin_mirage.ml
@@ -33,7 +33,7 @@ module Irmin_git = struct
   module Memory (C: CONTEXT) = Irmin_git.Memory_ext(Context(C))(IO)
 end
 
-module Task (N: sig val name: string end) (C: V1.PCLOCK) = struct
+module Task (N: sig val name: string end) (C: Mirage_clock.PCLOCK) = struct
   let f c msg =
     C.now_d_ps c |>
     Ptime.v |> Ptime.to_float_s |> Int64.of_float |> fun date ->

--- a/src-mirage/irmin_mirage.mli
+++ b/src-mirage/irmin_mirage.mli
@@ -61,7 +61,7 @@ module Irmin_git: sig
 
 end
 
-module Task (N: sig val name: string end)(C: V1.PCLOCK): sig
+module Task (N: sig val name: string end)(C: Mirage_clock.PCLOCK): sig
 
   (** {1 Task creators} *)
 
@@ -75,7 +75,7 @@ end
     repository. *)
 module KV_RO (C: CONTEXT) (I: Git.Inflate.S): sig
 
-  include V1_LWT.KV_RO
+  include Mirage_kv_lwt.RO
 
   val connect: ?depth:int -> ?branch:string -> ?path:string ->
     Uri.t -> t Lwt.t


### PR DESCRIPTION
V1/V1_LWT does no longer exist, use mirage-clock / mirage-kv-lwt directly
adjust merlin/tags/opam and META files