### PR TITLE
Simplify Irmin_graphql.Make by removing SERVER

### DIFF
--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -12,7 +12,7 @@ module type S = sig
     unit Schema.schema ->
     Cohttp_lwt.Request.t ->
     Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-  val make_server : store -> server
+  val server : store -> server
 end
 
 let of_irmin_result = function
@@ -580,7 +580,7 @@ module Make(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S) = stru
 
   let execute_request ctx req = Graphql_server.execute_request ctx () req
 
-  let make_server store =
+  let server store =
     let schema = schema store in
     let callback = Graphql_server.make_callback (fun _ctx -> ()) schema in
     Server.make ~callback ()

--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -9,10 +9,10 @@ module type S = sig
 
   val schema : store -> unit Schema.schema
   val execute_request :
-      unit Schema.schema ->
-      Cohttp_lwt.Request.t ->
-      Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-  val run_server: server -> store -> unit Lwt.t
+    unit Schema.schema ->
+    Cohttp_lwt.Request.t ->
+    Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val make_server : store -> server
 end
 
 let of_irmin_result = function
@@ -29,23 +29,7 @@ module type CONFIG = sig
   val info: ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
 end
 
-module type SERVER = sig
-  type conn
-  type server
-
-  val respond_string :
-    ?flush:bool ->
-    ?headers:Cohttp.Header.t ->
-    status:Cohttp.Code.status_code ->
-    body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-
-  val run :
-    server ->
-    (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t ->
-      (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
-end
-
-module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S) = struct
+module Make(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S) = struct
   module Sync = Irmin.Sync (Store)
 
   type tree_item = {
@@ -64,7 +48,7 @@ module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S) = struct
       Config.info ""
 
   type store = Store.t
-  type server = Server.server
+  type server = Server.t
 
   module Input = struct
     let coerce_key = function
@@ -420,143 +404,143 @@ module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S) = struct
     | None -> []
 
   let to_tree tree l = Lwt_list.fold_left_s (fun tree ->
-    function
+      function
       | {key; value = Some v; metadata} ->
-          Store.Tree.add tree ?metadata key v
+        Store.Tree.add tree ?metadata key v
       | {key; value = None; _} ->
-          Store.Tree.remove tree key) tree l
+        Store.Tree.remove tree key) tree l
 
   let mutations s = Schema.[
-    io_field "set"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null Input.key);
-          arg "value" ~typ:(non_null Input.value);
-          arg "info" ~typ:Input.info;
-        ]
-      ~resolve:(fun _ _src branch k v i ->
-          mk_branch (Store.repo s) branch >>= fun t ->
-          let info = mk_info i in
-          (Store.set t k v ~info >>= function
-            | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
-            | Error e -> err_write e)
-        )
-    ;
-    io_field "set_tree"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null Input.key);
-          arg "tree" ~typ:(Input.tree);
-          arg "info" ~typ:Input.info;
-        ]
-      ~resolve:(fun _ _src branch k items i ->
-          mk_branch (Store.repo s) branch >>= fun t ->
-          let info = mk_info i in
-           Lwt.catch (fun () ->
-               let tree = Store.Tree.empty in
-               to_tree tree items
-               >>= fun tree ->
-               Store.set_tree_exn t ~info k tree >>= fun () ->
-               Store.Head.find t >>= Lwt.return_ok)
-           (function
-             | Failure e -> Lwt.return_error e
-             | e -> raise e)
-        )
-    ;
-    io_field "update_tree"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null Input.key);
-          arg "tree" ~typ:(Input.tree);
-          arg "info" ~typ:Input.info;
-        ]
-      ~resolve:(fun _ _src branch k items i ->
-          mk_branch (Store.repo s) branch >>= fun t ->
-          let info = mk_info i in
-           Lwt.catch (fun () ->
-               Store.with_tree_exn t k ~info (fun tree ->
-                   let tree = match tree with
-                     | Some t -> t
-                     | None -> Store.Tree.empty
-                   in
-                   to_tree tree items >>= Lwt.return_some)
-               >>= fun () ->
-               Store.Head.find t >>= Lwt.return_ok)
-           (function
-             | Failure e -> Lwt.return_error e
-             | e -> raise e)
-        )
-    ;
-    io_field "set_all"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null Input.key);
-          arg "value" ~typ:(non_null Input.value);
-          arg "metadata" ~typ:(Input.metadata);
-          arg "info" ~typ:Input.info;
-        ]
-      ~resolve:(fun _ _src branch k v m i ->
-          mk_branch (Store.repo s) branch >>= fun t ->
-          let info = mk_info i in
-          (Store.find_tree t k >>= (function
-             | Some tree -> Lwt.return tree
-             | None -> Lwt.return Store.Tree.empty) >>= fun tree ->
-           Store.Tree.add tree k ?metadata:m v >>= fun tree ->
-           Store.set_tree t k tree ~info >>= function
-           | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
-           | Error e -> err_write e)
-        )
-    ;
-    io_field "remove"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "key" ~typ:(non_null Input.key);
-          arg "info" ~typ:Input.info
-        ]
-      ~resolve:(fun _ _src branch key i ->
-          mk_branch (Store.repo s) branch >>= fun t ->
-          let info = mk_info i in
-          Store.remove t key ~info >>= function
+      io_field "set"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "key" ~typ:(non_null Input.key);
+            arg "value" ~typ:(non_null Input.value);
+            arg "info" ~typ:Input.info;
+          ]
+        ~resolve:(fun _ _src branch k v i ->
+            mk_branch (Store.repo s) branch >>= fun t ->
+            let info = mk_info i in
+            (Store.set t k v ~info >>= function
+              | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
+              | Error e -> err_write e)
+          )
+      ;
+      io_field "set_tree"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "key" ~typ:(non_null Input.key);
+            arg "tree" ~typ:(Input.tree);
+            arg "info" ~typ:Input.info;
+          ]
+        ~resolve:(fun _ _src branch k items i ->
+            mk_branch (Store.repo s) branch >>= fun t ->
+            let info = mk_info i in
+            Lwt.catch (fun () ->
+                let tree = Store.Tree.empty in
+                to_tree tree items
+                >>= fun tree ->
+                Store.set_tree_exn t ~info k tree >>= fun () ->
+                Store.Head.find t >>= Lwt.return_ok)
+              (function
+                | Failure e -> Lwt.return_error e
+                | e -> raise e)
+          )
+      ;
+      io_field "update_tree"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "key" ~typ:(non_null Input.key);
+            arg "tree" ~typ:(Input.tree);
+            arg "info" ~typ:Input.info;
+          ]
+        ~resolve:(fun _ _src branch k items i ->
+            mk_branch (Store.repo s) branch >>= fun t ->
+            let info = mk_info i in
+            Lwt.catch (fun () ->
+                Store.with_tree_exn t k ~info (fun tree ->
+                    let tree = match tree with
+                      | Some t -> t
+                      | None -> Store.Tree.empty
+                    in
+                    to_tree tree items >>= Lwt.return_some)
+                >>= fun () ->
+                Store.Head.find t >>= Lwt.return_ok)
+              (function
+                | Failure e -> Lwt.return_error e
+                | e -> raise e)
+          )
+      ;
+      io_field "set_all"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "key" ~typ:(non_null Input.key);
+            arg "value" ~typ:(non_null Input.value);
+            arg "metadata" ~typ:(Input.metadata);
+            arg "info" ~typ:Input.info;
+          ]
+        ~resolve:(fun _ _src branch k v m i ->
+            mk_branch (Store.repo s) branch >>= fun t ->
+            let info = mk_info i in
+            (Store.find_tree t k >>= (function
+                 | Some tree -> Lwt.return tree
+                 | None -> Lwt.return Store.Tree.empty) >>= fun tree ->
+             Store.Tree.add tree k ?metadata:m v >>= fun tree ->
+             Store.set_tree t k tree ~info >>= function
+             | Ok ()   -> Store.Head.find t >>= Lwt.return_ok
+             | Error e -> err_write e)
+          )
+      ;
+      io_field "remove"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "key" ~typ:(non_null Input.key);
+            arg "info" ~typ:Input.info
+          ]
+        ~resolve:(fun _ _src branch key i ->
+            mk_branch (Store.repo s) branch >>= fun t ->
+            let info = mk_info i in
+            Store.remove t key ~info >>= function
             | Ok () -> Store.Head.find t >>= Lwt.return_ok
             | Error e -> err_write e
-        )
-    ;
-    io_field "merge"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "from" ~typ:(non_null Input.branch);
-          arg "info" ~typ:Input.info;
-        ]
-      ~resolve:(fun _ _src into from i ->
-          mk_branch (Store.repo s) into >>= fun t ->
-          let info = mk_info i in
-          Store.merge_with_branch t from ~info >>= fun _ ->
-          Store.Head.find t >>=
-          Lwt.return_ok
-        )
-    ;
-    io_field "revert"
-      ~typ:(Lazy.force commit)
-      ~args:Arg.[
-          arg "branch" ~typ:Input.branch;
-          arg "commit" ~typ:(non_null Input.commit_hash);
-        ]
-      ~resolve:(fun _ _src branch commit ->
-          mk_branch (Store.repo s) branch >>= fun t ->
-          Store.Commit.of_hash (Store.repo s) commit >>= function
-          | Some commit ->
-            Store.Head.set t commit >>= fun () ->
-            Lwt.return_ok (Some commit)
-          | None -> Lwt.return_ok None
-        )
-    ;
-  ]
+          )
+      ;
+      io_field "merge"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "from" ~typ:(non_null Input.branch);
+            arg "info" ~typ:Input.info;
+          ]
+        ~resolve:(fun _ _src into from i ->
+            mk_branch (Store.repo s) into >>= fun t ->
+            let info = mk_info i in
+            Store.merge_with_branch t from ~info >>= fun _ ->
+            Store.Head.find t >>=
+            Lwt.return_ok
+          )
+      ;
+      io_field "revert"
+        ~typ:(Lazy.force commit)
+        ~args:Arg.[
+            arg "branch" ~typ:Input.branch;
+            arg "commit" ~typ:(non_null Input.commit_hash);
+          ]
+        ~resolve:(fun _ _src branch commit ->
+            mk_branch (Store.repo s) branch >>= fun t ->
+            Store.Commit.of_hash (Store.repo s) commit >>= function
+            | Some commit ->
+              Store.Head.set t commit >>= fun () ->
+              Lwt.return_ok (Some commit)
+            | None -> Lwt.return_ok None
+          )
+      ;
+    ]
 
   let schema s =
     let mutations = mutations s @ remote s in
