### PR TITLE
Irmin.Type: API cleanups

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -165,14 +165,11 @@ module Make_private
         | Error _ -> assert false
         | Ok s    -> s
 
-      let encode_bin buf off (t:t) =
+      let encode_bin ~toplevel:_ buf (t:t) =
         Log.debug (fun l -> l "Content.encode_bin");
-        let s = to_bin t in
-        let len = String.length s in
-        Bytes.blit_string s 0 buf off len;
-        off + len
+        Buffer.add_string buf (to_bin t)
 
-      let decode_bin buf off =
+      let decode_bin ~toplevel:_ buf off =
         Log.debug (fun l -> l "Content.decode_bin");
         let buf = Cstruct.of_string buf in
         let buf = Cstruct.shift buf off in
@@ -186,7 +183,7 @@ module Make_private
         | Ok _    -> failwith "wrong object kind"
         | Error e -> Fmt.invalid_arg "error %a" Raw.DecoderRaw.pp_error e
 
-      let size_of t = `Buffer (to_bin t)
+      let size_of ~toplevel:_ _t = None
 
     let t = Irmin.Type.like ~bin:(encode_bin, decode_bin, size_of) t
   end
@@ -299,14 +296,11 @@ module Make_private
          | Error _ -> assert false
          | Ok s    -> s
 
-       let encode_bin buf off (t:t) =
+       let encode_bin ~toplevel:_ buf (t:t) =
          Log.debug (fun l -> l "Tree.encode_bin");
-         let s = to_bin t in
-         let len = String.length s in
-         Bytes.blit_string s 0 buf off len;
-           off + len
+         Buffer.add_string buf (to_bin t)
 
-       let decode_bin buf off =
+       let decode_bin ~toplevel:_ buf off =
          Log.debug (fun l -> l "Tree.decode_bin");
          let buf = Cstruct.of_string buf in
          let buf = Cstruct.shift buf off in
@@ -315,10 +309,10 @@ module Make_private
          | Ok _    -> failwith "wrong object kind"
          | Error e -> Fmt.invalid_arg "error %a" Raw.DecoderRaw.pp_error e
 
-       let size_of t = `Buffer (to_bin t)
+       let size_of ~toplevel:_ _t = None
 
        let t =
-         Irmin.Type.like_map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
+         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
     end
 
     include Content_addressable (struct
@@ -412,14 +406,11 @@ module Make_private
         | Error _ -> assert false
         | Ok s    -> s
 
-      let encode_bin buf off (t:t) =
+      let encode_bin ~toplevel:_ buf (t:t) =
         Log.debug (fun l -> l "Commit.encode_bin");
-        let s = to_bin t in
-        let len = String.length s in
-        Bytes.blit_string s 0 buf off len;
-        off + len
+        Buffer.add_string buf (to_bin t)
 
-      let decode_bin buf off =
+      let decode_bin ~toplevel:_ buf off =
         Log.debug (fun l -> l "Commit.decode_bin");
         let buf = Cstruct.of_string buf in
         let buf = Cstruct.shift buf off in
@@ -428,10 +419,9 @@ module Make_private
         | Ok _    -> failwith "wrong object kind"
         | Error e -> Fmt.invalid_arg "error %a" Raw.DecoderRaw.pp_error e
 
-      let size_of t = `Buffer (to_bin t)
+      let size_of ~toplevel:_ _t = None
 
-      let t =
-        Irmin.Type.like_map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c
+      let t = Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c
     end
 
     module Key = H

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -304,9 +304,12 @@ module V1 = struct
   module String = struct
     include String
 
-    let t =
-      Type.(like_map (pair unit (string_of `Int64)))
-        (fun (_, x) -> x) (fun x -> (), x)
+    let t = Type.string_of `Int64
+    let size_of ~toplevel:_ = Type.size_of ~toplevel:false t
+    let decode_bin ~toplevel:_  = Type.decode_bin ~toplevel:false t
+    let encode_bin ~toplevel:_  = Type.encode_bin ~toplevel:false t
+
+    let t = Type.like t ~bin:(encode_bin, decode_bin, size_of)
   end
 
 end

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -65,7 +65,7 @@ struct
 
   let pp_key = Type.pp K.t
 
-  let digest v = K.digest (Type.to_bin_string V.t v)
+  let digest v = K.digest (Type.pre_digest V.t v)
 
   let find t k =
     find t k >>= function

--- a/src/irmin/merge.ml
+++ b/src/irmin/merge.ml
@@ -263,7 +263,7 @@ module MultiSet (K: sig
 
   module M = Map.Make(K)
   let of_alist l = List.fold_left (fun map (k, v)  -> M.add k v map) M.empty l
-  let t = Type.like_map Type.(list (pair K.t int64)) of_alist M.bindings
+  let t = Type.map Type.(list (pair K.t int64)) of_alist M.bindings
 
   let merge ~old m1 m2 =
     let get k m = try M.find k m with Not_found -> 0L in
@@ -294,7 +294,7 @@ struct
 
   module S = Set.Make(K)
   let of_list l = List.fold_left (fun set elt -> S.add elt set) S.empty l
-  let t = Type.(like_map @@ list K.t) of_list S.elements
+  let t = Type.(map @@ list K.t) of_list S.elements
   let pp = Type.pp t
 
   let merge ~old x y =
@@ -317,7 +317,7 @@ module Map (K: sig
 
   module M = Map.Make(K)
   let of_alist l = List.fold_left (fun map (k, v)  -> M.add k v map) M.empty l
-  let t x = Type.like_map Type.(list @@ pair K.t x) of_alist M.bindings
+  let t x = Type.map Type.(list @@ pair K.t x) of_alist M.bindings
   let iter2 f t1 t2 = alist_iter2 K.compare f (M.bindings t1) (M.bindings t2)
 
   let iter2 f m1 m2 =
@@ -429,7 +429,7 @@ let with_conflict rewrite (d, f) =
   d, f
 
 let conflict_t =
-  Type.(like_map string) (fun x -> `Conflict x) (function `Conflict x -> x)
+  Type.(map string) (fun x -> `Conflict x) (function `Conflict x -> x)
 
 let result_t ok =
   let open Type in

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -96,7 +96,7 @@ module Make (P: S.PRIVATE) = struct
         (fun (x, y) -> Contents (y, Some x))
       |> sealv
 
-    let t = Type.like_map value (fun v -> { v }) (fun t -> t.v)
+    let t = Type.map value (fun v -> { v }) (fun t -> t.v)
 
     let of_contents c = { v = Contents (c, None) }
     let of_key db k = { v = Key (db, k) }
@@ -185,20 +185,20 @@ module Make (P: S.PRIVATE) = struct
         List.fold_left (fun acc (k, v) -> StepMap.add k v acc) StepMap.empty x
       in
       let of_map m = StepMap.fold (fun k v acc -> (k, v) :: acc) m [] in
-      like_map (list (pair Path.step_t value)) to_map of_map
+      map (list (pair Path.step_t value)) to_map of_map
 
-    let node map =
+    let node m =
       let open Type in
       variant "Node.node" (fun map key both -> function
           | Map (x, y)   -> map (x, y)
           | Key (_,y)    -> key y
           | Both (_,y,z) -> both (y, z))
-      |~ case1 "Map" (pair map (option P.Node.Key.t)) (fun (x, y) -> Map (x, y))
+      |~ case1 "Map" (pair m (option P.Node.Key.t)) (fun (x, y) -> Map (x, y))
       |~ case1 "Key" P.Node.Key.t (fun _ -> assert false)
-      |~ case1 "Both" (pair P.Node.Key.t map) (fun (x, y) -> Map (y, Some x))
+      |~ case1 "Both" (pair P.Node.Key.t m) (fun (x, y) -> Map (y, Some x))
       |> sealv
 
-    let t node = Type.like_map node (fun v -> { v }) (fun t -> t.v)
+    let t node = Type.map node (fun v -> { v }) (fun t -> t.v)
 
     let _, t = Type.mu2 (fun _ y ->
         let value = value y in

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -95,12 +95,22 @@ type 'a decode_json = Json.decoder -> ('a, [`Msg of string]) result
 
 (* Raw (disk) *)
 
