### PR TITLE
Simplify redundant keys in Commit and Node

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -292,7 +292,7 @@ module Make_private
               (to_step name, mk_c node perm) :: acc
           ) [] (G.Value.Tree.to_list t)
 
-       module N = Irmin.Private.Node.Make (H)(H)(P)(Metadata)
+       module N = Irmin.Private.Node.Make(H)(P)(Metadata)
        let to_n t = N.v (alist t)
        let of_n n = v (N.list n)
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -328,7 +328,7 @@ module Make_private
         let of_git = function G.Value.Tree t -> Ok (Some t) | _ -> Ok None
       end)
   end
-  module Node = Irmin.Private.Node.Store(P)(Metadata)(XNode)(Contents)
+  module Node = Irmin.Private.Node.Store(Contents)(P)(Metadata)(XNode)
 
   module XCommit = struct
     module Val = struct
@@ -444,7 +444,7 @@ module Make_private
       end)
 
   end
-  module Commit = Irmin.Private.Commit.Store(XCommit)(Node)
+  module Commit = Irmin.Private.Commit.Store(Node)(XCommit)
 
 end
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -335,11 +335,9 @@ module Make_private
       type t = G.Value.Commit.t
       let pp = G.Value.Commit.pp
 
-      type commit = H.t
-      type node = H.t
+      type hash = H.t
 
-      let commit_t = H.t
-      let node_t = H.t
+      let hash_t = H.t
 
       let info_of_git author message =
         let id = author.Git.User.name in
@@ -446,7 +444,7 @@ module Make_private
       end)
 
   end
-  module Commit = Irmin.Private.Commit.Store(Node)(XCommit)
+  module Commit = Irmin.Private.Commit.Store(XCommit)(Node)
 
 end
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -204,23 +204,20 @@ module Make_private
       type t = G.Value.Tree.t
       let pp = G.Value.Tree.pp
       type metadata = Metadata.t
-      type contents = Contents.key
-      type node = Key.t
+      type hash = Key.t
       type step = Path.step
-      type value = [`Node of node | `Contents of contents * metadata ]
+      type value = [`Node of hash | `Contents of hash * metadata ]
       let metadata_t = Metadata.t
-      let contents_t = Contents.Key.t
-      let node_t = Key.t
+      let hash_t = Key.t
       let step_t = Path.step_t
 
       let value_t =
         let open Irmin.Type in
-        let contents_t = pair contents_t metadata_t in
         variant "Tree.value" (fun node contents -> function
             | `Node n     -> node n
             | `Contents c -> contents c)
-        |~ case1 "node"     node_t     (fun n -> `Node n)
-        |~ case1 "contents" contents_t (fun c -> `Contents c)
+        |~ case1 "node"     hash_t     (fun n -> `Node n)
+        |~ case1 "contents" (pair hash_t metadata_t) (fun c -> `Contents c)
         |> sealv
 
       let of_step = Irmin.Type.to_string P.step_t
@@ -331,7 +328,7 @@ module Make_private
         let of_git = function G.Value.Tree t -> Ok (Some t) | _ -> Ok None
       end)
   end
-  module Node = Irmin.Private.Node.Store(Contents)(P)(Metadata)(XNode)
+  module Node = Irmin.Private.Node.Store(P)(Metadata)(XNode)(Contents)
 
   module XCommit = struct
     module Val = struct

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -403,7 +403,7 @@ module Make_private
         let message = G.Value.Commit.message g in
         info_of_git author message
 
-      module C = Irmin.Private.Commit.Make(H)(H)
+      module C = Irmin.Private.Commit.Make(H)
 
       let of_c c = to_git (C.info c) (C.node c) (C.parents c)
 

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -398,7 +398,7 @@ struct
         module Val = Irmin.Private.Node.Make(H)(P)(M)
         include AO(Client)(Key)(Val)
       end
-      include Irmin.Private.Node.Store(Contents)(P)(M)(X)
+      include Irmin.Private.Node.Store(P)(M)(X)(Contents)
       let v ?ctx config = X.v ?ctx config "tree" "trees"
     end
     module Commit = struct

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -407,7 +407,7 @@ struct
         module Val = Irmin.Private.Commit.Make(H)
         include AO(Client)(Key)(Val)
       end
