### PR TITLE
Add a simplified KV functor to build a store by only providing contents

### DIFF
--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -16,7 +16,6 @@
 
 open Lwt.Infix
 open Cmdliner
-open Irmin_unix
 open Ir_resolver
 
 let () = Irmin_unix.set_listen_dir_hook ()
@@ -115,7 +114,7 @@ let init = {
     let init (S ((module S), store)) daemon uri =
       run begin
         store >>= fun t ->
-        let module HTTP = Irmin_http_server.Make(S) in
+        let module HTTP = Irmin_unix.Http.Server(S) in
         if daemon then
           let uri = Uri.of_string uri in
           let spec = HTTP.v (S.repo t) in

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -12,8 +12,9 @@ let what =
   \  - concatenate `lca` and `l3`; This gives the final result."
 
 open Lwt.Infix
-open Irmin_unix
 open Astring
+
+let info = Irmin_unix.info
 
 let time = ref 0
 
@@ -113,11 +114,7 @@ end = struct
 
 end
 
-module Store =
-  Irmin_git.FS(Log)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+module Store = Irmin_unix.Git.FS.KV(Log)
 
 let config = Irmin_git.config ~bare:true Config.root
 

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -1,12 +1,6 @@
 open Lwt.Infix
-open Irmin_unix
 
-module Store =
-  Irmin_git.FS
-    (Irmin.Contents.String)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 
 let config =
   let head = Git.Reference.of_raw "refs/heads/upstream" in

--- a/examples/irmin_git_store.ml
+++ b/examples/irmin_git_store.ml
@@ -1,14 +1,10 @@
 (* Simple example of reading and writing in a Git repository *)
 open Lwt.Infix
-open Irmin_unix
 open Printf
 
-module Store =
-  Irmin_git.FS
-    (Irmin.Contents.String)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+let info = Irmin_unix.info
+
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 
 let update t k v =
   let msg = sprintf "Updating /%s" (String.concat "/" k) in

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -1,7 +1,6 @@
 (* Connect to http://localhost:8080/dump *)
 
 open Lwt.Infix
-open Irmin_unix
 open Printf
 
 let fin () =
@@ -68,12 +67,7 @@ let branch image =
 
 let images = [| (*ubuntu; *) wordpress; mysql |]
 
-module Store =
-  Irmin_git.FS
-    (Irmin.Contents.String)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 
 let config = Irmin_git.config
     ~bare:true

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -1,19 +1,13 @@
 open Lwt.Infix
-open Irmin_unix
 
+let info = Irmin_unix.info
 let path =
   if Array.length Sys.argv = 2 then
     Sys.argv.(1)
   else
     "git://github.com/mirage/ocaml-git.git"
 
-module Store =
-  Irmin_git.FS
-    (Irmin.Contents.String)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
-
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 module Sync = Irmin.Sync(Store)
 
 let upstream = Irmin.remote_uri path

--- a/examples/views.ml
+++ b/examples/views.ml
@@ -1,12 +1,8 @@
 open Lwt.Infix
-open Irmin_unix
 
-module Store =
-  Irmin_git.FS
-    (Irmin.Contents.String)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+let info = Irmin_unix.info
+
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 
 module Tree = Store.Tree
 

--- a/src-http/irmin_http.ml
+++ b/src-http/irmin_http.ml
@@ -438,3 +438,11 @@ struct
   end
   include Irmin.Make_ext(X)
 end
+
+module KV (H: Cohttp_lwt.Client) (C: Irmin.Contents.S) =
+  Make (H)
+    (Irmin.Metadata.None)
+    (C)
+    (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Irmin.Hash.SHA1)

--- a/src-http/irmin_http.mli
+++ b/src-http/irmin_http.mli
@@ -20,4 +20,5 @@ val config: ?config:Irmin.config -> Uri.t -> Irmin.config
 
 val uri: Uri.t option Irmin.Private.Conf.key
 
-module Make (C: Cohttp_lwt.Client) (M: Irmin.Metadata.S): Irmin.S_MAKER
+module Make (C: Cohttp_lwt.Client): Irmin.S_MAKER
+module KV (C: Cohttp_lwt.Client): Irmin.KV_MAKER

--- a/src/ir_s.mli
+++ b/src/ir_s.mli
@@ -511,6 +511,7 @@ module type STORE = sig
 end
 
 module type MAKER =
+  functor (M: METADATA) ->
   functor (C: CONTENTS) ->
   functor (P: PATH) ->
   functor (B: BRANCH) ->
@@ -519,6 +520,7 @@ module type MAKER =
   with type key = P.t
    and type step = P.step
    and module Key = P
+   and type metadata = M.t
    and type contents = C.t
    and type branch = B.t
    and type Commit.Hash.t = H.t

--- a/src/irmin.ml
+++ b/src/irmin.ml
@@ -60,10 +60,10 @@ struct
   include Conv2Raw(C)
 end
 
-module Make_with_metadata
-    (M: Ir_s.METADATA)
+module Make
     (AO: Ir_s.AO_MAKER)
     (RW: Ir_s.RW_MAKER)
+    (M: Ir_s.METADATA)
     (C: Ir_s.CONTENTS)
     (P: Ir_s.PATH)
     (B: Ir_s.BRANCH)
@@ -128,7 +128,6 @@ struct
   include Ir_store.Make(X)
 end
 
-module Make = Make_with_metadata(Ir_node.No_metadata)
 module Make_ext = Ir_store.Make
 
 module type RO = Ir_s.RO
@@ -147,6 +146,13 @@ module type LINK_MAKER = Ir_s.LINK_MAKER
 
 module type RW_MAKER = Ir_s.RW_MAKER
 module type S_MAKER = Ir_s.MAKER
+
+module type KV =
+  S with type key = string list
+     and type step = string
+     and type branch = string
+
+module type KV_MAKER = functor (C: Contents.S) -> KV with type contents = C.t
 
 module Private = struct
   module Conf = Ir_conf

--- a/src/irmin_fs.ml
+++ b/src/irmin_fs.ml
@@ -249,6 +249,7 @@ struct
 end
 
 module Make_ext (IO: IO) (Obj: Config) (Ref: Config)
+    (M: Irmin.Metadata.S)
     (C: Irmin.Contents.S)
     (P: Irmin.Path.S)
     (B: Irmin.Branch.S)
@@ -256,7 +257,7 @@ module Make_ext (IO: IO) (Obj: Config) (Ref: Config)
 = struct
   module AO = AO_ext(IO)(Obj)
   module RW = RW_ext(IO)(Ref)
-  include Irmin.Make(AO)(RW)(C)(P)(B)(H)
+  include Irmin.Make(AO)(RW)(M)(C)(P)(B)(H)
 end
 
 let string_chop_prefix ~prefix str =
@@ -323,6 +324,14 @@ module AO (IO: IO) = AO_ext (IO)(Obj)
 module Link (IO: IO) = Link_ext (IO)(Links)
 module RW (IO: IO) = RW_ext (IO)(Ref)
 module Make (IO: IO) = Make_ext (IO)(Obj)(Ref)
+
+module KV (IO: IO) (C: Irmin.Contents.S) =
+  Make (IO)
+    (Irmin.Metadata.None)
+    (C)
+    (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Irmin.Hash.SHA1)
 
 module IO_mem = struct
 

--- a/src/irmin_fs.mli
+++ b/src/irmin_fs.mli
@@ -69,6 +69,7 @@ module AO (IO: IO): Irmin.AO_MAKER
 module Link (IO: IO): Irmin.LINK_MAKER
 module RW (IO: IO): Irmin.RW_MAKER
 module Make (IO: IO): Irmin.S_MAKER
+module KV (IO: IO): Irmin.KV_MAKER
 
 (** {2 Advanced configuration} *)
 

--- a/src/irmin_mem.ml
+++ b/src/irmin_mem.ml
@@ -133,5 +133,10 @@ let config () = Irmin.Private.Conf.empty
 
 module Make = Irmin.Make(AO)(RW)
 
-module Make_with_metadata (M: Irmin.Metadata.S) =
-  Irmin.Make_with_metadata(M)(AO)(RW)
+module KV (C: Irmin.Contents.S) =
+  Make
+    (Irmin.Metadata.None)
+    (C)
+    (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Irmin.Hash.SHA1)

--- a/src/irmin_mem.mli
+++ b/src/irmin_mem.mli
@@ -36,5 +36,5 @@ module RW: Irmin.RW_MAKER
 module Make: Irmin.S_MAKER
 (** An in-memory Irmin store. *)
 
-module Make_with_metadata (M: Irmin.Metadata.S): Irmin.S_MAKER
-(** An in-memory Irmin store with custom node's metadata. *)
+module KV: Irmin.KV_MAKER
+(** An in-memory KV-store. *)

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -57,19 +57,22 @@ let line msg =
   Logs.info (fun f -> f "ASSERT %s" msg);
   line ()
 
-let store: (module Irmin.S_MAKER) -> (module Test_S) = fun (module B) ->
-  let module S = struct
-    include
-      B (Irmin.Contents.String)
-        (Irmin.Path.String_list)
-        (Irmin.Branch.String)
-        (Irmin.Hash.SHA1)
+let store:
+  (module Irmin.S_MAKER) -> (module Irmin.Metadata.S) -> (module Test_S) =
+  fun (module B) (module M) ->
+    let module S = struct
+      include
+        B (M)
+          (Irmin.Contents.String)
+          (Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
 
-    module Git = struct
-      let git_commit _t _id = failwith "Only used for testing Git stores"
+      module Git = struct
+        let git_commit _t _id = failwith "Only used for testing Git stores"
+      end
     end
-  end
-  in (module S)
+    in (module S)
 
 type kind = [
   | `Core

--- a/test/test_fs.ml
+++ b/test/test_fs.ml
@@ -34,5 +34,5 @@ let config = Irmin_fs.config test_db
 let link = (module Link: Test_link.S)
 let clean () = Lwt.return_unit
 let stats = None
-let store = store (module Irmin_fs.Make(IO))
+let store = store (module Irmin_fs.Make(IO)) (module Irmin.Metadata.None)
 let suite = { name = "FS"; kind = `Core; init; clean; config; store; stats }

--- a/test/test_http.ml
+++ b/test/test_http.ml
@@ -24,7 +24,7 @@ let uri = Uri.of_string "http://127.0.0.1:8080"
 let pid_file = Filename.get_temp_dir_name () / "irmin-test.pid"
 
 let http_store (module S: Test_S) =
-  store (module Irmin_http.Make(Cohttp_lwt_unix.Client)(S.Metadata))
+  store (module Irmin_http.Make(Cohttp_lwt_unix.Client)) (module S.Metadata)
 
 (* See https://github.com/mirage/ocaml-cohttp/issues/511 *)
 let () = Lwt.async_exception_hook := (fun e ->

--- a/test/test_mem.ml
+++ b/test/test_mem.ml
@@ -17,7 +17,7 @@
 open Lwt.Infix
 open Test_common
 
-let store = store (module Irmin_mem.Make)
+let store = store (module Irmin_mem.Make) (module Irmin.Metadata.None)
 
 module Link = struct
   include Irmin_mem.Link(Irmin.Hash.SHA1)

--- a/test/test_unix.ml
+++ b/test/test_unix.ml
@@ -29,7 +29,7 @@ module FS = struct
 
   let test_db = Test_fs.test_db
   let config = Test_fs.config
-  let store = store (module Irmin_unix.Irmin_fs.Make)
+  let store = store (module Irmin_unix.FS.Make) (module Irmin.Metadata.None)
 
   let init () =
     if Sys.file_exists test_db then begin
@@ -46,7 +46,7 @@ module FS = struct
   let suite = { name = "FS"; kind = `Unix; clean; init; store; stats; config }
 
   module Link = struct
-    include Irmin_unix.Irmin_fs.Link(Irmin.Hash.SHA1)
+    include Irmin_unix.FS.Link(Irmin.Hash.SHA1)
     let v () = v (Irmin_fs.config test_db)
   end
 
@@ -58,7 +58,7 @@ end
 
 module Git = struct
 
-  let store = store (module Irmin_unix.Irmin_git.FS)
+  let store = (module Irmin_unix.Git.FS.KV(Irmin.Contents.String): Test_S)
   let test_db = Test_git.test_db
 
   let init () =


### PR DESCRIPTION
KV stores use string lists as paths and strings as branches. The rest of the
types (hashes, metadata) is left abstract.

Also add `Metadata` as a parameter to the main `Make` functors.