### PR TITLE
Add MirageOS support for GraphQL servers

### DIFF
--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -18,7 +18,6 @@ depends: [
   "dune"    {build}
   "irmin"
   "graphql" {>= "0.7"}
-  "graphql-lwt"
 ]
 
 

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -20,6 +20,7 @@ depends: [
   "graphql" {>= "0.8"}
   "graphql-lwt" {>= "0.8"}
   "graphql-cohttp" {>= "0.8"}
+  "cohttp-lwt"
 ]
 
 

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -18,6 +18,7 @@ depends: [
   "dune"    {build}
   "irmin"
   "graphql" {>= "0.7"}
+  "graphql-lwt"
 ]
 
 

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -17,8 +17,9 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {build}
   "irmin"
-  "graphql" {>= "0.7"}
-  "graphql-lwt"
+  "graphql" {>= "0.8"}
+  "graphql-lwt" {>= "0.8"}
+  "graphql-cohttp" {>= "0.8"}
 ]
 
 

--- a/irmin-mirage.opam
+++ b/irmin-mirage.opam
@@ -17,6 +17,7 @@ depends: [
   "irmin"      {>= "1.3.0"}
   "irmin-git"  {>= "1.3.0"}
   "irmin-mem"  {>= "1.3.0"}
+  "irmin-graphql"
   "git-mirage" {>= "1.11.4"}
   "ptime"
   "mirage-kv-lwt"

--- a/src/irmin-graphql/dune
+++ b/src/irmin-graphql/dune
@@ -1,4 +1,4 @@
 (library
   (name irmin_graphql)
   (public_name irmin-graphql)
-  (libraries graphql-lwt irmin))
+  (libraries graphql cohttp-lwt irmin))

--- a/src/irmin-graphql/dune
+++ b/src/irmin-graphql/dune
@@ -1,4 +1,4 @@
 (library
   (name irmin_graphql)
   (public_name irmin-graphql)
-  (libraries graphql cohttp-lwt irmin))
+  (libraries graphql-lwt graphql-cohttp cohttp-lwt irmin))

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -8,7 +8,10 @@ module type S = sig
   type server
 
   val schema : store -> unit Schema.schema
-  val execute_request : unit Schema.schema -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val execute_request :
+      unit Schema.schema ->
+      Cohttp_lwt.Request.t ->
+      Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   val run_server: server -> store -> unit Lwt.t
 end
 
