### PR TITLE
Fix Irmin.Tree.diff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 - Expose `Irmin.Merge.idempotent` for values with idempotent operations
   (#433, @samoht)
 - Add a `S.repo` type as an alias to the `S.Repo.t` (#436, @samoht)
+- Fix regression in `S.Tree.diff` intoduced in the 1.0 release: nested
+  differences where reported with the wrong path (#438, @samoht)
 
 **irmin-unix**
 

--- a/src/ir_tree.ml
+++ b/src/ir_tree.ml
@@ -756,7 +756,7 @@ module Make (P: Ir_s.PRIVATE) = struct
     in
     Ir_merge.v tree_t f
 
-  let entries key tree =
+  let entries path tree =
     let rec aux acc = function
       | []              -> Lwt.return acc
       | (path, h)::todo ->
@@ -771,7 +771,7 @@ module Make (P: Ir_s.PRIVATE) = struct
         in
         aux acc todo
     in
-    aux [] [Path.v [key], tree]
+    aux [] [path, tree]
 
   let diff_node (x:node) (y:node) =
     let bindings n =
@@ -808,7 +808,7 @@ module Make (P: Ir_s.PRIVATE) = struct
                 removed !acc (path, x) >|= fun x ->
                 acc := x
               | `Left (`Node x) ->
-                entries key x >>= fun xs ->
+                entries path x >>= fun xs ->
                 Lwt_list.fold_left_s removed !acc xs >|= fun xs ->
                 acc := xs
 
@@ -817,7 +817,7 @@ module Make (P: Ir_s.PRIVATE) = struct
                 added !acc (path, y) >|= fun y ->
                 acc := y
               | `Right (`Node y) ->
-                entries key y >>= fun ys ->
+                entries path y >>= fun ys ->
                 Lwt_list.fold_left_s added !acc ys >|= fun ys ->
                 acc := ys
 
@@ -827,13 +827,13 @@ module Make (P: Ir_s.PRIVATE) = struct
                 Lwt.return_unit
 
               | `Both (`Contents x, `Node y) ->
-                entries key y >>= fun ys ->
+                entries path y >>= fun ys ->
                 removed !acc (path, x) >>= fun x ->
                 Lwt_list.fold_left_s added x ys >|= fun ys ->
                 acc := ys
 
               | `Both (`Node x, `Contents y) ->
-                entries key x >>= fun xs ->
+                entries path x >>= fun xs ->
                 added !acc (path, y) >>= fun y ->
                 Lwt_list.fold_left_s removed y xs >|= fun ys ->
                 acc := ys

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -1122,8 +1122,15 @@ module Make (S: Test_S) = struct
       check_diffs "diff 2" [ ["foo";"1"], `Removed (foo1, d0) ] d2;
 
       S.Tree.diff v1 v2 >>= fun d3 ->
-      check_diffs "diff 2" [ ["foo";"1"], `Updated ((foo1, d0), (foo2, d0));
+      check_diffs "diff 3" [ ["foo";"1"], `Updated ((foo1, d0), (foo2, d0));
                              ["foo";"2"], `Added (foo1, d0)] d3;
+
+      S.Tree.add v2 ["foo"; "bar"; "1"] foo1 >>= fun v3 ->
+      S.Tree.diff v2 v3 >>= fun d4 ->
+      check_diffs "diff 4" [ ["foo"; "bar"; "1" ], `Added (foo1, d0) ] d4;
+      S.Tree.diff v3 v2 >>= fun d5 ->
+      check_diffs "diff 4" [ ["foo"; "bar"; "1" ], `Removed (foo1, d0) ] d5;
+
 
       (* Testing other View operations. *)
 


### PR DESCRIPTION
Regression introduced in 1.0: nested diffs where reported with the wrong path.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>