### PR TITLE
Irmin graphql subscriptions

### DIFF
--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -17,9 +17,9 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {build}
   "irmin"
-  "graphql" {>= "0.8"}
-  "graphql-lwt" {>= "0.8"}
-  "graphql-cohttp" {>= "0.8"}
+  "graphql" {>= "0.9"}
+  "graphql-lwt" {>= "0.9"}
+  "graphql-cohttp" {>= "0.9"}
   "cohttp-lwt"
 ]
 

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -1,14 +1,22 @@
 module Schema : Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
 
 module type S = sig
+  module IO : Cohttp_lwt.S.IO
   type store
   type server
+
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (IO.ic
+                    -> IO.oc
+                    -> unit Lwt.t)
+    | `Response of Cohttp.Response.t * Cohttp_lwt.Body.t ]
 
   val schema : store -> unit Schema.schema
   val execute_request :
       unit Schema.schema ->
       Cohttp_lwt.Request.t ->
-      Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+      Cohttp_lwt.Body.t -> response_action Lwt.t
   val server : store -> server
 end
 


### PR DESCRIPTION
~~⚠️ Experimental! Depends on https://github.com/andreas/ocaml-graphql-server/pull/133 ⚠️~~

~~This PR updates `irmin-graphql` to use `graphql-cohttp`. This change should happen regardless, as `graphql_lwt` no longer includes a HTTP server.~~ (no longer necessary)

This PR adds the ability to watch the entire store or a specific key with notifications delivered via the GraphQL subscription mechanism (currently only websockets, possibly Server-Sent Events or chunked HTTP responses in the future).

Adding `Irmin_unix.set_listen_dir_hook ()` to `cli.ml` may be required...

![irmin-graphql-subscriptions-demo-low-res](https://user-images.githubusercontent.com/2518/49969142-1f145100-ff28-11e8-8dde-eb0442130880.gif)

- [x] Pending the release of `graphql` 0.9.0 ([PR](https://github.com/ocaml/opam-repository/pull/13427))

/cc @zshipko 