### PR TITLE
Stop printing errors on invalid branch names

### DIFF
--- a/src-git/irmin_git.ml
+++ b/src-git/irmin_git.ml
@@ -523,6 +523,7 @@ module Irmin_branch_store (G: Git.Store.S) (B: Branch) = struct
   type watch = W.watch * (unit -> unit Lwt.t)
 
   let branch_of_git r =
+    Log.debug (fun l -> l "branch_of_git %a" Git.Reference.pp r);
     let str = String.trim @@ Git.Reference.to_raw r in
     match B.of_ref str with
     | Ok r           -> Some r
@@ -899,7 +900,7 @@ module Mem = struct
 
   module Ref (IO: IO) (I: Git.Inflate.S) (C: Irmin.Contents.S) = struct
     module Git_mem = Git.Memory.Make(Digest(H))(I)
-    include Make_ext (IO) (Git_mem) (C) (Irmin.Path.String_list) (Ref)
+    include Make_ext(IO) (Git_mem) (C) (Irmin.Path.String_list) (Ref)
   end
 
 end

--- a/src-git/irmin_git.ml
+++ b/src-git/irmin_git.ml
@@ -523,13 +523,10 @@ module Irmin_branch_store (G: Git.Store.S) (B: Branch) = struct
   type watch = W.watch * (unit -> unit Lwt.t)
 
   let branch_of_git r =
-    Log.debug (fun l -> l "branch_of_git %a" Git.Reference.pp r);
     let str = String.trim @@ Git.Reference.to_raw r in
     match B.of_ref str with
     | Ok r           -> Some r
-    | Error (`Msg e) ->
-      Log.err (fun l -> l "invalid branch name: %s" e);
-      None
+    | Error (`Msg _) -> None
 
   let git_of_branch r = Git.Reference.of_raw (Fmt.to_to_string B.pp_ref r)
   let commit_of_git k = Val.of_raw (Git_hash.to_raw k)

--- a/src-git/irmin_git.mli
+++ b/src-git/irmin_git.mli
@@ -167,3 +167,23 @@ module Mem: sig
   module KV (IO: IO) (I: Git.Inflate.S): KV_MAKER
   module Ref (IO: IO) (I: Git.Inflate.S): REF_MAKER
 end
+
+module type Branch = sig
+  include Irmin.Branch.S
+  val pp_ref: t Fmt.t
+  val of_ref: string -> (t, [`Msg of string]) result
+end
+
+module Branch (B: Irmin.Branch.S): Branch
+
+module Ref: Branch with type t = reference
+
+module Make_ext (IO: IO) (S: Git.Store.S)
+    (C: Irmin.Contents.S)
+    (P: Irmin.Path.S)
+    (B: Branch):
+  Irmin.S with type key = P.t
+           and type step = P.step
+           and module Key = P
+           and type contents = C.t
+           and type branch = B.t

--- a/test/main_git.ml
+++ b/test/main_git.ml
@@ -15,9 +15,7 @@
  *)
 
 let misc = [
-  "misc", [
-    "Testing sort order", `Quick, Test_git.test_sort_order Test_git.store
-  ]
+  "GIT.misc", Test_git.tests Test_git.store;
 ]
 
 let () =

--- a/test/main_unix.ml
+++ b/test/main_unix.ml
@@ -17,6 +17,7 @@
 let misc = [
   "LINK"     , [Test_link.test "unix" Test_unix.FS.link];
   "GIT-BARE" , [Test_unix.Git.misc];
+  "GIT"      , Test_git.tests Test_unix.Git.store;
 ]
 
 let () =

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -69,7 +69,8 @@ let store:
           (Irmin.Hash.SHA1)
 
       module Git = struct
-        let git_commit _t _id = failwith "Only used for testing Git stores"
+        let none () = failwith "Only used for testing Git stores"
+        let git_commit _t _id = none ()
       end
     end
     in (module S)

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -28,13 +28,24 @@ module IO = struct
   let ctx () = Lwt.return_none
 end
 
+module type Test_S = sig
+  include Irmin.S with type step = string
+                   and type key = string list
+                   and type contents = string
+                   and type branch = string
+  module Git: Git.Store.S
+end
+
 module Mem = Irmin_git.Mem.KV (IO) (Git_unix.Zlib) (Irmin.Contents.String)
 
 let store = (module Mem: Test_S)
 let stats = None
 let init () = Mem.Git_mem.clear_all (); Lwt.return_unit
 let clean () = Lwt.return_unit