@@ -596,8 +580,8 @@ module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S) = struct
 
   let execute_request ctx req = Graphql_server.execute_request ctx () req
 
-  let run_server server store =
+  let make_server store =
     let schema = schema store in
     let callback = Graphql_server.make_callback (fun _ctx -> ()) schema in
-    Server.run server callback
+    Server.make ~callback ()
 end

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -9,7 +9,7 @@ module type S = sig
       unit Schema.schema ->
       Cohttp_lwt.Request.t ->
       Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-  val make_server : store -> server
+  val server : store -> server
 end
 
 module type CONFIG = sig

--- a/src/irmin-graphql/irmin_graphql.mli
+++ b/src/irmin-graphql/irmin_graphql.mli
@@ -9,7 +9,7 @@ module type S = sig
       unit Schema.schema ->
       Cohttp_lwt.Request.t ->
       Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-  val run_server: server -> store -> unit Lwt.t
+  val make_server : store -> server
 end
 
 module type CONFIG = sig
@@ -17,22 +17,6 @@ module type CONFIG = sig
   val info: ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
 end
 
-module type SERVER = sig
-  type conn
-  type server
-
-  val respond_string :
-      ?flush:bool ->
-      ?headers:Cohttp.Header.t ->
-      status:Cohttp.Code.status_code ->
-      body:string -> unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-
-  val run :
-      server ->
-      (conn -> Cohttp_lwt.Request.t -> Cohttp_lwt.Body.t ->
-        (Cohttp_lwt.Response.t * Cohttp_lwt.Body.t) Lwt.t) -> unit Lwt.t
-end
-
-module Make(Server : SERVER)(Config: CONFIG)(Store : Irmin.S): S
+module Make(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S): S
   with type store = Store.t
