### PR TITLE
irmin-graphql depends on graphql_parser.0.11.0

### DIFF
--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -21,6 +21,7 @@ depends: [
   "graphql-lwt" {>= "0.9"}
   "graphql-cohttp" {>= "0.10"}
   "cohttp-lwt"
+  "graphql_parser" {>= "0.11"}
 ]
 
 


### PR DESCRIPTION
`graphql_parser.0.11.0` replaces the dependency on `Str` with `Re`, which makes it Mirage-friendly.  See https://github.com/mirage/irmin/issues/632