### PR TITLE
Simplify the new sync API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - ALCOTEST_SHOW_ERRORS=1
-  - REVDEPS="irmin-indexeddb"
-  - PINS="irmin.dev:. irmin-mem.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-mirage.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. git.dev:--dev git git-unix.dev:--dev git-mirage.dev:--dev git-http.dev:--dev digestif.dev:--dev"
+  - PINS="irmin.dev:. irmin-mem.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-mirage.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. git.dev:--dev git git-unix.dev:--dev git-mirage.dev:--dev git-http.dev:--dev digestif.dev:--dev decompress.dev:--dev"
   matrix:
   - OCAML_VERSION=4.03 PACKAGE="irmin-fs.dev" TESTS=true
   - OCAML_VERSION=4.04 PACKAGE="irmin-mem.dev" TESTS=true
@@ -13,4 +12,4 @@ env:
   - OCAML_VERSION=4.06 PACKAGE="irmin-http.dev" TESTS=true
   - OCAML_VERSION=4.06 PACKAGE="irmin-chunk.dev" TESTS=true
   - OCAML_VERSION=4.05 PACKAGE="irmin-mirage.dev"
-  - OCAML_VERSION=4.06 PACKAGE="irmin-unix.dev" TESTS=true EXTRA_DEPS=inotify
+  - OCAML_VERSION=4.06 PACKAGE="irmin-unix.dev" TESTS=true EXTRA_DEPS=inotify REVDEPS="irmin-indexeddb"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
     OPAM_SWITCH: 4.06.1+mingw64c
-    PINS: "irmin.dev:. irmin-mem.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-mirage.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. git.dev:--dev git git-unix.dev:--dev git-mirage.dev:--dev git-http.dev:--dev digestif.dev:--dev"
+    PINS: "irmin.dev:. irmin-mem.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-mirage.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. git.dev:--dev git git-unix.dev:--dev git-mirage.dev:--dev git-http.dev:--dev digestif.dev:--dev decompress.dev:--dev"
   matrix:
   - PACKAGE: "irmin-mirage.dev"
 

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -10,8 +10,7 @@ let path =
 module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
 module Sync = Irmin.Sync(Store)
 
-let endpoint = Git_unix.endpoint @@ Uri.of_string path
-let upstream = Sync.remote endpoint
+let upstream = Store.remote path
 
 let test () =
   Config.init ();

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -580,9 +580,6 @@ struct
 
   type endpoint = S.Endpoint.t
 
-  type Irmin.remote += E of endpoint
-  let remote e = E e
-
   let git_of_branch_str str = G.Reference.of_string ("refs/heads/" ^ str)
   let git_of_branch r = git_of_branch_str (Irmin.Type.to_string B.t r)
 
@@ -937,7 +934,7 @@ module type S_MAKER = functor
        and type contents = C.t
        and type branch = B.t
        and module Git = G
-       and type endpoint = S.Endpoint.t
+       and type Private.Sync.endpoint = S.Endpoint.t
 
 module type KV_MAKER = functor
   (G: G)
@@ -948,7 +945,7 @@ module type KV_MAKER = functor
        and type contents = C.t
        and type branch = string
        and module Git = G
-       and type endpoint = S.Endpoint.t
+       and type Private.Sync.endpoint = S.Endpoint.t
 
 module type REF_MAKER = functor
   (G: G)
@@ -959,6 +956,6 @@ module type REF_MAKER = functor
        and type contents = C.t
        and type branch = reference
        and module Git = G
-       and type endpoint = S.Endpoint.t
+       and type Private.Sync.endpoint = S.Endpoint.t
 
 include Conf

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -94,7 +94,7 @@ module type S_MAKER = functor
      and type contents = C.t
      and type branch = B.t
      and module Git = G
-     and type endpoint = S.Endpoint.t
+     and type Private.Sync.endpoint = S.Endpoint.t
 
 module type KV_MAKER = functor
   (G: G)
@@ -105,7 +105,7 @@ module type KV_MAKER = functor
      and type contents = C.t
      and type branch = string
      and module Git = G
