### PR TITLE
Fix Tree.to_concrete handling of nested trees

### DIFF
--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1067,8 +1067,8 @@ module Make (P: S.PRIVATE) = struct
       | `Contents _ as v -> k v
       | `Node n ->
         Node.to_map n >>= function
-        | None   -> Lwt.return (`Tree [])
-        | Some n -> node [] (fun n -> Lwt.return (`Tree n)) (StepMap.bindings n)
+        | None   -> k (`Tree [])
+        | Some n -> node [] (fun n -> k (`Tree n)) (StepMap.bindings n)
     and contents k (c, m) =
       Contents.v c >>= function
       | None   -> k None


### PR DESCRIPTION
Fixes #524 - I think this is all that's needed. I've tested it on some trees of different depths and it seems to be acting as expected now.