-let suite = { name = "GIT"; kind = `Git; clean; init; store; stats; config }
+
+let suite =
+  let store = (module Mem: Test_common.Test_S) in
+  { name = "GIT"; kind = `Git; clean; init; store; stats; config }
 
 let get = function
   | Some x -> x
@@ -57,6 +68,7 @@ let test_sort_order (module S: Test_S) =
   in
   let info = Irmin.Info.none in
   S.master repo >>= fun master ->
+  S.remove master ~info [] >>= fun () ->
   S.set master ~info ["foo.c"] "foo.c" >>= fun () ->
   S.set master ~info ["foo1"] "foo1" >>= fun () ->
   S.set master ~info ["foo"; "foo.o"] "foo.o" >>= fun () ->
@@ -71,4 +83,46 @@ let test_sort_order (module S: Test_S) =
   Alcotest.(check (list string)) "Sort order" ["foo"; "foo.c"; "foo1"] items;
   Lwt.return ()
 
-let test_sort_order store () = Lwt_main.run (test_sort_order store)
+module Ref (S: Git.Store.S) =
+  Irmin_git.Make_ext(IO)(S)(Irmin.Contents.String)(Irmin.Path.String_list)
+    (Irmin_git.Ref)
+
+let pp_reference ppf = function
+  | `Branch s -> Fmt.pf ppf "branch: %s" s
+  | `Remote s -> Fmt.pf ppf "remote: %s" s
+  | `Tag s    -> Fmt.pf ppf "tag: %s" s
+  | `Other s  -> Fmt.pf ppf "other: %s" s
+
+let reference = Alcotest.testable pp_reference (=)
+
+let test_list_refs (module S: Test_S) =
+  let module R = Ref(S.Git) in
+  init () >>= fun () ->
+  R.Repo.v (Irmin_git.config test_db) >>= fun repo ->
+  R.master repo >>= fun master ->
+  R.set master ~info:Irmin.Info.none ["test"] "toto" >>= fun () ->
+  R.Head.get master >>= fun head ->
+  R.Branch.set repo (`Remote "datakit/master") head >>= fun () ->
+  R.Branch.set repo (`Other "foo/bar/toto") head >>= fun () ->
+  R.Branch.set repo (`Branch "foo") head >>= fun () ->
+
+  R.Repo.branches repo >>= fun bs ->
+  Alcotest.(check (slist reference compare)) "raw branches"
+    [`Branch "foo";
+     `Branch "master";
+     `Other  "foo/bar/toto";
+     `Remote "datakit/master";
+    ] bs;
+
+  S.Repo.v (Irmin_git.config test_db) >>= fun repo ->
+  S.Repo.branches repo >>= fun bs ->
+  Alcotest.(check (slist string String.compare)) "filtered branches"
+    ["master";"foo"] bs;
+  Lwt.return ()
+
+let tests store =
+  let run f () = Lwt_main.run (f store) in
+  [
+    "Testing sort order"  , `Quick, run test_sort_order;
+    "Testing listing refs", `Quick, run test_list_refs;
+  ]

--- a/test/test_unix.ml
+++ b/test/test_unix.ml
@@ -58,7 +58,8 @@ end
 
 module Git = struct
 
-  let store = (module Irmin_unix.Git.FS.KV(Irmin.Contents.String): Test_S)
+  module S = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+  let store = (module S: Test_git.Test_S)
   let test_db = Test_git.test_db
 
   let init () =
@@ -80,10 +81,11 @@ module Git = struct
     let head = Git.Reference.of_raw "refs/heads/test" in
     Irmin_git.config ~head ~bare:true test_db
 
-  let suite = { name = "GIT"; kind = `Unix; clean; init; store; stats; config }
+  let suite =
+    let store = (module S: Test_S) in
+    { name = "GIT"; kind = `Unix; clean; init; store; stats; config }
 
   let test_non_bare () =
-    let (module S: Test_S) = store in
     init () >>= fun () ->
     let config = Irmin_git.config ~bare:false test_db in
     let info = Irmin_unix.info in


### PR DESCRIPTION
Fix #440 /cc @talex5 