-      include Irmin.Private.Commit.Store(Node)(X)
+      include Irmin.Private.Commit.Store(X)(Node)
       let v ?ctx config = X.v ?ctx config "commit" "commits"
     end
     module Branch = struct

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -404,7 +404,7 @@ struct
     module Commit = struct
       module X = struct
         module Key = H
-        module Val = Irmin.Private.Commit.Make(H)(H)
+        module Val = Irmin.Private.Commit.Make(H)
         include AO(Client)(Key)(Val)
       end
       include Irmin.Private.Commit.Store(Node)(X)

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -398,7 +398,7 @@ struct
         module Val = Irmin.Private.Node.Make(H)(P)(M)
         include AO(Client)(Key)(Val)
       end
-      include Irmin.Private.Node.Store(P)(M)(X)(Contents)
+      include Irmin.Private.Node.Store(Contents)(P)(M)(X)
       let v ?ctx config = X.v ?ctx config "tree" "trees"
     end
     module Commit = struct
@@ -407,7 +407,7 @@ struct
         module Val = Irmin.Private.Commit.Make(H)
         include AO(Client)(Key)(Val)
       end
-      include Irmin.Private.Commit.Store(X)(Node)
+      include Irmin.Private.Commit.Store(Node)(X)
       let v ?ctx config = X.v ?ctx config "commit" "commits"
     end
     module Branch = struct

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -395,7 +395,7 @@ struct
     module Node = struct
       module X = struct
         module Key = H
-        module Val = Irmin.Private.Node.Make(H)(H)(P)(M)
+        module Val = Irmin.Private.Node.Make(H)(P)(M)
         include AO(Client)(Key)(Val)
       end
       include Irmin.Private.Node.Store(Contents)(P)(M)(X)

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -22,12 +22,11 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make (K: Type.S) = struct
 
-  type node = K.t
-  type commit = K.t
+  type hash = K.t
 
   type t = {
-    node   : K.t;
-    parents: K.t list;
+    node   : hash;
+    parents: hash list;
     info   : Info.t;
   }
 
@@ -44,38 +43,36 @@ module Make (K: Type.S) = struct
     |+ field "info"    Info.t  (fun t -> t.info)
     |> sealr
 
-  let node_t = K.t
-  let commit_t = K.t
+  let hash_t = K.t
 end
 
 module Store