-     and type endpoint = S.Endpoint.t
+     and type Private.Sync.endpoint = S.Endpoint.t
 
 type reference = [
   | `Branch of string
@@ -123,7 +123,7 @@ module type REF_MAKER = functor
      and type contents = C.t
      and type branch = reference
      and module Git = G
-     and type endpoint = S.Endpoint.t
+     and type Private.Sync.endpoint = S.Endpoint.t
 
 module Make: S_MAKER
 module Ref : REF_MAKER

--- a/src/irmin-mirage/irmin_mirage.mli
+++ b/src/irmin-mirage/irmin_mirage.mli
@@ -28,6 +28,15 @@ module Info (N: sig val name: string end)(C: Mirage_clock.PCLOCK): sig
 
 end
 
+module type S = sig
+  include Irmin_git.S with type Private.Sync.endpoint = Git_mirage.endpoint
+  val remote:
+    ?conduit:Conduit_mirage.conduit ->
+    ?resolver:Resolver_lwt.t ->
+    ?headers:Cohttp.Header.t ->
+    string -> Irmin.remote
+end
+
 module Git: sig
 
   module Make
@@ -35,33 +44,30 @@ module Git: sig
     (C: Irmin.Contents.S)
     (P: Irmin.Path.S)
     (B: Irmin.Branch.S):
-    Irmin_git.S with type key = P.t
-                 and type step = P.step
-                 and module Key = P
-                 and type contents = C.t
-                 and type branch = B.t
-                 and module Git = G
-                 and type endpoint = Git_mirage.endpoint
+    S with type key = P.t
+       and type step = P.step
+       and module Key = P
+       and type contents = C.t
+       and type branch = B.t
+       and module Git = G
 
   module KV
       (G: Irmin_git.G)
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = string list
-                 and type step = string
-                 and type contents = C.t
-                 and type branch = string
-                 and module Git = G
-                 and type endpoint = Git_mirage.endpoint
+    S with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = string
+       and module Git = G
 
   module Ref
       (G: Irmin_git.G)
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = string list
-                 and type step = string
-                 and type contents = C.t
-                 and type branch = Irmin_git.reference
-                 and module Git = G
-                 and type endpoint = Git_mirage.endpoint
+    S with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = Irmin_git.reference
+       and module Git = G
 
   module type KV_RO = sig
 
@@ -76,7 +82,7 @@ module Git: sig
       ?conduit:Conduit_mirage.t ->
       ?resolver:Resolver_lwt.t ->
       ?headers:Cohttp.Header.t ->
-      git -> Uri.t -> t Lwt.t
+      git -> string -> t Lwt.t
     (** [connect ?depth ?branch ?path g uri] clones the given [uri] into
         [g] repository, using the given [branch], [depth] and
         ['/']-separated sub-[path]. By default, [branch] is master,
@@ -99,32 +105,29 @@ module Git: sig
         (C: Irmin.Contents.S)
         (P: Irmin.Path.S)
         (B: Irmin.Branch.S):
-      Irmin_git.S with type key = P.t
-                   and type step = P.step
-                   and module Key = P
-                   and type contents = C.t
-                   and type branch = B.t
-                   and module Git = G
-                   and type endpoint = Git_mirage.endpoint
+      S with type key = P.t
+         and type step = P.step
+         and module Key = P
+         and type contents = C.t
+         and type branch = B.t
+         and module Git = G
 
     module Ref
         (C: Irmin.Contents.S):
-      Irmin_git.S with type key = string list
-                   and type step = string
-                   and type contents = C.t
-                   and type branch = Irmin_git.reference
-                   and module Git = G
-                   and type endpoint = Git_mirage.endpoint
+      S with type key = string list
+         and type step = string
+         and type contents = C.t
+         and type branch = Irmin_git.reference
+         and module Git = G
 
     module KV
         (C: Irmin.Contents.S):
-      Irmin_git.S with type key = Irmin.Path.String_list.t
-                   and type step = string
-                   and module Key = Irmin.Path.String_list
-                   and type contents = C.t
-                   and type branch = string
-                   and module Git = G
-                   and type endpoint = Git_mirage.endpoint
+      S with type key = Irmin.Path.String_list.t
+         and type step = string
+         and module Key = Irmin.Path.String_list
+         and type contents = C.t
+         and type branch = string
+         and module Git = G
 
     module KV_RO: KV_RO with type git := G.t
   end
@@ -138,30 +141,27 @@ module Git: sig
         (C: Irmin.Contents.S)
         (P: Irmin.Path.S)
         (B: Irmin.Branch.S):
-      Irmin_git.S with type key = P.t
-                   and type step = P.step
-                   and module Key = P
-                   and type contents = C.t
-                   and type branch = B.t
-                   and module Git = G
-                   and type endpoint = Git_mirage.endpoint
+      S with type key = P.t
+         and type step = P.step
+         and module Key = P
+         and type contents = C.t
+         and type branch = B.t
+         and module Git = G
 
     module Ref (C: Irmin.Contents.S):
-      Irmin_git.S with type key = string list
-                   and type step = string
-                   and type contents = C.t
-                   and type branch = Irmin_git.reference
-                   and module Git = G
-                   and type endpoint = Git_mirage.endpoint
+      S with type key = string list
+         and type step = string
+         and type contents = C.t
+         and type branch = Irmin_git.reference
+         and module Git = G
 
     module KV (C: Irmin.Contents.S):
-      Irmin_git.S with type key = Irmin.Path.String_list.t
-                   and type step = string
-                   and module Key = Irmin.Path.String_list
-                   and type contents = C.t
-                   and type branch = string
-                   and module Git = G
-                   and type endpoint = Git_mirage.endpoint
+      S with type key = Irmin.Path.String_list.t
+         and type step = string
+         and module Key = Irmin.Path.String_list
+         and type contents = C.t
+         and type branch = string
+         and module Git = G
 
     module KV_RO: KV_RO with type git := G.t
   end

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -297,9 +297,9 @@ let remove = {
 }
 
 let apply e f = match e, f with
-  | E e, Some f -> f e
-  | E _, None   -> Fmt.failwith "invalid remote for that kind of store"
-  | r  , _      -> r
+  | R (h, e), Some f -> f ?headers:h e
+  | R _     , None   -> Fmt.failwith "invalid remote for that kind of store"
+  | r       , _      -> r
 
 (* CLONE *)
 let clone = {

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -80,38 +80,40 @@ module Git: sig
 
   (** {1 Git Store} *)
 
+  module type S = sig
+    include Irmin_git.S with type Private.Sync.endpoint = Git_unix.endpoint
+    val remote: ?headers:Cohttp.Header.t -> string -> Irmin.remote
+  end
+
   module Make
-    (G: Irmin_git.G)
-    (C: Irmin.Contents.S)
-    (P: Irmin.Path.S)
-    (B: Irmin.Branch.S):
-    Irmin_git.S with type key = P.t
-                 and type step = P.step
-                 and module Key = P
-                 and type contents = C.t
-                 and type branch = B.t
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+      (G: Irmin_git.G)
+      (C: Irmin.Contents.S)
+      (P: Irmin.Path.S)
+      (B: Irmin.Branch.S):
+    S with type key = P.t
+       and type step = P.step
+       and module Key = P
+       and type contents = C.t
+       and type branch = B.t
+       and module Git = G
 
   module KV
       (G: Irmin_git.G)
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = string list
-                 and type step = string
-                 and type contents = C.t
-                 and type branch = string
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = string
+       and module Git = G
 
   module Ref
       (G: Irmin_git.G)
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = string list
-                 and type step = string
-                 and type contents = C.t
-                 and type branch = Irmin_git.reference
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = Irmin_git.reference
+       and module Git = G
 
   (** Embed an Irmin store into a local Git repository. *)
   module FS: sig
@@ -122,32 +124,29 @@ module Git: sig
         (C: Irmin.Contents.S)
         (P: Irmin.Path.S)
         (B: Irmin.Branch.S):
-      Irmin_git.S with type key = P.t
-                   and type step = P.step
-                   and module Key = P
-                   and type contents = C.t
-                   and type branch = B.t
-                   and module Git = G
-                   and type endpoint = Git_unix.endpoint
+      S with type key = P.t
+         and type step = P.step
+         and module Key = P
+         and type contents = C.t
+         and type branch = B.t
+         and module Git = G
 
     module Ref
         (C: Irmin.Contents.S):
-      Irmin_git.S with type key = string list
-                   and type step = string
-                   and type contents = C.t
-                   and type branch = Irmin_git.reference
-                   and module Git = G
-                   and type endpoint = Git_unix.endpoint
+      S with type key = string list
+         and type step = string
+         and type contents = C.t
+         and type branch = Irmin_git.reference
+         and module Git = G
 
     module KV
         (C: Irmin.Contents.S):
-      Irmin_git.S with type key = Irmin.Path.String_list.t
+      S with type key = Irmin.Path.String_list.t
           and type step = string
           and module Key = Irmin.Path.String_list
           and type contents = C.t
           and type branch = string
           and module Git = G
-          and type endpoint = Git_unix.endpoint
 
   end
 
@@ -160,31 +159,28 @@ module Git: sig
         (C: Irmin.Contents.S)
         (P: Irmin.Path.S)
         (B: Irmin.Branch.S):
-      Irmin_git.S with type key = P.t
-                   and type step = P.step
-                   and module Key = P
-                   and type contents = C.t
-                   and type branch = B.t
-                   and module Git = G
-                   and type endpoint = Git_unix.endpoint
+      S with type key = P.t
+         and type step = P.step
+         and module Key = P
+         and type contents = C.t
+         and type branch = B.t
+         and module Git = G
 
     module Ref
         (C: Irmin.Contents.S):
-      Irmin_git.S with type key = string list
-                   and type step = string
-                   and type contents = C.t
-                   and type branch = Irmin_git.reference
-                   and module Git = G
-                   and type endpoint = Git_unix.endpoint
+      S with type key = string list
+         and type step = string
+         and type contents = C.t
+         and type branch = Irmin_git.reference
+         and module Git = G
 
     module KV (C: Irmin.Contents.S):
-      Irmin_git.S with type key = Irmin.Path.String_list.t
+      S with type key = Irmin.Path.String_list.t
         and type step = string
         and module Key = Irmin.Path.String_list
         and type contents = C.t
         and type branch = string
         and module Git = G
-        and type endpoint = Git_unix.endpoint
 
   end
 

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -41,7 +41,9 @@ module Store: sig
      contains: the store implementation a creator of store's state and
      endpoint. *)
 
-  val v: ?endpoint:(Git_unix.endpoint -> Irmin.remote) -> (module Irmin.S) -> t
+  type remote_fn = ?headers:Cohttp.Header.t -> string -> Irmin.remote
+
+  val v: ?remote:remote_fn -> (module Irmin.S) -> t
 
   val mem: contents -> t
   val irf: contents -> t
@@ -53,7 +55,7 @@ module Store: sig
 
 end
 
-type Irmin.remote += E of Git_unix.endpoint
+type Irmin.remote += R of Cohttp.Header.t option * string
 
 val remote: Irmin.remote Lwt.t Cmdliner.Term.t
 (** Parse a remote store location. *)
@@ -63,7 +65,7 @@ val remote: Irmin.remote Lwt.t Cmdliner.Term.t
 type store =
   | S: (module Irmin.S with type t = 'a)
        * 'a Lwt.t
-       * (Git_unix.endpoint -> Irmin.remote) option
+       * Store.remote_fn option
     -> store
 
 val store: store Cmdliner.Term.t

--- a/src/irmin-unix/xgit.mli
+++ b/src/irmin-unix/xgit.mli
@@ -14,38 +14,40 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module type S = sig
+  include Irmin_git.S with type Private.Sync.endpoint = Git_unix.endpoint
+  val remote: ?headers:Cohttp.Header.t -> string -> Irmin.remote
+end
+
 module Make
     (G: Irmin_git.G)
     (C: Irmin.Contents.S)
     (P: Irmin.Path.S)
     (B: Irmin.Branch.S):
-  Irmin_git.S with type key = P.t
-               and type step = P.step
-               and module Key = P
-               and type contents = C.t
-               and type branch = B.t
-               and module Git = G
-               and type endpoint = Git_unix.endpoint
+  S with type key = P.t
+     and type step = P.step
+     and module Key = P
+     and type contents = C.t
+     and type branch = B.t
+     and module Git = G
 
 module KV
     (G: Irmin_git.G)
     (C: Irmin.Contents.S):
-  Irmin_git.S with type key = string list
-               and type step = string
-               and type contents = C.t
-               and type branch = string
-               and module Git = G
-               and type endpoint = Git_unix.endpoint
+  S with type key = string list
+     and type step = string
+     and type contents = C.t
+     and type branch = string
+     and module Git = G
 
 module Ref
     (G: Irmin_git.G)
     (C: Irmin.Contents.S):
-  Irmin_git.S with type key = string list
-               and type step = string
-               and type contents = C.t
-               and type branch = Irmin_git.reference
-               and module Git = G
-               and type endpoint = Git_unix.endpoint
+  S with type key = string list
+     and type step = string
+     and type contents = C.t
+     and type branch = Irmin_git.reference
+     and module Git = G
 
 module FS: sig
 
@@ -55,32 +57,29 @@ module FS: sig
       (C: Irmin.Contents.S)
       (P: Irmin.Path.S)
       (B: Irmin.Branch.S):
-    Irmin_git.S with type key = P.t
-                 and type step = P.step
-                 and module Key = P
-                 and type contents = C.t
-                 and type branch = B.t
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = P.t
+       and type step = P.step
+       and module Key = P
+       and type contents = C.t
+       and type branch = B.t
+       and module Git = G
 
   module Ref
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = string list
-                 and type step = string
-                 and type contents = C.t
-                 and type branch = Irmin_git.reference
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = Irmin_git.reference
+       and module Git = G
 
   module KV
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = Irmin.Path.String_list.t
-                 and type step = string
-                 and module Key = Irmin.Path.String_list
-                 and type contents = C.t
-                 and type branch = string
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = Irmin.Path.String_list.t
+       and type step = string
+       and module Key = Irmin.Path.String_list
+       and type contents = C.t
+       and type branch = string
+       and module Git = G
 
 end
 
@@ -92,30 +91,27 @@ module Mem: sig
       (C: Irmin.Contents.S)
       (P: Irmin.Path.S)
       (B: Irmin.Branch.S):
-    Irmin_git.S with type key = P.t
-                 and type step = P.step
-                 and module Key = P
-                 and type contents = C.t
-                 and type branch = B.t
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = P.t
+       and type step = P.step
+       and module Key = P
+       and type contents = C.t
+       and type branch = B.t
+       and module Git = G
 
   module Ref
       (C: Irmin.Contents.S):
-    Irmin_git.S with type key = string list
-                 and type step = string
-                 and type contents = C.t
-                 and type branch = Irmin_git.reference
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = Irmin_git.reference
+       and module Git = G
 
   module KV (C: Irmin.Contents.S):
-    Irmin_git.S with type key = Irmin.Path.String_list.t
-                 and type step = string
-                 and module Key = Irmin.Path.String_list
-                 and type contents = C.t
-                 and type branch = string
-                 and module Git = G
-                 and type endpoint = Git_unix.endpoint
+    S with type key = Irmin.Path.String_list.t
+       and type step = string
+       and module Key = Irmin.Path.String_list
+       and type contents = C.t
+       and type branch = string
+       and module Git = G
 
 end

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -254,7 +254,6 @@ module type SYNC = sig
   type commit
   type branch
   type endpoint
-  val remote: endpoint -> remote
   val fetch: t -> ?depth:int -> endpoint -> branch ->
     (commit, [`No_head | `Not_available | `Msg of string]) result Lwt.t
   val push: t -> ?depth:int -> endpoint -> branch ->
