### PR TITLE
 Irmin.Type: add an optional header option to encode/decode/size_of

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -165,11 +165,11 @@ module Make_private
         | Error _ -> assert false
         | Ok s    -> s
 
-      let encode_bin buf (t:t) =
+      let encode_bin ?headers:_ buf (t:t) =
         Log.debug (fun l -> l "Content.encode_bin");
         Buffer.add_string buf (to_bin t)
 
-      let decode_bin buf off =
+      let decode_bin ?headers:_ buf off =
         Log.debug (fun l -> l "Content.decode_bin");
         let buf = Cstruct.of_string buf in
         let buf = Cstruct.shift buf off in
@@ -183,7 +183,7 @@ module Make_private
         | Ok _    -> failwith "wrong object kind"
         | Error e -> Fmt.invalid_arg "error %a" Raw.DecoderRaw.pp_error e
 
-      let size_of t = `Buffer (to_bin t)
+      let size_of ?headers:_ t = `Buffer (to_bin t)
 
     let t = Irmin.Type.like ~bin:(encode_bin, decode_bin, size_of) t
   end
@@ -296,11 +296,11 @@ module Make_private
          | Error _ -> assert false
          | Ok s    -> s
 
-       let encode_bin buf (t:t) =
+       let encode_bin ?headers:_ buf (t:t) =
          Log.debug (fun l -> l "Tree.encode_bin");
          Buffer.add_string buf (to_bin t)
 
-       let decode_bin buf off =
+       let decode_bin ?headers:_ buf off =
          Log.debug (fun l -> l "Tree.decode_bin");
          let buf = Cstruct.of_string buf in
          let buf = Cstruct.shift buf off in
@@ -309,7 +309,7 @@ module Make_private
          | Ok _    -> failwith "wrong object kind"
          | Error e -> Fmt.invalid_arg "error %a" Raw.DecoderRaw.pp_error e
 
-       let size_of t = `Buffer (to_bin t)
+       let size_of ?headers:_ t = `Buffer (to_bin t)
 
        let t =
          Irmin.Type.like_map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
@@ -406,11 +406,11 @@ module Make_private
         | Error _ -> assert false
         | Ok s    -> s
 
-      let encode_bin buf (t:t) =
+      let encode_bin ?headers:_ buf (t:t) =
         Log.debug (fun l -> l "Commit.encode_bin");
         Buffer.add_string buf (to_bin t)
 
-      let decode_bin buf off =
+      let decode_bin ?headers:_ buf off =
         Log.debug (fun l -> l "Commit.decode_bin");
         let buf = Cstruct.of_string buf in
         let buf = Cstruct.shift buf off in
@@ -419,7 +419,7 @@ module Make_private
         | Ok _    -> failwith "wrong object kind"
         | Error e -> Fmt.invalid_arg "error %a" Raw.DecoderRaw.pp_error e
 
-      let size_of t = `Buffer (to_bin t)
+      let size_of ?headers:_ t = `Buffer (to_bin t)
 
       let t =
         Irmin.Type.like_map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -452,14 +452,14 @@ module V1 (C: S.COMMIT) = struct
 
     let h = Type.string_of `Int64
 
-    let size_of x =
-      Type.size_of h (Type.to_bin_string C.hash_t x)
+    let size_of ?headers x =
+      Type.size_of ?headers h (Type.to_bin_string C.hash_t x)
 
-    let encode_bin buf e =
-      Type.encode_bin h buf (Type.to_bin_string C.hash_t e)
+    let encode_bin ?headers buf e =
+      Type.encode_bin ?headers h buf (Type.to_bin_string C.hash_t e)
 
-    let decode_bin buf off =
-      let n, v = Type.decode_bin h buf off in
+    let decode_bin ?headers buf off =
+      let n, v = Type.decode_bin ?headers h buf off in
       n, match Type.of_bin_string C.hash_t v with
       | Ok v -> v
       | Error (`Msg e) -> Fmt.failwith "decode_bin: %s" e

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -59,14 +59,14 @@ module V1 (K: S.HASH): S.HASH with type t = K.t = struct
 
   let h = Type.string_of `Int64
 
-  let size_of x =
-    Type.size_of h (Type.to_bin_string K.t x)
+  let size_of ?headers x =
+    Type.size_of ?headers h (Type.to_bin_string K.t x)
 
-  let encode_bin buf e =
-    Type.encode_bin h buf (Type.to_bin_string K.t e)
+  let encode_bin ?headers buf e =
+    Type.encode_bin ?headers h buf (Type.to_bin_string K.t e)
 
-  let decode_bin buf off =
-    let n, v = Type.decode_bin h buf off in
+  let decode_bin ?headers buf off =
+    let n, v = Type.decode_bin ?headers h buf off in
     n, match Type.of_bin_string K.t v with
     | Ok v -> v
     | Error (`Msg e) -> Fmt.failwith "decode_bin: %s" e

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -425,13 +425,16 @@ module Type: sig
 
   (** {2 Binary Converters} *)
 