@@ -36,7 +39,10 @@ module type SERVER = sig
     status:Cohttp.Code.status_code ->
     body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-  val run : server -> (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
+  val run :
+    server ->
+    (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t ->
+      (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
 end
 
 module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S) = struct
@@ -595,4 +601,3 @@ module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S) = struct
     let callback = Graphql_server.make_callback (fun _ctx -> ()) schema in
     Server.run server callback
 end
-

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -170,7 +170,7 @@ module Make(Store : STORE) : S with type store = Store.t = struct
                 ~resolve:(fun _ (_, key) -> Irmin.Type.to_string Store.key_t key)
               ;
               io_field "get"
-                ~args:Arg.[arg "key" ~typ:Input.step]
+                ~args:Arg.[arg "step" ~typ:Input.step]
                 ~typ:node
                 ~resolve:(fun _ (tree, key) step ->
                     Store.Tree.get_tree tree key >>= fun tree ->

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -1,16 +1,7 @@
 open Lwt.Infix
 
-module HttpBody = struct
-  include Cohttp_lwt.Body
-
-  type +'a io = 'a Lwt.t
-  type 'a stream = 'a Lwt_stream.t * (unit -> unit)
-
-  let of_stream (stream, _) = Cohttp_lwt.Body.of_stream stream
-end
-
 module Schema = Graphql_lwt.Schema
-module Graphql_server = Graphql_cohttp.Make(Schema)(HttpBody)
+module Graphql_server = Graphql_cohttp.Make(Schema)(Cohttp_lwt.Body)
 
 module type S = sig
   type store

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -17,12 +17,6 @@ type commit_input = {
   message: string option;
 }
 
-type tree_item = {
-  key: string;
-  value: string option;
-  metadata: string option;
-}
-
 module type STORE = sig
   include Irmin.S
   val remote: (?headers:Cohttp.Header.t -> string -> Irmin.remote) option
@@ -31,6 +25,12 @@ end
 
 module Make(Store : STORE) : S with type store = Store.t = struct
   module Sync = Irmin.Sync (Store)
+
+  type tree_item = {
+    key: Store.key;
+    value: Store.contents option;
+    metadata: Store.metadata option;
+  }
 
   let mk_info input =
     match input with
@@ -49,9 +49,19 @@ module Make(Store : STORE) : S with type store = Store.t = struct
         of_irmin_result (Irmin.Type.of_string Store.key_t s )
       | _ -> Error "invalid key encoding"
 
+    let coerce_value = function
+      | `String s ->
+        of_irmin_result (Irmin.Type.of_string Store.contents_t s)
+      | _ -> Error "invalid value encoding"
+
+    let coerce_metadata = function
+      | `String s ->
+        of_irmin_result (Irmin.Type.of_string Store.metadata_t s)
+      | _ -> Error "invalid metadata encoding"
+
     let coerce_step = function
       | `String s -> of_irmin_result (Irmin.Type.of_string Store.step_t s)
-      | _ -> Error "invalid step"
+      | _ -> Error "invalid step encoding"
 
     let coerce_branch = function
       | `String s -> of_irmin_result @@ Irmin.Type.of_string Store.branch_t s
@@ -74,6 +84,8 @@ module Make(Store : STORE) : S with type store = Store.t = struct
     let commit_hash = Schema.Arg.(scalar "CommitHash" ~coerce:coerce_hash)
     let branch = Schema.Arg.(scalar "BranchName" ~coerce:coerce_branch)
     let remote = Schema.Arg.(scalar "Remote" ~coerce:coerce_remote)
+    let value = Schema.Arg.(scalar "Value" ~coerce:coerce_value)
+    let metadata = Schema.Arg.(scalar "Metadata" ~coerce:coerce_metadata)
     let info = Schema.Arg.(
         obj "InfoInput"
           ~fields:[
@@ -86,9 +98,9 @@ module Make(Store : STORE) : S with type store = Store.t = struct
     let item = Schema.Arg.(
         obj "TreeItem"
           ~fields:[
-            arg "key" ~typ:(non_null string);
-            arg "value" ~typ:string;
-            arg "metadata" ~typ:string;
+            arg "key" ~typ:(non_null key);
+            arg "value" ~typ:value;
+            arg "metadata" ~typ:metadata;
           ]
           ~coerce:(fun key value metadata -> {key; value; metadata})
       )
@@ -384,161 +396,111 @@ module Make(Store : STORE) : S with type store = Store.t = struct
       ]
     | None -> []
 
-  let unwrap_metadata m =
-    match m with
-    | Some m ->
-      (match Irmin.Type.of_string Store.metadata_t m with
-       | Ok m -> Some m
-       | Error (`Msg e) -> failwith e)
-    | None -> None
-
   let to_tree tree l = Lwt_list.fold_left_s (fun tree ->
     function
-      | {key; value = Some x; metadata} ->
-        let k = Irmin.Type.of_string Store.key_t key in
-        let v = Irmin.Type.of_string Store.contents_t x in
-        let metadata = unwrap_metadata metadata in
-        (match k, v with
-         | Ok k, Ok v ->
-           Store.Tree.add tree ?metadata k v
-         | Error (`Msg e), _ | _, Error (`Msg e) -> failwith e)
+      | {key; value = Some v; metadata} ->
+          Store.Tree.add tree ?metadata key v
       | {key; value = None; _} ->
-        let k = Irmin.Type.of_string Store.key_t key in
-        (match k with
-         | Ok k ->
-           Store.Tree.remove tree k
-         | Error (`Msg e) -> failwith e)) tree l
-
+          Store.Tree.remove tree key) tree l
 
   let mutations s = Schema.[
     io_field "set"
       ~typ:(Lazy.force commit)
       ~args:Arg.[
           arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null string);
-          arg "value" ~typ:(non_null string);
+          arg "key" ~typ:(non_null Input.key);
+          arg "value" ~typ:(non_null Input.value);
           arg "info" ~typ:Input.info;
         ]
       ~resolve:(fun _ _src branch k v i ->
           mk_branch (Store.repo s) branch >>= fun t ->
           let info = mk_info i in
-          let key = Irmin.Type.of_string Store.key_t k in
-          let value = Irmin.Type.of_string Store.contents_t v in
-          match key, value with
-          | Ok key, Ok value ->
-            (Store.set t key value ~info >>= function
-              | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
-              | Error e -> err_write e)
-          | Error (`Msg msg), _ | _, Error (`Msg msg) -> Lwt.return_error msg
+          (Store.set t k v ~info >>= function
+            | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
+            | Error e -> err_write e)
         )
     ;
     io_field "set_tree"
       ~typ:(Lazy.force commit)
       ~args:Arg.[
           arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null string);
+          arg "key" ~typ:(non_null Input.key);
           arg "tree" ~typ:(Input.tree);
           arg "info" ~typ:Input.info;
         ]
       ~resolve:(fun _ _src branch k items i ->
           mk_branch (Store.repo s) branch >>= fun t ->
           let info = mk_info i in
-          let key = Irmin.Type.of_string Store.key_t k in
-          (match key with
-           | Ok key ->
-             Lwt.catch (fun () ->
-                 let tree = Store.Tree.empty in
-                 to_tree tree items
-                 >>= fun tree ->
-                 Store.set_tree_exn t ~info key tree >>= fun () ->
-                 Store.Head.find t >>= Lwt.return_ok)
-               (function
-                 | Failure e -> Lwt.return_error e
-                 | e -> raise e)
-           | Error (`Msg msg) -> Lwt.return_error msg)
+           Lwt.catch (fun () ->
+               let tree = Store.Tree.empty in
+               to_tree tree items
+               >>= fun tree ->
+               Store.set_tree_exn t ~info k tree >>= fun () ->
+               Store.Head.find t >>= Lwt.return_ok)
+           (function
+             | Failure e -> Lwt.return_error e
+             | e -> raise e)
         )
     ;
     io_field "update_tree"
       ~typ:(Lazy.force commit)
       ~args:Arg.[
           arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null string);
+          arg "key" ~typ:(non_null Input.key);
           arg "tree" ~typ:(Input.tree);
           arg "info" ~typ:Input.info;
         ]
       ~resolve:(fun _ _src branch k items i ->
           mk_branch (Store.repo s) branch >>= fun t ->
           let info = mk_info i in
-          let key = Irmin.Type.of_string Store.key_t k in
-          (match key with
-           | Ok key ->
-             Lwt.catch (fun () ->
-                 Store.with_tree_exn t key ~info (fun tree ->
-                     let tree = match tree with
-                       | Some t -> t
-                       | None -> Store.Tree.empty
-                     in
-                     to_tree tree items >>= Lwt.return_some)
-                 >>= fun () ->
-                 Store.Head.find t >>= Lwt.return_ok)
-               (function
-                 | Failure e -> Lwt.return_error e
-                 | e -> raise e)
-           | Error (`Msg msg) -> Lwt.return_error msg)
+           Lwt.catch (fun () ->
+               Store.with_tree_exn t k ~info (fun tree ->
+                   let tree = match tree with
+                     | Some t -> t
+                     | None -> Store.Tree.empty
+                   in
+                   to_tree tree items >>= Lwt.return_some)
+               >>= fun () ->
+               Store.Head.find t >>= Lwt.return_ok)
+           (function
+             | Failure e -> Lwt.return_error e
+             | e -> raise e)
         )
     ;
     io_field "set_all"
       ~typ:(Lazy.force commit)
       ~args:Arg.[
           arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null string);