-    (N: S.NODE_STORE)
-    (S: sig
+    (CS: sig
        include S.CONTENT_ADDRESSABLE_STORE
        module Key: S.HASH with type t = key
        module Val: S.COMMIT with type t = value
-                                and type commit = key
-                                and type node = N.key
+                            and type hash = key
      end)
+     (N: S.NODE_STORE with type key = CS.key)
 = struct
 
   module Node = N
-  type t = N.t * S.t
-  type key = S.key
-  type value = S.value
+  type t = N.t * CS.t
+  type key = CS.key
+  type value = CS.value
 
-  let add (_, t) = S.add t
-  let mem (_, t) = S.mem t
-  let find (_, t) = S.find t
+  let add (_, t) = CS.add t
+  let mem (_, t) = CS.mem t
+  let find (_, t) = CS.find t
   let merge_node (n, _) = Merge.f (N.merge n)
 
-  let pp_key = Type.pp S.Key.t
+  let pp_key = Type.pp CS.Key.t
 
   let err_not_found k =
     Fmt.kstrf invalid_arg "Commit.get: %a not found" pp_key k
 
   let get (_, t) k =
-    S.find t k >>= function
+    CS.find t k >>= function
     | None   -> err_not_found k
     | Some v -> Lwt.return v
 
@@ -83,13 +80,13 @@ module Store
     | None -> N.add n N.Val.empty
     | Some node -> Lwt.return node
 
-  let equal_opt_keys = Type.(equal (option S.Key.t))
+  let equal_opt_keys = Type.(equal (option CS.Key.t))
 
   let merge_commit info t ~old k1 k2 =
     get t k1 >>= fun v1   ->
     get t k2 >>= fun v2   ->
-    if List.mem k1 (S.Val.parents v2) then Merge.ok k2
-    else if List.mem k2 (S.Val.parents v1) then Merge.ok k1
+    if List.mem k1 (CS.Val.parents v2) then Merge.ok k2
+    else if List.mem k2 (CS.Val.parents v1) then Merge.ok k1
     else
       (* If we get an error while looking the the lca, then we
          assume that there is no common ancestor. Maybe we want to
@@ -108,20 +105,20 @@ module Store
           | None     -> Merge.ok None
           | Some old ->
             get t old >>= fun vold ->
-            Merge.ok (Some (Some (S.Val.node vold)))
+            Merge.ok (Some (Some (CS.Val.node vold)))
         in
-        merge_node t ~old (Some (S.Val.node v1)) (Some (S.Val.node v2))
+        merge_node t ~old (Some (CS.Val.node v1)) (Some (CS.Val.node v2))
         >>=* fun node ->
         empty_if_none t node >>= fun node ->
         let parents = [k1; k2] in
-        let commit = S.Val.v ~node ~parents ~info:(info ()) in
+        let commit = CS.Val.v ~node ~parents ~info:(info ()) in
         add t commit >>= fun key ->
         Merge.ok key
 
-  let merge t ~info = Merge.(option (v S.Key.t (merge_commit info t)))
+  let merge t ~info = Merge.(option (v CS.Key.t (merge_commit info t)))
 
-  module Key = S.Key
-  module Val = S.Val
+  module Key = CS.Key
+  module Val = CS.Val
 end
 
 module History (S: S.COMMIT_STORE) = struct

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -20,14 +20,14 @@ open Merge.Infix
 let src = Logs.Src.create "irmin.commit" ~doc:"Irmin commits"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make (C: Type.S) (N: Type.S) = struct
+module Make (K: Type.S) = struct
 
-  type node = N.t
-  type commit = C.t
+  type node = K.t
+  type commit = K.t
 
   type t = {
-    node   : N.t;
-    parents: C.t list;
+    node   : K.t;
+    parents: K.t list;
     info   : Info.t;
   }
 
@@ -39,13 +39,13 @@ module Make (C: Type.S) (N: Type.S) = struct
   let t =
     let open Type in
     record "commit" (fun node parents info -> { node; parents; info })
-    |+ field "node"    N.t        (fun t -> t.node)
-    |+ field "parents" (list C.t) (fun t -> t.parents)
+    |+ field "node"    K.t        (fun t -> t.node)
+    |+ field "parents" (list K.t) (fun t -> t.parents)
     |+ field "info"    Info.t  (fun t -> t.info)
     |> sealr
 
-  let node_t = N.t
-  let commit_t = C.t
+  let node_t = K.t
+  let commit_t = K.t
 end
 
 module Store

--- a/src/irmin/commit.mli
+++ b/src/irmin/commit.mli
@@ -16,8 +16,8 @@
 
 (** Manage the database history. *)
 
-module Make (C: Type.S) (N: Type.S):
-  S.COMMIT with type commit = C.t and type node = N.t
+module Make (K: Type.S):
+  S.COMMIT with type commit = K.t and type node = K.t
 
 module Store
     (N: S.NODE_STORE)

--- a/src/irmin/commit.mli
+++ b/src/irmin/commit.mli
@@ -17,17 +17,16 @@
 (** Manage the database history. *)
 
 module Make (K: Type.S):
-  S.COMMIT with type commit = K.t and type node = K.t
+  S.COMMIT with type hash = K.t
 
 module Store
-    (N: S.NODE_STORE)
     (C: sig
        include S.CONTENT_ADDRESSABLE_STORE
        module Key: S.HASH with type t = key
        module Val: S.COMMIT with type t = value
-                             and type commit = key
-                             and type node = N.key
-     end):
+                             and type hash = key
+     end)
+     (N: S.NODE_STORE with type key = C.key):
   S.COMMIT_STORE
   with  type t = N.t * C.t
    and type key = C.key

--- a/src/irmin/commit.mli
+++ b/src/irmin/commit.mli
@@ -20,13 +20,13 @@ module Make (K: Type.S):
   S.COMMIT with type hash = K.t
 
 module Store
+    (N: S.NODE_STORE)
     (C: sig
-       include S.CONTENT_ADDRESSABLE_STORE
+       include S.CONTENT_ADDRESSABLE_STORE with type key = N.key
        module Key: S.HASH with type t = key
        module Val: S.COMMIT with type t = value
                              and type hash = key
-     end)
-     (N: S.NODE_STORE with type key = C.key):
+     end):
   S.COMMIT_STORE
   with  type t = N.t * C.t
    and type key = C.key

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -108,7 +108,7 @@ struct
         module Val = N
         include CA (Key)(Val)
       end
