### PR TITLE
Remove non-portable `Type.int` and `Merge.int`

### DIFF
--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -4,4 +4,5 @@
   ((name         main)
    (public_name irmin)
    (package     irmin-unix)
-   (libraries   (irmin-unix cmdliner irmin-mem fmt.cli logs.cli fmt.tty))))
+   (libraries   (irmin-unix cmdliner irmin-mem
+                 logs.fmt logs.cli fmt.cli fmt.tty))))

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -74,9 +74,6 @@ module Type: sig
   val char: char t
   (** [char] is a representation of the character type. *)
 
-  val int: int t
-  (** [int] is a representation of the integer type. *)
-
   val int32: int32 t
   (** [int32] is a representation of the 32-bit integers type. *)
 
@@ -551,9 +548,6 @@ module Merge: sig
   val char: char t
   (** [char] is the default merge function for characters. *)
 
-  val int: int t
-  (** [int] is the default merge function for integers. *)
-
   val int32: int32 t
   (** [int32] is the default merge function for 32-bits integers. *)
 
@@ -581,14 +575,14 @@ module Merge: sig
 
   (** {1 Counters and Multisets} *)
 
-  type counter = int
+  type counter = int64
   (** The type for counter values. It is expected that the only valid
       operations on counters are {e increment} and {e decrement}. The
       following merge functions ensure that the counter semantics are
       preserved: {e i.e.} it ensures that the number of increments and
       decrements is preserved. *)
 
-  val counter: int t
+  val counter: counter t
   (** The merge function for mergeable counters. *)
 
   (** Multi-sets. *)

--- a/src/irmin/merge.mli
+++ b/src/irmin/merge.mli
@@ -45,13 +45,12 @@ val idempotent: 'a Type.t -> 'a t
 val unit: unit t
 val bool: bool t
 val char: char t
-val int: int t
 val int32: int32 t
 val int64: int64 t
 val float: float t
 val string: string t
 
-type counter = int
+type counter = int64
 val counter: counter t
 
 val option: 'a t -> 'a option t

--- a/src/irmin/type.ml
+++ b/src/irmin/type.ml
@@ -73,7 +73,6 @@ and 'a prim =
   | Unit   : unit prim
   | Bool   : bool prim
   | Char   : char prim
-  | Int    : int prim
   | Int32  : int32 prim
   | Int64  : int64 prim
   | Float  : float prim
@@ -140,7 +139,6 @@ module Refl = struct
     | Unit  , Unit   -> Some Refl
     | Bool  , Bool   -> Some Refl
     | Char  , Char   -> Some Refl
-    | Int   , Int    -> Some Refl
     | Int32 , Int32  -> Some Refl
     | Int64 , Int64  -> Some Refl
     | Float , Float   -> Some Refl
@@ -180,7 +178,6 @@ end
 let unit = Prim Unit
 let bool = Prim Bool
 let char = Prim Char
-let int = Prim Int
 let int32 = Prim Int32
 let int64 = Prim Int64
 let float = Prim Float
@@ -298,7 +295,6 @@ module Dump = struct
   let unit ppf () = Fmt.string ppf "()"
   let bool = Fmt.bool
   let char = Fmt.char
-  let int = Fmt.int
   let int32 = Fmt.int32
   let int64 = Fmt.int64
   let float = Fmt.float
@@ -332,7 +328,6 @@ module Dump = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float
@@ -423,7 +418,6 @@ module Equal = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float
@@ -537,7 +531,6 @@ module Compare = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float
@@ -588,7 +581,6 @@ module Encode_json = struct
   let float e f = lexeme e (`Float f)
   let int32 e i = float e (Int32.to_float i)
   let int64 e i = float e (Int64.to_float i)
-  let int e i = float e (float_of_int i)
   let bool e = function false -> float e 0. | _ -> float e 1.
 
   let cstruct e c =
@@ -644,7 +636,6 @@ module Encode_json = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float
@@ -739,7 +730,6 @@ module Size_of = struct
   | Unit   -> unit
   | Bool   -> bool
   | Char   -> char
-  | Int    -> int
   | Int32  -> int32
   | Int64  -> int64
   | Float  -> float
@@ -840,7 +830,6 @@ module Encode_cstruct = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float
@@ -960,7 +949,6 @@ module Decode_cstruct = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float
@@ -1154,7 +1142,6 @@ module Decode_json = struct
     | Unit   -> unit
     | Bool   -> bool
     | Char   -> char
-    | Int    -> int
     | Int32  -> int32
     | Int64  -> int64
     | Float  -> float

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -20,7 +20,6 @@ type 'a t
 val unit: unit t
 val bool: bool t
 val char: char t
-val int: int t
 val int32: int32 t
 val int64: int64 t
 val float: float t

--- a/test/common/test_store.ml
+++ b/test/common/test_store.ml
@@ -667,8 +667,8 @@ module Make (S: Test_S) = struct
     (* simple merges *)
     let check_merge () =
       let ok = Irmin.Merge.ok in
-      let dt = T.(option int) in
-      let dx = T.(list (pair string int)) in
+      let dt = T.(option int64) in
+      let dx = T.(list (pair string int64)) in
       let merge_skip ~old:_ _ _ = ok None in
       let merge_left ~old:_ x _ = ok x in
       let merge_right ~old:_ _ y = ok y in
@@ -679,11 +679,11 @@ module Make (S: Test_S) = struct
         | "skip"  -> Irmin.Merge.v dt merge_skip
         | _ -> merge_default
       in
-      let merge_x = Irmin.Merge.alist T.string T.int merge in
-      let old () = ok (Some [ "left", 1; "foo", 2; ]) in
-      let x =   [ "left", 2; "right", 0] in
-      let y =   [ "left", 1; "bar"  , 3; "skip", 0 ] in
-      let m =   [ "left", 2; "bar"  , 3] in
+      let merge_x = Irmin.Merge.alist T.string T.int64 merge in
+      let old () = ok (Some [ "left", 1L; "foo", 2L; ]) in
+      let x =   [ "left", 2L; "right", 0L] in
+      let y =   [ "left", 1L; "bar"  , 3L; "skip", 0L ] in
+      let m =   [ "left", 2L; "bar"  , 3L] in
       Irmin.Merge.(f merge_x) ~old x y >>= function
       | Error (`Conflict c) -> failf "conflict %s" c
       | Ok m'               ->


### PR DESCRIPTION
Let the programmer decide which size of ints to use to avoid 32/64b
conversion issues.

/cc @hannesm 