-          arg "value" ~typ:(non_null string);
-          arg "metadata" ~typ:(string);
+          arg "key" ~typ:(non_null Input.key);
+          arg "value" ~typ:(non_null Input.value);
+          arg "metadata" ~typ:(Input.metadata);
           arg "info" ~typ:Input.info;
         ]
       ~resolve:(fun _ _src branch k v m i ->
           mk_branch (Store.repo s) branch >>= fun t ->
           let info = mk_info i in
-          let key = Irmin.Type.of_string Store.key_t k in
-          let value = Irmin.Type.of_string Store.contents_t v in
-          let metadata = match m with
-            | Some m ->
-              (match Irmin.Type.of_string Store.metadata_t m with
-               | Ok x -> Ok (Some x)
-               | Error msg -> Error msg)
-            | None -> Ok None
-          in
-          match key, value, metadata with
-          | Ok key, Ok value, Ok metadata ->
-            (Store.find_tree t key >>= (function
-                 | Some tree -> Lwt.return tree
-                 | None -> Lwt.return Store.Tree.empty) >>= fun tree ->
-             Store.Tree.add tree key ?metadata value >>= fun tree ->
-             Store.set_tree t key tree ~info >>= function
-             | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
-             | Error e -> err_write e)
-          | Error (`Msg msg), _, _
-          | _, Error (`Msg msg), _
-          | _, _, Error (`Msg msg) -> Lwt.return_error msg
+          (Store.find_tree t k >>= (function
+             | Some tree -> Lwt.return tree
+             | None -> Lwt.return Store.Tree.empty) >>= fun tree ->
+           Store.Tree.add tree k ?metadata:m v >>= fun tree ->
+           Store.set_tree t k tree ~info >>= function
+           | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
+           | Error e -> err_write e)
         )
     ;
     io_field "remove"
       ~typ:(Lazy.force commit)
       ~args:Arg.[
           arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null string);
+          arg "key" ~typ:(non_null Input.key);
           arg "info" ~typ:Input.info
         ]
       ~resolve:(fun _ _src branch key i ->
           mk_branch (Store.repo s) branch >>= fun t ->
           let info = mk_info i in
-          let key = Irmin.Type.of_string Store.key_t key in
-          match key with
-          | Ok key ->
-            (Store.remove t key ~info >>= function
-              | Ok () -> Store.Head.find t >>= Lwt.return_ok
-              | Error e -> err_write e)
-          | Error (`Msg msg) -> Lwt.return_error msg
+          Store.remove t key ~info >>= function
+            | Ok () -> Store.Head.find t >>= Lwt.return_ok
+            | Error e -> err_write e
         )
     ;
     io_field "merge"

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -359,7 +359,7 @@ module Make(Store : STORE) : S with type store = Store.t = struct
             )
         ;
         io_field "push"