-      include Node.Store(P)(M)(CA)(Contents)
+      include Node.Store(Contents)(P)(M)(CA)
       let v = CA.v
     end
     module Commit = struct
@@ -117,7 +117,7 @@ struct
         module Val = CT
         include CA (Key)(Val)
       end
-      include Commit.Store(CA)(Node)
+      include Commit.Store(Node)(CA)
       let v = CA.v
     end
     module Branch = struct

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -88,8 +88,7 @@ module Make_ext
     (B: Branch.S)
     (H: Hash.S)
     (N: S.NODE with type metadata = M.t
-                and type contents = H.t
-                and type node = H.t
+                and type hash = H.t
                 and type step = P.step)
     (CT: S.COMMIT with type node = H.t and type commit = H.t)
 =
@@ -109,7 +108,7 @@ struct
         module Val = N
         include CA (Key)(Val)
       end
-      include Node.Store(Contents)(P)(M)(CA)
+      include Node.Store(P)(M)(CA)(Contents)
       let v = CA.v
     end
     module Commit = struct

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -90,7 +90,7 @@ module Make_ext
     (N: S.NODE with type metadata = M.t
                 and type hash = H.t
                 and type step = P.step)
-    (CT: S.COMMIT with type node = H.t and type commit = H.t)
+    (CT: S.COMMIT with type hash = H.t)
 =
 struct
 
@@ -117,7 +117,7 @@ struct
         module Val = CT
         include CA (Key)(Val)
       end
-      include Commit.Store(Node)(CA)
+      include Commit.Store(CA)(Node)
       let v = CA.v
     end
     module Branch = struct

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -163,7 +163,7 @@ module Make
     (B: S.BRANCH)
     (H: S.HASH) =
 struct
-  module N = Node.Make(H)(H)(P)(M)
+  module N = Node.Make(H)(P)(M)
   module CT = Commit.Make(H)(H)
   include Make_ext(CA)(AW)(M)(C)(P)(B)(H)(N)(CT)
 end

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -164,7 +164,7 @@ module Make
     (H: S.HASH) =
 struct
   module N = Node.Make(H)(P)(M)
-  module CT = Commit.Make(H)(H)
+  module CT = Commit.Make(H)
   include Make_ext(CA)(AW)(M)(C)(P)(B)(H)(N)(CT)
 end
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1752,8 +1752,8 @@ module Private: sig
 
     (** [Make] provides a simple implementation of commit values,
         parameterized by the commit [C] and node [N]. *)
-    module Make (C: Type.S) (N: Type.S):
-      S with type commit = C.t and type node = N.t
+    module Make (K: Type.S):
+      S with type commit = K.t and type node = K.t
 
     (** [STORE] specifies the signature for commit stores. *)
     module type STORE = sig

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1548,9 +1548,9 @@ module Private: sig
 
     (** [Node] provides a simple node implementation, parameterized by
         the contents [C], node [N], paths [P] and metadata [M]. *)
-    module Make (C: Type.S) (N: Type.S) (P: Path.S) (M: Metadata.S):
-      S with type contents = C.t
-         and type node = N.t
+    module Make (K: Type.S) (P: Path.S) (M: Metadata.S):
+      S with type contents = K.t
+         and type node = K.t
          and type step = P.step
          and type metadata = M.t
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1576,17 +1576,17 @@ module Private: sig
 
     (** [Store] creates node stores. *)
     module Store
