### PR TITLE
Fix JSON encoding for non-UTF8 safe characters

### DIFF
--- a/irmin.opam
+++ b/irmin.opam
@@ -24,8 +24,8 @@ depends: [
   "ocamlgraph"
   "logs"    {>= "0.5.0"}
   "astring"
+  "hex"
   "alcotest" {with-test}
-  "hex"      {with-test}
 ]
 synopsis: """
 Irmin, a distributed database that follows the same design principles as Git

--- a/irmin.opam
+++ b/irmin.opam
@@ -20,11 +20,12 @@ depends: [
   "uri"     {>= "1.3.12"}
   "jsonm"   {>= "1.0.0"}
   "lwt"     {>= "2.4.7"}
+  "base64"
   "digestif"
   "ocamlgraph"
   "logs"    {>= "0.5.0"}
   "astring"
-  "hex"
+  "hex"      {with-test}
   "alcotest" {with-test}
 ]
 synopsis: """

--- a/irmin.opam
+++ b/irmin.opam
@@ -20,7 +20,7 @@ depends: [
   "uri"     {>= "1.3.12"}
   "jsonm"   {>= "1.0.0"}
   "lwt"     {>= "2.4.7"}
-  "base64"
+  "base64"  {>= "2.0.0"}
   "digestif"
   "ocamlgraph"
   "logs"    {>= "0.5.0"}

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,4 +1,4 @@
 (library
  (name        irmin)
  (public_name irmin)
- (libraries   fmt uri jsonm lwt ocamlgraph logs astring digestif))
+ (libraries   fmt uri jsonm lwt ocamlgraph logs astring hex digestif))

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,4 +1,4 @@
 (library
  (name        irmin)
  (public_name irmin)
- (libraries   fmt uri jsonm lwt ocamlgraph logs astring hex digestif))
+ (libraries   fmt uri jsonm lwt ocamlgraph logs astring base64 digestif))

--- a/src/irmin/type.ml
+++ b/src/irmin/type.ml
@@ -603,9 +603,9 @@ module Encode_json = struct
 
   let base64 e s =
     let x = Base64.encode_exn s in
-    let () = lexeme e `Os in
-    let () = lexeme e (`Name "base64") in
-    let () = lexeme e (`String x) in
+    lexeme e `Os;
+    lexeme e (`Name "base64");
+    lexeme e (`String x);
     lexeme e `Oe
 
   let string e s =

--- a/src/irmin/type.ml
+++ b/src/irmin/type.ml
@@ -601,29 +601,26 @@ module Encode_json = struct
 
   let unit e () = lexeme e `Null
 
+  let hex e s =
+    let `Hex x = Hex.of_string s in
+    let () = lexeme e `Os in
+    let () = lexeme e (`Name "hex") in
+    let () = lexeme e (`String x) in
+    lexeme e `Oe
+
   let string e s =
     if is_valid_utf8 s then
       lexeme e (`String s)
     else
-      let `Hex x = Hex.of_string s in
-      let () = lexeme e `Os in
-      let () = lexeme e (`Name "hex") in
-      let () = lexeme e (`String x) in
-      lexeme e `Oe
+      hex e s
 
   let bytes e b =
     let s = Bytes.unsafe_to_string b in
     string e s
 
   let char e c =
-    let i = int_of_char c in
-    if i > 127 then
-      let () = lexeme e `Os in
-      let () = lexeme e (`Name "hex") in
-      let () = lexeme e (`String (Printf.sprintf "%x" i)) in
-      lexeme e `Oe
-    else
-      string e (String.make 1 c)
+    let s = String.make 1 c in
+    string e s
 
   let float e f = lexeme e (`Float f)
   let int e i = float e (float_of_int i)

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -78,7 +78,10 @@ let test_json () =
   Alcotest.(check (ok string)) "JSON to hex2" (Ok "foo") x;
 
   let x = T.to_json_string hex2 "foo" in
-  Alcotest.(check string) "JSON of hex2" "[\"foo\",\"666f6f\"]" x
+  Alcotest.(check string) "JSON of hex2" "[\"foo\",\"666f6f\"]" x;
+
+  let x = T.to_json_string T.char (char_of_int 128) in
+  Alcotest.(check string) "JSON char larger than 128" "{\"hex\":\"80\"}" x
 
 let l =
   let hex = T.like_map (T.string_of (`Fixed 3)) ~cli:(pp_hex, of_hex_string) id id in

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -81,7 +81,7 @@ let test_json () =
   Alcotest.(check string) "JSON of hex2" "[\"foo\",\"666f6f\"]" x;
 
   let x = T.to_json_string T.char (char_of_int 128) in
-  Alcotest.(check string) "JSON char larger than 127" "{\"hex\":\"80\"}" x;
+  Alcotest.(check string) "JSON char larger than 127" "{\"base64\":\"gA==\"}" x;
 
   let x = T.to_json_string T.string "\128\129a" in
   Alcotest.(check (ok string)) "JSON string with chars larger than 127" (T.of_json_string T.string x) (Ok "\128\129a")

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -81,7 +81,10 @@ let test_json () =
   Alcotest.(check string) "JSON of hex2" "[\"foo\",\"666f6f\"]" x;
 
   let x = T.to_json_string T.char (char_of_int 128) in
-  Alcotest.(check string) "JSON char larger than 128" "{\"hex\":\"80\"}" x
+  Alcotest.(check string) "JSON char larger than 127" "{\"hex\":\"80\"}" x;
+
+  let x = T.to_json_string T.string "\128\129a" in
+  Alcotest.(check (ok string)) "JSON string with chars larger than 127" (T.of_json_string T.string x) (Ok "\128\129a")
 
 let l =
   let hex = T.like_map (T.string_of (`Fixed 3)) ~cli:(pp_hex, of_hex_string) id id in


### PR DESCRIPTION
This PR adds a special case when encoding/decoding strings with characters outside the range of 0-127.

Similar to `ezjsonm` a string containing invalid characters, such as `"\128\129"`, will be encoded as `{"hex": "8081"}`.

A few concerns about this change should be noted:

- The entire string must be scanned to determine if it's UTF8 safe when encoding
- A string containing a single invalid character becomes twice as long after JSON encoding

I'm happy to address these if there are any ideas regarding how to escape the string more efficiently, but I haven't found a better solution.

Fixes #631
