### PR TITLE
Add get_tree and set_tree methods to irmin-graphql server

### DIFF
--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -20,3 +20,6 @@ depends: [
   "graphql" {>= "0.7"}
   "graphql-lwt"
 ]
+
+
+synopsis: "GraphQL server for Irmin"

--- a/irmin-mem.opam
+++ b/irmin-mem.opam
@@ -19,3 +19,6 @@ depends: [
   "irmin"      {>= "1.3.0"}
   "irmin-test" {with-test}
 ]
+
+
+synopsis: "Generic in-memory Irmin stores"

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -145,12 +145,13 @@ module Make(Store : STORE) : S with type store = Store.t = struct
                 ~args:Arg.[arg "key" ~typ:Input.step]
                 ~typ:node
                 ~resolve:(fun _ (tree, key) step ->
+                  Store.Tree.get_tree tree key >>= fun tree ->
                     let key =
                       match step with
                       | Some s ->
-                          let conv = (Irmin.Type.of_string Store.step_t) in
+                          let conv = (Irmin.Type.of_string Store.key_t) in
                           (match from_string_err "key" conv  s with
-                          | Ok step -> Ok (Store.Key.rcons key step)
+                          | Ok k -> Ok k
                           | Error e -> Error e)
                       | None -> Ok Store.Key.empty
                     in

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -253,9 +253,11 @@ module Make(Store : STORE) : S with type store = Store.t = struct
                 ~resolve:(fun _ (s, _) key ->
                     match from_string_err "key" (Irmin.Type.of_string Store.key_t) key with
                     | Ok key ->
-                      (Store.find_tree s key >>= function
-                        | Some tree -> Lwt.return_ok (Some (tree, key))
-                        | None -> Lwt.return_ok None)
+                      (Store.mem_tree s key >>= function
+                        | true ->
+                            Store.get_tree s Store.Key.empty >>= fun tree ->
+                            Lwt.return_ok (Some (tree, key))
+                        | false -> Lwt.return_ok None)
                     | Error msg -> Lwt.return_error msg
                   )
               ;


### PR DESCRIPTION
Unfortunately there isn't a good way to model the tree input arguments as recursive objects (as I had hoped):

```json
{
    "a": {"b": {"c": "123"}}, 
    "foo": "bar"
}
```

Instead, we have to use a flat array of objects:

```json
[
    {"key": "a/b/c", "value": "123"}, 
    {"key": "foo", "value": "bar"}
]
``` 
Despite this one minor flaw, I think this is a pretty nice way of supporting read/write transactions in `irmin-graphql`!

