### PR TITLE
Irmin.Hash.of_string should not raise an exception on invalid hash

### DIFF
--- a/src/ir_hash.ml
+++ b/src/ir_hash.ml
@@ -156,7 +156,10 @@ module SHA1 = struct
 
   let digest = sha_1
   let pp ppf x = Fmt.string ppf (to_hex x)
-  let of_string x = Ok (of_hex x)
+
+  let of_string x =
+    try Ok (of_hex x)
+    with Invalid e -> Error (`Msg e)
 
   let has_kind = function
     | `SHA1 -> true


### PR DESCRIPTION
It should return an Error value instead