### PR TITLE
irmin-graphql depends on graphql-cohttp >= 0.12

### DIFF
--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -19,7 +19,7 @@ depends: [
   "irmin"
   "graphql" {>= "0.9"}
   "graphql-lwt" {>= "0.9"}
-  "graphql-cohttp" {>= "0.10"}
+  "graphql-cohttp" {>= "0.12"}
   "cohttp-lwt"
   "graphql_parser" {>= "0.11"}
 ]


### PR DESCRIPTION
@zshipko noticed `graphql-cohttp` was using `Str`. This PR bumps the dependency to `0.12` which got rid of this (https://github.com/andreas/ocaml-graphql-server/pull/146).

Awaiting https://github.com/ocaml/opam-repository/pull/13719 to be merged.