### PR TITLE
Change Digestif_sig.S to Digestif.S  and link digestif where needed

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -843,7 +843,7 @@ module Make_ext
 
 end
 
-module Mem (H: Digestif_sig.S) = struct
+module Mem (H: Digestif.S) = struct
 
   include Git.Mem.Store(H)
 

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -55,7 +55,7 @@ module type G = sig
     unit -> (t, error) result Lwt.t
 end
 
-module Mem (H: Digestif_sig.S): G
+module Mem (H: Digestif.S): G
 (** In-memory Git store. *)
 
 module type S = sig

--- a/src/irmin-unix/bin/jbuild
+++ b/src/irmin-unix/bin/jbuild
@@ -4,4 +4,4 @@
   ((name         main)
    (public_name irmin)
    (package     irmin-unix)
-   (libraries   (checkseum.c irmin-unix))))
+   (libraries   (checkseum.c digestif.c irmin-unix))))

--- a/test/irmin-git/jbuild
+++ b/test/irmin-git/jbuild
@@ -8,7 +8,7 @@
 (executable
  ((name      test)
   (modules   (test))
-  (libraries (checkseum.c test_git))))
+  (libraries (checkseum.c digestif.c test_git))))
 
 (alias
  ((name runtest)

--- a/test/irmin-http/jbuild
+++ b/test/irmin-http/jbuild
@@ -8,7 +8,7 @@
 (executable
  ((name      test)
   (modules   (test))
-  (libraries (checkseum.c test_http))))
+  (libraries (checkseum.c digestif.c test_http))))
 
 (alias
  ((name runtest)

--- a/test/irmin-unix/jbuild
+++ b/test/irmin-unix/jbuild
@@ -8,7 +8,7 @@
 (executable
  ((name      test)
   (modules   (test))
-  (libraries (checkseum.c test_unix))))
+  (libraries (checkseum.c digestif.c test_unix))))
 
 (alias
  ((name runtest)


### PR DESCRIPTION
I was setting up a new machine today and encountered some errors building with the latest dev version of `Digestif`. Is that the correct version or should I be using 0.6.1?

Please let me know if there's anything I'm missing!