@@ -479,9 +478,6 @@ module type STORE = sig
   module Key: PATH with type t = key and type step = step
   module Metadata: METADATA with type t = metadata
 
-  type endpoint
-  val remote: endpoint -> remote
-
   val step_t: step Type.t
   val key_t: key Type.t
   val metadata_t: metadata Type.t
@@ -506,8 +502,9 @@ module type STORE = sig
        and type Branch.key = branch
        and type Slice.t = slice
        and type Repo.t = repo
-       and type Sync.endpoint = endpoint
   end
+
+  type remote += E of Private.Sync.endpoint
 end
 
 module type MAKER =

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -31,11 +31,10 @@ module Make (P: S.PRIVATE) = struct
   module Key = P.Node.Path
   type key = Key.t
 
-  type endpoint = P.Sync.endpoint
-  let remote = P.Sync.remote
-
   module Metadata = P.Node.Metadata
   module H = Commit.History(P.Commit)
+
+  type S.remote += E of P.Sync.endpoint
 
   module Contents = struct
     include P.Contents.Val

--- a/src/irmin/store.mli
+++ b/src/irmin/store.mli
@@ -28,6 +28,5 @@ module Make (P: S.PRIVATE): S.STORE
    and type step = P.Node.Path.step
    and type metadata = P.Node.Val.metadata
    and module Key = P.Node.Path
