### PR TITLE
Make sure all GraphQL modules conform to the same layout

### DIFF
--- a/src/irmin-mirage/irmin_mirage.ml
+++ b/src/irmin-mirage/irmin_mirage.ml
@@ -52,35 +52,35 @@ module Git = struct
         and module Git = G
 
   module type KV_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) -> S
-                                                                             with type 
+                                                                             with type
                                                                              key =
                                                                                string
                                                                                list
-                                                                              and type 
+                                                                              and type
                                                                              step =
                                                                                string
-                                                                              and type 
+                                                                              and type
                                                                              contents =
                                                                                C
                                                                                .t
-                                                                              and type 
+                                                                              and type
                                                                              branch =
                                                                                string
                                                                               and module Git = G
 
   module type REF_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) -> S
-                                                                              with type 
+                                                                              with type
                                                                               key =
                                                                                string
                                                                                list
-                                                                               and type 
+                                                                               and type
                                                                               step =
                                                                                string
-                                                                               and type 
+                                                                               and type
                                                                               contents =
                                                                                C
                                                                                .t
-                                                                               and type 
+                                                                               and type
                                                                               branch =
                                                                                Irmin_git
                                                                                .reference
@@ -483,50 +483,52 @@ module Git = struct
 end
 
 module Graphql = struct
-  module type S = sig
-    module Pclock : Mirage_clock_lwt.PCLOCK
+  module Server = struct
+    module type S = sig
+      module Pclock : Mirage_clock_lwt.PCLOCK
 
-    module Http : Cohttp_lwt.S.Server
+      module Http : Cohttp_lwt.S.Server
 
-    module Store :
-      Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
+      module Store :
+        Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
 
-    val start :
-      pclock:Pclock.t ->
-      http:(Http.t -> unit Lwt.t) ->
-      Store.repo ->
-      unit Lwt.t
-  end
+      val start :
+        pclock:Pclock.t ->
+        http:(Http.t -> unit Lwt.t) ->
+        Store.repo ->
+        unit Lwt.t
+    end
 
-  module Make
-      (Http : Cohttp_lwt.S.Server)
-      (Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
-      (Pclock : Mirage_clock_lwt.PCLOCK) =
-  struct
-    module Store = Store
-    module Pclock = Pclock
-    module Http = Http
+    module Make
+        (Http : Cohttp_lwt.S.Server)
+        (Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
+        (Pclock : Mirage_clock_lwt.PCLOCK) =
+    struct
+      module Store = Store
+      module Pclock = Pclock
+      module Http = Http
 
-    let init p =
-      let module Config = struct
-        let info ?(author = "irmin-graphql") fmt =
-          let module I = Info (Pclock) in
-          I.f ~author p fmt
+      let init p =
+        let module Config = struct
+          let info ?(author = "irmin-graphql") fmt =
+            let module I = Info (Pclock) in
+            I.f ~author p fmt
 
-        let remote =
-          Some
-            (fun ?headers uri ->
-              let e = Git_mirage.endpoint ?headers (Uri.of_string uri) in
-              Store.E e )
-      end in
-      (module Irmin_graphql.Server.Make (Http) (Config) (Store)
-      : Irmin_graphql.Server.S
-        with type server = Http.t
-         and type repo = Store.repo )
+          let remote =
+            Some
+              (fun ?headers uri ->
+                let e = Git_mirage.endpoint ?headers (Uri.of_string uri) in
+                Store.E e )
+        end in
+        (module Irmin_graphql.Server.Make (Http) (Config) (Store)
+        : Irmin_graphql.Server.S
+          with type server = Http.t
+           and type repo = Store.repo )
 
-    let start ~pclock ~http store =
-      let (module G) = init pclock in
-      let server = G.v store in
-      http server
+      let start ~pclock ~http store =
+        let (module G) = init pclock in
+        let server = G.v store in
+        http server
+    end
   end
 end

--- a/src/irmin-mirage/irmin_mirage.mli
+++ b/src/irmin-mirage/irmin_mirage.mli
@@ -57,35 +57,35 @@ module Git : sig
         and module Git = G
 
   module type KV_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) -> S
-                                                                             with type 
+                                                                             with type
                                                                              key =
                                                                                string
                                                                                list
-                                                                              and type 
+                                                                              and type
                                                                              step =
                                                                                string
-                                                                              and type 
+                                                                              and type
                                                                              contents =
                                                                                C
                                                                                .t
-                                                                              and type 
+                                                                              and type
                                                                              branch =
                                                                                string
                                                                               and module Git = G
 
   module type REF_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) -> S