+        (C: Contents.STORE)
         (P: Path.S)
         (M: Metadata.S)
         (S: sig
-           include CONTENT_ADDRESSABLE_STORE
+           include CONTENT_ADDRESSABLE_STORE with type key = C.key
            module Key: Hash.S with type t = key
            module Val: S with type t = value
                           and type hash = key
                           and type metadata = M.t
                           and type step = P.step
-         end)
-         (C: Contents.STORE with type key = S.key):
+         end):
       STORE with type t = C.t * S.t
              and type key = S.key
              and type value = S.value
@@ -1764,13 +1764,13 @@ module Private: sig
 
     (** [Store] creates a new commit store. *)
     module Store
+        (N: Node.STORE)
         (S: sig
-           include CONTENT_ADDRESSABLE_STORE
+           include CONTENT_ADDRESSABLE_STORE with type key = N.key
            module Key: Hash.S with type t = key
            module Val: S with type t = value
                           and type hash = key
-         end)
-         (N: Node.STORE with type key = S.key):
+         end):
       STORE with type t = N.t * S.t
              and type key = S.key
              and type value = S.value

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1541,7 +1541,7 @@ module Private: sig
     end
 
     (** [Node] provides a simple node implementation, parameterized by
-        the contents [C], node [N], paths [P] and metadata [M]. *)
+        the contents and notes keys [K], paths [P] and metadata [M]. *)
     module Make (K: Type.S) (P: Path.S) (M: Metadata.S):
       S with type hash = K.t
          and type step = P.step
@@ -1737,7 +1737,7 @@ module Private: sig
     end
 
     (** [Make] provides a simple implementation of commit values,
-        parameterized by the commit [C] and node [N]. *)
+        parameterized by the commit and node keys [K]. *)
     module Make (K: Type.S):
       S with type hash = K.t
 

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -111,41 +111,41 @@ struct
 end
 
 module Store
+    (C: S.CONTENTS_STORE)
     (P: S.PATH)
     (M: S.METADATA)
-    (CS: sig
-       include S.CONTENT_ADDRESSABLE_STORE
+    (S: sig
+       include S.CONTENT_ADDRESSABLE_STORE with type key = C.key
        module Key: S.HASH with type t = key
        module Val: S.NODE with type t = value
                            and type hash = key
                            and type metadata = M.t
                            and type step = P.step
-     end)
-    (C: S.CONTENTS_STORE with type key = CS.key) =
+     end) =
 struct
 
   module Contents = C
-  module Key = CS.Key
+  module Key = S.Key
   module Path = P
   module Metadata = M
 
-  type t = C.t * CS.t
-  type key = CS.key
-  type value = CS.value
+  type t = C.t * S.t
+  type key = S.key
+  type value = S.value
 
-  let mem (_, t) = CS.mem t
-  let find (_, t) = CS.find t
-  let add (_, t) = CS.add t
+  let mem (_, t) = S.mem t
+  let find (_, t) = S.find t
+  let add (_, t) = S.add t
 
   let all_contents t =