-   and type server = Server.server
+   and type server = Server.t

--- a/src/irmin-mirage/irmin_mirage.ml
+++ b/src/irmin-mirage/irmin_mirage.ml
@@ -221,28 +221,20 @@ module Graphql = struct
 
     val start:
       pclock:Pclock.t
-      -> http:(Conduit_mirage.server -> Http.t -> unit Lwt.t)
-      -> Conduit_mirage.server
+      -> http:(Http.t -> unit Lwt.t)
       -> Store.t -> unit Lwt.t
   end
 
   module Make
+      (Http: Cohttp_lwt.S.Server)
       (Store: Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
       (Pclock: Mirage_clock_lwt.PCLOCK)
-      (Http: Cohttp_lwt.S.Server)
   = struct
     module Store = Store
     module Pclock = Pclock
     module Http = Http
 
     let init p =
-      let module Server = struct
-        type conn = Http.conn
-        type server = Http.t -> unit Lwt.t
-        let respond_string = Http.respond_string
-        let run http callback =
-          http @@ Http.make ~callback ()
-      end in
       let module Config = struct
         let info ?(author = "irmin-graphql") fmt =
           let module I = Info(struct let name = author end)(Pclock) in
@@ -254,10 +246,11 @@ module Graphql = struct
             in
             Store.E e)
       end in
-      (module Irmin_graphql.Make(Server)(Config)(Store): Irmin_graphql.S with type server = Http.t -> unit Lwt.t and type store = Store.t)
+      (module Irmin_graphql.Make(Http)(Config)(Store): Irmin_graphql.S with type server = Http.t and type store = Store.t)
 
-    let start ~pclock ~http server store =
+    let start ~pclock ~http store =
       let (module G) = init pclock in
-      G.run_server (http server) store
+      let server = G.make_server store in
+      http server
   end
 end

