### PR TITLE
Irmin.Type: split the binary encoders/decoders into low-level and hig…

### DIFF
--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -98,9 +98,9 @@ module Chunk (K: Irmin.Hash.S) = struct
 
   let of_string b =
     let len = String.length b in
-    match Irmin.Type.of_bin_string ~exact:false v b with
-    | Error (`Msg e) -> invalid_arg e
-    | Ok v -> { len; v }
+    let n, v = Irmin.Type.decode_bin v b 0 in
+    if len=n then { len; v }
+    else Fmt.invalid_arg "invalid length: got %d, expecting %d" n len
 
   let to_string t =
     let buf = Bytes.make t.len '\000' in

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -98,13 +98,14 @@ module Chunk (K: Irmin.Hash.S) = struct
 
   let of_string b =
     let len = String.length b in
-    match Irmin.Type.decode_bin ~exact:false v b with
+    match Irmin.Type.of_bin_string ~exact:false v b with
     | Error (`Msg e) -> invalid_arg e
     | Ok v -> { len; v }
 
   let to_string t =
-    let buf = Bytes.make t.len '\000', 0 in
-    Irmin.Type.encode_bin ~buf v t.v
+    let buf = Bytes.make t.len '\000' in
+    let (_:int) = Irmin.Type.encode_bin v buf 0 t.v in
+    Bytes.unsafe_to_string buf
 
   let t = Irmin.Type.(like_map string) of_string to_string
 
@@ -224,7 +225,7 @@ struct
     find_leaves t key >>= fun bufs ->
     let buf = String.concat "" bufs in
     check_hash key buf >|= fun () ->
-    match Irmin.Type.decode_bin V.t buf with
+    match Irmin.Type.of_bin_string V.t buf with
     |Ok va   -> Some va
     |Error _ -> None
 
@@ -238,7 +239,7 @@ struct
   let pp_key = Irmin.Type.pp K.t
 
   let add t v =
