### PR TITLE
Implement sanity check for Conf.key

### DIFF
--- a/src/irmin/conf.ml
+++ b/src/irmin/conf.ml
@@ -83,9 +83,13 @@ let conv t = t.conv
 let default t = t.default
 
 let key ?docs ?docv ?doc name conv default =
-  let to_univ, of_univ = Univ.create () in
-  let id = Oo.id (object end) in
-  { id; to_univ; of_univ; name; docs; docv; doc; conv; default }
+  let re = Str.regexp ".*[^0-9a-z_-].*" in
+  let illegal = Str.string_match re name 0 in
+  if illegal then raise @@ Invalid_argument name
+  else
+    let to_univ, of_univ = Univ.create () in
+    let id = Oo.id (object end) in
+    {id; to_univ; of_univ; name; docs; docv; doc; conv; default}
 
 module Id = struct
   type t = int

--- a/src/irmin/conf.ml
+++ b/src/irmin/conf.ml
@@ -83,13 +83,16 @@ let conv t = t.conv
 let default t = t.default
 
 let key ?docs ?docv ?doc name conv default =
-  let re = Str.regexp ".*[^0-9a-z_-].*" in
-  let illegal = Str.string_match re name 0 in
-  if illegal then raise @@ Invalid_argument name
-  else
-    let to_univ, of_univ = Univ.create () in
-    let id = Oo.id (object end) in
-    {id; to_univ; of_univ; name; docs; docv; doc; conv; default}
+  let () =
+    String.iter
+      (function
+        | '-' | '_' | 'a' .. 'z' | '0' .. '9' -> ()
+        | _ -> raise @@ Invalid_argument name)
+      name
+  in
+  let to_univ, of_univ = Univ.create () in
+  let id = Oo.id (object end) in
+  {id; to_univ; of_univ; name; docs; docv; doc; conv; default}
 
 module Id = struct
   type t = int

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,4 +1,4 @@
 (library
  (name        irmin)
  (public_name irmin)
- (libraries   fmt uri jsonm lwt ocamlgraph logs astring digestif))
+ (libraries   str fmt uri jsonm lwt ocamlgraph logs astring digestif))

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,4 +1,4 @@
 (library
  (name        irmin)
  (public_name irmin)
- (libraries   str fmt uri jsonm lwt ocamlgraph logs astring digestif))
+ (libraries   fmt uri jsonm lwt ocamlgraph logs astring digestif))

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1276,7 +1276,6 @@ module Private: sig
 
         @raise Invalid_argument if the key name is not made of a
         sequence of ASCII lowercase letter, digit, dash or underscore.
-        FIXME not implemented.
 
         {b Warning.} No two keys should share the same [name] as this
         may lead to difficulties in the UI. *)


### PR DESCRIPTION
This PR implements the sanity check for Conf.key described in irmin.mli :
```
@raise Invalid_argument if the key name is not made of a
sequence of ASCII lowercase letter, digit, dash or underscore.
FIXME not implemented.
```