--- a/src/irmin-mirage/irmin_mirage.ml
+++ b/src/irmin-mirage/irmin_mirage.ml
@@ -250,7 +250,7 @@ module Graphql = struct
 
     let start ~pclock ~http store =
       let (module G) = init pclock in
-      let server = G.make_server store in
+      let server = G.server store in
       http server
   end
 end

--- a/src/irmin-mirage/irmin_mirage.mli
+++ b/src/irmin-mirage/irmin_mirage.mli
@@ -142,15 +142,14 @@ module Graphql: sig
 
     val start:
       pclock:Pclock.t
-      -> http:(Conduit_mirage.server -> Http.t -> unit Lwt.t)
-      -> Conduit_mirage.server
+      -> http:(Http.t -> unit Lwt.t)
       -> Store.t -> unit Lwt.t
   end
 
   module Make
+      (Http: Cohttp_lwt.S.Server)
       (Store: Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
-      (Pclock: Mirage_clock_lwt.PCLOCK)
-      (Http: Cohttp_lwt.S.Server):
+      (Pclock: Mirage_clock_lwt.PCLOCK):
     S with module Pclock = Pclock
       and module Store = Store
       and module Http = Http

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -605,7 +605,7 @@ let graphql = {
       run begin
         let module Server = Graphql.Make (S) (struct let remote = remote_fn end) in
         store >>= fun t ->
-        let server = Server.make_server t in
+        let server = Server.server t in
         Conduit_lwt_unix.init ~src:addr () >>= fun ctx ->
         let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
         Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port)) server

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -608,7 +608,10 @@ let graphql = {
         let server = Server.server t in
         Conduit_lwt_unix.init ~src:addr () >>= fun ctx ->
         let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
-        Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port)) server
+        let on_exn exn =
+          Logs.debug (fun l -> l "on_exn: %s" (Printexc.to_string exn))
+        in
+        Cohttp_lwt_unix.Server.create ~on_exn ~ctx ~mode:(`TCP (`Port port)) server
       end
     in
     Term.(mk graphql $ store $ port $ addr)

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -597,14 +597,21 @@ let graphql = {
       let doc = Arg.info ~doc:"Port for graphql server." ["p"; "port"] in
       Arg.(value & opt int 8080 & doc)
     in
-    let graphql (S ((module S), store, remote_fn)) port =
+    let addr =
+      let doc = Arg.info ~doc:"Address for graphql server." ["a"; "address"] in
+      Arg.(value & opt string "localhost" & doc)
+    in
+    let graphql (S ((module S), store, remote_fn)) port addr =
       run begin
         let module Server = Graphql.Make (S) (struct let remote = remote_fn end) in
         store >>= fun t ->
-        Server.run_server (None, (`TCP (`Port port))) t
+        let server = Server.make_server t in
+        Conduit_lwt_unix.init ~src:addr () >>= fun ctx ->
+        let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
+        Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port)) server
       end
     in
-    Term.(mk graphql $ store $ port)
+    Term.(mk graphql $ store $ port $ addr)
 }
 
 let default =

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -1,19 +1,3 @@
-module Server = struct
-  include Cohttp_lwt_unix.Server
-
-  type server = (Cohttp_lwt_unix.Net.ctx option * Conduit_lwt_unix.server)
-
-  let run (ctx, mode) callback =
-    let ctx = match ctx with
-      | Some ctx -> ctx
-      | None -> Cohttp_lwt_unix.Net.default_ctx
-    in
-    let server = Cohttp_lwt_unix.Server.make ~callback () in
-    let on_exn = fun e ->
-      Logs.debug (fun l -> l "Server exception: %s" (Printexc.to_string e)) in
-    Cohttp_lwt_unix.Server.create ~on_exn ~ctx ~mode server
-end
-
 module Remote = struct
   module None = struct
     let remote = None
@@ -23,7 +7,7 @@ end
 module Make(S: Irmin.S)(Remote: sig
   val remote: Resolver.Store.remote_fn option
 end) = struct
-  include Irmin_graphql.Make(Server)(struct
+  include Irmin_graphql.Make(Cohttp_lwt_unix.Server)(struct
     let info = Info.v
     let remote = Remote.remote
   end)(S)

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -9,4 +9,4 @@ module Make(S: Irmin.S)(Remote: sig
 end):
   Irmin_graphql.S
     with type store = S.t
-     and type server = (Cohttp_lwt_unix.Net.ctx option * Conduit_lwt_unix.server)
+     and type server = Cohttp_lwt_unix.Server.t


### PR DESCRIPTION
This PR removes the `SERVER` module type and replaces it with `Cohttp_lwt.S.Server` in the arguments to `Irmin_graphql.Make`. See: https://github.com/mirage/irmin/pull/598#issuecomment-447471791.

Sorry about all the whitespace changes! I forgot to disable `ocp-indent`.

/cc @andreas