-  type 'a encode_bin =  Buffer.t -> 'a -> unit
-  (** The type for binary encoders. *)
+  type 'a encode_bin =  ?headers:bool -> Buffer.t -> 'a -> unit
+  (** The type for binary encoders. If [headers] is not set, do not
+     output extra length headers for buffers. *)
 
-  type 'a decode_bin = string -> int -> int * 'a
-  (** The type for binary decoders. *)
+  type 'a decode_bin = ?headers:bool -> string -> int -> int * 'a
+  (** The type for binary decoders. IF [headers] is not set, do not
+     read extra length header for buffers and consider the whole
+     buffer instead. *)
 
-  type 'a size_of = 'a -> [`Size of int | `Buffer of string]
+  type 'a size_of = ?headers:bool -> 'a -> [`Size of int | `Buffer of string]
     (** The type for size function related to binary encoder/decoders. *)
 
   val encode_bin: 'a t -> 'a encode_bin
@@ -455,7 +458,7 @@ module Type: sig
       {b NOTE:} When [t] is {!Type.string}, the result is [x] (without
      copy). *)
 
-  val size_of: 'a t -> 'a -> [`Size of int | `Buffer of string]
+  val size_of: 'a t -> 'a size_of
   (** [size_of t x] is either the size of [encode_bin t x] or the
      binary encoding of [x], if the backend is not able to pre-compute
      serialisation lenghts. *)

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -377,14 +377,14 @@ module V1 (N: S.NODE) = struct
 
     let h = Type.string_of `Int64
 
-    let size_of x =
-      Type.size_of h (Type.to_bin_string N.hash_t x)
+    let size_of ?headers x =
+      Type.size_of ?headers h (Type.to_bin_string N.hash_t x)
 
-    let encode_bin buf e =
-      Type.encode_bin h buf (Type.to_bin_string N.hash_t e)
+    let encode_bin ?headers buf e =
+      Type.encode_bin ?headers h buf (Type.to_bin_string N.hash_t e)
 
-    let decode_bin buf off =
-      let n, v = Type.decode_bin h buf off in
+    let decode_bin ?headers buf off =
+      let n, v = Type.decode_bin ?headers h buf off in
       n, match Type.of_bin_string N.hash_t v with
       | Ok v -> v
       | Error (`Msg e) -> Fmt.failwith "decode_bin: %s" e

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -95,9 +95,9 @@ type 'a decode_json = Json.decoder -> ('a, [`Msg of string]) result
 
 (* Raw (disk) *)
 
-type 'a encode_bin =  Buffer.t -> 'a -> unit
-type 'a decode_bin = string -> int -> int * 'a
-type 'a size_of = 'a -> [ `Size of int | `Buffer of string ]
+type 'a encode_bin =  ?headers:bool -> Buffer.t -> 'a -> unit
+type 'a decode_bin = ?headers:bool -> string -> int -> int * 'a
+type 'a size_of = ?headers:bool -> 'a -> [ `Size of int | `Buffer of string ]
 
 val size_of: 'a t -> 'a size_of
 (* like *)


### PR DESCRIPTION
This is an extract of #649 

This allows to serialise a buffer (bytes/string) with or without a lenght header. I am not totally fond of the name of that option, but it's better than `toplevel`...

