### PR TITLE
Update CLI command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 Irmin is an OCaml library for building mergeable, branchable distributed data stores.
 
 ### Features
-- **Built-in snapshotting** - simple backup and restore
-- **Storage agnostic** - easy to use your own storage layer when needed
-- **Custom datatypes** - simple (de)serialization for custom data types
+- **Built-in snapshotting** - backup and restore
+- **Storage agnostic** - you can use Irmin on top of your own storage layer
+- **Custom datatypes** - (de)serialization for custom data types
 - **Highly portable** - runs anywhere from Linux to web browsers and Xen unikernels
 - **Git compatibility** - `irmin-git` uses an on-disk format that can be inspected and modified using Git
 - **Dynamic behavior** - allows the users to define custom merge functions, use in-memory transactions (to keep track of reads as well as writes) and to define event-driven workflows using a notification mechanism

--- a/README.md
+++ b/README.md
@@ -1,168 +1,125 @@
-## Irmin -- A distributed database that follows the same design principles as Git
-
-Irmin is a library for persistent stores with built-in snapshot,
-branching and reverting mechanisms. It is designed to use a large
-variety of backends. Irmin is written in pure OCaml and does not
-depend on external C stubs; it aims to run everywhere, from Linux,
-to browsers and Xen unikernels.
-
+## Irmin - A distributed database built on the same principles as Git
 [![Build Status](https://travis-ci.org/mirage/irmin.svg)](https://travis-ci.org/mirage/irmin)
 [![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/irmin/)
 
-### Description
+Irmin is an OCaml library for building mergeable, branchable distributed data stores.
 
-- **on-disk format** various formats are supported, including the Git format:
-  Irmin on-disk repositories can be inspected and modified using the classic
-  Git command-line tools.
+### Features
+- **Built-in snapshotting** - simple backup and restore
+- **Storage agnostic** - easy to use your own storage layer when needed
+- **Custom datatypes** - simple (de)serialization for custom data types
+- **Highly portable** - runs anywhere from Linux to web browsers and Xen unikernels
+- **Git compatibility** - `irmin-git` uses an on-disk format that can be inspected and modified using Git
+- **Dynamic behavior** - allows the users to define custom merge functions, use in-memory transactions (to keep track of reads as well as writes) and to define event-driven workflows using a notification mechanism
 
-- **wire format** various formats are supported, including the Git protocol
-  (only in client mode) or a simple JSON-based REST API (client and server).
+### Documentation
+Documentation can be found online at [https://mirage.github.io/irmin](https://mirage.github.io/irmin)
 
-- **dynamic behaviour** Irmin allows the users to define custom merge functions,
-  to use in-memory transactions (to keep track of reads as well as writes) and
-  to define event-driven workflows using a notification mechanism.
+The [wiki](https://github.com/mirage/irmin/wiki) also contains some tutorials.
 
-These abstractions allow developers to create applications with concurrent
-behaviors which are both efficient and safe.
+### Installation
+To install Irmin, the command-line tool and all optional dependencies using [opam](https://github.com/ocaml/opam):
 
-### Bindings to other languages
+    opam install irmin-unix
 
-- **Go** [irmin-go](https://github.com/magnuss/irmin-go)
-- **JavaScript** [irmin-js](https://github.com/talex5/irmin-js)
+A minimal installation, with no storage backends can be installed by running:
 
-### Backends
+    opam install irmin
 
-Irmin ships with various backends. It provides the following OCamlfind pacakges:
+To only install the in-memory storage backend:
 
-- `irmin.mem` is an in-memory backend.
-- `irmin.git` uses the Git format to persist data on disk.
-- `irmin.fs` uses [bin_prot](https://github.com/janestreet/bin_prot) to persist
-  data on disk.
-- `irmin.http` uses JSON over HTTP to speak with an Irmin server.
+    opam install irmin-mem
 
-Other external backends are available as external OPAM packages
-(use `opam install <pkg>` to install):
+The following packages have been made available on `opam`:
+- `irmin` - the base package, no storage implementations
+- `irmin-chunk` - chunked storage
+- `irmin-fs` - filesystem-based storage using `bin_prot`
+- `irmin-git` - Git compatible storage
+- `irmin-http` - a simple REST interface
+- `irmin-mem` - in-memory storage implementation
+- `irmin-mirage` - miragle compatibility
+- `irmin-unix` - unix compatibility
 
-- [irmin-chunk](https://github.com/mirage/irmin-chunk) stores raw contents into
-  a well-balanced rope where leafs are chunks of all the same size.
-- [irmin-indexdb](https://github.com/talex5/irmin-indexeddb) is a backend
-  for a web browser's IndexedDB store.
+For more information about an individual package consult the [online documentation](https://mirage.github.io/irmin)
 
-### Datastructures
-
-- [merge-queues](https://github.com/mirage/merge-queues) is an implementation
-  of mergeable queues.
-- [merge-ropes](https://github.com/mirage/merge-ropes) is an implementation
-  of mergeable ropes.
-- [diff-datatypes](https://github.com/gprano/diff-datatypes) is a collection
-  of automatic merge functions based on edit scripts. It is fairly generic but
-  contains specific implementation for mergeable trees, stacks and queues.
-- [irmin-datatypes](https://github.com/kayceesrk/irmin-datatypes) is a
-  collection of mergeable datatypes, including LWW registers, queues and sets.
-
-### Use-Cases
-
-Here a list of Irmin users:
-
-- [Cuekeeper](https://github.com/talex5/cuekeeper) a
-  version-controlled TODO list in the browser.
-- [imaplet](https://github.com/gregtatcam/imaplet-lwt), a version-controlled
-  IMAP server and client.
-- [jitsu](https://github.com/mirage/jitsu), a DNS server that automatically
-  starts unikernels on demand. The database is persisted with Irmin.
-- [Irmin+Xenstore](https://github.com/djs55/ocaml-xenstore/tree/irminsule), the
-  Xenstore deamon rewritten to use Irmin to persist its data.
-- [irmin-arp](https://github.com/yomimono/irmin-arp), a distributed ARP cache.
-- [dog](https://github.com/samoht/dog), a synchronisation tool.
-- [irminFS](https://github.com/dsheets/irminfs), a prototype version-controlled
-  file-system using Fuse.
-
-### Further Reading
-
-- [What a Distributed, Version-Controlled ARP Cache Gets
-You](http://www.somerandomidiot.com/blog/2015/04/24/what-a-distributed-version-controlled-ARP-cache-gets-you/).
-Blog post describing how Irmin can be used with Mirage to store the
-network stack's ARP cache, which allows the history to be viewed using
-the git tools.
-
-- [CueKeeper: Gitting Things Done in the
-Browser](http://roscidus.com/blog/blog/2015/04/28/cuekeeper-gitting-things-done-in-the-browser/).
-A GTD-based todo list running client-side in the browser, using Irmin
-compiled to JavaScript to provide history, revert and synchronisation
-between tabs. The data is stored using an IndexedDB Irmin backend.
-
-- [Using Irmin to add fault-tolerance to the Xenstore
-database.](https://mirage.io/blog/introducing-irmin-in-xenstore)
-Porting the Xen hypervisor toolstack to support Git persistence via
-Irmin.
-
-- [Introducing Irmin: Git-like distributed, branchable
-storage.](https://mirage.io/blog/introducing-irmin) This is the first
-post that describes Irmin, the new Git-like storage layer for Mirage
-OS 2.0.
-
-### Getting Started
-
-#### Install
-
-Irmin is packaged with [opam](https://opam.ocaml.org):
-
-```
-opam install irmin-unix # install all the optional depencies
-```
-
-#### Usage
-
-Irmin comes with a command-line tool called `irmin`. See `irmin
- --help` for further reading. Use either `irmin <command> --help` or
- `irmin help <command>` for more information on a specific command.
-
-To get the full capabilites of Irmin, use the [API](https://mirage.github.io/irmin):
+### Examples
+Below is a simple example of setting a key and getting the value out of a Git based, filesystem-backed store.
 
 ```ocaml
 open Lwt.Infix
-open Irmin_unix
-module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
+(* Irmin store with string contents *)
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+
+(* Database configuration *)
 let config = Irmin_git.config ~bare:true "/tmp/irmin/test"
-let info fmt = Irmin_unix.info ~author:"me <me@moi.com>" fmt
 
-let prog =
-  Store.Repo.v config >>= Store.master >>= fun t ->
-  Store.set t ~info:(info "Updating foo/bar") ["foo"; "bar"] "hi!" >>= fun () ->
-  Store.get t ["foo"; "bar"] >>= fun x ->
-  Printf.printf "Read: %s\n%!" x;
-  Lwt.return_unit
+(* Commit author *)
+let author = "Example <example@example.com>"
 
-let () = Lwt_main.run prog
+(* Commit information *)
+let info fmt = Irmin_unix.info ~author fmt
+
+let main =
+    (* Open the repo *)
+    Store.Repo.v config >>=
+
+    (* Load the master branch *)
+    Store.master >>= fun t ->
+
+    (* Set key "foo/bar" to "testing 123" *)
+    Store.set t ~info:(info "Updating foo/bar") ["foo"; "bar"] "testing 123" >>= fun () ->
+
+    (* Get key "foo/bar" and print it to stdout *)
+    Store.get t ["foo"; "bar"] >|= fun x ->
+    Printf.printf "foo/bar => '%s'\n" x
+
+(* Run the program *)
+let () = Lwt_main.run main
 ```
 
-To compile the example above, save it to a file called
-`example.ml`. Install irmin and git with opam (`opam install irmin-unix`) and
-run
+To compile the example above, save it to a file called `example.ml` and run:
 
-```ocaml
-$ ocamlfind ocamlopt example.ml -o example -package irmin.unix,lwt.unix -linkpkg
+```bash
+$ ocamlfind ocamlopt example.ml -o example -package irmin-unix,lwt.unix -linkpkg
 $ ./example
-Read: hi!
+foo/bar => 'testing 123'
+```
+The `examples` directory contains some more advanced examples.
+
+### Command-line
+The same thing can also be accomplished using `irmin`, the command-line application installed with `irmin-unix`, by running:
+
+```bash
+$ echo "root=." > .irminconfig
+$ irmin init
+$ irmin set foo/bar "testing 123"
+$ irmin get foo/bar
 ```
 
-The `examples` directory contains more examples. To build them, run
+`.irminconfig` allows for `irmin` flags to be set globally on a per-directory basis. Run `irmin help irminconfig` for further details.
 
-```ocaml
-$ jbuilder build examples/trees.exe
-$ _build/default/examples/trees.exe
-```
+Also see `irmin --help` for list of all commands and either `irmin <command> --help` or `irmin help <command>` for more help with a specific command.
 
-#### Tutorial
+### Related Projects
 
-Tutorials are available on the
-[wiki](https://github.com/mirage/irmin/wiki/).
+#### Bindings
+- [irmin-go](https://github.com/magnuss/irmin-go) - Go bindings
+- [irmin-js](https://github.com/talex5/irmin-js) - Javascript bindings
+
+#### Storage implementations
+- [irmin-chunk](https://github.com/mirage/irmin-chunk) - Storage using a well-balanced rope where leafs are all chunks of the same size.
+- [irmin-indexdb](https://github.com/talex5/irmin-indexeddb) -  Storage using a web browser's IndexedDB store.
+
+#### Datatypes
+- [merge-queues](https://github.com/mirage/merge-queues) - An implementation of mergeable queues.
+- [merge-ropes](https://github.com/mirage/merge-ropes) - An implementation of mergeable ropes.
+- [diff-datatypes](https://github.com/gprano/diff-datatypes) - A collection of automatic merge functions based on edit scripts. It is fairly generic but contains specific implementations for mergeable trees, stacks and queues.
+- [irmin-datatypes](https://github.com/kayceesrk/irmin-datatypes) - A collection of mergeable datatypes, including LWW registers, queues and sets.
 
 ### Issues
 
-To report any issues please use the [bugtracker on
-Github](https://github.com/mirage/irmin/issues).
+Feel free to to report any issues using the [Github bugtracker](https://github.com/mirage/irmin/issues).
 
 ### Conditions
 
@@ -170,5 +127,4 @@ See the [LICENSE file](./LICENSE.md).
 
 ### Acknowledgements
 
-Development of Irmin was supported in part by the EU FP7 User-Centric Networking
-project, Grant No. 611001.
+Development of Irmin was supported in part by the EU FP7 User-Centric Networking project, Grant No. 611001.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following packages have been made available on `opam`:
 - `irmin-git` - Git compatible storage
 - `irmin-http` - a simple REST interface
 - `irmin-mem` - in-memory storage implementation
-- `irmin-mirage` - miragle compatibility
+- `irmin-mirage` - mirage compatibility
 - `irmin-unix` - unix compatibility
 
 For more information about an individual package consult the [online documentation](https://mirage.github.io/irmin)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ to browsers and Xen unikernels.
 
 ### Description
 
-Irmin is a library to version-control application data. It has the following
-features:
-
 - **on-disk format** various formats are supported, including the Git format:
   Irmin on-disk repositories can be inspected and modified using the classic
   Git command-line tools.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Irmin is an OCaml library for building mergeable, branchable distributed data st
 ### Documentation
 Documentation can be found online at [https://mirage.github.io/irmin](https://mirage.github.io/irmin)
 
-The [wiki](https://github.com/mirage/irmin/wiki) also contains some tutorials.
 
 ### Installation
 To install Irmin, the command-line tool and all optional dependencies using [opam](https://github.com/ocaml/opam):

--- a/README.md
+++ b/README.md
@@ -100,24 +100,7 @@ $ irmin get foo/bar
 
 Also see `irmin --help` for list of all commands and either `irmin <command> --help` or `irmin help <command>` for more help with a specific command.
 
-### Related Projects
-
-#### Bindings
-- [irmin-go](https://github.com/magnuss/irmin-go) - Go bindings
-- [irmin-js](https://github.com/talex5/irmin-js) - Javascript bindings
-
-#### Storage implementations
-- [irmin-chunk](https://github.com/mirage/irmin-chunk) - Storage using a well-balanced rope where leafs are all chunks of the same size.
-- [irmin-indexdb](https://github.com/talex5/irmin-indexeddb) -  Storage using a web browser's IndexedDB store.
-
-#### Datatypes
-- [merge-queues](https://github.com/mirage/merge-queues) - An implementation of mergeable queues.
-- [merge-ropes](https://github.com/mirage/merge-ropes) - An implementation of mergeable ropes.
-- [diff-datatypes](https://github.com/gprano/diff-datatypes) - A collection of automatic merge functions based on edit scripts. It is fairly generic but contains specific implementations for mergeable trees, stacks and queues.
-- [irmin-datatypes](https://github.com/kayceesrk/irmin-datatypes) - A collection of mergeable datatypes, including LWW registers, queues and sets.
-
 ### Issues
-
 Feel free to to report any issues using the [Github bugtracker](https://github.com/mirage/irmin/issues).
 
 ### Conditions

--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ $ ocamlfind ocamlopt example.ml -o example -package irmin-unix,lwt.unix -linkpkg
 $ ./example
 foo/bar => 'testing 123'
 ```
-The `examples` directory contains some more advanced examples.
+The `examples` directory contains some more advanced examples. The build them, run:
+
+```bash
+$ jbuilder build examples/trees.exe
+$ _build/default/examples/trees.exe
+```
 
 ### Command-line
 The same thing can also be accomplished using `irmin`, the command-line application installed with `irmin-unix`, by running:

--- a/src/irmin-chunk/irmin_chunk.mli
+++ b/src/irmin-chunk/irmin_chunk.mli
@@ -18,8 +18,8 @@
 (**
     This package provides an Irmin backend to cut raw contents into blocks
     of the same size, while preserving the keys used in the store. It can
-    be used to optimize space usage when dealing with large files or as a
-    an intermediate layer for a raw block device backend.
+    be used to optimize space usage when dealing with large files or as an
+    intermediate layer for a raw block device backend.
 
     # Install
 

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -327,9 +327,7 @@ let fetch = {
       run begin
         store >>= fun t ->
         remote >>= fun r ->
-        let branch = match S.Branch.of_string "import" with
-          | Ok branch -> branch
-          | Error (`Msg e) -> failwith e in
+        let branch = branch S.Branch.of_string "import" in
         S.of_branch (S.repo t) branch >>= fun t ->
         Sync.pull_exn t r `Set
       end
@@ -401,9 +399,7 @@ let revert = {
     let revert (S ((module S), store)) snapshot =
       run begin
         store >>= fun t ->
-        let hash = match S.Commit.Hash.of_string snapshot with
-          | Ok hash -> hash
-          | Error (`Msg msg) -> failwith msg in
+        let hash = commit S.Commit.Hash.of_string snapshot in
         S.Commit.of_hash (S.repo t) hash >>= fun s ->
         match s with
         | Some s -> S.Head.set t s

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -411,7 +411,7 @@ let revert = {
 (* WATCH *)
 let watch = {
   name = "watch";
-  doc  = "Watch the contents of a store and be notified on updates.";
+  doc  = "Get notifications when values change.";
   man  = [];
   term =
     let watch (S ((module S), store)) path =

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -153,13 +153,13 @@ let value f x = get "value" f x
 let branch f x = get "branch" f x
 let commit f x = get "commit" f x
 
-(* READ *)
-let read = {
-  name = "read";
+(* GET *)
+let get = {
+  name = "get";
   doc  = "Read the contents of a node.";
   man  = [];
   term =
-    let read (S ((module S), store)) path =
+    let get (S ((module S), store)) path =
       run begin
         store >>= fun t ->
         S.find t (key S.Key.of_string path) >>= function
@@ -169,16 +169,16 @@ let read = {
           Lwt.return_unit
       end
     in
-    Term.(mk read $ store $ path);
+    Term.(mk get $ store $ path);
 }
 
-(* LS *)
-let ls = {
-  name = "ls";
+(* LIST *)
+let list = {
+  name = "list";
   doc  = "List subdirectories.";
   man  = [];
   term =
-    let ls (S ((module S), store)) path =
+    let list (S ((module S), store)) path =
       run begin
         store >>= fun t ->
         S.list t (key S.Key.of_string path) >>= fun paths ->
@@ -190,7 +190,7 @@ let ls = {
         Lwt.return_unit
       end
     in
-    Term.(mk ls $ store $ path);
+    Term.(mk list $ store $ path);
 }
 
 (* TREE *)
@@ -243,16 +243,16 @@ let tree = {
     Term.(mk tree $ store);
 }
 
-(* WRITE *)
-let write = {
-  name = "write";
+(* SET *)
+let set = {
+  name = "set";
   doc  = "Write/modify a node.";
   man  = [];
   term =
     let args =
       let doc = Arg.info ~docv:"VALUE" ~doc:"Value to add." [] in
       Arg.(value & pos_all string [] & doc) in
-    let write (S ((module S), store)) args =
+    let set (S ((module S), store)) args =
       run begin
         store >>= fun t ->
         let mk v = value S.Contents.of_string v in
@@ -261,25 +261,25 @@ let write = {
           | [path; value] -> key S.Key.of_string path, mk value
           | _             -> failwith "Too many arguments"
         in
-        S.set t ~info:(info "write") path value
+        S.set t ~info:(info "set") path value
       end
     in
-    Term.(mk write $ store $ args);
+    Term.(mk set $ store $ args);
 }
 
-(* RM *)
-let rm = {
-  name = "rm";
+(* REMOVE *)
+let remove = {
+  name = "remove";
   doc  = "Remove a node.";
   man  = [];
   term =
-    let rm (S ((module S), store)) path =
+    let remove (S ((module S), store)) path =
       run begin
         store >>= fun t ->
         S.remove t ~info:(info "rm %s." path) (key S.Key.of_string path)
       end
     in
-    Term.(mk rm $ store $ path);
+    Term.(mk remove $ store $ path);
 }
 
 (* CLONE *)
@@ -557,10 +557,10 @@ let default =
        \n\
        The most commonly used subcommands are:\n\
       \    init        %s\n\
-      \    read        %s\n\
-      \    write       %s\n\
-      \    rm          %s\n\
-      \    ls          %s\n\
+      \    get         %s\n\
+      \    set         %s\n\
+      \    remove      %s\n\
+      \    list        %s\n\
       \    tree        %s\n\
       \    clone       %s\n\
       \    fetch       %s\n\
@@ -573,7 +573,7 @@ let default =
        \n\
        See `irmin help <command>` for more information on a specific command.\n\
        %!"
-      init.doc read.doc write.doc rm.doc ls.doc tree.doc
+      init.doc get.doc set.doc remove.doc list.doc tree.doc
       clone.doc fetch.doc pull.doc push.doc snapshot.doc
       revert.doc watch.doc dot.doc
   in
@@ -587,10 +587,10 @@ let default =
 let commands = List.map create_command [
     help;
     init;
-    read;
-    write;
-    rm;
-    ls;
+    get;
+    set;
+    remove;
+    list;
     tree;
     clone;
     pull;

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -20,13 +20,12 @@ open Ir_resolver
 
 let () = Irmin_unix.set_listen_dir_hook ()
 
-let info fmt = Irmin_unix.info ~author:"irmin" fmt
+let info ?author:(author="irmin") fmt = Irmin_unix.info ~author fmt
 
 (* Help sections common to all commands *)
-let global_option_section = "COMMON OPTIONS"
 let help_sections = [
   `S global_option_section;
-  `P "These options are common to all commands.";
+  `P "These options can be passed to any command";
 
   `S "AUTHORS";
   `P "Thomas Gazagnaire   <thomas@gazagnaire.org>";
@@ -46,7 +45,7 @@ let setup_log =
 
 let term_info title ~doc ~man =
   let man = man @ help_sections in
-  Term.info ~sdocs:global_option_section ~doc ~man title
+  Term.info ~sdocs:global_option_section ~docs:global_option_section ~doc ~man title
 
 type command = unit Term.t * Term.info
 
@@ -74,7 +73,7 @@ let path =
     let print ppf path = pr_str ppf path in
     parse, print
   in
-  let doc = Arg.info ~docv:"PATH" ~doc:"Local path." [] in
+  let doc = Arg.info ~docv:"PATH" ~doc:"Key to lookup or modify." [] in
   Arg.(required & pos 0 (some path_conv) None & doc)
 
 let depth =
@@ -82,15 +81,23 @@ let depth =
     Arg.info ~docv:"DEPTH" ~doc:"Limit the history depth." ["d";"depth"] in
   Arg.(value & opt (some int) None & doc)
 
+let print_exc exc =
+  begin
+    match exc with
+    | Failure f -> Fmt.epr "%s\n%!" f
+    | e -> Fmt.epr "%a\n%!" Fmt.exn e
+  end;
+  exit 1
+
 let run t =
   Lwt_main.run (
     Lwt.catch
       (fun () -> t)
-      (function e -> Fmt.epr "%a\n%!" Fmt.exn e; exit 1)
+      print_exc
   )
 
 let mk (fn:'a): 'a Term.t =
-  Term.(pure (fun () -> fn) $ setup_log)
+  Term.(const (fun () -> fn) $ setup_log)
 
 (* INIT *)
 let init = {
@@ -226,10 +233,10 @@ let tree = {
               Fmt.to_to_string S.Key.pp k,
               Fmt.strf "%a" S.Contents.pp v
             ) all in
-        let max_lenght l =
+        let max_length l =
           List.fold_left (fun len s -> max len (String.length s)) 0 l in
-        let k_max = max_lenght (List.map fst all) in
-        let v_max = max_lenght (List.map snd all) in
+        let k_max = max_length (List.map fst all) in
+        let v_max = max_length (List.map snd all) in
         let pad = 79 + k_max + v_max in
         List.iter (fun (k,v) ->
             let dots =
@@ -243,28 +250,33 @@ let tree = {
     Term.(mk tree $ store);
 }
 
+let author =
+  let doc = Arg.info ~docv:"NAME" ~doc:"Commit author name" ["author"] in
+  Arg.(value & opt (some string) None & doc)
+
+let message =
+  let doc = Arg.info ~docv:"MESSAGE" ~doc:"Commit message" ["message"] in
+  Arg.(value & opt (some string) None & doc)
+
 (* SET *)
 let set = {
   name = "set";
-  doc  = "Write/modify a node.";
+  doc  = "Update the value associated with a key.";
   man  = [];
   term =
-    let args =
+    let v =
       let doc = Arg.info ~docv:"VALUE" ~doc:"Value to add." [] in
-      Arg.(value & pos_all string [] & doc) in
-    let set (S ((module S), store)) args =
+      Arg.(required & pos 1 (some string) None & doc) in
+    let set (S ((module S), store)) author message path v =
       run begin
+        let message = match message with Some s -> s | None -> "set" in
         store >>= fun t ->
-        let mk v = value S.Contents.of_string v in
-        let path, value = match args with
-          | [] | [_]      -> failwith "Not enough arguments"
-          | [path; value] -> key S.Key.of_string path, mk value
-          | _             -> failwith "Too many arguments"
-        in
-        S.set t ~info:(info "set") path value
+        let path = key S.Key.of_string path in
+        let value = value S.Contents.of_string v in
+        S.set t ~info:(info ?author "%s" message) path value
       end
     in
-    Term.(mk set $ store $ args);
+    Term.(mk set $ store $ author $ message $ path $ v);
 }
 
 (* REMOVE *)
@@ -273,13 +285,14 @@ let remove = {
   doc  = "Remove a node.";
   man  = [];
   term =
-    let remove (S ((module S), store)) path =
+    let remove (S ((module S), store)) author message path =
       run begin
+        let message = match message with Some s -> s | None -> "rm " ^ path in
         store >>= fun t ->
-        S.remove t ~info:(info "rm %s." path) (key S.Key.of_string path)
+        S.remove t ~info:(info ?author "%s" message) (key S.Key.of_string path)
       end
     in
-    Term.(mk remove $ store $ path);
+    Term.(mk remove $ store $ author $ message $ path);
 }
 
 (* CLONE *)
@@ -307,17 +320,23 @@ let fetch = {
   doc  = "Download objects and refs from another repository.";
   man  = [];
   term =
-    let fetch (S ((module S), store)) remote =
+    let fetch (S ((module S), store)) remote branch_name =
       let module Sync = Irmin.Sync (S) in
       run begin
         store >>= fun t ->
         remote >>= fun r ->
-        let branch = branch S.Branch.of_string "import" in
-        S.of_branch (S.repo t) branch >>= fun t ->
+        let branch =
+          match branch_name with
+          | Some name ->
+              let branch = branch S.Branch.of_string name in
+              S.of_branch (S.repo t) branch
+          | None -> S.master (S.repo t) in
+
+        branch >>= fun t ->
         Sync.pull_exn t r `Set
       end
     in
-    Term.(mk fetch $ store $ remote);
+    Term.(mk fetch $ store $ remote $ Ir_resolver.branch);
 }
 
 (* PULL *)
@@ -326,15 +345,16 @@ let pull = {
   doc  = "Fetch and merge with another repository.";
   man  = [];
   term =
-    let pull (S ((module S), store)) remote =
+    let pull (S ((module S), store)) message remote =
+      let message = match message with Some s -> s | None -> "pull" in
       let module Sync = Irmin.Sync (S) in
       run begin
         store >>= fun t ->
         remote >>= fun r ->
-        Sync.pull_exn t r (`Merge (Irmin_unix.info "Pulling"))
+        Sync.pull_exn t r (`Merge (Irmin_unix.info "%s" message))
       end
     in
-    Term.(mk pull $ store $ remote);
+    Term.(mk pull $ store $ message $ remote);
 }
 
 (* PUSH *)
@@ -546,7 +566,7 @@ let default =
     `P "Irmin is a distributed database with built-in snapshot, branch \
         and revert mechanisms. It is designed to use a large variety of backends, \
         although it is optimized for append-only ones.";
-    `P "Use either $(b,$(mname) <command> --help) or $(b,$(mname) help <command>) \
+    `P "Use either $(mname) <command> --help or $(mname) help <command> \
         for more information on a specific command.";
   ] in
   let usage () =
@@ -577,7 +597,7 @@ let default =
       clone.doc fetch.doc pull.doc push.doc snapshot.doc
       revert.doc watch.doc dot.doc
   in
-  Term.(mk usage $ pure ()),
+  Term.(mk usage $ const ()),
   Term.info "irmin"
     ~version:Irmin.version
     ~sdocs:global_option_section

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -84,8 +84,8 @@ let depth =
 let print_exc exc =
   begin
     match exc with
-    | Failure f -> Fmt.epr "%s\n%!" f
-    | e -> Fmt.epr "%a\n%!" Fmt.exn e
+    | Failure f -> Fmt.epr "ERROR: %s\n%!" f
+    | e -> Fmt.epr "ERROR: %a\n%!" Fmt.exn e
   end;
   exit 1
 
@@ -106,7 +106,7 @@ let init = {
   man  = [];
   term =
     let daemon =
-      let doc = Arg.info ~doc:"Start an Irmin server." ["d";"daemon"] in
+      let doc = Arg.info ~doc:"Start an Irmin HTTP server." ["d";"daemon"] in
       Arg.(value & flag & doc)
     in
     let uri =
@@ -163,7 +163,9 @@ let commit f x = get "commit" f x
 (* GET *)
 let get = {
   name = "get";
-  doc  = "Read the contents of a node.";
+  doc  = "Read the value associated with a key. \
+          If the key has not been set then the program \
+          will terminate with a non-zero exit code";
   man  = [];
   term =
     let get (S ((module S), store)) path =
@@ -251,11 +253,11 @@ let tree = {
 }
 
 let author =
-  let doc = Arg.info ~docv:"NAME" ~doc:"Commit author name" ["author"] in
+  let doc = Arg.info ~docv:"NAME" ~doc:"Commit author name." ["author"] in
   Arg.(value & opt (some string) None & doc)
 
 let message =
-  let doc = Arg.info ~docv:"MESSAGE" ~doc:"Commit message" ["message"] in
+  let doc = Arg.info ~docv:"MESSAGE" ~doc:"Commit message." ["message"] in
   Arg.(value & opt (some string) None & doc)
 
 (* SET *)
@@ -282,12 +284,12 @@ let set = {
 (* REMOVE *)
 let remove = {
   name = "remove";
-  doc  = "Remove a node.";
+  doc  = "Delete a key.";
   man  = [];
   term =
     let remove (S ((module S), store)) author message path =
       run begin
-        let message = match message with Some s -> s | None -> "rm " ^ path in
+        let message = match message with Some s -> s | None -> "remove " ^ path in
         store >>= fun t ->
         S.remove t ~info:(info ?author "%s" message) (key S.Key.of_string path)
       end
@@ -298,7 +300,7 @@ let remove = {
 (* CLONE *)
 let clone = {
   name = "clone";
-  doc  = "Clone a repository into a new store.";
+  doc  = "Copy a remote respository to a local store";
   man  = [];
   term =
     let clone (S ((module S), store)) remote depth =
@@ -308,7 +310,7 @@ let clone = {
         remote >>= fun remote ->
         Sync.fetch t ?depth remote >>= function
         | Ok d    -> S.Head.set t d
-        | Error e -> Format.eprintf "Error: %a!\n" Sync.pp_fetch_error e; exit 1
+        | Error e -> Format.eprintf "ERROR: %a!\n" Sync.pp_fetch_error e; exit 1
       end
     in
     Term.(mk clone $ store $ remote $ depth);
@@ -320,23 +322,19 @@ let fetch = {
   doc  = "Download objects and refs from another repository.";
   man  = [];
   term =
-    let fetch (S ((module S), store)) remote branch_name =
+    let fetch (S ((module S), store)) remote =
       let module Sync = Irmin.Sync (S) in
       run begin
         store >>= fun t ->
         remote >>= fun r ->
-        let branch =
-          match branch_name with
-          | Some name ->
-              let branch = branch S.Branch.of_string name in
-              S.of_branch (S.repo t) branch
-          | None -> S.master (S.repo t) in
-
-        branch >>= fun t ->
+        let branch = match S.Branch.of_string "import" with
+          | Ok branch -> branch
+          | Error (`Msg e) -> failwith e in
+        S.of_branch (S.repo t) branch >>= fun t ->
         Sync.pull_exn t r `Set
       end
     in
-    Term.(mk fetch $ store $ remote $ Ir_resolver.branch);
+    Term.(mk fetch $ store $ remote);
 }
 
 (* PULL *)
@@ -377,7 +375,7 @@ let push = {
 (* SNAPSHOT *)
 let snapshot = {
   name = "snapshot";
-  doc  = "Snapshot the contents of the store.";
+  doc  = "Return a snapshot for the current state of the database.";
   man  = [];
   term =
     let snapshot (S ((module S), store)) =
@@ -403,8 +401,13 @@ let revert = {
     let revert (S ((module S), store)) snapshot =
       run begin
         store >>= fun t ->
-        let s = commit (S.Commit.of_string @@ S.repo t) snapshot in
-        S.Head.set t s
+        let hash = match S.Commit.Hash.of_string snapshot with
+          | Ok hash -> hash
+          | Error (`Msg msg) -> failwith msg in
+        S.Commit.of_hash (S.repo t) hash >>= fun s ->
+        match s with
+        | Some s -> S.Head.set t s
+        | None -> failwith "invalid commit"
       end
     in
     Term.(mk revert $ store $ snapshot)
@@ -563,9 +566,9 @@ let default =
   let doc = "Irmin, the database that never forgets." in
   let man = [
     `S "DESCRIPTION";
-    `P "Irmin is a distributed database with built-in snapshot, branch \
-        and revert mechanisms. It is designed to use a large variety of backends, \
-        although it is optimized for append-only ones.";
+    `P "Irmin is a distributed database used primarily for application data. \
+        It is designed to work with a large variety of backends and has built-in \
+        snapshotting, reverting and branching mechanisms.";
     `P "Use either $(mname) <command> --help or $(mname) help <command> \
         for more information on a specific command.";
   ] in

--- a/src/irmin-unix/bin/ir_resolver.ml
+++ b/src/irmin-unix/bin/ir_resolver.ml
@@ -18,6 +18,8 @@ open Lwt.Infix
 open Cmdliner
 open Astring
 
+let global_option_section = "COMMON OPTIONS"
+
 type contents = (module Irmin.Contents.S)
 
 let create: (module Irmin.S_MAKER) -> contents -> (module Irmin.S) =
@@ -93,7 +95,7 @@ let config_term =
     |> add Irmin_git.level level
     |> add Irmin_http.uri uri
   in
-  Term.(pure create $
+  Term.(const create $
         opt_key Irmin.Private.Conf.root $
         flag_key Irmin_git.bare $
         opt_key Irmin_git.head $
@@ -113,14 +115,14 @@ let default_contents = `String
 
 let contents =
   let kind =
-    let doc = Arg.info ~doc:"The type of user-defined contents." ["contents";"c"] in
+    let doc = Arg.info ~doc:"The type of user-defined contents." ~docs:global_option_section ["contents";"c"] in
     Arg.(value & opt (enum contents_kinds) default_contents & doc)
   in
   Term.(const mk_contents $ kind)
 
 let store_term =
   let store =
-    let doc = Arg.info ~doc:"The kind of backend stores." ["s";"store"] in
+    let doc = Arg.info ~doc:"The kind of backend stores." ~docs:global_option_section ["s";"store"] in
     Arg.(value & opt (some (enum store_kinds)) None & doc)
   in
   let create store contents = match store with
@@ -193,15 +195,17 @@ let read_config_file (): t option =
     | None   -> Some (S ((module S), mk_master ()))
     | Some b -> Some (S ((module S), mk_branch b))
 
-let store =
   let branch =
     let doc =
       Arg.info
         ~doc:"The current branch name. Default is the store's master branch."
+        ~docs:global_option_section
+        ~docv:"BRANCH"
         ["b"; "branch"]
     in
     Arg.(value & opt (some string) None & doc)
-  in
+
+let store =
   let create store config branch =
     match store with
     | Some s ->

--- a/src/irmin-unix/bin/ir_resolver.ml
+++ b/src/irmin-unix/bin/ir_resolver.ml
@@ -116,7 +116,7 @@ let contents =
     let doc = Arg.info ~doc:"The type of user-defined contents." ["contents";"c"] in
     Arg.(value & opt (enum contents_kinds) default_contents & doc)
   in
-  Term.(pure mk_contents $ kind)
+  Term.(const mk_contents $ kind)
 
 let store_term =
   let store =
@@ -127,7 +127,7 @@ let store_term =
     | Some s -> Some (mk_store s contents)
     | None   -> None
   in
-  Term.(pure create $ store $ contents)
+  Term.(const create $ store $ contents)
 
 let cfg = ".irminconfig"
 
@@ -229,7 +229,7 @@ let store =
         let t = S.Repo.v config >>= fun repo -> S.master repo in
         S ((module S), t)
   in
-  Term.(pure create $ store_term $ config_term $ branch)
+  Term.(const create $ store_term $ config_term $ branch)
 
 (* FIXME: read the remote configuration in a file *)
 let (/) = Filename.concat
@@ -262,4 +262,4 @@ let remote =
     let doc = Arg.info ~docv:"REMOTE"
         ~doc:"The URI of the remote repository to clone from." [] in
     Arg.(required & pos 0 (some string) None & doc) in
-  Term.(pure infer_remote $ contents $ repo)
+  Term.(const infer_remote $ contents $ repo)

--- a/src/irmin-unix/bin/ir_resolver.mli
+++ b/src/irmin-unix/bin/ir_resolver.mli
@@ -21,6 +21,9 @@
 type contents = (module Irmin.Contents.S)
 
 val contents: contents Cmdliner.Term.t
+val branch: string option Cmdliner.Term.t
+
+val global_option_section: string
 
 (** {1 Global Configuration} *)
 

--- a/src/irmin/conf.ml
+++ b/src/irmin/conf.ml
@@ -118,4 +118,5 @@ let root =
   key
     ~docv:"ROOT"
     ~doc:"The location of the Git repository root."
+    ~docs:"COMMON OPTIONS"
     "root" (some string) None


### PR DESCRIPTION
This pull request is focused on the new functionality and updates to the command line API. It includes:

- Update CLI command names to match the OCaml API (read -> get, ls -> list, write -> set, rm -> remove)
- Switch from Cmdliner.Term.pure to Cmdliner.Term.const
- Move some of the command line flags (--root, --contents, ...) to the COMMON OPTIONS category to avoid cluttering the command specifics options
- Add the ability to use a custom commit author and message from the command line