-          ~typ:(string)
+          ~typ:(non_null bool)
           ~args:Arg.[
               arg "branch" ~typ:Input.branch;
               arg "remote" ~typ:(non_null Input.remote);
@@ -367,10 +367,10 @@ module Make(Store : STORE) : S with type store = Store.t = struct
           ~resolve:(fun _ _src branch remote ->
               mk_branch (Store.repo s) branch >>= fun t ->
               Sync.push t remote >>= function
-              | Ok _ -> Lwt.return_ok None
+              | Ok _ -> Lwt.return_ok true
               | Error e ->
                 let s = Fmt.to_to_string Sync.pp_push_error e in
-                Lwt.return_ok @@ Some s
+                Lwt.return_error s
             )
         ;
         io_field "pull"

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -1,13 +1,23 @@
 open Lwt.Infix
 
-module Schema = Graphql_schema.Make(Lwt)
+module HttpBody = struct
+  include Cohttp_lwt.Body
+
+  type +'a io = 'a Lwt.t
+  type 'a stream = 'a Lwt_stream.t * (unit -> unit)
+
+  let of_stream (stream, _) = Cohttp_lwt.Body.of_stream stream
+end
+
+module Schema = Graphql_lwt.Schema
+module Gql = Graphql_cohttp.Make(Schema)(HttpBody)
 
 module type S = sig
   type store
   type server
 
   val schema : store -> unit Schema.schema
-  val execute_request : unit Schema.schema -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val execute_request : unit Schema.schema -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   val run_server: server -> store -> unit Lwt.t
 end
 
@@ -588,43 +598,11 @@ module Make(Store : STORE)(Server : SERVER) = struct
             )
       ])
 
