### PR TITLE
backends: distinguish between read and writes operations

### DIFF
--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -122,9 +122,9 @@ struct
   type key = CA.key
   type value = V.t
 
-  type t = {
+  type 'a t = {
     chunking    : [`Max | `Best_fit];
-    db          : CA.t;             (* An handler to the underlying database. *)
+    db          : 'a CA.t;          (* An handler to the underlying database. *)
     chunk_size  : int;                                 (* the size of chunks. *)
     max_children: int;     (* the maximum number of children a node can have. *)
     max_data    : int; (* the maximum length (in bytes) of data stored in one
@@ -204,6 +204,8 @@ struct
            chunk_size K.digest_size max_data max_children);
     CA.v config >|= fun db ->
     { chunking; db; chunk_size; max_children; max_data }
+
+  let batch t f = CA.batch t.db (fun db -> f { t with db })
 
   let find_leaves t key =
     AO.find t.db key >>= function

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -56,7 +56,7 @@ struct
 
   type value = V.t
 
-  type t = {
+  type 'a t = {
     path: string;
   }
 
@@ -68,6 +68,9 @@ struct
     let path = get_path config in
     IO.mkdir path >|= fun () ->
     { path }
+
+  let cast t = (t :> [`Read | `Write] t)
+  let batch t f = f (cast t)
 
   let file_of_key { path; _ } key =
     path / S.file_of_key (Irmin.Type.to_string K.t key)
@@ -149,7 +152,7 @@ struct
   module RO = Read_only_ext(IO)(S)(K)(V)
   module W = Irmin.Private.Watch.Make(K)(V)
 
-  type t = { t: RO.t; w: W.t }
+  type t = { t: unit RO.t; w: W.t }
   type key = RO.key
   type value = RO.value
   type watch = W.watch * (unit -> unit Lwt.t)

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -101,7 +101,7 @@ module Make_private
 
   module Content_addressable (V: V) = struct
 
-    type t = G.t
+    type 'a t = G.t
     type key = H.t
     type value = V.t
 
@@ -847,6 +847,8 @@ module Make_ext
       let node_t t = contents_t t, t.g
       let commit_t t = node_t t, t.g
 
+      let batch t f = f (contents_t t) (node_t t) (commit_t t)
+
       type config = {
         root   : string;
         dot_git: string option;
@@ -984,7 +986,7 @@ module Content_addressable (G: Git.S) (V: Irmin.Type.S) = struct
   let state t =
     M.repo_of_git t >|= fun r ->
     M.Private.Repo.contents_t r
-  type t = G.t
+  type 'a t = G.t
   type key = X.key
   type value = X.value
   let with_state f t x = state t >>= fun t -> f t x

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -33,7 +33,7 @@ val dot_git: string option Irmin.Private.Conf.key
 
 module Content_addressable (G: Git.S) (V: Irmin.Type.S)
   : Irmin.CONTENT_ADDRESSABLE_STORE
-    with type t = G.t
+    with type 'a t = G.t
      and type key = G.Hash.t
      and type value = V.t
 

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -28,9 +28,12 @@ module Read_only (K: Irmin.Type.S) (V: Irmin.Type.S) = struct
 
   type key = K.t
   type value = V.t
-  type t = { mutable t: value KMap.t }
+  type 'a t = { mutable t: value KMap.t }
   let map = { t = KMap.empty }
   let v _config = Lwt.return map
+
+  let cast t = (t :> [`Read | `Write] t)
+  let batch t f = f (cast t)
 
   let pp_key = Irmin.Type.pp K.t
 
@@ -62,7 +65,7 @@ module Atomic_write (K: Irmin.Type.S) (V: Irmin.Type.S) = struct
   module W = Irmin.Private.Watch.Make(K)(V)
   module L = Irmin.Private.Lock.Make(K)
 
-  type t = { t: RO.t; w: W.t; lock: L.t }
+  type t = { t: unit RO.t; w: W.t; lock: L.t }
   type key = RO.key
   type value = RO.value
   type watch = W.watch

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -60,14 +60,15 @@ module Store
 = struct
 
   module Node = N
-  type t = N.t * S.t
+
+  type 'a t = 'a N.t * 'a S.t
   type key = S.key
   type value = S.value
 
   let add (_, t) = S.add t
   let mem (_, t) = S.mem t
   let find (_, t) = S.find t
-  let merge_node (n, _) = Merge.f (N.merge n)
+  let merge_node (t, _) = Merge.f (N.merge t)
 
   let pp_key = Type.pp S.Key.t
 
@@ -128,8 +129,7 @@ module History (S: S.COMMIT_STORE) = struct
 
   type commit = S.key
   type node = S.Node.key
-
-  type t = S.t
+  type 'a t = 'a S.t
   type v = S.Val.t
 
   let commit_t = S.Key.t

--- a/src/irmin/commit.mli
+++ b/src/irmin/commit.mli
@@ -29,14 +29,14 @@ module Store
                              and type node = N.key
      end):
   S.COMMIT_STORE
-  with  type t = N.t * C.t
+  with type 'a t = 'a N.t * 'a C.t
    and type key = C.key
    and type value = C.value
    and module Key = C.Key
    and module Val = C.Val
 
 module History (C: S.COMMIT_STORE):
-  S.COMMIT_HISTORY with type t = C.t
+  S.COMMIT_HISTORY with type 'a t = 'a C.t
                     and type v = C.Val.t
                     and type node = C.Node.key
                     and type commit = C.key

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -46,6 +46,6 @@ module Store
        module Val: S.CONTENTS with type t = value
      end):
   S.CONTENTS_STORE
