### PR TITLE
Always use hashes for commit parents instead of silently ignoring sha…

### DIFF
--- a/src/irmin-graphql/irmin_graphql.ml
+++ b/src/irmin-graphql/irmin_graphql.ml
@@ -134,21 +134,18 @@ module Make(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S) = stru
 
   let rec commit = lazy Schema.(
       obj "Commit"
-        ~fields:(fun commit -> [
-              io_field "node"
+        ~fields:(fun _ -> [
+              field "node"
                 ~typ:(non_null (Lazy.force node))
                 ~args:[]
-                ~resolve:(fun _ c ->
-                    Store.Commit.tree c >|= fun tree ->
-                    Ok (tree, Store.Key.empty)
-                  )
+                ~resolve:(fun _ c -> Store.Commit.tree c, Store.Key.empty)
               ;
-              io_field "parents"
-                ~typ:(non_null (list (non_null commit)))
+              field "parents"
+                ~typ:(non_null (list (non_null string)))
                 ~args:[]
-                ~resolve:(fun _ c -> Store.Commit.parents c >|= fun parents ->
-                           Ok parents
-                         )
+                ~resolve:(fun _ c ->
+                    let parents = Store.Commit.parents c in
+                    List.map (Irmin.Type.to_string Store.Hash.t) parents)
               ;
               field "info"
                 ~typ:(non_null Lazy.(force info))

--- a/src/irmin-mirage/irmin_mirage.ml
+++ b/src/irmin-mirage/irmin_mirage.ml
@@ -394,7 +394,7 @@ module KV_RW (G: Irmin_git.G) (C: Mirage_clock.PCLOCK) = struct
       S.Head.find t.t >>= function
       | None        -> Lwt.return None
       | Some origin ->
-        S.Commit.tree origin >>= fun tree ->
+        let tree = S.Commit.tree origin in
         S.Tree.find_tree tree t.root >|= function
         | Some t -> Some (origin, t)
         | None   -> Some (origin, S.Tree.empty)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -105,7 +105,8 @@ module Make (S: S) = struct
     S.Tree.of_hash repo kn3 >>= function
     | None    -> Alcotest.fail "r2"
     | Some t3 ->
-      S.Commit.v repo ~info:Irmin.Info.empty  ~parents:[kr1] (t3 :> S.tree)
+      S.Commit.v repo ~info:Irmin.Info.empty ~parents:[S.Commit.hash kr1]
+        (t3 :> S.tree)
 
   let run x test =
     try
@@ -832,11 +833,15 @@ module Make (S: S) = struct
          0->1->2->3->4
 
       *)
-      S.Commit.v repo ~info:(info 0) ~parents:[]   tree >>= fun k0 ->
-      S.Commit.v repo ~info:(info 1) ~parents:[k0] tree >>= fun k1 ->
-      S.Commit.v repo ~info:(info 2) ~parents:[k1] tree >>= fun k2 ->
-      S.Commit.v repo ~info:(info 3) ~parents:[k2] tree >>= fun k3 ->
-      S.Commit.v repo ~info:(info 4) ~parents:[k3] tree >>= fun k4 ->
+      S.Commit.v repo ~info:(info 0) ~parents:[] tree >>= fun k0 ->
+      S.Commit.v repo ~info:(info 1) ~parents:[S.Commit.hash k0] tree
+      >>= fun k1 ->
+      S.Commit.v repo ~info:(info 2) ~parents:[S.Commit.hash k1] tree
+      >>= fun k2 ->
+      S.Commit.v repo ~info:(info 3) ~parents:[S.Commit.hash k2] tree
+      >>= fun k3 ->
+      S.Commit.v repo ~info:(info 4) ~parents:[S.Commit.hash k3] tree
+      >>= fun k4 ->
 
       assert_lcas "line lcas 1" ~max_depth:0 3 k3 k4 [k3] >>= fun () ->
       assert_lcas "line lcas 2" ~max_depth:1 3 k2 k4 [k2] >>= fun () ->
@@ -851,14 +856,24 @@ module Make (S: S) = struct
              \--->12-->14-->16-->17
 
       *)
-      S.Commit.v repo ~info:(info 10) ~parents:[k4]       tree >>= fun k10 ->
-      S.Commit.v repo ~info:(info 11) ~parents:[k10]      tree >>= fun k11 ->
-      S.Commit.v repo ~info:(info 12) ~parents:[k10]      tree >>= fun k12 ->
-      S.Commit.v repo ~info:(info 13) ~parents:[k11]      tree >>= fun k13 ->
-      S.Commit.v repo ~info:(info 14) ~parents:[k12]      tree >>= fun k14 ->
-      S.Commit.v repo ~info:(info 15) ~parents:[k12; k13] tree >>= fun k15 ->
-      S.Commit.v repo ~info:(info 16) ~parents:[k14]      tree >>= fun k16 ->
-      S.Commit.v repo ~info:(info 17) ~parents:[k11; k16] tree >>= fun k17 ->
+      S.Commit.v repo ~info:(info 10) ~parents:[S.Commit.hash k4] tree
+      >>= fun k10 ->
+      S.Commit.v repo ~info:(info 11) ~parents:[S.Commit.hash k10] tree
+      >>= fun k11 ->
+      S.Commit.v repo ~info:(info 12) ~parents:[S.Commit.hash k10] tree
+      >>= fun k12 ->
+      S.Commit.v repo ~info:(info 13) ~parents:[S.Commit.hash k11] tree
+      >>= fun k13 ->
+      S.Commit.v repo ~info:(info 14) ~parents:[S.Commit.hash k12] tree
+      >>= fun k14 ->
+      S.Commit.v repo ~info:(info 15) ~parents:[S.Commit.hash k12;
+                                                S.Commit.hash k13] tree
+      >>= fun k15 ->
+      S.Commit.v repo ~info:(info 16) ~parents:[S.Commit.hash k14] tree
+      >>= fun k16 ->
+      S.Commit.v repo ~info:(info 17) ~parents:[S.Commit.hash k11;
+                                                S.Commit.hash k16] tree
+      >>= fun k17 ->
 
       assert_lcas "x lcas 0" ~max_depth:0 5 k10 k10 [k10]      >>= fun () ->
       assert_lcas "x lcas 1" ~max_depth:0 5 k14 k14 [k14]      >>= fun () ->
@@ -877,13 +892,22 @@ module Make (S: S) = struct
                  |        \--|--/
                  \-----------/
       *)
-      S.Commit.v repo ~info:(info 10) ~parents:[k4]      tree >>= fun k10 ->
-      S.Commit.v repo ~info:(info 11) ~parents:[k10]     tree >>= fun k11 ->
-      S.Commit.v repo ~info:(info 12) ~parents:[k11]     tree >>= fun k12 ->
-      S.Commit.v repo ~info:(info 13) ~parents:[k12]     tree >>= fun k13 ->
-      S.Commit.v repo ~info:(info 14) ~parents:[k11;k13] tree >>= fun k14 ->
-      S.Commit.v repo ~info:(info 15) ~parents:[k13;k14] tree >>= fun k15 ->
-      S.Commit.v repo ~info:(info 16) ~parents:[k11]     tree >>= fun k16 ->
+      S.Commit.v repo ~info:(info 10) ~parents:[S.Commit.hash k4] tree
+      >>= fun k10 ->
+      S.Commit.v repo ~info:(info 11) ~parents:[S.Commit.hash k10] tree
+      >>= fun k11 ->
+      S.Commit.v repo ~info:(info 12) ~parents:[S.Commit.hash k11] tree
+      >>= fun k12 ->
+      S.Commit.v repo ~info:(info 13) ~parents:[S.Commit.hash k12] tree
+      >>= fun k13 ->
+      S.Commit.v repo ~info:(info 14) ~parents:[S.Commit.hash k11;
+                                                S.Commit.hash k13] tree
+      >>= fun k14 ->
+      S.Commit.v repo ~info:(info 15) ~parents:[S.Commit.hash k13;
+                                                S.Commit.hash k14] tree
+      >>= fun k15 ->
+      S.Commit.v repo ~info:(info 16) ~parents:[S.Commit.hash k11] tree
+      >>= fun k16 ->
 
       assert_lcas "weird lcas 1" ~max_depth:0 3 k14 k15 [k14] >>= fun () ->
       assert_lcas "weird lcas 2" ~max_depth:0 3 k13 k15 [k13] >>= fun () ->
@@ -1258,7 +1282,9 @@ module Make (S: S) = struct
       r1 ~repo >>= fun r1 ->
       r2 ~repo >>= fun r2 ->
       let i0 = Irmin.Info.empty in
-      S.Commit.v repo ~info:Irmin.Info.empty ~parents:[r1;r2] v3 >>= fun c ->
+      S.Commit.v repo ~info:Irmin.Info.empty ~parents:[S.Commit.hash r1;
+                                                       S.Commit.hash r2] v3
+      >>= fun c ->
       S.Head.set t c >>= fun () ->
       S.Head.get t >>= fun h ->
 

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -33,7 +33,10 @@ module Make (K: Type.S) = struct
   let parents t = t.parents
   let node t = t.node
   let info t = t.info
-  let v ~info ~node ~parents = { node; parents; info }
+
+  let v ~info ~node ~parents =
+    let parents = List.fast_sort (Type.compare K.t) parents in
+    { node; parents; info }
 
   let t =
     let open Type in

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -2285,7 +2285,7 @@ module type S = sig
     (** [pp] is the pretty-printer for commit. Display only the
         hash. *)
 
-    val v: repo -> info:Info.t -> parents:commit list -> tree -> commit Lwt.t
+    val v: repo -> info:Info.t -> parents:hash list -> tree -> commit Lwt.t
     (** [v r i ~parents:p t] is the commit [c] such that:
         {ul
         {- [info c = i]}
@@ -2293,10 +2293,10 @@ module type S = sig
         {- [tree c = t]}}
     *)
 
-    val tree: commit -> tree Lwt.t
+    val tree: commit -> tree
     (** [tree c] is [c]'s root tree. *)
 
-    val parents: commit -> commit list Lwt.t
+    val parents: commit -> hash list
     (** [parents c] are [c]'s parents. *)
 
     val info: commit -> Info.t

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -390,9 +390,9 @@ module type STORE = sig
     type t = commit
     val t: Repo.t -> t Type.t
     val pp_hash: t Fmt.t
-    val v: Repo.t -> info:Info.t -> parents:commit list -> tree -> commit Lwt.t
-    val tree: commit -> tree Lwt.t
-    val parents: commit -> commit list Lwt.t
+    val v: Repo.t -> info:Info.t -> parents:hash list -> tree -> commit Lwt.t
+    val tree: commit -> tree
+    val parents: commit -> hash list
     val info: commit -> Info.t
     val hash: commit -> hash
     val of_hash: Repo.t -> hash -> commit option Lwt.t

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -107,7 +107,7 @@ let suite i server =
     init = begin fun () ->
       remove pid_file;
       Lwt_io.flush_all () >>= fun () ->
-      let _ = Sys.command @@ Fmt.strf "dune exec -- %s serve %d &" Sys.argv.(0) i in
+      let _ = Sys.command @@ Fmt.strf "dune exec --root . -- %s serve %d &" Sys.argv.(0) i in
       wait_for_the_server_to_start () >|= fun pid ->
       server_pid := pid
     end;


### PR DESCRIPTION
…llow parents

Related to #614 ; we let the user decide if they want to resolve the parents hashes or not themselves.

/cc @pascutto 

@zshipko: I have fixed the type for the graphql server to return strings instead of commits when asking for the parent. Should I modify the client to match as well ?