### PR TITLE
Fix examples/sync.ml for changes to remote API

### DIFF
--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -10,7 +10,8 @@ let path =
 module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 module Sync = Irmin.Sync(Store)
 
-let upstream = Irmin.remote_uri path
+let endpoint = Git_unix.endpoint @@ Uri.of_string path
+let upstream = Sync.remote endpoint
 
 let test () =
   Config.init ();


### PR DESCRIPTION
I also have a few questions about the new remote representation:

1) It seems like having both `Store.remote` and `Sync.remote` is kind of confusing, especially since `Sync.remote` works and `Store.remote` doesn't (at least in the case of the example) - Is there a reason both are exposed? This seems to be causing an issue when using `irmin pull` from the command-line as well (I will make another issue for that).

2) There is now no way to make an `endpoint` from a string or URI in a generic manner - is this true? If that's the case how do you think I should handle something like this: https://github.com/andreas/irmin-graphql/blob/master/src/irmin_graphql.ml#L275 -- I guess another parameter to `Make` that specifies the proper endpoint creation function wouldn't be *so* inconvenient, however maybe there is a better way that I'm just missing?