### PR TITLE
Use YAML for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ $ _build/default/examples/trees.exe
 The same thing can also be accomplished using `irmin`, the command-line application installed with `irmin-unix`, by running:
 
 ```bash
-$ echo "root=." > .irminconfig
+$ echo "root: ." > irmin.yaml
 $ irmin init
 $ irmin set foo/bar "testing 123"
 $ irmin get foo/bar
 ```
 
-`.irminconfig` allows for `irmin` flags to be set globally on a per-directory basis. Run `irmin help irminconfig` for further details.
+`irmin.yml` allows for `irmin` flags to be set globally on a per-directory basis. Run `irmin help irmin.yml` for further details.
 
 Also see `irmin --help` for list of all commands and either `irmin <command> --help` or `irmin help <command>` for more help with a specific command.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ _build/default/examples/trees.exe
 The same thing can also be accomplished using `irmin`, the command-line application installed with `irmin-unix`, by running:
 
 ```bash
-$ echo "root: ." > irmin.yaml
+$ echo "root: ." > irmin.yml
 $ irmin init
 $ irmin set foo/bar "testing 123"
 $ irmin get foo/bar

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -22,6 +22,7 @@ depends: [
   "irmin-fs"   {>= "1.3.0"}
   "git-unix"   {>= "1.11.4"}
   "irmin-watcher" {>= "0.2.0"}
+  "yaml"     {>= "0.1.0"}
   "alcotest" {test}
   "mtime"    {test & >= "1.0.0"}
 ]

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -503,33 +503,29 @@ let dot = {
     Term.(mk dot $ store $ basename $ depth $ no_dot_call $ full);
 }
 
-let irminconfig_man =
+let config_man =
   let version_string = Printf.sprintf "Irmin %s" Irmin.version in
-  ("irminconfig", 5, "", version_string, "Irmin Manual"), [
+  ("irmin.yml", 5, "", version_string, "Irmin Manual"), [
     `S Manpage.s_name;
-    `P "irminconfig - Specify certain command-line options to save on typing";
+    `P "irmin.yml";
 
     `S Manpage.s_synopsis;
-    `P ".irminconfig";
+    `P "Configure certain command-line options to cut down on mistakes and save on typing";
 
     `S Manpage.s_description;
-    `P "An $(b,irminconfig) file lets the user specify repetitve command-line options \
-        in a text file. The $(b,irminconfig) file is only read if it is found in \
-        the current working directory. Every line is of the form $(i,key)=$(i,value), \
-        where $(i,key) is one of the following: $(b,contents), $(b,store), $(b,branch), \
-        $(b,root), $(b,bare), $(b,head), or $(b,uri). These correspond to the irmin \
+    `P "An $(b,irmin.yml) file lets the user specify repetitve command-line options \
+        in a YAML file. The $(b,irmin.yml) file is only read if it is found in \
+        the current working directory. \
+
+        The following keys are allowed: $(b,contents), $(b,store), \
+        $(b,branch), $(b,root), $(b,bare), $(b,head), or $(b,uri). These correspond to the irmin \
         options of the same names.";
 
-    `S "NOTES";
-    `P "When specifying a value for the $(b,contents) or $(b,store) options, the \
-        shortest unique substring starting from index 0 is sufficient. For example, \
-        \"store=g\" is equivalent to \"store=git\".";
-
     `S Manpage.s_examples;
-    `P "Here is an example $(b,irminconfig) for accessing a local http irmin store. This \
-       $(b,irminconfig) prevents the user from having to specify the $(b,store) and $(b,uri) \
+    `P "Here is an example $(b,irmin.yml) for accessing a local http irmin store. This \
+       $(b,irmin.yml) prevents the user from having to specify the $(b,store) and $(b,uri) \
        options for every command.";
-    `Pre "    \\$ cat .irminconfig\n    store=http\n    uri=http://127.0.0.1:8080";
+    `Pre "    \\$ cat irmin.yml\n    store: http\n    uri: http://127.0.0.1:8080";
   ] @ help_sections
 
 (* HELP *)
@@ -547,13 +543,13 @@ let help = {
     let help man_format cmds topic = match topic with
       | None       -> `Help (`Pager, None)
       | Some topic ->
