### PR TITLE
adapt some examples to new API

### DIFF
--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -114,7 +114,7 @@ end = struct
 
 end
 
-module Store = Irmin_unix.Git.FS.KV(Log)
+module Store = Irmin_unix.Git.KV(Irmin_unix.Git.G)(Log)
 
 let config = Irmin_git.config ~bare:true Config.root
 

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+module Store = Irmin_unix.Git.KV(Irmin_unix.Git.G)(Irmin.Contents.String)
 
 let config =
   let head = Git.Reference.of_raw "refs/heads/upstream" in

--- a/examples/irmin_git_store.ml
+++ b/examples/irmin_git_store.ml
@@ -4,7 +4,7 @@ open Printf
 
 let info = Irmin_unix.info
 
-module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+module Store = Irmin_unix.Git.KV(Irmin_unix.Git.G)(Irmin.Contents.String)
 
 let update t k v =
   let msg = sprintf "Updating /%s" (String.concat "/" k) in

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -67,7 +67,7 @@ let branch image =
 
 let images = [| (*ubuntu; *) wordpress; mysql |]
 
-module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+module Store = Irmin_unix.Git.KV(Irmin_unix.Git.G)(Irmin.Contents.String)
 
 let config = Irmin_git.config
     ~bare:true

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -7,7 +7,7 @@ let path =
   else
     "git://github.com/mirage/ocaml-git.git"
 
-module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+module Store = Irmin_unix.Git.KV(Irmin_unix.Git.G)(Irmin.Contents.String)
 module Sync = Irmin.Sync(Store)
 
 let upstream = Irmin.remote_uri path

--- a/examples/trees.ml
+++ b/examples/trees.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 let info = Irmin_unix.info
 
-module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+module Store = Irmin_unix.Git.KV(Irmin_unix.Git.G)(Irmin.Contents.String)
 
 module Tree = Store.Tree
 


### PR DESCRIPTION
there are still calls to `Git.Reference.of_raw "refs/heads/upstream"` (in deploy.ml and process.ml) which I can't find in the new API, but I was mainly interested in getting irmin_git_store to work