-    let kvs = CS.Val.list t in
+    let kvs = S.Val.list t in
     List.fold_left (fun acc -> function
         | k, `Contents c -> (k, c) :: acc
         | _ -> acc
       ) [] kvs
 
   let all_succ t =
-    let kvs = CS.Val.list t in
+    let kvs = S.Val.list t in
     List.fold_left (fun acc -> function
         | k, `Node n -> (k, n) :: acc
         | _ -> acc
@@ -178,38 +178,38 @@ struct
       (fun _step -> merge_contents_meta c)
 
   let merge_parents merge_key =
-    Merge.alist step_t CS.Key.t (fun _step -> merge_key)
+    Merge.alist step_t S.Key.t (fun _step -> merge_key)
 
   let merge_value (c, _) merge_key =
     let explode t = all_contents t, all_succ t in
     let implode (contents, succ) =
       let xs = List.map (fun (s, c) -> s, `Contents c) contents in
       let ys = List.map (fun (s, n) -> s, `Node n) succ in
-      CS.Val.v (xs @ ys)
+      S.Val.v (xs @ ys)
     in
     let merge =
       Merge.pair (merge_contents_meta c) (merge_parents merge_key)
     in
-    Merge.like CS.Val.t merge explode implode
+    Merge.like S.Val.t merge explode implode
 
   let rec merge t =
     let merge_key =
       Merge.v
-        (Type.option CS.Key.t)
+        (Type.option S.Key.t)
         (fun ~old x y -> Merge.(f (merge t)) ~old x y)
     in
     let merge = merge_value t merge_key in
     let read = function
-      | None   -> Lwt.return CS.Val.empty
-      | Some k -> find t k >|= function None -> CS.Val.empty | Some v -> v
+      | None   -> Lwt.return S.Val.empty
+      | Some k -> find t k >|= function None -> S.Val.empty | Some v -> v
     in
     let add v =
-      if CS.Val.is_empty v then Lwt.return_none
+      if S.Val.is_empty v then Lwt.return_none
       else add t v >>= fun k -> Lwt.return (Some k)
     in
-    Merge.like_lwt Type.(option CS.Key.t) merge read add
+    Merge.like_lwt Type.(option S.Key.t) merge read add
 
-  module Val = CS.Val
+  module Val = S.Val
 
 end
 

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -46,11 +46,11 @@ module No_metadata = struct
   let merge = Merge.v t (fun ~old:_ () () -> Merge.ok ())
 end
 
-module Make (K_c: Type.S) (K_n: Type.S) (P: S.PATH) (M: S.METADATA) =
+module Make (K: Type.S) (P: S.PATH) (M: S.METADATA) =
 struct
 
-  type contents = K_c.t
-  type node = K_n.t
+  type contents = K.t
+  type node = K.t
   type step = P.step
   type metadata = M.t
 
@@ -103,10 +103,10 @@ struct
     let map' = StepMap.remove k map in
     if map == map' then t else of_map map'
 
-  let value_t = node ~default:M.default K_c.t M.t K_n.t
+  let value_t = node ~default:M.default K.t M.t K.t
   let step_t = P.step_t
-  let node_t = K_n.t
-  let contents_t = K_c.t
+  let node_t = K.t
+  let contents_t = K.t
   let metadata_t = M.t
   let t = Type.like Type.(list (pair P.step_t value_t)) of_list list
 

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -26,17 +26,17 @@ module Make (K: Type.S) (P: S.PATH) (M: S.METADATA):
           and type metadata = M.t
 
 module Store
+    (C: S.CONTENTS_STORE)
     (P: S.PATH)
     (M: S.METADATA)
     (N: sig
-       include S.CONTENT_ADDRESSABLE_STORE
+       include S.CONTENT_ADDRESSABLE_STORE with type key = C.key
        module Key: S.HASH with type t = key
        module Val: S.NODE with type t = value
                            and type hash = key
                            and type metadata = M.t
                            and type step = P.step
-     end)
-     (C: S.CONTENTS_STORE with type key = N.key):
+     end):
   S.NODE_STORE with type t = C.t * N.t
                 and type key = N.key
                 and type value = N.value

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -20,9 +20,9 @@
 
 module No_metadata: S.METADATA with type t = unit
 
-module Make (C: Type.S) (N: Type.S) (P: S.PATH) (M: S.METADATA):
-  S.NODE with type contents = C.t
-          and type node = N.t
+module Make (K: Type.S) (P: S.PATH) (M: S.METADATA):
+  S.NODE with type contents = K.t
+          and type node = K.t
           and type step = P.step
           and type metadata = M.t
 

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -21,24 +21,22 @@
 module No_metadata: S.METADATA with type t = unit
 
 module Make (K: Type.S) (P: S.PATH) (M: S.METADATA):
-  S.NODE with type contents = K.t
-          and type node = K.t
+  S.NODE with type hash = K.t
           and type step = P.step
           and type metadata = M.t
 
 module Store
