### PR TITLE
Allow to use the HTTP API over unix local domain sockets

### DIFF
--- a/src/irmin-http/irmin_http.mli
+++ b/src/irmin-http/irmin_http.mli
@@ -20,5 +20,10 @@ val config: ?config:Irmin.config -> Uri.t -> Irmin.config
 
 val uri: Uri.t option Irmin.Private.Conf.key
 
-module Make (C: Cohttp_lwt.S.Client): Irmin.S_MAKER
-module KV (C: Cohttp_lwt.S.Client): Irmin.KV_MAKER
+module type CLIENT = sig
+  include Cohttp_lwt.S.Client
+  val ctx: unit -> ctx option
+end
+
+module Make (C: CLIENT): Irmin.S_MAKER
+module KV (C: CLIENT): Irmin.KV_MAKER

--- a/src/irmin-unix/ir_unix.ml
+++ b/src/irmin-unix/ir_unix.ml
@@ -363,7 +363,17 @@ module Git = struct
 end
 
 module Http = struct
-  module Make = Irmin_http.Make(Cohttp_lwt_unix.Client)
+  module Client = struct
+    include Cohttp_lwt_unix.Client
+    let ctx () =
+      let resolver =
+        let h = Hashtbl.create 1 in
+        Hashtbl.add h "irmin" (`Unix_domain_socket "/var/run/irmin.sock");
+        Resolver_lwt_unix.static h
+      in
+      Some (Cohttp_lwt_unix.Client.custom_ctx ~resolver ())
+  end
+  module Make = Irmin_http.Make(Client)
   module KV (C: Irmin.Contents.S) =
     Make
       (Irmin.Metadata.None)


### PR DESCRIPTION
I am not totally sure about the signature that `ctx` should have. `Uri.t -> ctx option Lwt.t` seems pretty generic, but maybe we want something simpler (with `Uri.t` and `Lwt.t`).