-  let execute_query schema ?variables ?operation_name query =
-    Schema.execute schema () ?variables ?operation_name query >>= function
-    | Ok data ->
-        let body = Yojson.Basic.to_string data in
-        Server.respond_string ~status:`OK ~body ()
-    | Error err ->
-        let body = Yojson.Basic.to_string err in
-        Server.respond_string ~status:`Internal_server_error ~body ()
-
-  let execute_request schema body =
-    Cohttp_lwt.Body.to_string body >>= fun body' ->
-    let json = Yojson.Basic.from_string body' in
-    let query = Yojson.Basic.(Util.member "query" json |> Util.to_string) in
-    let variables = try Yojson.Basic.Util.(member "variables" json |> to_assoc) with _ -> [] in
-    let variables = (variables :> (string * Graphql_parser.const_value) list) in
-    let operation_name =
-      try Some Yojson.Basic.Util.(member "operationName" json |> to_string)
-      with _ -> None
-    in
-    match Graphql_parser.parse query with
-    | Ok query ->
-        execute_query schema ~variables ?operation_name query
-    | Error err ->
-        Server.respond_string ~status:`Bad_request ~body:err ()
-
-  let mk_callback schema _ (req : Cohttp.Request.t) body =
-    let req_path = Cohttp.Request.uri req |> Uri.path in
-    let path_parts = Astring.String.cuts ~sep:"/" req_path in
-      match req.meth, path_parts with
-      (*| `GET,  ["graphql"]       -> static_file_response "index.html"
-      | `GET,  ["graphql"; path] -> static_file_response path*)
-      | `POST, ["graphql"]       -> execute_request schema body
-      | _ -> Server.respond_string ~status:`Not_found ~body:"" ()
+  let execute_request ctx req = Gql.execute_request ctx () req
 
   let run_server server store =
     let schema = schema store in
-    let callback = mk_callback schema in
+    let callback = Gql.make_callback (fun _ctx -> ()) schema in
     Server.run server callback
 end
 

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -10,7 +10,7 @@ module HttpBody = struct
 end
 
 module Schema = Graphql_lwt.Schema
-module Gql = Graphql_cohttp.Make(Schema)(HttpBody)
+module Graphql_server = Graphql_cohttp.Make(Schema)(HttpBody)
 
 module type S = sig
   type store
@@ -598,11 +598,11 @@ module Make(Store : STORE)(Server : SERVER) = struct
             )
       ])
 
-  let execute_request ctx req = Gql.execute_request ctx () req
+  let execute_request ctx req = Graphql_server.execute_request ctx () req
 
   let run_server server store =
     let schema = schema store in
-    let callback = Gql.make_callback (fun _ctx -> ()) schema in
+    let callback = Graphql_server.make_callback (fun _ctx -> ()) schema in
     Server.run server callback
 end
 

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -1,5 +1,5 @@
 module Schema : sig
-  include Graphql_intf.Schema with type 'a io = 'a Lwt.t
+  include Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
 end
 
 module type S = sig
@@ -7,7 +7,7 @@ module type S = sig
   type server
 
   val schema : store -> unit Schema.schema
-  val execute_request : unit Schema.schema -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val execute_request : unit Schema.schema -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   val run_server: server -> store -> unit Lwt.t
 end
 

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -4,10 +4,11 @@ end
 
 module type S = sig
   type store
+  type server
 
   val schema : store -> unit Schema.schema
   val execute_request : unit Schema.schema -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-  val start_server: ?hostname:string -> ?port:int -> store -> unit Lwt.t
+  val run_server: server -> store -> unit Lwt.t
 end
 
 module type STORE = sig
@@ -18,14 +19,17 @@ end
 
 module type SERVER = sig
   type conn
+  type server
 
-   val respond_string :
-      ?flush:bool ->
-      ?headers:Cohttp.Header.t ->
-      status:Cohttp.Code.status_code ->
-      body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val respond_string :
+    ?flush:bool ->
+    ?headers:Cohttp.Header.t ->
+    status:Cohttp.Code.status_code ->
+    body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-  val create : ?hostname:string -> ?port:int -> (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
+  val run : server -> (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
 end
 
-module Make(Store : STORE)(Server : SERVER) : S with type store = Store.t
+module Make(Store : STORE)(Server : SERVER) : S
+  with type store = Store.t
+   and type server = Server.server

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -1,13 +1,14 @@
-module Schema : sig
-  include Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
-end
+module Schema : Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
 
 module type S = sig
   type store
   type server
 
   val schema : store -> unit Schema.schema
-  val execute_request : unit Schema.schema -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val execute_request :
+      unit Schema.schema ->
+      Cohttp_lwt.Request.t ->
+      Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   val run_server: server -> store -> unit Lwt.t
 end
 
@@ -21,12 +22,15 @@ module type SERVER = sig
   type server
 
   val respond_string :
-    ?flush:bool ->
-    ?headers:Cohttp.Header.t ->
-    status:Cohttp.Code.status_code ->
-    body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+      ?flush:bool ->
+      ?headers:Cohttp.Header.t ->
+      status:Cohttp.Code.status_code ->
+      body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-  val run : server -> (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
+  val run :
+      server ->
+      (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t ->
+        (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
 end
 
 module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S): S

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -11,8 +11,7 @@ module type S = sig
   val run_server: server -> store -> unit Lwt.t
 end
 
-module type STORE = sig
-  include Irmin.S
+module type CONFIG = sig
   val remote: (?headers:Cohttp.Header.t -> string -> Irmin.remote) option
   val info: ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
 end
@@ -30,6 +29,6 @@ module type SERVER = sig
   val run : server -> (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
 end
 
-module Make(Store : STORE)(Server : SERVER) : S
+module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S): S
   with type store = Store.t
    and type server = Server.server

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -1,8 +1,13 @@
+module Schema : sig
+  include Graphql_intf.Schema with type 'a io = 'a Lwt.t
+end
+
 module type S = sig
   type store
 
-  val schema : store -> unit Graphql_lwt.Schema.schema
-  val start_server : ?port:int -> store -> unit Lwt.t
+  val schema : store -> unit Schema.schema
+  val execute_request : unit Schema.schema -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val start_server: ?hostname:string -> ?port:int -> store -> unit Lwt.t
 end
 
 module type STORE = sig
@@ -11,4 +16,16 @@ module type STORE = sig
   val info: ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
 end
 
-module Make(Store : STORE) : S with type store = Store.t
+module type SERVER = sig
+  type conn
+
+   val respond_string :
+      ?flush:bool ->
+      ?headers:Cohttp.Header.t ->
+      status:Cohttp.Code.status_code ->
+      body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+
+  val create : ?hostname:string -> ?port:int -> (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t -> (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
+end
+
+module Make(Store : STORE)(Server : SERVER) : S with type store = Store.t

--- a/src/irmin-mirage/dune
+++ b/src/irmin-mirage/dune
@@ -1,5 +1,5 @@
 (library
  (name        irmin_mirage)
  (public_name irmin-mirage)
- (libraries   irmin irmin-mem irmin-git git-mirage ptime
+ (libraries   irmin irmin-mem irmin-git irmin-graphql git-mirage ptime
               mirage-kv-lwt mirage-clock))

--- a/src/irmin-mirage/irmin_mirage.ml
+++ b/src/irmin-mirage/irmin_mirage.ml
@@ -213,9 +213,7 @@ module Graphql = struct
         let run http callback =
           http @@ Http.make ~callback ()
       end in
-      let module Store = struct
-        include Store
-
+      let module Config = struct
         let info ?(author = "irmin-graphql") fmt =
           let module I = Info(struct let name = author end)(Pclock) in
           I.f p fmt
@@ -224,9 +222,9 @@ module Graphql = struct
             let e =
               Git_mirage.endpoint ?headers (Uri.of_string uri)
             in
-            E e)
+            Store.E e)
       end in
-      (module Irmin_graphql.Make(Store)(Server): Irmin_graphql.S with type server = Http.t -> unit Lwt.t and type store = Store.t)
+      (module Irmin_graphql.Make(Server)(Config)(Store): Irmin_graphql.S with type server = Http.t -> unit Lwt.t and type store = Store.t)
 
     let start ~pclock ~http server store =
       let (module G) = init pclock in

--- a/src/irmin-mirage/irmin_mirage.mli
+++ b/src/irmin-mirage/irmin_mirage.mli
@@ -133,15 +133,21 @@ end
 module Graphql: sig
   module type S = sig
     module Pclock: Mirage_clock_lwt.PCLOCK
-    module Flow: Mirage_flow_lwt.S
+    module Http: Cohttp_lwt.S.Server
+    module Store: Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
 
-    val init: Pclock.t -> (module Irmin_graphql.S)
+    val start:
+      pclock:Pclock.t
+      -> http:(Conduit_mirage.server -> Http.t -> unit Lwt.t)
+      -> Conduit_mirage.server
+      -> Store.t -> unit Lwt.t
   end
 
   module Make
       (Store: Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
       (Pclock: Mirage_clock_lwt.PCLOCK)
-      (Flow: Mirage_flow_lwt.S):
+      (Http: Cohttp_lwt.S.Server):
     S with module Pclock = Pclock
-       and module Flow = Flow
+      and module Store = Store
+      and module Http = Http
 end

--- a/src/irmin-mirage/irmin_mirage.mli
+++ b/src/irmin-mirage/irmin_mirage.mli
@@ -129,3 +129,19 @@ module Git: sig
     module KV_RO: KV_RO with type git := G.t
   end
 end
+
+module Graphql: sig
+  module type S = sig
+    module Pclock: Mirage_clock_lwt.PCLOCK
+    module Flow: Mirage_flow_lwt.S
+
+    val init: Pclock.t -> (module Irmin_graphql.S)
+  end
+
+  module Make
+      (Store: Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
+      (Pclock: Mirage_clock_lwt.PCLOCK)
+      (Flow: Mirage_flow_lwt.S):
+    S with module Pclock = Pclock
+       and module Flow = Flow
+end

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -599,12 +599,8 @@ let graphql = {
     in
     let graphql (S ((module S), store, remote_fn)) port =
       run begin
+        let module Server = Graphql.Make (S) (struct let remote = remote_fn end) in
         store >>= fun t ->
-        let module Server = Irmin_graphql.Make (struct
-          include S
-          let info = info
-          let remote = remote_fn
-        end) in
         Server.start_server ~port t
       end
     in

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -601,7 +601,7 @@ let graphql = {
       run begin
         let module Server = Graphql.Make (S) (struct let remote = remote_fn end) in
         store >>= fun t ->
-        Server.start_server ~port t
+        Server.run_server (None, (`TCP (`Port port))) t
       end
     in
     Term.(mk graphql $ store $ port)

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -1,13 +1,17 @@
-open Lwt.Infix
-
 module Server = struct
   include Cohttp_lwt_unix.Server
 
-  let create ?(hostname = "127.0.0.1") ?(port = 8080) callback =
-    Conduit_lwt_unix.init ~src:hostname () >>= fun ctx ->
-    let srv = Cohttp_lwt_unix.Server.make ~callback () in
+  type server = (Conduit_lwt_unix.ctx option * Conduit_lwt_unix.server)
+
+  let run (ctx, mode) callback =
+    let ctx =
+      match ctx with
+      | Some ctx -> ctx
+      | None -> Conduit_lwt_unix.default_ctx
+    in
     let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
-    Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port)) srv
+    let server = Cohttp_lwt_unix.Server.make ~callback () in
+    Cohttp_lwt_unix.Server.create ~ctx ~mode server
 end
 
 module Make(S: Irmin.S)(Remote: sig

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -9,7 +9,9 @@ module Server = struct
       | None -> Cohttp_lwt_unix.Net.default_ctx
     in
     let server = Cohttp_lwt_unix.Server.make ~callback () in
-    Cohttp_lwt_unix.Server.create ~ctx ~mode server
+    let on_exn = fun e ->
+      Logs.debug (fun l -> l "Server exception: %s" (Printexc.to_string e)) in
+    Cohttp_lwt_unix.Server.create ~on_exn ~ctx ~mode server
 end
 
 module Remote = struct

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -12,6 +12,12 @@ module Server = struct
     Cohttp_lwt_unix.Server.create ~ctx ~mode server
 end
 
+module Remote = struct
+  module None = struct
+    let remote = None
+  end
+end
+
 module Make(S: Irmin.S)(Remote: sig
   val remote: Resolver.Store.remote_fn option
 end) = struct

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -1,15 +1,13 @@
 module Server = struct
   include Cohttp_lwt_unix.Server
 
-  type server = (Conduit_lwt_unix.ctx option * Conduit_lwt_unix.server)
+  type server = (Cohttp_lwt_unix.Net.ctx option * Conduit_lwt_unix.server)
 
   let run (ctx, mode) callback =
-    let ctx =
-      match ctx with
+    let ctx = match ctx with
       | Some ctx -> ctx
-      | None -> Conduit_lwt_unix.default_ctx
+      | None -> Cohttp_lwt_unix.Net.default_ctx
     in
-    let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
     let server = Cohttp_lwt_unix.Server.make ~callback () in
     Cohttp_lwt_unix.Server.create ~ctx ~mode server
 end
@@ -17,10 +15,8 @@ end
 module Make(S: Irmin.S)(Remote: sig
   val remote: Resolver.Store.remote_fn option
 end) = struct
-  include Irmin_graphql.Make(struct
-    include S
+  include Irmin_graphql.Make(Server)(struct
     let info = Info.v
     let remote = Remote.remote
-  end) (Server)
+  end)(S)
 end
-

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -1,0 +1,22 @@
+open Lwt.Infix
+
+module Server = struct
+  include Cohttp_lwt_unix.Server
+
+  let create ?(hostname = "127.0.0.1") ?(port = 8080) callback =
+    Conduit_lwt_unix.init ~src:hostname () >>= fun ctx ->
+    let srv = Cohttp_lwt_unix.Server.make ~callback () in
+    let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
+    Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port)) srv
+end
+
+module Make(S: Irmin.S)(Remote: sig
+  val remote: Resolver.Store.remote_fn option
+end) = struct
+  include Irmin_graphql.Make(struct
+    include S
+    let info = Info.v
+    let remote = Remote.remote
+  end) (Server)
+end
+

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -1,3 +1,9 @@
+module Remote: sig
+  module None: sig
+    val remote: Resolver.Store.remote_fn option
+  end
+end
+
 module Make(S: Irmin.S)(Remote: sig
   val remote: Resolver.Store.remote_fn option
 end):

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -1,3 +1,6 @@
 module Make(S: Irmin.S)(Remote: sig
   val remote: Resolver.Store.remote_fn option
-end): Irmin_graphql.S with type store = S.t
+end):
+  Irmin_graphql.S
+    with type store = S.t
+     and type server = (Conduit_lwt_unix.ctx option * Conduit_lwt_unix.server)

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -3,4 +3,4 @@ module Make(S: Irmin.S)(Remote: sig
 end):
   Irmin_graphql.S
     with type store = S.t
-     and type server = (Conduit_lwt_unix.ctx option * Conduit_lwt_unix.server)
+     and type server = (Cohttp_lwt_unix.Net.ctx option * Conduit_lwt_unix.server)

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -1,0 +1,3 @@
+module Make(S: Irmin.S)(Remote: sig
+  val remote: Resolver.Store.remote_fn option
+end): Irmin_graphql.S with type store = S.t

--- a/src/irmin-unix/irmin_unix.ml
+++ b/src/irmin-unix/irmin_unix.ml
@@ -19,6 +19,7 @@ let set_listen_dir_hook = Hook.init
 
 module Git = Xgit
 module Http = Http
+module Graphql = Graphql
 module FS = Fs
 module Cli = Cli
 module Resolver = Resolver

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -214,5 +214,6 @@ val set_listen_dir_hook: unit -> unit
 (** Install {!Irmin_watcher.hook} as the listen hook for watching
     changes in directories. *)
 
+module Graphql = Graphql
 module Cli = Cli
 module Resolver = Resolver


### PR DESCRIPTION
Because [graphql-cohttp](https://opam.ocaml.org/packages/graphql-cohttp/) was released over the weekend, we can now merge this code which adds MirageOS support for `irmin-graphql`!

This change-set also includes a major overhaul to the way that GraphQL values are converted to the corresponding Irmin types. This is nice because it significantly reduces the complexity of the method implementations and as well as the number of times that `Irmin.Type.of_string` is used directly.