### PR TITLE
Irmin.Type: add a way to have separate pre_digest and serialisation i…

### DIFF
--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -47,7 +47,7 @@ module BLAKE2S = Make(Digestif.BLAKE2S)
 
 module With_digest (K: S.HASH) (V: Type.S) = struct
   include K
-  let digest v = K.digest (Type.to_bin_string V.t v)
+  let digest v = K.digest (Type.pre_digest V.t v)
 end
 
 module V1 (K: S.HASH): S.HASH with type t = K.t = struct

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -65,7 +65,7 @@ struct
 
   let pp_key = Type.pp K.t
 
-  let digest v = K.digest (Type.to_bin_string V.t v)
+  let digest v = K.digest (Type.pre_digest V.t v)
 
   let find t k =
     find t k >>= function

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -437,6 +437,12 @@ module Type: sig
   type 'a size_of = ?headers:bool -> 'a -> int option
     (** The type for size function related to binary encoder/decoders. *)
 
+  val pre_digest: 'a t -> 'a -> string
+  (** [pre_digest t x] is the string representation of [x], of type
+      [t], which will be used to compute the digest of the value. By
+      default it's [to_bin_string t x] but it can be overriden by {!v},
+      {!like} and {!map} operators. *)
+
   val encode_bin: 'a t -> 'a encode_bin
   (** [encode_bin t] is the binary encoder for values of type [t]. *)
 
@@ -472,6 +478,7 @@ module Type: sig
     equal:('a -> 'a -> bool) ->
     compare:('a -> 'a -> int) ->
     hash:('a -> int) ->
+    pre_digest:('a -> string) ->
     'a t
 
   val like:
@@ -481,6 +488,7 @@ module Type: sig
     ?equal:('a -> 'a -> bool) ->
     ?compare:('a -> 'a -> int) ->
     ?hash:('a -> int) ->
+    ?pre_digest:('a -> string) ->
     'a t -> 'a t
 
   val map:
@@ -490,6 +498,7 @@ module Type: sig
     ?equal:('a -> 'a -> bool) ->
     ?compare:('a -> 'a -> int) ->
     ?hash:('a -> int) ->
+    ?pre_digest:('a -> string) ->
     'b t -> ('b -> 'a) -> ('a -> 'b) -> 'a t
 
   type 'a ty = 'a t

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -109,6 +109,7 @@ val v:
   equal:('a -> 'a -> bool) ->
   compare:('a -> 'a -> int) ->
   hash:('a -> int) ->
+  pre_digest:('a -> string) ->
   'a t
 
 val like:
@@ -118,6 +119,7 @@ val like:
   ?equal:('a -> 'a -> bool) ->
   ?compare:('a -> 'a -> int) ->
   ?hash:('a -> int) ->
+  ?pre_digest:('a -> string) ->
   'a t -> 'a t
 
 val map:
@@ -127,6 +129,7 @@ val map:
   ?equal:('b -> 'b -> bool) ->
   ?compare:('b -> 'b -> int) ->
   ?hash:('b -> int) ->
+  ?pre_digest:('b -> string) ->
   'a t ->  ('a -> 'b) -> ('b -> 'a) -> 'b t
 
 (* convenient functions. *)
@@ -135,6 +138,7 @@ val to_string: 'a t -> 'a -> string
 
 val pp_json: ?minify:bool -> 'a t -> 'a Fmt.t
 
+val pre_digest: 'a t -> 'a -> string
 val encode_json: 'a t -> Jsonm.encoder -> 'a -> unit
 val decode_json: 'a t -> Jsonm.decoder -> ('a, [`Msg of string]) result
 val decode_json_lexemes: 'a t -> Jsonm.lexeme list -> ('a, [`Msg of string]) result

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -220,10 +220,10 @@ module Commit_v1 = Irmin.Private.Commit.V1(Commit)
 module Hash_v1 = Irmin.Hash.V1(Hash)
 
 let hash c =
-  Hash.digest (Irmin.Type.to_bin_string Irmin.Contents.String.t c)
+  Hash.digest (Irmin.Type.pre_digest Irmin.Contents.String.t c)
 
 let hash_v1 c =
-  Hash_v1.digest (Irmin.Type.to_bin_string Irmin.Contents.V1.String.t c)
+  Hash_v1.digest (Irmin.Type.pre_digest Irmin.Contents.V1.String.t c)
 
 let test_hashes () =
   let digest t x =


### PR DESCRIPTION
…mages

This is useful if ones want to optimise the storage format while keeping
a stable hash with previous versions.

This is the last bit of #649 