-        let topics = "irminconfig" :: cmds in
+        let topics = "irmin.yml" :: cmds in
         let conv, _ = Arg.enum (List.rev_map (fun s -> (s, s)) ("topics" :: topics)) in
         match conv topic with
         | `Error e                -> `Error (false, e)
         | `Ok t when t = "topics" -> List.iter print_endline topics; `Ok ()
-        | `Ok t when t = "irminconfig" ->
-          `Ok (Cmdliner.Manpage.print man_format Format.std_formatter irminconfig_man)
+        | `Ok t when t = "irmin.yml" ->
+          `Ok (Cmdliner.Manpage.print man_format Format.std_formatter config_man)
         | `Ok t                   -> `Help (man_format, Some t) in
     Term.(ret (mk help $Term.man_format $Term.choice_names $topic))
 }

--- a/src/irmin-unix/bin/ir_cli.ml
+++ b/src/irmin-unix/bin/ir_cli.ml
@@ -514,8 +514,9 @@ let config_man =
 
     `S Manpage.s_description;
     `P "An $(b,irmin.yml) file lets the user specify repetitve command-line options \
-        in a YAML file. The $(b,irmin.yml) file is only read if it is found in \
-        the current working directory. \
+        in a YAML file. The $(b,irmin.yml) is read by default if it is found in \
+        the current working directory. The configuration file path can also be set using the  \
+        $(b,--config) command-line flag. \
 
         The following keys are allowed: $(b,contents), $(b,store), \
         $(b,branch), $(b,root), $(b,bare), $(b,head), or $(b,uri). These correspond to the irmin \

--- a/src/irmin-unix/bin/ir_resolver.ml
+++ b/src/irmin-unix/bin/ir_resolver.ml
@@ -148,10 +148,12 @@ let read_config_file (): t option =
     in
     let string_value = function
       | `String s -> s
-      | _ -> ""
+      | _ -> raise Not_found
     in
     let assoc name fn =
-      try Some (fn (List.assoc name y |> string_value)) with Not_found -> None
+      try
+        Some (fn (List.assoc name y |> string_value))
+      with Not_found -> None
     in
     let contents =
       let kind =

--- a/src/irmin-unix/bin/ir_resolver.ml
+++ b/src/irmin-unix/bin/ir_resolver.ml
@@ -152,11 +152,9 @@ let read_config_file (): t option =
       | _ -> raise Not_found
     in
     let assoc name fn =
-      try
-        Some (fn (List.assoc name y |> string_value))
+      try Some (fn (List.assoc name y |> string_value))
       with Not_found -> None
     in
-
     let contents =
       let kind =
         match assoc "contents" (fun x -> List.assoc x contents_kinds) with

--- a/src/irmin-unix/bin/ir_resolver.ml
+++ b/src/irmin-unix/bin/ir_resolver.ml
@@ -135,6 +135,7 @@ let cfg = "irmin.yml"
 
 type t = S: (module Irmin.S with type t = 'a) * 'a Lwt.t -> t
 
+(* Read configuration from a YAML file *)
 let read_config_file (): t option =
   if not (Sys.file_exists cfg) then None
   else
@@ -155,6 +156,7 @@ let read_config_file (): t option =
         Some (fn (List.assoc name y |> string_value))
       with Not_found -> None
     in
+
     let contents =
       let kind =
         match assoc "contents" (fun x -> List.assoc x contents_kinds) with

--- a/src/irmin-unix/jbuild
+++ b/src/irmin-unix/jbuild
@@ -5,4 +5,4 @@
   (public_name irmin-unix)
   (wrapped     false)
   (libraries   (irmin irmin-fs git irmin-git irmin-http git-unix
-                irmin-watcher))))
+                irmin-watcher yaml))))


### PR DESCRIPTION
This update converts the configuration format to YAML, using `ocaml-yaml` as discussed in #502. The name of the configuration file has also been changed from `.irminconfig` to `irmin.yml`

Additionally, I have made it possible to set the path to the configuration file on the command-line.

When this is released we will need to emphasize the fact that old `.irminconfig` files need to be updated to the new format.