### PR TITLE
Merge all the S.Private.*.Hash modules into S.Hash

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -800,9 +800,7 @@ end
 module type S = sig
   module Git: Git.S
   include Irmin.S with type metadata = Metadata.t
-                   and type Commit.Hash.t = Git.Hash.t
-                   and type Contents.Hash.t = Git.Hash.t
-                   and type Tree.Hash.t = Git.Hash.t
+                   and type hash = Git.Hash.t
   val git_commit: Repo.t -> commit -> Git.Value.Commit.t option Lwt.t
   val git_of_repo: Repo.t -> Git.t
   val repo_of_git: ?head:Git.Reference.t -> ?bare:bool -> ?lock:Lwt_mutex.t ->
@@ -827,7 +825,6 @@ module Make_ext
 = struct
 
   module R = Irmin_branch_store(G)(B)
-  module Hash = Irmin.Hash.Make(G.Hash)
 
   type r = {
     config: Irmin.config;
@@ -836,6 +833,7 @@ module Make_ext
   }
 
   module P = struct
+    module Hash = Irmin.Hash.Make(G.Hash)
     module XSync = struct
       include Irmin_sync_store(G)(S)(R.Key)
       let v repo = Lwt.return repo.g

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -65,9 +65,7 @@ module type S = sig
   module Git: Git.S
 
   include Irmin.S with type metadata = Metadata.t
-                   and type Commit.Hash.t = Git.Hash.t
-                   and type Contents.Hash.t = Git.Hash.t
-                   and type Tree.Hash.t = Git.Hash.t
+                   and type hash = Git.Hash.t
 
   val git_commit: Repo.t -> commit -> Git.Value.Commit.t option Lwt.t
   (** [git_commit repo h] is the commit corresponding to [h] in the

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -88,7 +88,7 @@ module Make(Store : STORE) : S with type store = Store.t = struct
               field "hash"
                 ~typ:(non_null string)
                 ~args:[]
-                ~resolve:(fun _ c -> Irmin.Type.to_string Store.Commit.Hash.t (Store.Commit.hash c))
+                ~resolve:(fun _ c -> Irmin.Type.to_string Store.Hash.t (Store.Commit.hash c))
               ;
             ])
     )
