### PR TITLE
Require a user-defined Node.merge instead of forcing our own.

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -354,6 +354,8 @@ struct
 
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
+
+      let merge merge_key = Irmin.Merge.like t (N.merge merge_key) to_n of_n
     end
 
     include Content_addressable (struct

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1551,6 +1551,9 @@ module Private : sig
       val t : t Type.t
       (** [t] is the value type for {!t}. *)
 
+      val merge : hash option Merge.t -> t Merge.t
+      (** [merge] is the merge function for values of type {!t}. *)
+
       val default : metadata
       (** [default] is the default metadata value. *)
 

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -134,6 +134,8 @@ module type NODE = sig
 
   val t : t Type.t
 
+  val merge : hash option Merge.t -> t Merge.t
+
   val default : metadata
 
   val metadata_t : metadata Type.t


### PR DESCRIPTION
This will help untangling the Tree implementation from the underlying Node
implementation (e.g. it might not be exactly a value StepMap.t anymore in
the near future).