### PR TITLE
Remove XXX error when `AlreadySync is encountered

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -683,7 +683,7 @@ struct
 
   let o_head_of_git = function
     | None   -> Error `No_head
-    | Some k -> Ok k
+    | Some k -> Ok (Some k)
 
   let fetch t ?depth e br =
     let uri = S.Endpoint.uri e in
@@ -710,9 +710,7 @@ struct
     S.fetch_one t e ~reference:references >|= function
     | Error e -> Fmt.kstrf (fun e -> Error (`Msg e)) "%a" S.pp_error e
     | Ok (`Sync refs) -> result refs
-    | Ok `AlreadySync ->
-      (* FIXME: we want to get the hash *)
-      Error (`Msg "XXX")
+    | Ok `AlreadySync -> Ok None
 
   let push t ?depth:_ e br =
     let uri = S.Endpoint.uri e in

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1934,7 +1934,7 @@ module Private: sig
       (** The type for sync endpoints. *)
 
       val fetch: t -> ?depth:int -> endpoint -> branch ->
-        (commit, [`No_head | `Not_available | `Msg of string]) result Lwt.t
+        (commit option, [`No_head | `Not_available | `Msg of string]) result Lwt.t
       (** [fetch t uri] fetches the contents of the remote store
           located at [uri] into the local store [t]. Return the head
           of the remote branch with the same name, which is now in the

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -255,7 +255,7 @@ module type SYNC = sig
   type branch
   type endpoint
   val fetch: t -> ?depth:int -> endpoint -> branch ->
-    (commit, [`No_head | `Not_available | `Msg of string]) result Lwt.t
+    (commit option, [`No_head | `Not_available | `Msg of string]) result Lwt.t
   val push: t -> ?depth:int -> endpoint -> branch ->
     (unit, [`No_head | `Not_available | `Msg of string | `Detached_head])
       result Lwt.t

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -108,11 +108,15 @@ module Make (S: S.STORE) = struct
           B.v (S.repo t) >>= fun g ->
           B.fetch g ?depth e br >>= function
           | Error _ as e -> Lwt.return e
-          | Ok c         ->
-            Log.debug (fun l -> l "Fetched %a" pp_hash c);
+          | Ok (Some c)         ->
+            (Log.debug (fun l -> l "Fetched %a" pp_hash c);
             S.Commit.of_hash (S.repo t) c >|= function
             | None   -> Error `No_head
-            | Some x -> Ok x
+            | Some x -> Ok x)
+          | Ok None ->
+            S.Head.find t >>= function
+            | Some h -> Lwt.return_ok h
+            | None -> Lwt.return_error `No_head
       end
     | _ -> Lwt.return (Error `Not_available)
 


### PR DESCRIPTION
This should fix #594, although I'm not sure it's the right solution.

I'm happy to make some changes if there's a better way to handle this!