-   and module Private.Contents = P.Contents
    and type repo = P.Repo.t
-   and type endpoint = P.Sync.endpoint
+   and module Private = P

--- a/src/irmin/sync.ml
+++ b/src/irmin/sync.ml
@@ -18,7 +18,6 @@ module None (H: Type.S) (R: Type.S) = struct
   type t = unit
   let v _ = Lwt.return ()
   type endpoint = unit
-  let remote () = assert false
   type commit = H.t
   type branch = R.t
   let fetch () ?depth:_ _ _br = Lwt.return (Error `Not_available)

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -75,9 +75,6 @@ module Make (S: S.STORE) = struct
     | `Msg of string
   ]
 
-  type remote += E of B.endpoint
-  let remote e = E e
-
   let pp_branch = Type.pp S.Branch.t
   let pp_hash = Type.pp S.Commit.Hash.t
 
@@ -103,7 +100,7 @@ module Make (S: S.STORE) = struct
             | Ok h    -> Ok h
             | Error e -> Error (e :> fetch_error)
       end
-    | E e ->
+    | S.E e ->
       begin match S.status t with
         | `Empty | `Commit _ -> Lwt.return (Error `No_head)
         | `Branch br ->
@@ -178,7 +175,7 @@ module Make (S: S.STORE) = struct
             | Error e -> Lwt.return (Error (e :> push_error))
             | Ok h    -> R.Head.set r h >|= fun () -> Ok ()
       end
-    | E e ->
+    | S.E e ->
       begin match S.status t with
         | `Empty    -> Lwt.return (Error `No_head)
         | `Commit _ -> Lwt.return (Error `Detached_head)

--- a/src/irmin/sync_ext.mli
+++ b/src/irmin/sync_ext.mli
@@ -18,7 +18,5 @@
 
 val remote_store: (module S.STORE with type t = 'a) -> 'a -> S.remote
 
-module Make (X: S.STORE): sig
-  include S.SYNC_STORE with type db = X.t and type commit = X.commit
-  val remote: X.endpoint -> S.remote
-end
+module Make (X: S.STORE):
+  S.SYNC_STORE with type db = X.t and type commit = X.commit


### PR DESCRIPTION
/cc @zshipko and @dinosaure (for Canopy)

no more `Sync.remote` and now `Store.remote` is working (so this fixes #547) and the API is as simple as before: every store where it is possible to use a special remote has a `remote` function with the right type.