-    let buf = Irmin.Type.encode_bin V.t v in
+    let buf = Irmin.Type.to_bin_string V.t v in
     let key = K.digest buf in
     let len = String.length buf in
     if len <= t.max_data then (

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -83,7 +83,7 @@ struct
     IO.file_exists file
 
   let value v =
-    match Irmin.Type.decode_bin V.t v with
+    match Irmin.Type.of_bin_string V.t v with
     | Ok v           -> Some v
     | Error (`Msg e) ->
       Log.err (fun l -> l "Irmin_fs.value %s" e);
@@ -137,7 +137,7 @@ struct
     IO.file_exists file >>= function
     | true  -> Lwt.return_unit
     | false ->
-      let str = Irmin.Type.encode_bin V.t value in
+      let str = Irmin.Type.to_bin_string V.t value in
       IO.write_file ~temp_dir file str
 
 end
@@ -207,7 +207,7 @@ struct
     stop () >>= fun () ->
     W.unwatch t.w id
 
-  let raw_value v = Irmin.Type.encode_bin V.t v
+  let raw_value v = Irmin.Type.to_bin_string V.t v
 
   let set t key value =
     Log.debug (fun f -> f "update %a" RO.pp_key key);

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -160,7 +160,7 @@ module Make_private
       include C
 
       let to_bin t =
-        let blob = G.Value.Blob.of_string (Irmin.Type.encode_bin C.t t) in
+        let blob = G.Value.Blob.of_string (Irmin.Type.to_bin_string C.t t) in
         match Raw.to_raw (G.Value.blob blob) with
         | Error _ -> assert false
         | Ok s    -> s
@@ -177,7 +177,7 @@ module Make_private
         let buf = Cstruct.of_string buf in
         let buf = Cstruct.shift buf off in
         let blob t =
-          match Irmin.Type.decode_bin C.t (G.Value.Blob.to_string t) with
+          match Irmin.Type.of_bin_string C.t (G.Value.Blob.to_string t) with
           | Ok t -> t
           | Error (`Msg e) -> Fmt.failwith "cannot read blob: %s" e
         in

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -1082,7 +1082,7 @@ module Generic
       (S.Private.Contents.Val)
       (S.Private.Node.Path)
       (S.Branch)
-      (S.Private.Contents.Key)
+      (S.Private.Hash)
       (S.Private.Node.Val)
       (S.Private.Commit.Val)
 end

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -118,7 +118,7 @@ module Store
 
   let merge t ~info = Merge.(option (v S.Key.t (merge_commit info t)))
 
-  module Key = S.Key
+  module Key = Hash.With_digest(S.Key)(S.Val)
   module Val = S.Val
 end
 

--- a/src/irmin/commit.mli
+++ b/src/irmin/commit.mli
@@ -31,7 +31,7 @@ module Store
   with type 'a t = 'a N.t * 'a C.t
    and type key = C.key
    and type value = C.value
-   and module Key = C.Key
+   and type Key.t = C.Key.t
    and module Val = C.Val
 
 module History (C: S.COMMIT_STORE):

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -265,6 +265,8 @@ module Bytes = struct
   let merge = Merge.idempotent Type.(option t)
 end
 
+module type STORE = S.CONTENTS_STORE
+
 module Store
     (S: sig
        include S.CONTENT_ADDRESSABLE_STORE
@@ -272,7 +274,17 @@ module Store
        module Val: S.CONTENTS with type t = value
      end) =
 struct
-  include S
+
+  module Key = Hash.With_digest(S.Key)(S.Val)
+  module Val = S.Val
+
+  type 'a t = 'a S.t
+  type key = S.key
+  type value = S.value
+
+  let find = S.find
+  let add = S.add
+  let mem = S.mem
 
   let read_opt t = function
     | None   -> Lwt.return_none

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -44,3 +44,8 @@ module SHA384 = Make(Digestif.SHA384)
 module SHA512 = Make(Digestif.SHA512)
 module BLAKE2B = Make(Digestif.BLAKE2B)
 module BLAKE2S = Make(Digestif.BLAKE2S)
+
+module With_digest (K: S.HASH) (V: Type.S) = struct
+  include K
+  let digest v = K.digest (Type.to_bin_string V.t v)
+end

--- a/src/irmin/hash.mli
+++ b/src/irmin/hash.mli
@@ -26,3 +26,8 @@ module SHA384: S.HASH
 module SHA512: S.HASH
 module BLAKE2B: S.HASH
 module BLAKE2S: S.HASH
+
+module With_digest (K: S.HASH) (V: Type.S): sig
+  include S.HASH with type t = K.t
+  val digest: V.t -> t
+end

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -65,7 +65,7 @@ struct
 
   let pp_key = Type.pp K.t
 
-  let digest v = K.digest (Type.encode_bin V.t v)
+  let digest v = K.digest (Type.to_bin_string V.t v)
 
   let find t k =
     find t k >>= function
@@ -108,10 +108,10 @@ struct
       type 'a t = 'a Values.t
       type key = Key.t
       type value = V.t
-      let add t v = Values.add t (Type.encode_bin V.t v)
+      let add t v = Values.add t (Type.to_bin_string V.t v)
       let find t k = Values.find t k >|= function
         | None -> None
-        | Some v -> match Type.decode_bin V.t v with
+        | Some v -> match Type.of_bin_string V.t v with
           | Ok v -> Some v
           | _ -> None
       let mem t k =

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1152,7 +1152,10 @@ module Contents: sig
 
         If any of these operations fail, return [`Conflict]. *)
 
-    module Key: Hash.S with type t = key
+    module Key: sig
+      include Hash.S with type t = key
+      val digest: value -> key
+    end
     (** [Key] provides base functions for user-defined contents keys. *)
 
     module Val: S with type t = value
@@ -1562,7 +1565,10 @@ module Private: sig
       val merge: [`Read | `Write] t -> key option Merge.t
       (** [merge] is the 3-way merge function for nodes keys. *)
 
-      module Key: Hash.S with type t = key
+      module Key: sig
+        include Hash.S with type t = key
+        val digest: value -> key
+      end
       (** [Key] provides base functions for node keys. *)
 
       module Metadata: Metadata.S
@@ -1596,7 +1602,7 @@ module Private: sig
              and type value = S.value
              and module Path = P
              and module Metadata = M
-             and module Key = S.Key
+             and type Key.t = S.Key.t
              and module Val = S.Val
 
 
@@ -1755,7 +1761,10 @@ module Private: sig
       val merge: [`Read | `Write] t -> info:Info.f -> key option Merge.t
       (** [merge] is the 3-way merge function for commit keys. *)
 
-      module Key: Hash.S with type t = key
+      module Key: sig
+        include Hash.S with type t = key
+        val digest: value -> key
+      end
       (** [Key] provides base functions for commit keys. *)
 
       (** [Val] provides functions for commit values. *)
@@ -1778,7 +1787,7 @@ module Private: sig
       STORE with type 'a t = 'a N.t * 'a S.t
              and type key = S.key
              and type value = S.value
-             and module Key = S.Key
+             and type Key.t = S.Key.t
              and module Val = S.Val
 
     (** [History] specifies the signature for commit history. The

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -441,20 +441,19 @@ module Type: sig
   (** [decode_bin t] is the binary decoder for values of type [t]. *)
 
   val to_bin_string: 'a t -> 'a -> string
-  (** [to_bin_string t x] use {!encode_bin} to convert [x] to a string.
+  (** [to_bin_string t x] use {!encode_bin} to convert [x], of type
+     [t], to a string.
 
-      {b NOTE:} When the parameter [t] is a single buffer (of type
-      [bytes] or [string]) the original buffer is returned without
-      being copied. *)
+      {b NOTE:} When [t] is {!Type.string} or {!Type.bytes}, the
+     original buffer [x] is not prefixed by its size as {!encode_bin}
+     would do. If [t] is {!Type.string}, the result is [x] (without
+     copy). *)
 
-  val of_bin_string: ?exact:bool -> ?off:int -> ?len:int -> 'a t ->
-    string -> ('a, [`Msg of string]) result
-  (** [decode_bin t buf] decodes values of type [t] as produced by
-      [to_bin_string t v].
+  val of_bin_string:'a t -> string -> ('a, [`Msg of string]) result
+  (** [of_bin_string t s] is [v] such that [s = to_bin_string t v].
 
-      {b NOTE:} When the parameter [t] is a single buffer (of type
-      [bytes] or [string]) the original buffer is returned without
-      being copied. *)
+      {b NOTE:} When [t] is {!Type.string}, the result is [x] (without
+     copy). *)
 
   val size_of: 'a t -> 'a -> [`Size of int | `Buffer of string]
   (** [size_of t x] is either the size of [encode_bin t x] or the

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -434,19 +434,23 @@ module Type: sig
   type 'a size_of = 'a -> [`Size of int | `Buffer of string]
     (** The type for size function related to binary encoder/decoders. *)
 
-  val encode_bin: ?buf:(bytes * int) -> 'a t -> 'a -> string
-  (** [encode_bin t e] encodes [t] into a [string] buffer. The size
-     of the returned buffer is precomputed and the buffer is allocated
-     at once or it can be passed using the optional argument [buf].
+  val encode_bin: 'a t -> 'a encode_bin
+  (** [encode_bin t] is the binary encoder for values of type [t]. *)
 
-      {b NOTE:} There is a special case when the parameter [t] is a
-     single buffer (of type [bytes] or [string]): the original value
-     is returned as is, without being copied. *)
+  val decode_bin: 'a t -> 'a decode_bin
+  (** [decode_bin t] is the binary decoder for values of type [t]. *)
 
-  val decode_bin: ?exact:bool -> ?off:int -> 'a t ->
+  val to_bin_string: 'a t -> 'a -> string
+  (** [to_bin_string t x] use {!encode_bin} to convert [x] to a string.
+
+      {b NOTE:} When the parameter [t] is a single buffer (of type
+      [bytes] or [string]) the original buffer is returned without
+      being copied. *)
+
+  val of_bin_string: ?exact:bool -> ?off:int -> ?len:int -> 'a t ->
     string -> ('a, [`Msg of string]) result
   (** [decode_bin t buf] decodes values of type [t] as produced by
-      [encode_string t v].
+      [to_bin_string t v].
 
       {b NOTE:} When the parameter [t] is a single buffer (of type
       [bytes] or [string]) the original buffer is returned without

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -2961,6 +2961,14 @@ module type S = sig
   type remote += E of Private.Sync.endpoint
   (** Extend the [remote] type with [endpoint]. *)
 
+  (** Converters to private types. *)
+
+  val to_private_node: node -> Private.Node.value option Lwt.t
+  val of_private_node: repo -> Private.Node.value -> node
+
+  val to_private_commit: commit -> Private.Commit.value
+  val of_private_commit: repo -> Private.Commit.value -> commit
+
 end
 
 (** [Json_tree] is used to project JSON values onto trees. Instead of the entire object being stored under one key, it
@@ -3002,9 +3010,9 @@ module type S_MAKER = functor
      and type contents = C.t
      and type branch = B.t
      and type hash = H.t
-
 (** [KV] is similar to {!S} but choose sensible implementations for
     path and branch. *)
+
 module type KV =
   S with type key = string list
      and type step = string

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -125,7 +125,7 @@ module Store
 struct
 
   module Contents = C
-  module Key = S.Key
+  module Key = Hash.With_digest(S.Key)(S.Val)
   module Path = P
   module Metadata = M
 

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -42,7 +42,7 @@ module Store
                 and type value = N.value
                 and module Path = P
                 and module Metadata = M
-                and module Key = N.Key
+                and type Key.t = N.key
                 and module Val = N.Val
 
 module Graph (N: S.NODE_STORE):

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -619,6 +619,12 @@ module type STORE = sig
   end
 
   type remote += E of Private.Sync.endpoint
+
+  val to_private_node: node -> Private.Node.value option Lwt.t
+  val of_private_node: repo -> Private.Node.value -> node
+
+  val to_private_commit: commit -> Private.Commit.value
+  val of_private_commit: repo -> Private.Commit.value -> commit
 end
 
 module type MAKER =

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -69,7 +69,10 @@ end
 module type CONTENTS_STORE = sig
   include CONTENT_ADDRESSABLE_STORE
   val merge: [`Read | `Write] t -> key option Merge.t
-  module Key: HASH with type t = key
+  module Key: sig
+    include HASH with type t = key
+    val digest: value -> t
+  end
   module Val: CONTENTS with type t = value
 end
 
@@ -120,7 +123,10 @@ module type NODE_STORE = sig
   include CONTENT_ADDRESSABLE_STORE
   module Path: PATH
   val merge: [`Read | `Write] t -> key option Merge.t
-  module Key: HASH with type t = key
+  module Key: sig
+    include HASH with type t = key
+    val digest: value -> t
+  end
   module Metadata: METADATA
   module Val: NODE
     with type t = value
@@ -147,7 +153,10 @@ end
 module type COMMIT_STORE = sig
   include CONTENT_ADDRESSABLE_STORE
   val merge: [`Read| `Write] t -> info:Info.f -> key option Merge.t
-  module Key: HASH with type t = key
+  module Key: sig
+    include HASH with type t = key
+    val digest: value -> t
+  end
   module Val: COMMIT
     with type t = value
      and type hash = key

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -91,6 +91,7 @@ module Make (P: S.PRIVATE) = struct
     let equal x y = Type.equal Hash.t x.h y.h
     let hash t = t.h
     let info t = P.Commit.Val.info t.v
+    let pp_hash ppf t = Type.pp Hash.t ppf t.h
 
     let of_hash r h =
       P.Commit.find (P.Repo.commit_t r) h >|= function
@@ -100,7 +101,11 @@ module Make (P: S.PRIVATE) = struct
     let parents t =
       Lwt_list.filter_map_p (of_hash t.r) (P.Commit.Val.parents t.v)
 
-    let pp_hash ppf t = Type.pp Hash.t ppf t.h
+    let to_private_commit t = t.v
+
+    let of_private_commit r v =
+      let h = P.Commit.Key.digest v in
+      { r; h; v }
 
     let equal_opt x y =
       match x, y with
@@ -111,6 +116,12 @@ module Make (P: S.PRIVATE) = struct
   end
 
   type commit = Commit.t
+
+  let to_private_node = Tree.to_private_node
+  let of_private_node = Tree.of_private_node
+
+  let to_private_commit = Commit.to_private_commit
+  let of_private_commit = Commit.of_private_commit
 
   type head_ref = [ `Branch of branch | `Head of commit option ref ]
 

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -43,7 +43,7 @@ module Make (P: S.PRIVATE) = struct
     include P.Contents.Val
     let of_hash r h = P.Contents.find (P.Repo.contents_t r) h
     let hash c =
-      let s = Type.encode_bin P.Contents.Val.t c in
+      let s = Type.to_bin_string P.Contents.Val.t c in
       P.Hash.digest s
   end
 

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -42,9 +42,7 @@ module Make (P: S.PRIVATE) = struct
   module Contents = struct
     include P.Contents.Val
     let of_hash r h = P.Contents.find (P.Repo.contents_t r) h
-    let hash c =
-      let s = Type.to_bin_string P.Contents.Val.t c in
-      P.Hash.digest s
+    let hash c = P.Contents.Key.digest c
   end
 
   module Tree = struct

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -31,8 +31,8 @@ module Make (S: S.STORE) = struct
   type commit = S.commit
 
   let conv dx dy x =
-    let str = Type.encode_bin dx x in
-    Type.decode_bin dy str
+    let str = Type.to_bin_string dx x in
+    Type.of_bin_string dy str
 
   let convert_slice (type r) (type s)
       (module RP: PRIVATE with type Slice.t = r)

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -101,7 +101,7 @@ module Make (P: S.PRIVATE) = struct
 
     let key c = match c.v with
       | Both (_, k, _) | Key (_, k) -> k
-      | Contents v -> P.Hash.digest (Type.encode_bin P.Contents.Val.t v)
+      | Contents v -> P.Hash.digest (Type.to_bin_string P.Contents.Val.t v)
 
     let v t = match t.v with
       | Both (_, _, c)
@@ -237,7 +237,7 @@ module Make (P: S.PRIVATE) = struct
 
     and key_of_map map =
       let v = export_map map in
-      P.Hash.digest (Type.encode_bin P.Node.Val.t v)
+      P.Hash.digest (Type.to_bin_string P.Node.Val.t v)
 
     let to_map t = match t.v with
       | Map m | Both (_, _, m) -> Lwt.return (Some m)
@@ -1026,6 +1026,6 @@ module Make (P: S.PRIVATE) = struct
   let hash (t:tree) = match t with
     | `Node n -> `Node (Node.key n)
     | `Contents (c, m) ->
-      let str = Type.encode_bin P.Contents.Val.t c in
+      let str = Type.to_bin_string P.Contents.Val.t c in
       `Contents (P.Hash.digest str, m)
 end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -101,7 +101,7 @@ module Make (P: S.PRIVATE) = struct
 
     let key c = match c.v with
       | Both (_, k, _) | Key (_, k) -> k
-      | Contents v -> P.Hash.digest (Type.to_bin_string P.Contents.Val.t v)
+      | Contents v -> P.Contents.Key.digest v
 
     let v t = match t.v with
       | Both (_, _, c)
@@ -236,8 +236,7 @@ module Make (P: S.PRIVATE) = struct
       P.Node.Val.v alist
 
     and key_of_map map =
-      let v = export_map map in
-      P.Hash.digest (Type.to_bin_string P.Node.Val.t v)
+      P.Node.Key.digest (export_map map)
 
     let to_map t = match t.v with
       | Map m | Both (_, _, m) -> Lwt.return (Some m)
@@ -1025,7 +1024,5 @@ module Make (P: S.PRIVATE) = struct
 
   let hash (t:tree) = match t with
     | `Node n -> `Node (Node.key n)
-    | `Contents (c, m) ->
-      let str = Type.to_bin_string P.Contents.Val.t c in
-      `Contents (P.Hash.digest str, m)
+    | `Contents (c, m) -> `Contents (P.Contents.Key.digest c, m)
 end

--- a/src/irmin/tree.mli
+++ b/src/irmin/tree.mli
@@ -29,4 +29,6 @@ module Make (P: S.PRIVATE): sig
   val node_t: node Type.t
   val tree_t: tree Type.t
   val hash: tree -> [`Contents of (P.Hash.t * metadata) | `Node of P.Hash.t]
+  val of_private_node: P.Repo.t -> P.Node.value -> node
+  val to_private_node: node -> P.Node.value option Lwt.t
 end

--- a/src/irmin/type.ml
+++ b/src/irmin/type.ml
@@ -1361,31 +1361,17 @@ let decode_bin t buf off =
   in
   aux t buf
 
-let of_bin_string ?(exact=true) ?(off=0) ?len t x =
-  let return length sub x =
-    let n = length x in
-    let len = match len with
-      | None   -> n - off
-      | Some n -> n
-    in
-    if off+len > n && exact then Error (`Msg "not enough input")
-    else if off = 0 && len = n then Ok x
-    else
-      let len = min len (n - off) in
-      Ok (sub x off len)
-  in
-  let return_string = return String.length String.sub in
-  let return_bytes = return Bytes.length Bytes.sub in
+let of_bin_string t x =
   let rec aux
     : type a. a t -> string -> (a, [`Msg of string]) result
     = fun t x -> match t with
       | Like l when l.decode_bin = None -> aux l.x x |> map_result l.f
       | Self s          -> aux s.self x
-      | Prim (String _) -> return_string x
-      | Prim (Bytes _)  -> return_bytes (Bytes.of_string x)
+      | Prim (String _) -> Ok x
+      | Prim (Bytes _)  -> Ok (Bytes.of_string x)
       | _ ->
-        let last, v = Decode_bin.t t x off in
-        if exact then assert (last = String.length x);
+        let last, v = Decode_bin.t t x 0 in
+        assert (last = String.length x);
         Ok v
   in
   try aux t x

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -137,7 +137,7 @@ val encode_bin: 'a t -> 'a encode_bin
 val to_bin_string: 'a t -> 'a to_string
 
 val decode_bin: 'a t -> 'a decode_bin
-val of_bin_string: ?exact:bool -> ?off:int -> ?len:int -> 'a t -> 'a of_string
+val of_bin_string: 'a t -> 'a of_string
 
 type 'a ty = 'a t
 

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -133,8 +133,11 @@ val decode_json_lexemes: 'a t -> Jsonm.lexeme list -> ('a, [`Msg of string]) res
 val to_json_string: ?minify:bool -> 'a t -> 'a to_string
 val of_json_string: 'a t -> 'a of_string
 
-val encode_bin: ?buf:(bytes * int) -> 'a t -> 'a to_string
-val decode_bin: ?exact:bool -> ?off:int -> 'a t -> 'a of_string
+val encode_bin: 'a t -> 'a encode_bin
+val to_bin_string: 'a t -> 'a to_string
+
+val decode_bin: 'a t -> 'a decode_bin
+val of_bin_string: ?exact:bool -> ?off:int -> ?len:int -> 'a t -> 'a of_string
 
 type 'a ty = 'a t
 

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -35,7 +35,7 @@ let test_add_read ?(stable=false) (module AO: Test_chunk.S) () =
     let v = String.make size 'x' in
     AO.batch t (fun t -> AO.add t v) >>= fun k ->
     if stable then (
-      let str = Irmin.Type.encode_bin Test_chunk.Value.t v in
+      let str = Irmin.Type.to_bin_string Test_chunk.Value.t v in
       Alcotest.(check key_t) (name ^ " is stable") k (Test_chunk.Key.digest str)
     );
     AO.find t k >|= fun v' ->


### PR DESCRIPTION
…h-level bits, as requested on https://github.com/mirage/irmin/pull/619#discussion_r258448889

/cc @hannesm 

I have a subsequent PR to simplify most of the use of that function anyway, I'll push it in a separate branch.