### PR TITLE
Abstract digest serialization

### DIFF
--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -115,7 +115,7 @@ struct
 end
 
 module AO_ext (IO: IO) (S: Config)
-    (K: Irmin.Hash.S) (V: Irmin.Contents.Raw) =
+    (K: Irmin.Hash.S) (V: Irmin.Contents.Conv) =
 struct
 
   include RO_ext(IO)(S)(K)(V)

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -81,7 +81,7 @@ struct
     IO.file_exists file
 
   let value v =
-    match V.of_string (Cstruct.to_string v) with
+    match Irmin.Type.decode_cstruct V.t v with
     | Ok v           -> Some v
     | Error (`Msg e) ->
       Log.err (fun l -> l "Irmin_fs.value %s" e);
@@ -124,8 +124,8 @@ struct
 
   let add t value =
     Log.debug (fun f -> f "add");
-    let value = V.raw value in
-    let key = K.digest value in
+    let value = Irmin.Type.encode_cstruct V.t value in
+    let key = K.digest Irmin.Type.cstruct value in
     let file = file_of_key t key in
     let temp_dir = temp_dir t in
     (IO.file_exists file >>= function
@@ -148,13 +148,13 @@ module Link_ext (IO: IO) (S: Config) (K:Irmin.Hash.S) = struct
  let add t index key =
    Log.debug (fun f -> f "add link");
    let file = file_of_key t index in
-   let value = Fmt.to_to_string K.pp key in
+   let value = Irmin.Type.encode_cstruct K.t key in
    let temp_dir = temp_dir t in
    IO.file_exists file >>= function
    | true  -> Lwt.return_unit
    | false ->
      Lwt.catch
-       (fun () -> IO.write_file ~temp_dir file @@ Cstruct.of_string value)
+       (fun () -> IO.write_file ~temp_dir file value)
        (fun e -> Lwt.fail e)
 
 end
@@ -217,7 +217,7 @@ struct
     stop () >>= fun () ->
     W.unwatch t.w id
 
-  let raw_value v = Cstruct.of_string (Fmt.to_to_string V.pp v)
+  let raw_value v = Irmin.Type.encode_cstruct V.t v
 
   let set t key value =
     Log.debug (fun f -> f "update");

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -91,7 +91,7 @@ module Hash (G: VALUE_STORE) = struct
   type t = Git.Hash.t
   let digest_size = 20 (* FIXME: expose Git.Hash.digest_size *)
   let t = Irmin.Type.(like string) SHA_IO.of_hex Git.Hash.to_hex
-  let digest = G.Digest.cstruct
+  let digest t x = G.Digest.cstruct (Irmin.Type.encode_cstruct t x)
   let to_raw t = Cstruct.of_string (Git.Hash.to_raw t)
   let of_raw t = Git.Hash.of_raw (Cstruct.to_string t)
   let has_kind = function `SHA1 -> true | _ -> false
@@ -852,9 +852,9 @@ end
 module Digest (H: Irmin.Hash.S): Git.Hash.DIGEST = struct
   (* FIXME: lots of allocations ... *)
   let cstruct buf =
-    Git.Hash.of_raw (Cstruct.to_string (H.to_raw (H.digest buf)))
+    Git.Hash.of_raw (Cstruct.to_string (H.to_raw (H.digest Irmin.Type.cstruct buf)))
   let string str = cstruct (Cstruct.of_string str)
-  let length = Cstruct.len @@ H.to_raw (H.digest (Cstruct.of_string ""))
+  let length = Cstruct.len @@ H.to_raw (H.digest Irmin.Type.cstruct (Cstruct.of_string ""))
 end
 
 module FS = struct

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -48,7 +48,7 @@ module AO (K: Irmin.Hash.S) (V: Irmin.Contents.Raw) = struct
   include RO(K)(V)
 
   let add t value =
-    let key = K.digest (V.raw value) in
+    let key = K.digest V.t value in
     Log.debug (fun f -> f "add -> %a" K.pp key);
     t.t <- KMap.add key value t.t;
     Lwt.return key

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -43,7 +43,7 @@ module RO (K: Irmin.Contents.Conv) (V: Irmin.Contents.Conv) = struct
 
 end
 
-module AO (K: Irmin.Hash.S) (V: Irmin.Contents.Raw) = struct
+module AO (K: Irmin.Hash.S) (V: Irmin.Contents.Conv) = struct
 
   include RO(K)(V)
 

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -154,7 +154,9 @@ module SHA1 = struct
 
   let t = Type.(like string) of_hex to_hex
 
-  let digest = sha_1
+  let digest t x =
+    sha_1 (Type.encode_cstruct t x)
+
   let pp ppf x = Fmt.string ppf (to_hex x)
 
   let of_string x =

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -911,7 +911,7 @@ module Hash: sig
     val of_string: string -> (t, [`Msg of string]) result
     (** [of_string] parses paths. *)
 
-    val digest: Cstruct.t -> t
+    val digest: 'a Type.t -> 'a -> t
     (** Compute a deterministic store key from a {!Cstruct.t} value. *)
 
     val has_kind: [> `SHA1] -> bool

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -372,6 +372,9 @@ module Type: sig
   (** [decode_json_lexemes] is similar to {!decode_json} but use an
       already decoded list of JSON lexemes instead of a decoder. *)
 
+  val encode_cstruct: 'a t -> 'a -> Cstruct.t
+  val decode_cstruct: 'a t -> Cstruct.t -> ('a, [`Msg of string]) result
+
 end
 
 (** Commit info are used to keep track of the origin of write

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -987,17 +987,6 @@ module Contents: sig
 
   end
 
-  (** [Raw] is the signature for contents. *)
-  module type Raw = sig
-
-    include Conv
-
-    val raw: t -> Cstruct.t
-    (** [raw t] is the raw contents of [t] to be used for computing
-        stable digests. *)
-
-  end
-
   module type S = sig
 
     (** {1 Signature for store contents} *)
@@ -3009,7 +2998,7 @@ end
 (** [AO_MAKER] is the signature exposed by append-only store
     backends. [K] is the implementation of keys and [V] is the
     implementation of values. *)
-module type AO_MAKER = functor (K: Hash.S) -> functor (V: Contents.Raw) -> sig
+module type AO_MAKER = functor (K: Hash.S) -> functor (V: Contents.Conv) -> sig
 
   include AO with type key = K.t and type value = V.t
 

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -29,11 +29,6 @@ module type CONV = sig
   val of_string: string -> (t, [`Msg of string]) result
 end
 
-module type RAW = sig
-  include CONV
-  val raw: t -> Cstruct.t
-end
-
 module type PATH = sig
   type t
   val pp: t Fmt.t
@@ -88,7 +83,7 @@ module type AO = sig
   val add: t -> value -> key Lwt.t
 end
 
-module type AO_MAKER = functor (K: HASH) -> functor (V: RAW) ->
+module type AO_MAKER = functor (K: HASH) -> functor (V: CONV) ->
 sig
   include AO with type key = K.t and type value = V.t
   val v: Conf.t -> t Lwt.t

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -57,7 +57,7 @@ module type HASH = sig
   type t
   val pp: t Fmt.t
   val of_string: string -> (t, [`Msg of string]) result
-  val digest: Cstruct.t -> t
+  val digest: 'a Type.t -> 'a -> t
   val has_kind: [> `SHA1] -> bool
   val to_raw: t -> Cstruct.t
   val of_raw: Cstruct.t -> t

--- a/src/irmin/type.ml
+++ b/src/irmin/type.ml
@@ -138,8 +138,14 @@ module Refl = struct
   let prim: type a b. a prim -> b prim -> (a, b) eq option = fun a b ->
     match a, b with
     | Unit  , Unit   -> Some Refl
+    | Bool  , Bool   -> Some Refl
+    | Char  , Char   -> Some Refl
     | Int   , Int    -> Some Refl
+    | Int32 , Int32  -> Some Refl
+    | Int64 , Int64  -> Some Refl
+    | Float , Float   -> Some Refl
     | String, String -> Some Refl
+    | Cstruct, Cstruct -> Some Refl
     | _ -> None
 
   let rec eq: type a b. a t -> b t -> (a, b) eq option = fun a b ->

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -72,3 +72,6 @@ val encode_json: 'a t -> Jsonm.encoder -> 'a -> unit
 val decode_json: 'a t -> Jsonm.decoder -> ('a, [`Msg of string]) result
 val decode_json_lexemes:
   'a t -> Jsonm.lexeme list -> ('a, [`Msg of string]) result
+
+val encode_cstruct: 'a t -> 'a -> Cstruct.t
+val decode_cstruct: 'a t -> Cstruct.t -> ('a, [`Msg of string]) result

--- a/test/common/test_link.ml
+++ b/test/common/test_link.ml
@@ -24,7 +24,7 @@ module type S = sig
   val v: unit -> t Lwt.t
 end
 
-let key x = Hash.digest (Cstruct.of_string x)
+let key x = Hash.digest Irmin.Type.string x
 let key_t = testable Hash.t
 
 let test (module M: S) () =


### PR DESCRIPTION
On a trivial benchmark (commiting a view with a lot of new key/values), this series of patch introduce a 20-times speed-up (from around 60 seconds to around 3 seconds).

After some profiling, it looks like most of the time was spent on `memcpy` and `to_hex`. To remove unrequired copy/conversion, this series of patch abstract the signature of `Hash.digest` from `Cstruct.t -> t` to `'a Type.t -> 'a -> t`.

Our trivial benchmark is based on `irmin-mem` and `Irmin.Contents.Cstruct`. Half of the speed-up comes from the serialisation of leafs (no encoding to hexadecimal anymore). The rest of the speed is gained from the 'hashing' of nodes (no intermediate JSON representation).

Further optimisation seems doable, but these simple one looks like the only one that requires some change in the functor signatures.

Note: for program where readability is more a matter than performances, it is still possible to dump hexadecimal on disk rather than raw bytes. This only requires an alternative implementation of `Irmin.Contents.Cstruct`.