### PR TITLE
Depend on cohttp 1.0.0

### DIFF
--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -18,7 +18,7 @@ depends: [
   "crunch"
   "webmachine" {>= "0.3.2"}
   "irmin"  {>= "1.3.0"}
-  "cohttp-lwt" {>= "0.99.0"}
+  "cohttp-lwt" {>= "1.0.0"}
   "irmin-git" {test & >= "1.3.0"}
   "irmin-mem" {test & >= "1.3.0"}
   "alcotest"  {test}

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -134,7 +134,7 @@ module Helper (Client: Cohttp_lwt.S.Client) = struct
 
   let map_string_response parse (r, b) =
     check_version r >>= fun () ->
-    Cohttp_lwt_body.to_string b >>= fun b ->
+    Cohttp_lwt.Body.to_string b >>= fun b ->
     if is_success r then
       match parse b with
       | Ok x           -> Lwt.return x
@@ -146,10 +146,10 @@ module Helper (Client: Cohttp_lwt.S.Client) = struct
   let map_stream_response t (r, b) =
     check_version r >>= fun () ->
     if not (is_success r) then
-      Cohttp_lwt_body.to_string b >>= fun b ->
+      Cohttp_lwt.Body.to_string b >>= fun b ->
       Lwt.fail_with ("Server error: " ^ b)
     else
-      let stream = Cohttp_lwt_body.to_stream b in
+      let stream = Cohttp_lwt.Body.to_stream b in
       let stream = json_stream stream in
       let stream =
         let aux j =
@@ -285,7 +285,7 @@ module RW (Client: Cohttp_lwt.S.Client)
         match Cohttp.Response.status r with
         | `Not_found | `OK -> Lwt.return_unit
         | _ ->
-          Cohttp_lwt_body.to_string b >>= fun b ->
+          Cohttp_lwt.Body.to_string b >>= fun b ->
           Fmt.kstrf Lwt.fail_with "cannot remove %a: %s" K.pp key b
       )
 

--- a/src/irmin-http/irmin_http_server.ml
+++ b/src/irmin-http/irmin_http_server.ml
@@ -41,7 +41,7 @@ module Make (HTTP: Cohttp_lwt.S.Server) (S: Irmin.S) = struct
   module P = S.Private
 
   class virtual resource = object
-    inherit [Cohttp_lwt_body.t] Wm.resource
+    inherit [Cohttp_lwt.Body.t] Wm.resource
     method! finish_request rd =
       Wm.Rd.with_resp_headers (fun h ->
           Cohttp.Header.add h irmin_version Irmin.version
@@ -75,7 +75,7 @@ module Make (HTTP: Cohttp_lwt.S.Server) (S: Irmin.S) = struct
       method content_types_accepted rd = Wm.continue [] rd
 
       method! process_post rd =
-        Cohttp_lwt_body.to_string rd.Wm.Rd.req_body >>= fun body ->
+        Cohttp_lwt.Body.to_string rd.Wm.Rd.req_body >>= fun body ->
         match V.of_string body with
         | Error e -> parse_error rd body e
         | Ok body ->
@@ -146,7 +146,7 @@ module Make (HTTP: Cohttp_lwt.S.Server) (S: Irmin.S) = struct
       inherit resource
 
       method private of_json rd =
-        Cohttp_lwt_body.to_string rd.Wm.Rd.req_body >>= fun body ->
+        Cohttp_lwt.Body.to_string rd.Wm.Rd.req_body >>= fun body ->
         match of_json (set_t V.t) body with
         | Error e -> parse_error rd body e
         | Ok v    ->
@@ -222,7 +222,7 @@ module Make (HTTP: Cohttp_lwt.S.Server) (S: Irmin.S) = struct
         `Stream stream
 
       method! process_post rd =
-        Cohttp_lwt_body.to_string rd.Wm.Rd.req_body >>= fun body ->
+        Cohttp_lwt.Body.to_string rd.Wm.Rd.req_body >>= fun body ->
         match of_json T.(list (init_t K.t V.t)) body with
         | Error e -> parse_error rd body e
         | Ok init ->
@@ -262,7 +262,7 @@ module Make (HTTP: Cohttp_lwt.S.Server) (S: Irmin.S) = struct
         `Stream stream
 
       method! process_post rd =
-        Cohttp_lwt_body.to_string rd.Wm.Rd.req_body >>= fun body ->
+        Cohttp_lwt.Body.to_string rd.Wm.Rd.req_body >>= fun body ->
         match of_json V.t body with
         | Error e -> parse_error rd body e
         | Ok init ->


### PR DESCRIPTION
This PR updates all Irmin packages to depend on `cohttp` v1.0.0.