-type 'a encode_bin =  bytes -> int -> 'a -> int
-type 'a decode_bin = string -> int -> int * 'a
-type 'a size_of = 'a -> [ `Size of int | `Buffer of string ]
+type 'a encode_bin =  toplevel:bool -> Buffer.t -> 'a -> unit
+type 'a decode_bin = toplevel:bool -> string -> int -> int * 'a
+type 'a size_of = toplevel:bool -> 'a -> int option
 
 val size_of: 'a t -> 'a size_of
 (* like *)
+
+val v:
+  cli:('a pp * 'a of_string) ->
+  json:('a encode_json * 'a decode_json) ->
+  bin:('a encode_bin * 'a decode_bin * 'a size_of) ->
+  equal:('a -> 'a -> bool) ->
+  compare:('a -> 'a -> int) ->
+  hash:('a -> int) ->
+  pre_digest:('a -> string) ->
+  'a t
 
 val like:
   ?cli:('a pp * 'a of_string) ->
@@ -109,16 +119,18 @@ val like:
   ?equal:('a -> 'a -> bool) ->
   ?compare:('a -> 'a -> int) ->
   ?hash:('a -> int) ->
+  ?pre_digest:('a -> string) ->
   'a t -> 'a t
 
-val like_map: 'a t ->
-  ?cli:('b pp * 'b of_string) ->
-  ?json:('b encode_json * 'b decode_json) ->
-  ?bin:('b encode_bin * 'b decode_bin * 'b size_of) ->
-  ?equal:('b -> 'b -> bool) ->
-  ?compare:('b -> 'b -> int) ->
-  ?hash:('b -> int) ->
-  ('a -> 'b) -> ('b -> 'a) -> 'b t
+val map:
+  ?cli:('a pp * 'a of_string) ->
+  ?json:('a encode_json * 'a decode_json) ->
+  ?bin:('a encode_bin * 'a decode_bin * 'a size_of) ->
+  ?equal:('a -> 'a -> bool) ->
+  ?compare:('a -> 'a -> int) ->
+  ?hash:('a -> int) ->
+  ?pre_digest:('a -> string) ->
+  'b t -> ('b -> 'a) -> ('a -> 'b) -> 'a t
 
 (* convenient functions. *)
 
@@ -139,9 +151,13 @@ val to_bin_string: 'a t -> 'a to_string
 val decode_bin: 'a t -> 'a decode_bin
 val of_bin_string: 'a t -> 'a of_string
 
+val pre_digest: 'a t -> 'a -> string
+
 type 'a ty = 'a t
 
 module type S = sig
   type t
   val t: t ty
 end
+
+val pp_ty: 'a ty Fmt.t


### PR DESCRIPTION
- allow to define custom types without the need to map to some pre-existing
  types (Type.v)
- Rename Type.like_map into Type.map
- allow to only overwrite the pre-digest functions
- use extensible buffer instead of fixed bytes for encoding

It's probably best if I split that PR into multiple ones to ease review. 