### PR TITLE
Improve chunking

### DIFF
--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -18,6 +18,9 @@
 open Lwt.Infix
 open Irmin
 
+let src = Logs.Src.create "irmin.chunk" ~doc:"Irmin chunks"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 module Conf = struct
 
   let min_size =
@@ -26,7 +29,7 @@ module Conf = struct
 
   let chunk_size =
     Irmin.Private.Conf.key ~doc:"Size of chunk" "size"
-      Irmin.Private.Conf.int 4666
+      Irmin.Private.Conf.int 4096
 
 end
 
@@ -51,73 +54,46 @@ let config ?(config=Irmin.Private.Conf.empty) ?size ?min_size () =
 
 module Chunk (K: Irmin.Hash.S) = struct
 
-  type index = Data | Indirect
-  type t = index * Cstruct.t
+  module K = struct
+    type t = K.t
+    let t =
+      Irmin.Type.(like @@ cstruct_of (`Fixed K.digest_size))
+        K.of_raw K.to_raw
+  end
 
-  let l_type = 1
-  let get_type x = Cstruct.get_uint8 x 0
-  let set_type x v = Cstruct.set_uint8 x 0 v
+  type v =
+    | Data  of bytes
+    | Index of K.t list
 
-  let l_len = 2
-  let get_length x = Cstruct.LE.get_uint16 x l_type
-  let set_length x v = Cstruct.LE.set_uint16 x l_type v
+  let v =
+    let open Irmin.Type in
+    variant "chunk" (fun d i -> function
+        | Data  data  -> d data
+        | Index index -> i index)
+    |~ case1 "Data" bytes (fun d -> Data d)
+    |~ case1 "Index" (list ~len:`Int16 K.t) (fun i -> Index i)
+    |> sealv
 
-  let head_length = l_type + l_len
-  let offset_payload = head_length
+  type t = { len: int; v: v }
 
-  let get_sub_key x pos =
-    let offset = offset_payload + (pos * K.digest_size) in
-    Cstruct.sub x offset K.digest_size
+  let of_bytes b =
+    let len = Bytes.length b in
+    match Irmin.Type.decode_bytes ~exact:false v b with
+    | Error (`Msg e) -> invalid_arg e
+    | Ok v -> { len; v }
 
-  let set_data src srcoff dst dstoff len =
-    Cstruct.blit src srcoff dst (offset_payload + dstoff) len
+  let to_bytes t =
+    let buf = Bytes.make t.len '\000' in
+    Irmin.Type.encode_bytes ~buf v t.v
 
-  let extract_data src srcoff dst dstoff len =
-    Cstruct.blit src (offset_payload + srcoff) dst dstoff len
+  let t = Irmin.Type.(like bytes) of_bytes to_bytes
 
-  let type_indirect = 0
-  let type_data = 1
-
-  let int_of_type = function
-    | Indirect -> type_indirect
-    | Data     -> type_data
-
-  let of_cstruct x =
-    match get_type x with
-    | 0 -> Indirect, x
-    | 1 -> Data, x
-    | _ -> failwith "Unknown type"
-
-  let create typ chunk_size len =
-    let c = Cstruct.create chunk_size in
-    Cstruct.memset c 0x00;
-    set_type c (int_of_type typ);
-    set_length c len;
-    of_cstruct c
-
-  let to_cstruct (_idx, c) =
-    c
-
-  (* The Irmin.Contents.Conv signature *)
-  let t = Irmin.Type.like Irmin.Type.cstruct of_cstruct to_cstruct
-  let pp = Irmin.Type.dump t
-  (* TODO: validate *)
-  let of_string s =
-    let cs = Cstruct.of_string s in
-    match of_cstruct cs with
-    |x -> Result.Ok x
-    |exception _exn -> Result.Error (`Msg "Invalid data")
+  let of_string s = Irmin.Type.decode_string t s
+  let pp ppf v = Fmt.string ppf (Irmin.Type.encode_string t v)
 
 end
 
-module AO (S:AO_MAKER) (K:Irmin.Hash.S) (V: Irmin.Contents.Conv)
-: sig
-    include Irmin.AO
-    val v : Irmin.config -> t Lwt.t
-  end
-  with type key = S(K)(Chunk(K)).key
-  and type value = V.t
-= struct
+module AO (S:AO_MAKER) (K:Irmin.Hash.S) (V: Irmin.Contents.Conv) = struct
 
   module Chunk = Chunk(K)
 
@@ -129,186 +105,120 @@ module AO (S:AO_MAKER) (K:Irmin.Hash.S) (V: Irmin.Contents.Conv)
     db          : AO.t;             (* An handler to the underlying database. *)
     chunk_size  : int;                                 (* the size of chunks. *)
     max_children: int;     (* the maximum number of children a node can have. *)
-    max_length  : int; (* the maximum lentgh (in bytes) of data stored in one
+    max_data    : int; (* the maximum length (in bytes) of data stored in one
                           chunk. *)
   }
 
-  let v_of_raw raw =
-    match Irmin.Type.decode_cstruct V.t raw with
-    |Ok va -> va
-    |Error _ -> invalid_arg "v_of_raw"
-
-  let raw_of_v v =
-    Irmin.Type.encode_cstruct V.t v
+  let data t v = { Chunk.v = Data v; len = t.chunk_size }
+  let index t i = { Chunk.v = Index i; len = t.chunk_size }
 
   module Tree = struct
 
-    let get_child t node pos =
-      let key = K.of_raw (Chunk.get_sub_key node pos) in
-      AO.find t.db key >>= function
-      |Some v -> Lwt.return_some v
-      |None -> Lwt.return_none
-
-    let walk_to_list t root =
-      let rec aux_walk t (idx, node) =
-        match idx with
-        | Chunk.Data ->
-          let dlen = Chunk.get_length node in
-          let leaf = Cstruct.create dlen in
-          Chunk.extract_data node 0 leaf 0 dlen;
-          Lwt.return_some [leaf]
-        | Chunk.Indirect ->
-          let nbr_child = Chunk.get_length node in
-          let rec loop i accu =
-            if i < nbr_child then
-              get_child t node i >>= function
-                |None -> Lwt.return_none
-                |Some x ->
-              aux_walk t x       >>= function
-                |None -> Lwt.return_none
-                |Some y ->
-              loop (i+1) (List.append accu y)
-            else
-              Lwt.return_some accu
-          in
-          loop 0 []
+    (* return all the tree leaves *)
+    let find_leaves t root =
+      let rec aux acc { Chunk.v; _ } = match v with
+        | Chunk.Data  d -> Lwt.return (d :: acc)
+        | Chunk.Index i ->
+          Lwt_list.fold_left_s (fun acc key ->
+              AO.find t.db key >>= function
+              | None   -> Lwt.return acc
+              | Some v -> aux acc v
+            ) acc i
       in
-      aux_walk t root
+      aux [] root >|= List.rev
 
-    let rec bottom_up t l r =
-      match l with
-      | [] -> Lwt.return r
-      | l ->
-        let n =
-          if List.length l >= t.max_children then t.max_children
-          else List.length l
-        in
-        let indir = Chunk.(create Indirect) t.chunk_size n in
-        let rec loop i l =
-          if i >= n then l
+    (* partition a list into a list of elements of at most size [n] *)
+    let list_partition n l =
+      let rec aux done_ i acc = function
+        | []   -> List.rev (List.rev acc :: done_)
+        | h::t ->
+          if i >= n then
+            aux (List.rev acc :: done_) 1 [h] t
           else
-            let x = List.hd l in
-            let rest = List.tl l in
-            let offset_hash = i * K.digest_size in
-            Chunk.set_data (K.to_raw x) 0 (Chunk.to_cstruct indir) offset_hash K.digest_size;
-            loop (i+1) rest
-        in
-        let calc = loop 0 l in
-        AO.add t.db indir >>= fun x ->
-        bottom_up t calc (x::r)
+            aux done_ (i+1) (h :: acc) t
+      in
+      aux [] 0 [] l
 
-    let rec create t = function
-      | [] -> failwith "Irmin_chunk.Tree.bottom_up"
-      | [e] -> Lwt.return e
-      | l   -> bottom_up t l [] >>= create t
+    let add t l =
+      let rec aux = function
+        | []  -> invalid_arg "Irmin_chunk.Tree.add"
+        | [k] -> Lwt.return k
+        | l   ->
+          let n =
+            if List.length l >= t.max_children
+            then t.max_children
+            else List.length l
+          in
+          let l = list_partition n l in
+          Lwt_list.map_p (fun i ->
+              AO.add t.db (index t i)
+            ) l >>=
+          aux
+      in
+      aux l
 
   end
 
   let v config =
     let module C = Irmin.Private.Conf in
     let chunk_size = C.get config Conf.chunk_size in
-    let max_length = chunk_size - Chunk.head_length - 1 in
-    let max_children = max_length / K.digest_size in
+    let max_data = chunk_size - 1 - 8 in
+    let max_children = chunk_size / K.digest_size in
     if max_children <= 1 then (
-      let min = Chunk.head_length + 1 + K.digest_size * 2 in
+      let min = 1 + K.digest_size * 2 in
       err_too_small ~min chunk_size;
     );
-    AO.v config >|=
-    fun db -> { db; chunk_size; max_children; max_length }
+    Log.debug
+      (fun l ->
+         l "config: chunk-size=%d digest-size=%d max-data=%d max-children=%d"
+           chunk_size K.digest_size max_data max_children);
+    AO.v config >|= fun db -> { db; chunk_size; max_children; max_data }
+
+  let find_leaves t key =
+    AO.find t.db key >>= function
+    | None    -> Lwt.return []
+    | Some x  -> Tree.find_leaves t x
 
   let find t key =
-    AO.find t.db key >>= function
-    | None   -> Lwt.return_none
-    | Some x ->
-      let (idx, c) = x in
-      match idx with
-      | Chunk.Data ->
-        let dlen = Chunk.get_length c in
-        let result = Cstruct.create dlen in
-        Chunk.extract_data c 0 result 0 dlen;
-        Lwt.return_some @@ v_of_raw result
-      | Chunk.Indirect ->
-        Tree.walk_to_list t x >>= function
-          |None -> Lwt.return_none
-          |Some y ->
-        let result = v_of_raw @@ Cstruct.concat y in
-        Lwt.return_some result
+    find_leaves t key >|= fun bufs ->
+    let buf = Bytes.concat Bytes.empty bufs in
+    match Irmin.Type.decode_bytes V.t buf with
+    |Ok va   -> Some va
+    |Error _ -> None
 
-  type params = {
-    used: int;                (* the total number of blocks which are needed. *)
-    last: int;               (* the number of useful bytes in the last block. *)
-  }
-
-  let split t ~data ~nodes i v =
-    let is_last = (i = nodes.used - 1) in
-    let chunks = if is_last then nodes.last else t.max_children in
-    let buf = Chunk.(create Indirect) t.chunk_size chunks in
-    let rec loop j =
-      let len, max_loop =
-        if not is_last then t.max_length, t.max_children
-        else
-          if j = nodes.last - 1 then data.last, nodes.last
-          else t.max_length, nodes.last
-      in
-      if j >= max_loop then Lwt.return_unit
-      else (
-        let chunk = Chunk.(create Data) t.chunk_size len in
-        let offset_value = (j + i * t.max_children) * t.max_length in
-        Chunk.set_data v offset_value (Chunk.to_cstruct chunk) 0 len;
-        let add_chunk () =
-          AO.add t.db chunk >>= fun x ->
-          let offset_hash = j * K.digest_size in
-          Chunk.set_data (K.to_raw x) 0 (Chunk.to_cstruct buf) offset_hash K.digest_size;
-          Lwt.return_unit
-        in
-        Lwt.join [add_chunk (); loop (j + 1)]
-      ) in
-    loop 0 >>= fun () ->
-    AO.add t.db buf >>= fun x ->
-    Lwt.return x
+  let list_range ~init ~stop ~step =
+    let rec aux acc n =
+      if n >= stop then List.rev acc
+      else aux (n :: acc) (n + step)
+    in
+    aux [] init
 
   let add t v =
-    let v = raw_of_v v in
-    let value_length = Cstruct.len v in
-    let rest_value_length = value_length mod t.max_length in
-    if value_length <= t.max_length then (
-      let chunk = Chunk.(create Data) t.chunk_size value_length  in
-      Chunk.set_data v 0 (Chunk.to_cstruct chunk) 0 value_length;
-      AO.add t.db chunk
+    let buf = Irmin.Type.encode_bytes V.t v in
+    let len = Bytes.length buf in
+    if len <= t.max_data then (
+      AO.add t.db (data t buf) >|= fun k ->
+      Log.debug (fun l -> l "add -> %a (no split)" K.pp k);
+      k
     ) else (
-      let data = (* the number of data blocks *)
-        let x = value_length / t.max_length in
-        if rest_value_length = 0 then
-          { used = x; last = t.max_length }
-        else
-          { used = x + 1; last = rest_value_length }
+      let offs = list_range ~init:0 ~stop:len ~step:t.max_data in
+      let aux off =
+        let len = min t.max_data (Bytes.length buf - off) in
+        let payload = Bytes.sub buf off len in
+        AO.add t.db (data t payload)
       in
-      let nodes = (* the number of tree nodes *)
-        let x = data.used / t.max_children in
-        let y = data.used mod t.max_children in
-        if y = 0 then
-          { used = x; last = t.max_children }
-        else
-          { used = x + 1; last = y }
-      in
-      let loop () =
-        let rec aux acc = function
-          | i when i = nodes.used -> Lwt.return (List.rev acc)
-          | i when i < nodes.used ->
-            split t ~data ~nodes i v >>= fun x ->
-            aux (x::acc) (i+1)
-          | _ -> assert false
-        in
-        aux [] 0
-      in
-      loop () >>= Tree.create t
+      Lwt_list.map_s aux offs >>= Tree.add t >|= fun k ->
+      Log.debug (fun l -> l "add -> %a (split)" K.pp k);
+      k
     )
 
   let mem t key = AO.mem t.db key
 
 end
 
-module AO_stable (L: LINK_MAKER) (S: AO_MAKER) (K: Hash.S) (V: Irmin.Contents.Conv) = struct
+module AO_stable
+    (L: LINK_MAKER) (S: AO_MAKER) (K: Hash.S) (V: Irmin.Contents.Conv)
+= struct
 
   module AO = AO(S)(K)(V)
   module Link = L(K)

--- a/src/irmin-chunk/irmin_chunk.mli
+++ b/src/irmin-chunk/irmin_chunk.mli
@@ -20,22 +20,6 @@
     of the same size, while preserving the keys used in the store. It can
     be used to optimize space usage when dealing with large files or as an
     intermediate layer for a raw block device backend.
-
-    # Install
-
-    Use opam:
-
-    ```shell
-    opam install irmin-chunk
-    ```
-
-    # Use
-
-    ```ocaml
-    (* Build an Irmin store, where blobs are cut into chunks of same size *)
-    module AO = Irmin_chunk.AO_stable(Irmin_mem.Link)(Irmin_mem.AO)
-    module Store = Irmin.Make(AO)(Irmin_mem.RW)
-    ```
 *)
 
 (** Managing Chunks.
@@ -51,16 +35,16 @@
     A chunk has the following structure:
 
     {v
-     --------------------------
-     | uint8_t type            |
-     ---------------------------
-     | uint16_t length         |
-     ---------------------------
-     | byte data[length]       |
-     ---------------------------
+     --------------------------      --------------------------
+     | uint8_t type            |     | uint8_t type            |
+     ---------------------------     ---------------------------
+     | uint16_t                |     | uint64_t                |
+     ---------------------------     ---------------------------
+     | key children[length]    |     | byte data[length]       |
+     ---------------------------     ---------------------------
 v}
 
-    [type] is either [Data] (0) or [Node] (1). If the chunk contains
+    [type] is either [Data] (0) or [Index] (1). If the chunk contains
     data, [length] is the payload length. Otherwise it is the number
     of children that the node has.
 

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -38,7 +38,8 @@ let test_add_read ?(stable=false) (module AO: Test_chunk.S) () =
     let v = value (String.make size 'x') in
     AO.add t v  >>= fun k ->
     if stable then
-      Alcotest.(check key_t) (name ^ " is stable") k (Test_chunk.Key.digest Test_chunk.Value.t v);
+      Alcotest.(check key_t)
+        (name ^ " is stable") k (Test_chunk.Key.digest Test_chunk.Value.t v);
     AO.find t k >|= fun v' ->
     Alcotest.(check @@ option value_t) name (Some v) v'
   in
@@ -64,7 +65,6 @@ let stable =
   ]
 
 let () =
-  Alcotest.run "irmin-chunk" [simple; stable] ~and_exit:false;
-  Test_store.run "irmin-chunk" ~misc:[] [
+  Test_store.run "irmin-chunk" ~misc:[simple; stable] [
     `Quick, Test_chunk.suite
   ]


### PR DESCRIPTION
- use the new `Irmin.Type` combinator instead of a custom serialisation format
- ensure the index trees are well-balanced