### PR TITLE
GraphQL schema suggestions

### DIFF
--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -231,8 +231,9 @@ module Make_ext(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S)(Pr
               field "key"
                 ~typ:(non_null string)
                 ~args:[]
-                ~resolve:(fun _ (_, key) -> Irmin.Type.to_string Store.key_t key)
-              ;
+                ~resolve:(fun _ (_, key) ->
+                  Irmin.Type.to_string Store.key_t key
+                );
               io_field "get"
                 ~args:Arg.[arg "step" ~typ:Input.step]
                 ~typ:node
@@ -263,22 +264,26 @@ module Make_ext(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S)(Pr
                     Option.map Presentation.Metadata.to_src >|=
                     Result.ok
                  );
-              io_field "hash"
+              field "hash"
                 ~typ:(non_null string)
                 ~args:[]
-                ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.get_tree tree key >>= fun tree ->
-                    Lwt.return_ok (Irmin.Type.to_string Store.Hash.t (Store.Tree.hash tree))
+                ~resolve:(fun _ (tree, _) ->
+                    let hash = Store.Tree.hash tree in
+                    Irmin.Type.to_string Store.Hash.t hash
                 );
               io_field "tree"
                 ~typ:(non_null (list (non_null tree)))
                 ~args:[]
                 ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.list tree key >>= Lwt_list.map_p (fun (step, kind) ->
+                    Store.Tree.list tree Store.Key.empty >>= Lwt_list.map_p (fun (step, kind) ->
                         let key' = Store.Key.rcons key step in
                         match kind with
-                        | `Contents -> Lwt.return (Lazy.(force contents_as_tree) (tree, key'))
-                        | `Node -> Lwt.return (Lazy.(force node_as_tree) (tree, key'))
+                        | `Contents ->
+                          Store.Tree.get_all tree key' >|= fun (c, m) ->
+                          Lazy.(force contents_as_tree (c, m, key'))
+                        | `Node ->
+                          Store.Tree.get_tree tree key' >|= fun t ->
+                          Lazy.(force node_as_tree (t, key'))
                       ) >>= Lwt.return_ok
                 );
             ])
@@ -312,19 +317,20 @@ module Make_ext(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S)(Pr
               ;
               io_field "get_tree"
                 ~args:Arg.[arg "key" ~typ:(non_null Input.key)]
-                ~typ:(list (non_null @@ Lazy.force contents))
+                ~typ:(list (non_null Lazy.(force contents)))
                 ~resolve:(fun _ (t, _) key ->
-                    let rec tree_list base tree key acc =
+                    let rec tree_list tree key acc =
                       match tree with
-                      | `Contents (_, _) ->
-                        (Store.Tree.of_concrete base, key) :: acc
+                      | `Contents (c, m) -> [c, m, key]
                       | `Tree l ->
-                        List.fold_right (fun (step, t) acc -> tree_list base t (Store.Key.rcons key step) [] @ acc) l acc
+                        List.fold_right (fun (step, t) acc ->
+                          tree_list t (Store.Key.rcons key step) [] @ acc
+                        ) l acc
                     in
                     Store.find_tree t key >>= function
                     | Some tree ->
                       Store.Tree.to_concrete tree >>= fun tree ->
-                      let l = tree_list tree tree Store.Key.empty [] in
+                      let l = tree_list tree Store.Key.empty [] in
                       Lwt.return_ok (Some l)
                     | None -> Lwt.return_ok None
                   )
@@ -335,8 +341,8 @@ module Make_ext(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S)(Pr
                 ~resolve:(fun _ (t, _) key ->
                     Store.mem_tree t key >>= function
                     | true ->
-                      Store.get_tree t Store.Key.empty >>= fun tree ->
-                      Lwt.return_ok (Some (tree, key))
+                      Store.get_all t Store.Key.empty >>= fun (c, m) ->
+                      Lwt.return_ok (Some (c, m, key))
                     | false -> Lwt.return_ok None
                   )
               ;
@@ -357,44 +363,34 @@ module Make_ext(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S)(Pr
             ])
     )
 
-  and contents : ('ctx, (Store.tree * Store.key) option) Schema.typ Lazy.t = lazy Schema.(
+  and contents : ('ctx, (Store.contents * Store.metadata * Store.key) option) Schema.typ Lazy.t = lazy Schema.(
       obj "Contents"
         ~fields:(fun _contents -> [
               field "key"
                 ~typ:(non_null string)
                 ~args:[]
-                ~resolve:(fun _ (_, key) -> Irmin.Type.to_string Store.key_t key)
-              ;
-              io_field "metadata"
-                ~typ:Presentation.Metadata.schema_typ
+                ~resolve:(fun _ (_, _, key) ->
+                  Irmin.Type.to_string Store.key_t key
+                );
+              field "metadata"
+                ~typ:(non_null Presentation.Metadata.schema_typ)
                 ~args:[]
-                ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.find_all tree key >|=
-                    Option.map snd >|=
-                    Option.map Presentation.Metadata.to_src >|=
-                    Result.ok
-                  )
-              ;
-              io_field "value"
-                ~typ:Presentation.Contents.schema_typ
+                ~resolve:(fun _ (_, metadata, _) ->
+                    Presentation.Metadata.to_src metadata
+                  );
+              field "value"
+                ~typ:(non_null Presentation.Contents.schema_typ)
                 ~args:[]
-                ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.find tree key >|=
-                    Option.map Presentation.Contents.to_src >|=
-                    Result.ok
-                  )
-              ;
-              io_field "hash"
-                ~typ:string
+                ~resolve:(fun _ (contents, _, _) ->
+                    Presentation.Contents.to_src contents
+                  );
+              field "hash"
+                ~typ:(non_null string)
                 ~args:[]
-                ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.find tree key >|= function
-                    | None -> Ok None
-                    | Some contents ->
-                      let contents = Store.Contents.hash contents in
-                      Ok (Some (Irmin.Type.to_string Store.Hash.t contents))
-                )
-              ;
+                ~resolve:(fun _ (contents, _, _) ->
+                    let hash = Store.Contents.hash contents in
+                    Irmin.Type.to_string Store.Hash.t hash
+                );
             ])
     )
 

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -247,23 +247,7 @@ module Make_ext(Server: Cohttp_lwt.S.Server)(Config: CONFIG)(Store : Irmin.S)(Pr
                     Lwt.return_ok (Some (tree, key))
                   )
               ;
-              io_field "value"
-                ~args:[]
-                ~typ:Presentation.Contents.schema_typ
-                ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.find tree key >|=
-                    Option.map Presentation.Contents.to_src >|=
-                    Result.ok
                   );
-              io_field "metadata"
-                ~args:[]
-                ~typ:Presentation.Metadata.schema_typ
-                ~resolve:(fun _ (tree, key) ->
-                    Store.Tree.find_all tree key >|=
-                    Option.map snd >|=
-                    Option.map Presentation.Metadata.to_src >|=
-                    Result.ok
-                 );
               field "hash"
                 ~typ:(non_null string)
                 ~args:[]


### PR DESCRIPTION
As part of reviewing the GraphQL schema, I thought some aspects were slightly confusing as detailed below.

### Nullable fields on `Contents`

The fields `value`, `metadata` and `hash` are optional for the type `Contents`. This reflects that a particular key could be either present or not, but I suggest this should rather be reflected by returning `null` rather than "empty" Contents object.

In practice, this means instead of returning this JSON ...

```json
{
  "someContentsField": {
    "key": "key/not/present",
    "value": null,
    "metadata": null,
    "hash": null
  }
}
```

... return this JSON instead:

```json
{
  "someContentsField": null
}
```

Suggested diff in SDL terms:

```diff
 type Contents {
-  hash: String
+  hash: String!
   key: String!
-  metadata: String
-  value: String
+  metadata: String!
+  value: String!
 }
```

### Relationship between `Node` and `Contents`

The relationship between the types `Node` ("folders") and `Contents` ("files") are not clear to me right now. The type `Node` has fields `value` and `metadata` similar to `Contents`, which makes it "file-like". I think we should either:

#### Option 1: Collapse types

The types `Node` and `Contents` could be collapsed into a single type. This would probably require adding a new field `kind: TreeKind!`, where `TreeKind` is an enum of `NODE` and `CONTENTS`.

Suggested diff in SDL terms:

```diff
-type Contents {
-  ...
-}

-union Tree = Contents | Node

+enum TreeKind {
+  NODE
+  CONTENTS
+}

-type Node {
+type Tree {
  hash: String!
  key: String!
  metadata: String
  tree: [Tree!]!
  value: String
+  kind: TreeKind!
}
```

(the above diff includes renaming `Node` to `Tree`)

This is the simplest approach and somewhat mirrors the types in OCaml, where "files and folders" are not clearly differentiated either IMHO 😛 I don't find it particularly clean though, and I'm concerned it will lead to suboptimal client code.

#### Option 2: More clearly disambiguate

We could more clearly disambiguate between "folders" (`Node`) and "files" (`Contents`). To pursue this option, I think we should remove the fields `value` and `metadata` from `Node`. This requires changing the type of the field `Node.get` to `Tree` rather than `Node` to reflect it could be either a “file or folder”.

Suggested changes in SDL terms:

```diff
 type Node {
-  get(step: Step): Node
+  get(key: Key!): Tree
   hash: String!
   key: String!
-  metadata: String
   tree: [Tree!]!
-  value: String
 }
```

If we pursue this approach, I think we should also consider how to make the following fields and their types more consistent:

```graphql
type Branch {
  get(key: Key!): String
  get_tree(key: Key!): [Contents!]
  get_all(key: Key!): Contents
  ...
}

type Node {
  get(key: Key!): Tree
  ...
}
```

### Changes in this PR

The changes in this PR include:

- Making fields on `Contents` non-nullable.
- Implementing option 2 (disambiguation) by removing fields `value` and `metadata` from `Node` and changing the type of the field `Node.get`.
- Getting rid of the scalar type `Step`, which was only used in a single instance, which I found inconsistent.
- The source type of Node is not changed (`tree * key`), but the semantics change: the tree is now fully resolved to the actual subtree, and the key is only part of the source type to support the `key` field.