-                                                                              with type 
+                                                                              with type
                                                                               key =
                                                                                string
                                                                                list
-                                                                               and type 
+                                                                               and type
                                                                               step =
                                                                                string
-                                                                               and type 
+                                                                               and type
                                                                               contents =
                                                                                C
                                                                                .t
-                                                                               and type 
+                                                                               and type
                                                                               branch =
                                                                                Irmin_git
                                                                                .reference
@@ -197,27 +197,29 @@ module Git : sig
 end
 
 module Graphql : sig
-  module type S = sig
-    module Pclock : Mirage_clock_lwt.PCLOCK
+  module Server: sig
+    module type S = sig
+      module Pclock : Mirage_clock_lwt.PCLOCK
 
-    module Http : Cohttp_lwt.S.Server
+      module Http : Cohttp_lwt.S.Server
 
-    module Store :
-      Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
+      module Store :
+        Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
 
-    val start :
-      pclock:Pclock.t ->
-      http:(Http.t -> unit Lwt.t) ->
-      Store.repo ->
-      unit Lwt.t
+      val start :
+        pclock:Pclock.t ->
+        http:(Http.t -> unit Lwt.t) ->
+        Store.repo ->
+        unit Lwt.t
+    end
+
+    module Make
+        (Http : Cohttp_lwt.S.Server)
+        (Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
+        (Pclock : Mirage_clock_lwt.PCLOCK) :
+      S
+      with module Pclock = Pclock
+       and module Store = Store
+       and module Http = Http
   end
-
-  module Make
-      (Http : Cohttp_lwt.S.Server)
-      (Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
-      (Pclock : Mirage_clock_lwt.PCLOCK) :
-    S
-    with module Pclock = Pclock
-     and module Store = Store
-     and module Http = Http
 end

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -653,7 +653,7 @@ let graphql =
        let graphql (S ((module S), store, remote_fn)) port addr =
          run
            (let module Server =
-              Graphql.Make
+              Graphql.Server.Make
                 (S)
                 (struct
                   let remote = remote_fn

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -1,20 +1,22 @@
-module Remote = struct
-  module None = struct
-    let remote = None
+module Server = struct
+  module Remote = struct
+    module None = struct
+      let remote = None
+    end
   end
-end
 
-module Make
-    (S : Irmin.S) (Remote : sig
-        val remote : Resolver.Store.remote_fn option
-    end) =
-struct
-  include Irmin_graphql.Server.Make
-            (Cohttp_lwt_unix.Server)
-            (struct
-              let info = Info.v
+  module Make
+      (S : Irmin.S) (Remote : sig
+          val remote : Resolver.Store.remote_fn option
+      end) =
+  struct
+    include Irmin_graphql.Server.Make
+              (Cohttp_lwt_unix.Server)
+              (struct
+                let info = Info.v
 
-              let remote = Remote.remote
-            end)
-            (S)
+                let remote = Remote.remote
+              end)
+              (S)
+  end
 end

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -1,13 +1,15 @@
-module Remote : sig
-  module None : sig
-    val remote : Resolver.Store.remote_fn option
+module Server: sig
+  module Remote : sig
+    module None : sig
+      val remote : Resolver.Store.remote_fn option
+    end
   end
-end
 
-module Make
-    (S : Irmin.S) (Remote : sig
-        val remote : Resolver.Store.remote_fn option
-    end) :
-  Irmin_graphql.Server.S
-  with type repo = S.repo
-   and type server = Cohttp_lwt_unix.Server.t
+  module Make
+      (S : Irmin.S) (Remote : sig
+          val remote : Resolver.Store.remote_fn option
+      end) :
+    Irmin_graphql.Server.S
+    with type repo = S.repo
+     and type server = Cohttp_lwt_unix.Server.t
+end


### PR DESCRIPTION
The initial renaming of GraphQL modules didn't cover the `irmin-unix`/`irmin-mirage`, so this PR makes sure that all GraphQL server related code is in a module named `*.Graphql.Server`