### PR TITLE
Allow to create generic Git stores

### DIFF
--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -150,3 +150,13 @@ module Make_ext
      and module Key = P
      and type contents = C.t
      and type branch = B.t
+
+module Generic (AO: Irmin.AO_MAKER) (RW: Irmin.RW_MAKER)
+    (C: Irmin.Contents.S)
+    (P: Irmin.Path.S)
+    (B: Irmin.Branch.S):
+  Irmin.S
+
+module Generic_KV (AO: Irmin.AO_MAKER) (RW: Irmin.RW_MAKER)
+    (C: Irmin.Contents.S):
+  Irmin.KV

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -443,7 +443,7 @@ struct
 
     end
   end
-  include Irmin.Make_ext(X)
+  include Irmin.Of_private(X)
 end
 
 module KV (H: CLIENT) (C: Irmin.Contents.S) =

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -3199,8 +3199,30 @@ module Make (AO: AO_MAKER) (RW: RW_MAKER): S_MAKER
 (** Simple store creator. Use the same type of all of the internal
     keys and store all the values in the same store. *)
 
+module Make_ext (AO: AO_MAKER) (RW: RW_MAKER)
+    (Metadata: Metadata.S)
+    (Contents: Contents.S)
+    (Path    : Path.S)
+    (Branch  : Branch.S)
+    (Hash    : Hash.S)
+    (N: Private.Node.S with type metadata = Metadata.t
+                        and type contents = Hash.t
+                        and type node = Hash.t
+                        and type step = Path.step)
+    (CT: Private.Commit.S with type node = Hash.t
+                           and type commit = Hash.t):
+  S with type key = Path.t
+     and type contents = Contents.t
+     and type branch = Branch.t
+     and type Commit.Hash.t = Hash.t
+     and type Tree.Hash.t = Hash.t
+     and type Contents.Hash.t = Hash.t
+     and type step = Path.step
+     and type metadata = Metadata.t
+     and type Key.step = Path.step
+
 (** Advanced store creator. *)
-module Make_ext (P: Private.S): S
+module Of_private (P: Private.S): S
   with type key = P.Node.Path.t
    and type contents = P.Contents.value
    and type branch = P.Branch.key

--- a/src/irmin/type.ml
+++ b/src/irmin/type.ml
@@ -1006,8 +1006,8 @@ end
 
 let size_of t x =
   let rec aux: type a. a t -> a size_of = fun t x -> match t with
+    | Like l when l.size_of = None -> aux l.x (l.g x)
     | Self s           -> aux s.self x
-    | Like l           -> aux l.x (l.g x)
     | Prim (String _)  -> `Size (String.length x)
     | Prim (Bytes _)   -> `Size (Bytes.length x)
     | _ -> Size_of.t t x
@@ -1163,8 +1163,8 @@ let err_invalid_bounds =
 
 let encode_bin_bytes ?buf t x =
   let rec aux: type a. a t -> a -> bytes = fun t x -> match t with
+    | Like l when l.encode_bin = None -> aux l.x (l.g x)
     | Self s           -> aux s.self x
-    | Like l           -> aux l.x (l.g x)
     | Prim (String _)  -> Bytes.of_string x
     | Prim (Bytes _)   -> x
     | _ ->
@@ -1187,8 +1187,8 @@ let encode_bin_bytes ?buf t x =
 
 let encode_bin ?buf t x =
   let rec aux: type a. a t -> a -> string = fun t x -> match t with
+    | Like l when l.encode_bin = None -> aux l.x (l.g x)
     | Self s           -> aux s.self x
-    | Like l           -> aux l.x (l.g x)
     | Prim (String _)  -> x
     | Prim (Bytes _)   -> Bytes.to_string x
     | _ -> Bytes.unsafe_to_string (encode_bin_bytes ?buf t x)
@@ -1326,8 +1326,8 @@ let decode_bin ?(exact=true) t x =
   let rec aux
     : type a. a t -> string -> (a, [`Msg of string]) result
     = fun t x -> match t with
+      | Like l when l.decode_bin = None -> aux l.x x |> map_result l.f
       | Self s          -> aux s.self x
-      | Like l          -> aux l.x x |> map_result l.f
       | Prim (String _) -> Ok x
       | Prim (Bytes _)  -> Ok (Bytes.of_string x)
       | _ ->


### PR DESCRIPTION
These stores use the underlying AO and RW storage but use the Git format
to serialise objects, which means that the hashes are compatible with
other Git repositories.

This fixes Sync.pull between Git and non-Git repositories.