@@ -195,7 +195,7 @@ module Make(Store : STORE) : S with type store = Store.t = struct
                 ~typ:(non_null (list (non_null (Lazy.force commit))))
                 ~args:Arg.[arg "commit" ~typ:(non_null Input.commit_hash)]
                 ~resolve:(fun _ (s, _) commit ->
-                    match from_string_err "commit" (Irmin.Type.of_string Store.Commit.Hash.t) commit with
+                    match from_string_err "commit" (Irmin.Type.of_string Store.Hash.t) commit with
                     | Ok commit ->
                       (Store.Commit.of_hash (Store.repo s) commit >>= function
                       | Some commit ->
@@ -391,7 +391,7 @@ module Make(Store : STORE) : S with type store = Store.t = struct
           ]
         ~resolve:(fun _ _src branch commit ->
             let branch = to_branch branch in
-            match from_string_err "commit" (Irmin.Type.of_string Store.Commit.Hash.t) commit, branch with
+            match from_string_err "commit" (Irmin.Type.of_string Store.Hash.t) commit, branch with
             | Ok commit, Ok branch ->
               (mk_branch (Store.repo s) branch >>= fun t ->
               Store.Commit.of_hash (Store.repo s) commit >>= function
@@ -413,7 +413,7 @@ module Make(Store : STORE) : S with type store = Store.t = struct
             arg "hash" ~typ:(non_null Input.commit_hash)
           ]
           ~resolve:(fun _ _src hash ->
-            match from_string_err "hash" (Irmin.Type.of_string Store.Commit.Hash.t) hash with
+            match from_string_err "hash" (Irmin.Type.of_string Store.Hash.t) hash with
             | Ok commit -> Store.Commit.of_hash (Store.repo s) commit >>= Lwt.return_ok
             | Error msg -> Lwt.return_error msg
         );

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -384,6 +384,7 @@ module Make
     (H: Irmin.Hash.S) =
 struct
   module X = struct
+    module Hash = H
     module XContents = struct
       module Key = H
       module Val = C

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -88,16 +88,18 @@ module Make (S: S) = struct
 
   let r1 ~repo =
     n2 ~repo >>= fun kn2 ->
-    S.Tree.of_hash repo (`Node kn2) >>= function
+    S.Tree.of_hash repo kn2 >>= function
     | None      -> Alcotest.fail "r1"
-    | Some tree -> S.Commit.v repo ~info:Irmin.Info.empty ~parents:[] tree
+    | Some tree ->
+      S.Commit.v repo ~info:Irmin.Info.empty ~parents:[] (tree :> S.tree)
 
   let r2 ~repo =
     n3 ~repo >>= fun kn3 ->
     r1 ~repo >>= fun kr1 ->
-    S.Tree.of_hash repo (`Node kn3) >>= function
+    S.Tree.of_hash repo kn3 >>= function
     | None    -> Alcotest.fail "r2"
-    | Some t3 -> S.Commit.v repo ~info:Irmin.Info.empty  ~parents:[kr1] t3
+    | Some t3 ->
+      S.Commit.v repo ~info:Irmin.Info.empty  ~parents:[kr1] (t3 :> S.tree)
 
   let run x test =
     try
@@ -755,20 +757,20 @@ module Make (S: S) = struct
           Irmin.Merge.f @@ History.merge h ~info:(fun () -> info)
         ) ~old:(old kr2) kr2 kr3 >>= fun kr3_id' ->
       merge_exn "kr3_id'" kr3_id' >>= fun kr3_id' ->
-      check S.Commit.Hash.t "kr3 id with immediate parent'" kr3 kr3_id';
+      check S.Hash.t "kr3 id with immediate parent'" kr3 kr3_id';
 
       with_info 5 (fun h ~info ->
           Irmin.Merge.f @@ History.merge h ~info:(fun () -> info)
         ) ~old:(old kr0) kr0 kr3 >>= fun kr3_id ->
       merge_exn "kr3_id" kr3_id >>= fun kr3_id ->
-      check S.Commit.Hash.t "kr3 id with old parent" kr3 kr3_id;
+      check S.Hash.t "kr3 id with old parent" kr3 kr3_id;
 
       with_info 3 @@ History.v ~node:k4 ~parents:[kr1; kr2] >>= fun (kr3', _) ->
 
       P.Commit.find c kr3 >>= fun r3 ->
       P.Commit.find c kr3' >>= fun r3' ->
       check T.(option P.Commit.Val.t) "r3" r3 r3';
-      check S.Commit.Hash.t "kr3" kr3 kr3';
+      check S.Hash.t "kr3" kr3 kr3';
       Lwt.return_unit
     in
     run x test

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -431,7 +431,7 @@ let revert = {
     let revert (S ((module S), store, _)) snapshot =
       run begin
         store >>= fun t ->
-        let hash = commit S.Commit.Hash.t snapshot in
+        let hash = commit S.Hash.t snapshot in
         S.Commit.of_hash (S.repo t) hash >>= fun s ->
         match s with
         | Some s -> S.Head.set t s

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -58,6 +58,7 @@ module Make_ext
 struct
 
   module X = struct
+    module Hash = H
     module XContents = struct
       include AO(H)(C)
       module Key = H

--- a/src/irmin/store.mli
+++ b/src/irmin/store.mli
@@ -21,9 +21,7 @@ module Make (P: S.PRIVATE): S.STORE
   with type key = P.Node.Path.t
    and type contents = P.Contents.value
    and type branch = P.Branch.key
-   and type Commit.Hash.t = P.Commit.key
-   and type Tree.Hash.t = P.Node.key
-   and type Contents.Hash.t = P.Contents.key
+   and type hash = P.Hash.t
    and type slice = P.Slice.t
    and type step = P.Node.Path.step
    and type metadata = P.Node.Val.metadata

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -76,7 +76,7 @@ module Make (S: S.STORE) = struct
   ]
 
   let pp_branch = Type.pp S.Branch.t
-  let pp_hash = Type.pp S.Commit.Hash.t
+  let pp_hash = Type.pp S.Hash.t
 
   let fetch t ?depth remote: (commit, fetch_error) result Lwt.t =
     match remote with

--- a/src/irmin/tree.mli
+++ b/src/irmin/tree.mli
@@ -24,7 +24,8 @@ module Make (P: S.PRIVATE): sig
   val import: P.Repo.t -> P.Node.key -> node
   val export: P.Repo.t -> node -> P.Node.key Lwt.t
   val dump: tree Fmt.t
-  val equal: tree -> tree -> bool Lwt.t
+  val equal: tree -> tree -> bool
   val node_t: node Type.t
   val tree_t: tree Type.t
+  val hash: tree -> [`Contents of (P.Hash.t * metadata) | `Node of P.Hash.t]
 end


### PR DESCRIPTION
This allows to make the `hash` functions not blocking, and allow to
check for equality without doing any writes.