-  with type t = C.t
+  with type 'a t = 'a C.t
    and type key = C.key
    and type value = C.value

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -132,7 +132,7 @@ struct
   module Path = P
   module Metadata = M
 
-  type t = C.t * S.t
+  type 'a t = 'a C.t * 'a S.t
   type key = S.key
   type value = S.value
 
@@ -227,7 +227,7 @@ module Graph (S: S.NODE_STORE) = struct
   type contents = Contents.t
   type node = S.key
   type path = Path.t
-  type t = S.t
+  type 'a t = 'a S.t
 
   type value = [ `Contents of contents * metadata | `Node of node ]
 

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -39,7 +39,7 @@ module Store
                            and type contents = C.key
                            and type step = P.step
      end):
-  S.NODE_STORE with type t = C.t * N.t
+  S.NODE_STORE with type 'a t = 'a C.t * 'a N.t
                 and type key = N.key
                 and type value = N.value
                 and module Path = P
@@ -48,7 +48,7 @@ module Store
                 and module Val = N.Val
 
 module Graph (N: S.NODE_STORE):
-  S.NODE_GRAPH with type t = N.t
+  S.NODE_GRAPH with type 'a t = 'a N.t
                 and type contents = N.Contents.key
                 and type metadata = N.Val.metadata
                 and type node = N.key

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -787,8 +787,8 @@ module Make (P: S.PRIVATE) = struct
 
   let import repo k = Node.of_key repo k
 
-  let export repo n =
-    let node n = P.Node.add (P.Repo.node_t repo) (Node.export_map n) in
+  let export repo contents_t node_t n =
+    let node n = P.Node.add node_t (Node.export_map n) in
     let todo = Stack.create () in
     let rec add_to_todo n =
       match n.Node.v with
@@ -822,7 +822,7 @@ module Make (P: S.PRIVATE) = struct
             | Contents.Key _       -> ()
             | Contents.Contents x  ->
               Stack.push (fun () ->
-                  P.Contents.add (P.Repo.contents_t repo) x >|= fun k ->
+                  P.Contents.add contents_t x >|= fun k ->
                   c.Contents.v <- Contents.Both (repo, k, x);
                 ) todo
           ) !contents;

--- a/src/irmin/tree.mli
+++ b/src/irmin/tree.mli
@@ -22,7 +22,8 @@ module Make (P: S.PRIVATE): sig
                   and type contents = P.Contents.value
 
   val import: P.Repo.t -> P.Node.key -> node
-  val export: P.Repo.t -> node -> P.Node.key Lwt.t
+  val export: P.Repo.t -> [> `Write] P.Contents.t -> [> `Write] P.Node.t ->
+    node -> P.Node.key Lwt.t
   val dump: tree Fmt.t
   val equal: tree -> tree -> bool
   val node_t: node Type.t

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -29,11 +29,11 @@ let run f () =
   flush stdout
 
 let test_add_read ?(stable=false) (module AO: Test_chunk.S) () =
-  AO.create () >>= fun t ->
+  AO.v () >>= fun t ->
   let test size =
     let name = Printf.sprintf "size %d" size in
     let v = String.make size 'x' in
-    AO.add t v  >>= fun k ->
+    AO.batch t (fun t -> AO.add t v) >>= fun k ->
     if stable then (
       let str = Irmin.Type.encode_bin Test_chunk.Value.t v in
       Alcotest.(check key_t) (name ^ " is stable") k (Test_chunk.Key.digest str)

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -34,7 +34,8 @@ end
 module type S = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
     with type key = Key.t and type value = Value.t
-  val create: unit -> t Lwt.t
+  val v: unit -> [`Read] t Lwt.t
+  val batch: [`Read] t -> ([`Read|`Write] t -> 'a Lwt.t) -> 'a Lwt.t
 end
 
 module Append_only = Irmin_mem.Append_only
@@ -42,13 +43,13 @@ module Content_addressable = Irmin.Content_addressable(Append_only)
 
 module Mem = struct
   include Content_addressable(Key)(Value)
-  let create () = v @@ Irmin_mem.config ()
+  let v () = v @@ Irmin_mem.config ()
 end
 
 module MemChunk = struct
   include Content_addressable(Key)(Value)
   let small_config = Irmin_chunk.config ~min_size:44 ~size:44 ()
-  let create () = v small_config
+  let v () = v small_config
 end
 
 let init () =


### PR DESCRIPTION
This allows the backends to batch multiple writes.