### PR TITLE
Revert the `empty` -> empty ()` change

### DIFF
--- a/bin/ir_cli.ml
+++ b/bin/ir_cli.ml
@@ -411,10 +411,10 @@ let watch = {
             let view (c, _) =
               S.of_commit c >>= fun t ->
               S.find_tree t path >|= function
-              | None   -> S.Tree.empty ()
+              | None   -> S.Tree.empty
               | Some v -> v
             in
-            let empty = Lwt.return (S.Tree.empty ()) in
+            let empty = Lwt.return S.Tree.empty in
             let x, y = match d with
               | `Updated (x, y) -> view x, view y
               | `Added x        -> empty , view x

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -18,7 +18,7 @@ let provision repo =
 
   Store.of_branch repo "upstream" >>= fun t ->
 
-  Store.Tree.empty () |> fun v ->
+  Store.Tree.empty |> fun v ->
   Store.Tree.add v ["etc"; "manpath"]
     "/usr/share/man\n\
      /usr/local/share/man"

--- a/examples/views.ml
+++ b/examples/views.ml
@@ -21,7 +21,7 @@ let view_of_t t =
       Tree.add v [si;"x"] t2.x >>= fun v ->
       Tree.add v [si;"y"] (string_of_int t2.y) >|= fun v ->
       (v, i + 1)
-    ) (Tree.empty (), 0) t
+    ) (Tree.empty, 0) t
   >|= fun (v, _) -> v
 
 let t_of_view v =

--- a/src/ir_s.mli
+++ b/src/ir_s.mli
@@ -318,7 +318,7 @@ module type TREE = sig
   type contents
   type node
   type tree = [ `Node of node | `Contents of contents * metadata ]
-  val empty: unit -> tree
+  val empty: tree
   val of_contents: ?metadata:metadata -> contents -> tree
   val of_node: node -> tree
   val kind: tree -> key -> [`Contents | `Node] option Lwt.t

--- a/src/irmin.mli
+++ b/src/irmin.mli
@@ -2249,8 +2249,8 @@ module type S = sig
 
     (** {1 Constructors} *)
 
-    val empty: unit -> tree
-    (** [empty ()] is the empty tree. Empty trees do not have
+    val empty: tree
+    (** [empty] is the empty tree. The empty tree does not have
         associated backend configuration values, as they can perform
         in-memory operation, independently of any given backend. *)
 

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -789,7 +789,7 @@ module Make (S: Test_S) = struct
         let i = Int64.of_int date in
         Irmin.Info.v ~date:i ~author:"test" "Test commit"
       in
-      let tree = S.Tree.empty () in
+      let tree = S.Tree.empty in
       let assert_lcas_err msg err l2 =
         let err_str = function
           | `Too_many_lcas    -> "Too_many_lcas"
@@ -1080,7 +1080,7 @@ module Make (S: Test_S) = struct
 
       (* Testing [View.remove] *)
 
-      S.Tree.empty () |> fun v1 ->
+      S.Tree.empty |> fun v1 ->
 
       S.Tree.add v1 ["foo";"1"] foo1 >>= fun v1 ->
       S.Tree.add v1 ["foo";"2"] foo2 >>= fun v1 ->
@@ -1105,9 +1105,9 @@ module Make (S: Test_S) = struct
       let normal c = Some (c, S.Metadata.default) in
       let d0 = S.Metadata.default in
 
-      S.Tree.empty () |> fun v0 ->
-      S.Tree.empty () |> fun v1 ->
-      S.Tree.empty () |> fun v2 ->
+      S.Tree.empty |> fun v0 ->
+      S.Tree.empty |> fun v1 ->
+      S.Tree.empty |> fun v2 ->
       S.Tree.add v1 ["foo";"1"] foo1 >>= fun v1 ->
       S.Tree.find_all v1 ["foo"; "1"] >>= fun f ->
       check_val "view udate" (normal foo1) f;
@@ -1127,7 +1127,7 @@ module Make (S: Test_S) = struct
 
       (* Testing other View operations. *)
 
-      S.Tree.empty () |> fun v0 ->
+      S.Tree.empty |> fun v0 ->
 
       S.Tree.add v0 [] foo1 >>= fun v0 ->
       S.Tree.find_all v0 [] >>= fun foo1' ->
@@ -1229,7 +1229,7 @@ module Make (S: Test_S) = struct
       S.Tree.find_all view px >>= fun vx' ->
       check_val "updates" (normal vx) vx';
 
-      S.Tree.empty () |> fun v ->
+      S.Tree.empty |> fun v ->
       S.Tree.add v [] vx >>= fun v ->
       S.set_tree t ~info:(infof "update file as view") ["a"] v >>= fun () ->
       S.find_all t ["a"] >>= fun vx' ->


### PR DESCRIPTION
And fix the weird case of caching the empty value while the store is being reset.
It is better to have a cleaner API and pay a small runtime cost when handling the
empty tree.