### PR TITLE
Expose tree and key to custom GraphQL presenter

### DIFF
--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -5,18 +5,35 @@ module Server = struct
     end
   end
 
+  module Make_ext
+      (S : Irmin.S) (Remote : sig
+          val remote : Resolver.Store.remote_fn option
+      end)
+      (P : Irmin_graphql.Server.PRESENTATION
+           with type contents := S.contents
+            and type metadata := S.metadata
+            and type tree := S.tree
+            and type key := S.key) =
+    Irmin_graphql.Server.Make_ext
+      (Cohttp_lwt_unix.Server)
+      (struct
+        let info = Info.v
+
+        let remote = Remote.remote
+      end)
+      (S)
+      (P)
+
   module Make
       (S : Irmin.S) (Remote : sig
           val remote : Resolver.Store.remote_fn option
       end) =
-  struct
-    include Irmin_graphql.Server.Make
-              (Cohttp_lwt_unix.Server)
-              (struct
-                let info = Info.v
+    Irmin_graphql.Server.Make
+      (Cohttp_lwt_unix.Server)
+      (struct
+        let info = Info.v
 
-                let remote = Remote.remote
-              end)
-              (S)
-  end
+        let remote = Remote.remote
+      end)
+      (S)
 end

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -1,4 +1,4 @@
-module Server: sig
+module Server : sig
   module Remote : sig
     module None : sig
       val remote : Resolver.Store.remote_fn option
@@ -9,6 +9,19 @@ module Server: sig
       (S : Irmin.S) (Remote : sig
           val remote : Resolver.Store.remote_fn option
       end) :
+    Irmin_graphql.Server.S
+    with type repo = S.repo
+     and type server = Cohttp_lwt_unix.Server.t
+
+  module Make_ext
+      (S : Irmin.S) (Remote : sig
+          val remote : Resolver.Store.remote_fn option
+      end)
+      (P : Irmin_graphql.Server.PRESENTATION
+           with type contents := S.contents
+            and type metadata := S.metadata
+            and type tree := S.tree
+            and type key := S.key) :
     Irmin_graphql.Server.S
     with type repo = S.repo
      and type server = Cohttp_lwt_unix.Server.t


### PR DESCRIPTION
This PR exposes the current tree and key to the custom GraphQL presenter. In particular, the type of `Irmin_graphql.Server.PRESENTER.to_src` has changed in the following way:

```diff
- val to_src : t -> src
+ val to_src : tree -> key -> t -> src
```

This allows the custom presenter to look up other data in the tree as part of presenting the value (a use case coming from Bushel).

To facilitate this change, the functor `Irmin_graphql.Server.Default_presenter` has been replaced with the functor `Irmin_graphql.Server.Default_presentation`. This is motivated by the type of the tree and key now being part of the `Irmin_graphql.Server.PRESENTER`-signature.

Overriding the default presentation changes in the following way (assuming a module `S` of type `Irmin.S` is in scope):

```ocaml
(* Before this PR *)
module Presentation = struct
  module Metadata = Irmin_graphql.Server.Default_presenter (S.Metadata)
  module Contents = struct
    (* something custom *)
  end
end

(* After this PR *)
module Presentation = struct
  module Defaults = Irmin_graphql.Server.Default_presentation (S)
  module Metadata = Defaults.Metadata
  module Contents = struct
    (* something custom *)
  end
end

```
The source is formatted with ocamlformat 0.9.