### PR TITLE
core: more precise merge strategy

### DIFF
--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -16,6 +16,8 @@
 
 open Lwt.Infix
 
+include Store.Exn
+
 module Type = Type
 module Diff = Diff
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -2017,6 +2017,9 @@ end
     }
 *)
 
+exception Conflict of string
+exception Too_many_retries of int
+
 (** Irmin stores. *)
 module type S = sig
 
@@ -2535,8 +2538,11 @@ module type S = sig
   (** {1 Transactions} *)
 
   type 'a transaction =
-    ?allow_empty:bool -> ?strategy:[`Set | `Test_and_set | `Merge] ->
-    ?max_depth:int -> ?n:int -> info:Info.f -> 'a -> unit Lwt.t
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Set | `Test_and_set | `Merge_with_parent of commit] ->
+    info:Info.f ->
+    'a -> unit Lwt.t
   (** The type for transactions. *)
 
   val with_tree: t -> key -> (tree option -> tree option Lwt.t) transaction
@@ -2555,10 +2561,11 @@ module type S = sig
       {ul
       {- if [strategy = `Set], the {e last write wins}. }
       {- if [strategy = `Test_and_set] (default), the transaction is
-         restarted.}
-      {- if [strategy = `Merge], concurrent changes are merged with
-         [f v]. If the merge has a conflict, the transaction is
-         restarted.}  }
+         restarted. Can raise with [Too_many_retries n] if the operation cannot
+         be completed after [n] attempts.}
+      {- if [strategy = `Merge parent], concurrent changes are merged with
+         [f v] using [parent] as common ancestor. In case of conflict, abort
+         without retyring by raising [Conflit msg].}  }
 
       {b Note:} Irmin transactions provides
       {{:https://en.wikipedia.org/wiki/Snapshot_isolation}snapshot

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -429,8 +429,11 @@ module type STORE = sig
   val find_tree: t -> key -> tree option Lwt.t
   val get_tree: t -> key -> tree Lwt.t
   type 'a transaction =
-    ?allow_empty:bool -> ?strategy:[`Set | `Test_and_set | `Merge] ->
-    ?max_depth:int -> ?n:int -> info:Info.f -> 'a -> unit Lwt.t
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Set | `Test_and_set | `Merge_with_parent of commit] ->
+    info:Info.f ->
+    'a -> unit Lwt.t
   val with_tree: t -> key -> (tree option -> tree option Lwt.t) transaction
   val set: t -> key -> ?metadata:metadata -> contents transaction
   val set_tree: t -> key -> tree transaction

--- a/src/irmin/store.mli
+++ b/src/irmin/store.mli
@@ -17,6 +17,11 @@
 (** Branch-consistent stores: read-write store with support fork/merge
     operations. *)
 
+module Exn: sig
+  exception Conflict of string
+  exception Too_many_retries of int
+end
+
 module Make (P: S.PRIVATE): S.STORE
   with type key = P.Node.Path.t
    and type contents = P.Contents.value


### PR DESCRIPTION
Irmin.{set, set_tree, remove} now only accepts a `Merge_with_parent c` argument
so that they don't have to run 3-way merges themselves.

Aslo the logic for aborting operatin is now simpler:
- with set: no need, the operation always succeed
- test_and_set: there is a new "retry" parameter to limit the number of retries
  in case someone updates the same subtree at the same time at the current
  operation.
- merge: no retry operation; if the merge fails, raise an exception and let the
  application code deal with that. Retrying in this case doesn't make sense,
  as things will not (usually) improve by themselves on the main branch...