-    (C: S.CONTENTS_STORE)
     (P: S.PATH)
     (M: S.METADATA)
     (N: sig
        include S.CONTENT_ADDRESSABLE_STORE
        module Key: S.HASH with type t = key
        module Val: S.NODE with type t = value
-                           and type node = key
+                           and type hash = key
                            and type metadata = M.t
-                           and type contents = C.key
                            and type step = P.step
-     end):
+     end)
+     (C: S.CONTENTS_STORE with type key = N.key):
   S.NODE_STORE with type t = C.t * N.t
                 and type key = N.key
                 and type value = N.value

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -138,15 +138,13 @@ type 'a diff = 'a Diff.t
 
 module type COMMIT = sig
   type t
-  type commit
-  type node
-  val v: info:Info.t -> node:node -> parents:commit list -> t
-  val node: t -> node
-  val parents: t -> commit list
+  type hash
+  val v: info:Info.t -> node:hash -> parents:hash list -> t
+  val node: t -> hash
+  val parents: t -> hash list
   val info: t -> Info.t
   val t: t Type.t
-  val commit_t: commit Type.t
-  val node_t: node Type.t
+  val hash_t: hash Type.t
 end
 
 module type COMMIT_STORE = sig
@@ -155,8 +153,8 @@ module type COMMIT_STORE = sig
   module Key: HASH with type t = key
   module Val: COMMIT
     with type t = value
-     and type commit = key
-  module Node: NODE_STORE with type key = Val.node
+     and type hash = key
+  module Node: NODE_STORE with type key = Val.hash
 end
 
 module type COMMIT_HISTORY = sig
@@ -259,7 +257,7 @@ module type PRIVATE = sig
   module Node: NODE_STORE
     with type key = Hash.t and type Val.hash = Contents.key
   module Commit: COMMIT_STORE
-    with type key = Hash.t and type Val.node = Node.key
+    with type key = Hash.t and type Val.hash = Node.key
   module Branch: BRANCH_STORE
     with type value = Commit.key
   module Slice: SLICE

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -79,10 +79,9 @@ end
 module type NODE = sig
   type t
   type metadata
-  type contents
-  type node
+  type hash
   type step
-  type value = [ `Node of node | `Contents of contents * metadata ]
+  type value = [ `Node of hash | `Contents of hash * metadata ]
   val v: (step * value) list -> t
   val list: t -> (step * value) list
   val empty: t
@@ -92,8 +91,7 @@ module type NODE = sig
   val remove: t -> step -> t
   val t: t Type.t
   val metadata_t: metadata Type.t
-  val contents_t: contents Type.t
-  val node_t: node Type.t
+  val hash_t: hash Type.t
   val step_t: step Type.t
   val value_t: value Type.t
 end
@@ -129,10 +127,10 @@ module type NODE_STORE = sig
   module Metadata: METADATA
   module Val: NODE
     with type t = value
-     and type node = key
+     and type hash = key
      and type metadata = Metadata.t
      and type step = Path.step
-  module Contents: CONTENTS_STORE with type key = Val.contents
+  module Contents: CONTENTS_STORE with type key = Val.hash
 end
 
 type config = Conf.t
@@ -259,7 +257,7 @@ module type PRIVATE = sig
   module Contents: CONTENTS_STORE
     with type key = Hash.t
   module Node: NODE_STORE
-    with type key = Hash.t and type Val.contents = Contents.key
+    with type key = Hash.t and type Val.hash = Contents.key
   module Commit: COMMIT_STORE
     with type key = Hash.t and type Val.node = Node.key
   module Branch: BRANCH_STORE


### PR DESCRIPTION
The motivation for this PR is that all calls to `Commit.Make` (resp. `Node.Make`) in this repository are using the same value for commit (`C`) and node (`N`) (resp. node (`N`) and contents (`C`)) values.
This PR hence proposes to merge these values. This involves public API changes.

1.  At the `Make` functor level, have only one key argument for both commits/nodes (resp nodes/contents).
2. In the type itself, merging the two types into a `type hash`.

Of course, `1` is doable without `2` to still allow implementations with different key types.
