### PR TITLE
JSON contents

### DIFF
--- a/src/irmin-unix/bin/ir_resolver.ml
+++ b/src/irmin-unix/bin/ir_resolver.ml
@@ -1,0 +1,281 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Lwt.Infix
+open Cmdliner
+open Astring
+
+let global_option_section = "COMMON OPTIONS"
+
+type contents = (module Irmin.Contents.S)
+
+let create: (module Irmin.S_MAKER) -> contents -> (module Irmin.S) =
+  fun (module S) (module C) ->
+    let module S =
+      S(Irmin.Metadata.None)(C)
+        (Irmin.Path.String_list)
+        (Irmin.Branch.String)
+        (Irmin.Hash.SHA1)
+    in
+    (module S)
+
+let mem_store = create (module Irmin_mem.Make)
+let irf_store = create (module Irmin_unix.FS.Make)
+let http_store = create (module Irmin_unix.Http.Make)
+
+let git_store (module C: Irmin.Contents.S) =
+  (module Irmin_unix.Git.KV(Irmin_unix.Git.G)(C) : Irmin.S)
+
+let mk_store = function
+  | `Mem  -> mem_store
+  | `Irf  -> irf_store
+  | `Http -> http_store
+  | `Git  -> git_store
+
+let store_kinds = [
+  ("git" , `Git);
+  ("irf" , `Irf);
+  ("http", `Http);
+  ("mem" , `Mem);
+]
+
+let default_store = `Git
+
+let flag_key k =
+  let doc = Irmin.Private.Conf.doc k in
+  let docs = Irmin.Private.Conf.docs k in
+  let docv = Irmin.Private.Conf.docv k in
+  let default = Irmin.Private.Conf.default k in
+  let name =
+    let x = Irmin.Private.Conf.name k in
+    if default then "no-" ^ x else x
+  in
+  let i = Arg.info ?docv ?doc ?docs [name] in
+  if default then Arg.(value & vflag true [false, i])
+  else Arg.(value & flag i)
+
+let pconv (parse, pp) =
+  let parse str = match parse str with
+    | Ok x           -> `Ok x
+    | Error (`Msg e) -> `Error e
+  in
+  parse, pp
+
+let key k default =
+  let doc = Irmin.Private.Conf.doc k in
+  let docs = Irmin.Private.Conf.docs k in
+  let docv = Irmin.Private.Conf.docv k in
+  let mk = pconv (Irmin.Private.Conf.conv k) in
+  let name = Irmin.Private.Conf.name k in
+  let i = Arg.info ?docv ?doc ?docs [name] in
+  Arg.(value & opt mk default i)
+
+let opt_key k = key k (Irmin.Private.Conf.default k)
+
+let config_path_key =
+  Irmin.Private.Conf.key
+    ~docs:global_option_section
+    ~docv:"PATH"
+    ~doc:"Allows configuration file to be specified on the command-line"
+    "config" Irmin.Private.Conf.string "irmin.yml"
+
+let config_term =
+  let add k v config = Irmin.Private.Conf.add config k v in
+  let create root bare head level uri config_path =
+    Irmin.Private.Conf.empty
+    |> add Irmin.Private.Conf.root root
+    |> add Irmin_git.bare bare
+    |> add Irmin_git.head head
+    |> add Irmin_git.level level
+    |> add Irmin_http.uri uri
+    |> add config_path_key config_path
+  in
+  Term.(const create $
+        opt_key Irmin.Private.Conf.root $
+        flag_key Irmin_git.bare $
+        opt_key Irmin_git.head $
+        opt_key Irmin_git.level $
+        opt_key Irmin_http.uri $
+        opt_key config_path_key)
+
+let mk_contents k: contents = match k with
+  | `String  -> (module Irmin.Contents.String)
+  | `Cstruct -> (module Irmin.Contents.Cstruct)
+  | `Json -> (module Irmin.Contents.Json)
+
+let contents_kinds = [
+  "string" , `String;
+  "cstruct", `Cstruct;
+  "json", `Json;
+]
+
+let default_contents = `String
+
+let contents =
+  let kind =
+    let doc = Arg.info ~doc:"The type of user-defined contents." ~docs:global_option_section ["contents";"c"] in
+    Arg.(value & opt (enum contents_kinds) default_contents & doc)
+  in
+  Term.(const mk_contents $ kind)
+
+let store_term =
+  let store =
+    let doc = Arg.info ~doc:"The kind of backend stores." ~docs:global_option_section ["s";"store"] in
+    Arg.(value & opt (some (enum store_kinds)) None & doc)
+  in
+  let create store contents = match store with
+    | Some s -> Some (mk_store s contents)
+    | None   -> None
+  in
+  Term.(const create $ store $ contents)
+
+type t = S: (module Irmin.S with type t = 'a) * 'a Lwt.t -> t
+
+(* Read configuration from a YAML file *)
+let read_config_file cfg: t option =
+  if not (Sys.file_exists cfg) then None
+  else
+    let oc = open_in cfg in
+    let len = in_channel_length oc in
+    let buf = really_input_string oc len in
+    close_in oc;
+    let y = match Yaml.of_string buf with
+      | Ok (`O y) -> y
+      | _ -> []
+    in
+    let string_value = function
+      | `String s -> s
+      | _ -> raise Not_found
+    in
+    let assoc name fn =
+      try Some (fn (List.assoc name y |> string_value))
+      with Not_found -> None
+    in
+    let contents =
+      let kind =
+        match assoc "contents" (fun x -> List.assoc x contents_kinds) with
+        | None   -> default_contents
+        | Some c -> c
+      in
+      mk_contents kind
+    in
+    let store =
+      let kind =
+        match assoc "store" (fun x -> List.assoc x store_kinds) with
+        | None   -> default_store
+        | Some s -> s
+      in
+      mk_store kind contents
+    in
+    let module S = (val store) in
+    let branch = assoc "branch" (fun x -> match S.Branch.of_string x with
+        | Ok x           -> x
+        | Error (`Msg e) -> failwith e)
+    in
+    let config =
+      let root = assoc "root" (fun x -> x) in
+      let bare = match assoc "bare" bool_of_string with
+        | None   -> Irmin.Private.Conf.default Irmin_git.bare
+        | Some b -> b
+      in
+      let head = assoc "head" (fun x -> Git.Reference.of_string x) in
+      let uri = assoc "uri" Uri.of_string in
+      let add k v config = Irmin.Private.Conf.add config k v in
+      Irmin.Private.Conf.empty
+      |> add Irmin.Private.Conf.root root
+      |> add Irmin_git.bare bare
+      |> add Irmin_git.head head
+      |> add Irmin_http.uri uri
+    in
+    let mk_master () = S.Repo.v config >>= fun repo -> S.master repo in
+    let mk_branch b = S.Repo.v config >>= fun repo -> S.of_branch repo b in
+    match branch with
+    | None   -> Some (S ((module S), mk_master ()))
+    | Some b -> Some (S ((module S), mk_branch b))
+
+  let branch =
+    let doc =
+      Arg.info
+        ~doc:"The current branch name. Default is the store's master branch."
+        ~docs:global_option_section
+        ~docv:"BRANCH"
+        ["b"; "branch"]
+    in
+    Arg.(value & opt (some string) None & doc)
+
+let store =
+  let create store config branch =
+    match store with
+    | Some s ->
+      let module S = (val s: Irmin.S) in
+      let mk_master () = S.Repo.v config >>= fun repo -> S.master repo in
+      let mk_branch b =
+        S.Repo.v config >>= fun repo ->
+        S.of_branch repo b
+      in
+      (* first look at the command-line options *)
+      let t = match branch with
+        | None   -> mk_master ()
+        | Some t -> mk_branch (match S.Branch.of_string t with
+            | Ok x           -> x
+            | Error (`Msg e) -> failwith e)
+      in
+      S ((module S), t)
+    | None ->
+      let cfg = Irmin.Private.Conf.get config config_path_key in
+      (* then look at the config file options *)
+      match read_config_file cfg with
+      | Some c -> c
+      | None   ->
+        let s = mk_store `Git (mk_contents `String) in
+        let module S = (val s: Irmin.S) in
+        let t = S.Repo.v config >>= fun repo -> S.master repo in
+        S ((module S), t)
+  in
+  Term.(const create $ store_term $ config_term $ branch)
+
+(* FIXME: read the remote configuration in a file *)
+let (/) = Filename.concat
+
+(* FIXME: this is a very crude heuristic to choose the remote
+   kind. Would be better to read the config file and look for remote
+   alias. *)
+let infer_remote contents str =
+  if Sys.file_exists str then (
+    let r =
+      if Sys.file_exists (str / ".git")
+      then git_store contents
+      else irf_store contents
+    in
+    let module R = (val r) in
+    let config =
+      let add k v c = Irmin.Private.Conf.add c k v in
+      Irmin.Private.Conf.empty
+      |> add Irmin_http.uri (Some (Uri.of_string str))
+      |> add Irmin.Private.Conf.root (Some str)
+    in
+    R.Repo.v config >>= fun repo ->
+    R.master repo >|= fun r ->
+    Irmin.remote_store (module R) r
+    ) else
+      Lwt.return (Irmin.remote_uri str)
+
+let remote =
+  let repo =
+    let doc = Arg.info ~docv:"REMOTE"
+        ~doc:"The URI of the remote repository to clone from." [] in
+    Arg.(required & pos 0 (some string) None & doc) in
+  Term.(const infer_remote $ contents $ repo)

--- a/src/irmin-unix/ir_cli.ml
+++ b/src/irmin-unix/ir_cli.ml
@@ -308,7 +308,7 @@ let clone = {
         remote >>= fun remote ->
         Sync.fetch t ?depth remote >>= function
         | Ok d    -> S.Head.set t d
-        | Error e -> Format.eprintf "ERROR: %a!\n" Sync.pp_fetch_error e; exit 1
+        | Error e -> failwith (Fmt.to_to_string Sync.pp_fetch_error e)
       end
     in
     Term.(mk clone $ store $ remote $ depth);
@@ -350,7 +350,8 @@ let merge = {
         S.merge_with_branch t branch ~info:(info ?author "%s" message) >|= function
           | Ok () -> ()
           | Error conflict ->
-            Format.eprintf "ERROR: %a!\n" (Irmin.Type.pp_json Irmin.Merge.conflict_t) conflict
+            let fmt = Irmin.Type.pp_json Irmin.Merge.conflict_t in
+            Fmt.epr "CONFLICT: %a\n%!" fmt conflict
       end
     in
     let branch_name =

--- a/src/irmin-unix/ir_resolver.ml
+++ b/src/irmin-unix/ir_resolver.ml
@@ -74,8 +74,7 @@ type contents = (module Irmin.Contents.S)
 let contents_kinds = ref [
   "string" , (module Irmin.Contents.String: Irmin.Contents.S);
   "cstruct", (module Irmin.Contents.Cstruct);
-  "json-string", (module Irmin.Contents.Json);
-  "json-tree", (module Irmin.Json_tree(Irmin.Path.String_list)(Irmin.Metadata.None));
+  "json", (module Irmin.Contents.Json);
 ]
 let default_contents = ref (module Irmin.Contents.String: Irmin.Contents.S)
 let add_content_type name ?default:(default=false) m =

--- a/src/irmin-unix/ir_resolver.ml
+++ b/src/irmin-unix/ir_resolver.ml
@@ -74,6 +74,7 @@ type contents = (module Irmin.Contents.S)
 let contents_kinds = ref [
   "string" , (module Irmin.Contents.String: Irmin.Contents.S);
   "cstruct", (module Irmin.Contents.Cstruct);
+  "json", (module Irmin.Contents.Json);
 ]
 let default_contents = ref (module Irmin.Contents.String: Irmin.Contents.S)
 let add_content_type name ?default:(default=false) m =

--- a/src/irmin-unix/ir_resolver.ml
+++ b/src/irmin-unix/ir_resolver.ml
@@ -75,7 +75,7 @@ let contents_kinds = ref [
   "string" , (module Irmin.Contents.String: Irmin.Contents.S);
   "cstruct", (module Irmin.Contents.Cstruct);
   "json-string", (module Irmin.Contents.Json);
-  "json-tree", (module Irmin.Proj(Irmin.Path.String_list)(Irmin.Metadata.None));
+  "json-tree", (module Irmin.Json_tree(Irmin.Path.String_list)(Irmin.Metadata.None));
 ]
 let default_contents = ref (module Irmin.Contents.String: Irmin.Contents.S)
 let add_content_type name ?default:(default=false) m =

--- a/src/irmin-unix/ir_resolver.ml
+++ b/src/irmin-unix/ir_resolver.ml
@@ -74,7 +74,8 @@ type contents = (module Irmin.Contents.S)
 let contents_kinds = ref [
   "string" , (module Irmin.Contents.String: Irmin.Contents.S);
   "cstruct", (module Irmin.Contents.Cstruct);
-  "json", (module Irmin.Contents.Json);
+  "json-string", (module Irmin.Contents.Json);
+  "json-tree", (module Irmin.Proj(Irmin.Path.String_list)(Irmin.Metadata.None));
 ]
 let default_contents = ref (module Irmin.Contents.String: Irmin.Contents.S)
 let add_content_type name ?default:(default=false) m =

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -62,12 +62,7 @@ let json =
 module Json = struct
   type t = (string * json) list
 
-  let t =
-    Type.like json
-    (function
-      | `O obj -> obj
-      | _ -> raise (Invalid_argument "Irmin value must be a JSON object"))
-    (fun x -> `O x)
+  let t = Type.(list (pair string json))
 
   let merge_object a b =
     List.fold_right (fun (k, v) acc ->
@@ -127,6 +122,8 @@ module Json = struct
     let s = Buffer.contents buffer in
     Fmt.pf fmt "%s" s
 
+
+
   let decode_json d =
     let decode d = match Jsonm.decode d with
       | `Lexeme l -> l
@@ -150,18 +147,19 @@ module Json = struct
       | `Name k ->
           let v = unwrap (decode d) d in
           obj ((k, v) :: ms) d
-      | _ -> failwith "invalid json object"
+      | _ -> failwith "invalid JSON object"
     in
     try
       Ok (unwrap (decode d) d)
     with
       | Failure msg -> Error (`Msg msg)
 
+
   let of_string s =
     let decoder = Jsonm.decoder (`String s) in
     match decode_json decoder with
     | Ok (`O obj) -> Ok obj
-    | Ok _ -> Error (`Msg "Irmin value must be a JSON object")
+    | Ok _ -> Error (`Msg "Irmin JSON values must be objects")
     | Error _ as err -> err
 end
 

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -224,13 +224,13 @@ module Json_tree(P: S.PATH)(M: S.METADATA) = struct
     | `Contents of json * M.t
   ]
 
-  let to_concrete_tree (j: json): tree =
+  let rec to_concrete_tree (j: json): tree =
     match j with
     | `O j ->
       let x =
         List.fold_right (fun (k, v) acc ->
           match P.step_of_string k with
-          | Ok key -> (key, `Contents (v, M.default)) :: acc
+          | Ok key -> (key, to_concrete_tree v) :: acc
           | _ -> acc
        ) j []
       in
@@ -241,7 +241,8 @@ module Json_tree(P: S.PATH)(M: S.METADATA) = struct
    let step = Fmt.to_to_string P.pp_step in
    let rec aux k = function
      | `Contents (c, _) -> [k, c]
-     | `Tree tree -> List.fold_right (fun (k, tree) acc -> List.append (aux (step k) tree) acc) tree []
+     | `Tree ((k', v')::l) -> aux (step k') v' @ aux k (`Tree l)
+     | `Tree [] -> []
    in
    match c with
    | `Contents (c, _) -> c

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -43,11 +43,14 @@ let json =
   |~ case1 "array" (list ty) (fun arr -> `A arr)
   |> sealv)
 
+let assoc k l =
+  try Some (List.assoc k l) with Not_found -> None
+
 let merge_objects j a b =
   let equal = Type.equal json in
   try
     let v = List.fold_right (fun (k, v) acc ->
-      match List.assoc_opt k a, List.assoc_opt k b with
+      match assoc k a, assoc k b with
       | Some x, Some y when not (equal x y) -> failwith "Unable to merge JSON objects"
       | Some x, _ -> (k, x) :: acc
       | None, Some x -> (k, x) :: acc
@@ -180,7 +183,6 @@ end
 
 module Proj(P: S.PATH)(M: S.METADATA) = struct
   type t = json
-
   let t = json
   let merge = Merge.(option merge_json)
 

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -155,10 +155,7 @@ module Json = struct
     | Ok _ -> Error (`Msg "Irmin JSON values must be objects")
     | Error _ as err -> err
 
-  module Make(S: sig
-    type t
-    val t: t Type.t
-  end) = struct
+  module Make(S: S.S0) = struct
     include S
     let pp = Type.pp_json t
     let of_string s =

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -237,11 +237,11 @@ module Json_tree(P: S.PATH)(M: S.METADATA) = struct
      `Tree x
     | _ -> `Contents (j, M.default)
 
- let of_concrete_tree c : json =
+ let rec of_concrete_tree c : json =
    let step = Fmt.to_to_string P.pp_step in
    let rec aux k = function
      | `Contents (c, _) -> [k, c]
-     | `Tree ((k', v')::l) -> aux (step k') v' @ aux k (`Tree l)
+     | `Tree ((k', v')::l) -> (step k', of_concrete_tree v') :: aux k (`Tree l)
      | `Tree [] -> []
    in
    match c with

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -34,34 +34,135 @@ end
 
 type json = [
   | `Null
+  | `Bool of bool
   | `String of string
   | `Float of float
   | `O of (string * json) list
   | `A of json list
 ]
 
+let json =
+  let open Type in
+  mu (fun ty ->
+  variant "json" (fun null bool string float obj arr -> function
+    | `Null -> null
+    | `Bool b -> bool b
+    | `String s -> string s
+    | `Float f -> float f
+    | `O o -> obj o
+    | `A a -> arr a)
+  |~ case0 "null" `Null
+  |~ case1 "bool" bool (fun x -> `Bool x)
+  |~ case1 "string" string (fun x -> `String x)
+  |~ case1 "float" float (fun x -> `Float x)
+  |~ case1 "object" (list (pair string ty)) (fun obj -> `O obj)
+  |~ case1 "array" (list ty) (fun arr -> `A arr)
+  |> sealv)
+
 module Json = struct
-  type t = json
+  type t = (string * json) list
 
   let t =
-    let open Type in
-    mu (fun ty ->
-    variant "json" (fun null string float obj arr -> function
-      | `Null -> null
-      | `String s -> string s
-      | `Float f -> float f
-      | `O o -> obj o
-      | `A a -> arr a)
-    |~ case0 "null" `Null
-    |~ case1 "string" string (fun x -> `String x)
-    |~ case1 "float" float (fun x -> `Float x)
-    |~ case1 "object" (list (pair string ty)) (fun obj -> `O obj)
-    |~ case1 "array" (list ty) (fun arr -> `A arr)
-    |> sealv)
+    Type.like json
+    (function
+      | `O obj -> obj
+      | _ -> raise (Invalid_argument "Irmin value must be a JSON object"))
+    (fun x -> `O x)
 
-  let merge = Merge.idempotent Type.(option t)
-  let pp = Type.pp_json t
-  let of_string s = Type.decode_json t (Jsonm.decoder (`String s))
+  let merge_object a b =
+    List.fold_right (fun (k, v) acc ->
+      match acc with
+      | None -> None
+      | Some dst ->
+          (match List.assoc_opt k b with
+          | Some x when v <> x -> None
+          | Some _ -> acc
+          | _ -> Some ((k, v) :: dst))
+    ) a (Some b)
+
+  let merge' a b =
+    match merge_object a b with
+      | Some obj -> Merge.ok obj
+      | None -> Merge.conflict "Unable to merge JSON objects"
+
+  let merge ~old t1 t2 =
+    let open Merge.Infix in
+    old () >>=* function
+      | Some j ->
+          if j = t1 then
+            merge' t1 t2
+          else if j = t2 then
+            merge' t2 t1
+          else
+            merge' j t1 >>=* fun t1 ->
+            merge' t1 t2
+      | None -> merge' t1 t2
+
+  let merge = Merge.(option (v t merge))
+
+  let lexeme e x = ignore (Jsonm.encode e (`Lexeme x))
+
+  let rec encode_json e = function
+    | `Null -> lexeme e `Null
+    | `Bool b -> lexeme e (`Bool b)
+    | `String s -> lexeme e (`String s)
+    | `Float f -> lexeme e (`Float f)
+    | `A a ->
+        lexeme e `As;
+        List.iter (encode_json e) a;
+        lexeme e `Ae;
+    | `O o ->
+        lexeme e `Os;
+        List.iter (fun (k, v) ->
+          lexeme e (`Name k);
+          encode_json e v
+        ) o;
+        lexeme e `Oe
+
+  let pp fmt x =
+    let buffer = Buffer.create 32 in
+    let encoder = Jsonm.encoder (`Buffer buffer) in
+    encode_json encoder (`O x);
+    ignore @@ Jsonm.encode encoder `End;
+    let s = Buffer.contents buffer in
+    Fmt.pf fmt "%s" s
+
+  let decode_json d =
+    let decode d = match Jsonm.decode d with
+      | `Lexeme l -> l
+      | `Error e -> failwith (Fmt.strf "%a" Jsonm.pp_error e)
+      | _ -> failwith "invalid JSON encoding"
+    in
+    let rec unwrap v d = match v with
+      | `Os -> obj [] d
+      | `As -> arr [] d
+      | `Null | `Bool _ | `String _ | `Float _ as v -> v
+      | _ -> failwith "invalid JSON value"
+    and arr vs d =
+      match decode d with
+      | `Ae -> `A (List.rev vs)
+      | v ->
+          let v = unwrap v d in
+          arr (v::vs) d
+    and obj ms d =
+      match decode d with
+      | `Oe -> `O (List.rev ms)
+      | `Name k ->
+          let v = unwrap (decode d) d in
+          obj ((k, v) :: ms) d
+      | _ -> failwith "invalid json object"
+    in
+    try
+      Ok (unwrap (decode d) d)
+    with
+      | Failure msg -> Error (`Msg msg)
+
+  let of_string s =
+    let decoder = Jsonm.decoder (`String s) in
+    match decode_json decoder with
+    | Ok (`O obj) -> Ok obj
+    | Ok _ -> Error (`Msg "Irmin value must be a JSON object")
+    | Error _ as err -> err
 end
 
 module Store

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -31,7 +31,11 @@ module Json: S.CONTENTS with type t = (string * json) list
 module Json_value: S.CONTENTS with type t = json
 module Json_tree(P: S.PATH)(M: S.METADATA): sig
   include S.CONTENTS with type t = json
-  module type STORE = S.STORE with type contents = t and type key = P.t and type step = P.step and type metadata = M.t
+  module type STORE = S.STORE with
+    type contents = t
+    and type key = P.t
+    and type step = P.step
+    and type metadata = M.t
 
   val get_tree:
     (module STORE with type node = 'a) ->

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -16,8 +16,17 @@
 
 (** Values. *)
 
+type json = [
+  | `Null
+  | `String of string
+  | `Float of float
+  | `O of (string * json) list
+  | `A of json list
+]
+
 module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
+module Json: S.CONTENTS with type t = json
 
 module Store
     (C: sig

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -18,6 +18,7 @@
 
 type json = [
   | `Null
+  | `Bool of bool
   | `String of string
   | `Float of float
   | `O of (string * json) list
@@ -26,7 +27,7 @@ type json = [
 
 module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
-module Json: S.CONTENTS with type t = json
+module Json: S.CONTENTS with type t = (string * json) list
 
 module Store
     (C: sig

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -37,6 +37,14 @@ module Json_tree(P: S.PATH)(M: S.METADATA): sig
     and type step = P.step
     and type metadata = M.t
 
+  type tree = [
+    | `Tree of (P.step * tree) list
+    | `Contents of json * M.t
+  ]
+
+  val to_concrete_tree: t -> tree
+  val of_concrete_tree: tree -> t
+
   val get_tree:
     (module STORE with type node = 'a) ->
     [ `Contents of t * M.t | `Node of 'a ] ->

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -27,10 +27,7 @@ type json = [
 
 module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
-module Json: sig
-  include S.CONTENTS with type t = (string * json) list
-  module Make (C: S.S0) : S.CONTENTS with type t = C.t
-end
+module Json: S.CONTENTS with type t = (string * json) list
 
 module Store
     (C: sig

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -27,7 +27,13 @@ type json = [
 
 module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
-module Json: S.CONTENTS with type t = (string * json) list
+module Json: sig
+  include S.CONTENTS with type t = (string * json) list
+  module Make (C: sig
+    type t
+    val t: t Type.t
+  end) : S.CONTENTS with type t = C.t
+end
 
 module Store
     (C: sig

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -29,40 +29,14 @@ module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
 module Json: S.CONTENTS with type t = (string * json) list
 module Json_value: S.CONTENTS with type t = json
-module Json_tree(P: S.PATH)(M: S.METADATA): sig
+module Json_tree(Store: S.STORE with type contents = json): sig
   include S.CONTENTS with type t = json
-  module type STORE = S.STORE with
-    type contents = t
-    and type key = P.t
-    and type step = P.step
-    and type metadata = M.t
-
-  type tree = [
-    | `Tree of (P.step * tree) list
-    | `Contents of json * M.t
-  ]
-
-  val to_concrete_tree: t -> tree
-  val of_concrete_tree: tree -> t
-
-  val get_tree:
-    (module STORE with type node = 'a) ->
-    [ `Contents of t * M.t | `Node of 'a ] ->
-    P.t -> json Lwt.t
-
-  val set_tree :
-    (module STORE with type node = 'a and type t = 'b) ->
-    [ `Contents of t * M.t | `Node of 'a ] ->
-    P.t ->
-    json -> [ `Contents of t * M.t | `Node of 'a ] Lwt.t
-
-  val get :
-    (module STORE with type t = 'a) ->
-    'a -> P.t -> json Lwt.t
-
-  val set :
-    (module STORE with type t = 'a) ->
-    'a -> P.t -> json -> info:Info.f -> unit Lwt.t
+  val to_concrete_tree: t -> Store.Tree.concrete
+  val of_concrete_tree: Store.Tree.concrete -> t
+  val get_tree: Store.tree -> Store.key -> json Lwt.t
+  val set_tree : Store.tree -> Store.key -> json -> Store.tree Lwt.t
+  val get : Store.t -> Store.key -> json Lwt.t
+  val set : Store.t -> Store.key -> json -> info:Info.f -> unit Lwt.t
 end
 
 module Store

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -28,35 +28,29 @@ type json = [
 module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
 module Json: S.CONTENTS with type t = (string * json) list
-module Proj(P: S.PATH)(M: S.METADATA): sig
+module Json_value: S.CONTENTS with type t = json
+module Json_tree(P: S.PATH)(M: S.METADATA): sig
   include S.CONTENTS with type t = json
-    type tree =
-      [ `Tree of (P.step * tree) list
-      | `Contents of json * M.t ]
-
-  val to_concrete_tree: (string * json) list -> tree
-  val of_concrete_tree: tree -> (string * json) list
-
   module type STORE = S.STORE with type contents = t and type key = P.t and type step = P.step and type metadata = M.t
 
   val get_tree:
     (module STORE with type node = 'a) ->
     [ `Contents of t * M.t | `Node of 'a ] ->
-    P.t -> (string * t) list Lwt.t
+    P.t -> json Lwt.t
 
   val set_tree :
-   (module STORE with type node = 'a and type t = 'b) ->
-   [ `Contents of t * M.t | `Node of 'a ] ->
-   P.t ->
-   (string * t) list -> [ `Contents of t * M.t | `Node of 'a ] Lwt.t
+    (module STORE with type node = 'a and type t = 'b) ->
+    [ `Contents of t * M.t | `Node of 'a ] ->
+    P.t ->
+    json -> [ `Contents of t * M.t | `Node of 'a ] Lwt.t
 
   val get :
     (module STORE with type t = 'a) ->
-    'a -> P.t -> (string * t) list Lwt.t
+    'a -> P.t -> json Lwt.t
 
   val set :
     (module STORE with type t = 'a) ->
-    'a -> P.t -> (string * t) list -> info:Info.f -> unit Lwt.t
+    'a -> P.t -> json -> info:Info.f -> unit Lwt.t
 end
 
 module Store

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -29,10 +29,7 @@ module String: S.CONTENTS with type t = string
 module Cstruct: S.CONTENTS with type t = Cstruct.t
 module Json: sig
   include S.CONTENTS with type t = (string * json) list
-  module Make (C: sig
-    type t
-    val t: t Type.t
-  end) : S.CONTENTS with type t = C.t
+  module Make (C: S.S0) : S.CONTENTS with type t = C.t
 end
 
 module Store

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -189,4 +189,4 @@ module Metadata = struct
   module None = Node.No_metadata
 end
 
-module Proj = Contents.Proj
+module Json_tree = Contents.Json_tree

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -188,3 +188,5 @@ module Metadata = struct
   module type S = S.METADATA
   module None = Node.No_metadata
 end
+
+module Proj = Contents.Proj

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1035,7 +1035,19 @@ module Contents: sig
       function conflicts. Assume that update operations are
       idempotent. *)
 
-  module Json: S with type t = (string * Contents.json) list
+  type json = [
+    | `Null
+    | `Bool of bool
+    | `String of string
+    | `Float of float
+    | `O of (string * json) list
+    | `A of json list
+  ]
+
+  module Json: sig
+    include S with type t = (string * json) list
+    module Make (C: S0) : S with type t = C.t
+  end
 
   (** Contents store. *)
   module type STORE = sig

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1044,13 +1044,10 @@ module Contents: sig
     | `A of json list
   ]
 
-  module Json: sig
-    include S with type t = (string * json) list
-
-    (** [Make] creates a new `Content` type with `pp` and `of_string` defined using
-        [encode_json]/[decode_json] and a default merge operation *)
-    module Make (C: S0) : S with type t = C.t
-  end
+  module Json: S with type t = (string * json) list
+  (** Json values are associations from string to [json] value. If the same JSON key
+      has been modified concurrently with different values then the [merge] function
+      conflicts. *)
 
   (** Contents store. *)
   module type STORE = sig

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1072,11 +1072,12 @@ module Contents: sig
   ]
 
   module Json: S with type t = (string * json) list
-  (** Json contents are associations from string to [json] value stored as JSON encoded strings.
+  (** [Json] contents are associations from string to [json] value stored as JSON encoded strings.
      If the same JSON key has been modified concurrently with different values then the [merge]
      function conflicts. *)
 
   module Json_value: S with type t = json
+  (** [Json_value] allows any kind of json value to be stored, not only objects. *)
 
   (** Contents store. *)
   module type STORE = sig
@@ -2750,8 +2751,9 @@ end
 
 (** [Json_tree] is used to project JSON values onto trees. Instead of the entire object being stored under one key, it
     is split across several keys starting at the specified root key.  *)
-module Json_tree(Store: S.STORE with type contents = Contents.json): sig
-  include S.CONTENTS with type t = Contents.json
+module Json_tree(Store: S with type contents = Contents.json): sig
+  include Contents.S with type t = Contents.json
+
   val to_concrete_tree: t -> Store.Tree.concrete
   val of_concrete_tree: Store.Tree.concrete -> t
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1035,6 +1035,8 @@ module Contents: sig
       function conflicts. Assume that update operations are
       idempotent. *)
 
+  module Json: S with type t = (string * Contents.json) list
+
   (** Contents store. *)
   module type STORE = sig
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1046,6 +1046,9 @@ module Contents: sig
 
   module Json: sig
     include S with type t = (string * json) list
+
+    (** [Make] creates a new `Content` type with `pp` and `of_string` defined using
+        [encode_json]/[decode_json] and a default merge operation *)
     module Make (C: S0) : S with type t = C.t
   end
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -2754,6 +2754,14 @@ module Json_tree(P: Path.S)(M: Metadata.S): sig
   include Contents.S with type t = Contents.json
   module type STORE = S with type contents = t and type key = P.t and type step = P.step and type metadata = M.t
 
+  type tree = [
+    | `Tree of (P.step * tree) list
+    | `Contents of t * M.t
+  ]
+
+  val to_concrete_tree: t -> tree
+  val of_concrete_tree: tree -> t
+
   val get_tree:
     (module STORE with type node = 'a) ->
     [ `Contents of t * M.t | `Node of 'a ] ->


### PR DESCRIPTION
This is my current implementation of a JSON datatype -- it is roughly modeled after a document store, like CouchDB or MongoDB, so it restricts top-level values to objects only. 

I think it is a nice addition because even though the `String` type can already be used to store JSON contents, this allows for the JSON encoding to be validated when using the command line tool.

I'm not totally sure if it's ready to be merged but wanted to at least open this up to discussion in order to get some feedback before I continue.


