### PR TITLE
irmin-http: client and server should agree on how to serialise nodes …

### DIFF
--- a/src/irmin-http/dune
+++ b/src/irmin-http/dune
@@ -1,5 +1,4 @@
 (library
  (name        irmin_http)
  (public_name irmin-http)
- (wrapped     false)
  (libraries   irmin cohttp-lwt webmachine))

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -387,22 +387,15 @@ module type CLIENT = sig
   val ctx : unit -> ctx option
 end
 
-module Make
-    (Client : CLIENT)
-    (M : Irmin.Metadata.S)
-    (C : Irmin.Contents.S)
-    (P : Irmin.Path.S)
-    (B : Irmin.Branch.S)
-    (H : Irmin.Hash.S) =
-struct
+module Make (Client : CLIENT) (S : Irmin.S) = struct
   module X = struct
-    module Hash = H
+    module Hash = S.Hash
 
     module Contents = struct
       module X = struct
-        module Key = H
-        module Val = C
-        include AO (Client) (H) (C)
+        module Key = S.Hash
+        module Val = S.Contents
+        include AO (Client) (Key) (Val)
       end
 
       include Irmin.Contents.Store (X)
@@ -412,20 +405,20 @@ struct
 
     module Node = struct
       module X = struct
-        module Key = H
-        module Val = Irmin.Private.Node.Make (H) (P) (M)
+        module Key = S.Hash
+        module Val = S.Private.Node.Val
         include AO (Client) (Key) (Val)
       end
 
-      include Irmin.Private.Node.Store (Contents) (P) (M) (X)
+      include Irmin.Private.Node.Store (Contents) (S.Key) (S.Metadata) (X)
 
       let v ?ctx config = X.v ?ctx config "tree" "trees"
     end
 
     module Commit = struct
       module X = struct
-        module Key = H
-        module Val = Irmin.Private.Commit.Make (H)
+        module Key = S.Hash
+        module Val = S.Private.Commit.Val
         include AO (Client) (Key) (Val)
       end
 
@@ -434,16 +427,16 @@ struct
       let v ?ctx config = X.v ?ctx config "commit" "commits"
     end
 
+    module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
+    module Sync = Irmin.Private.Sync.None (Hash) (S.Branch)
+
     module Branch = struct
-      module Key = B
-      module Val = H
+      module Key = S.Branch
+      module Val = S.Hash
       include RW (Client) (Key) (Val)
 
       let v ?ctx config = v ?ctx config "branch" "branches"
     end
-
-    module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
-    module Sync = Irmin.Private.Sync.None (H) (B)
 
     module Repo = struct
       type t = {
@@ -485,8 +478,3 @@ struct
 
   include Irmin.Of_private (X)
 end
-
-module KV (H : CLIENT) (C : Irmin.Contents.S) =
-  Make (H) (Irmin.Metadata.None) (C) (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -381,13 +381,13 @@ struct
     Lwt.return_unit
 end
 
-module type CLIENT = sig
+module type HTTP_CLIENT = sig
   include Cohttp_lwt.S.Client
 
   val ctx : unit -> ctx option
 end
 
-module Make (Client : CLIENT) (S : Irmin.S) = struct
+module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
   module X = struct
     module Hash = S.Hash
 
@@ -478,3 +478,7 @@ module Make (Client : CLIENT) (S : Irmin.S) = struct
 
   include Irmin.Of_private (X)
 end
+
+module type SERVER = Irmin_http_server.S
+
+module Server = Irmin_http_server.Make

--- a/src/irmin-http/irmin_http.mli
+++ b/src/irmin-http/irmin_http.mli
@@ -26,6 +26,12 @@ module type CLIENT = sig
   val ctx : unit -> ctx option
 end
 
-module Make (C : CLIENT) : Irmin.S_MAKER
-
-module KV (C : CLIENT) : Irmin.KV_MAKER
+module Make (C : CLIENT) (S : Irmin.S) :
+  Irmin.S
+  with type key = S.key
+   and type contents = S.contents
+   and type branch = S.branch
+   and type hash = S.hash
+   and type step = S.step
+   and type metadata = S.metadata
+   and type Key.step = S.Key.step

--- a/src/irmin-unix/http.ml
+++ b/src/irmin-unix/http.ml
@@ -26,5 +26,5 @@ module HTTP = struct
     Some (Cohttp_lwt_unix.Client.custom_ctx ~resolver ())
 end
 
-module Client = Irmin_http.Make (HTTP)
-module Server = Irmin_http_server.Make (Cohttp_lwt_unix.Server)
+module Client = Irmin_http.Client (HTTP)
+module Server = Irmin_http.Server (Cohttp_lwt_unix.Server)

--- a/src/irmin-unix/http.ml
+++ b/src/irmin-unix/http.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Client = struct
+module HTTP = struct
   include Cohttp_lwt_unix.Client
 
   let ctx () =
@@ -26,8 +26,5 @@ module Client = struct
     Some (Cohttp_lwt_unix.Client.custom_ctx ~resolver ())
 end
 
-module Make = Irmin_http.Make (Client)
-module KV (C : Irmin.Contents.S) =
-  Make (Irmin.Metadata.None) (C) (Irmin.Path.String_list) (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+module Client = Irmin_http.Make (HTTP)
 module Server = Irmin_http_server.Make (Cohttp_lwt_unix.Server)

--- a/src/irmin-unix/http.mli
+++ b/src/irmin-unix/http.mli
@@ -25,6 +25,6 @@ module Client (S : Irmin.S) :
    and type Key.step = S.Key.step
 
 module Server (S : Irmin.S) :
-  Irmin_http_server.S
+  Irmin_http.SERVER
   with type repo = S.Repo.t
    and type t = Cohttp_lwt_unix.Server.t

--- a/src/irmin-unix/http.mli
+++ b/src/irmin-unix/http.mli
@@ -14,9 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make : Irmin.S_MAKER
-
-module KV : Irmin.KV_MAKER
+module Client (S : Irmin.S) :
+  Irmin.S
+  with type key = S.key
+   and type contents = S.contents
+   and type branch = S.branch
+   and type hash = S.hash
+   and type step = S.step
+   and type metadata = S.metadata
+   and type Key.step = S.Key.step
 
 module Server (S : Irmin.S) :
   Irmin_http_server.S

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -198,7 +198,7 @@ module Http : sig
 
   (** Server-side of the REST API over HTTP. *)
   module Server (S : Irmin.S) :
-    Irmin_http_server.S
+    Irmin_http.SERVER
     with type repo = S.Repo.t
      and type t = Cohttp_lwt_unix.Server.t
 end

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -184,9 +184,15 @@ module Http : sig
       to the server, all the high-level logic is done on the
       client. Hence a high-level operation might take multiple
       RTTs. *)
-  module Make : Irmin.S_MAKER
-
-  module KV : Irmin.KV_MAKER
+  module Client (S : Irmin.S) :
+    Irmin.S
+    with type key = S.key
+     and type contents = S.contents
+     and type branch = S.branch
+     and type hash = S.hash
+     and type step = S.step
+     and type metadata = S.metadata
+     and type Key.step = S.Key.step
 
   (** {1 HTTP server} *)
 

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -49,7 +49,7 @@ module Store : sig
 
   val irf : contents -> t
 
-  val http : contents -> t
+  val http : t -> t
 
   val git : contents -> t
 

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -39,7 +39,7 @@ module Client = struct
 end
 
 let http_store (module S : Irmin_test.S) =
-  let module M = Irmin_http.Make (Client) (S) in
+  let module M = Irmin_http.Client (Client) (S) in
   (module M : Irmin_test.S)
 
 (* See https://github.com/mirage/ocaml-cohttp/issues/511 *)
@@ -83,7 +83,7 @@ let serve servers n =
         Fmt.(option string)
         (root server.config) );
   let (module Server : Irmin_test.S) = server.store in
-  let module HTTP = Irmin_http_server.Make (Cohttp_lwt_unix.Server) (Server) in
+  let module HTTP = Irmin_http.Server (Cohttp_lwt_unix.Server) (Server) in
   let server () =
     server.init () >>= fun () ->
     Server.Repo.v server.config >>= fun repo ->

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -39,7 +39,8 @@ module Client = struct
 end
 
 let http_store (module S : Irmin_test.S) =
-  Irmin_test.store (module Irmin_http.Make (Client)) (module S.Metadata)
+  let module M = Irmin_http.Make (Client) (S) in
+  (module M : Irmin_test.S)
 
 (* See https://github.com/mirage/ocaml-cohttp/issues/511 *)
 let () =


### PR DESCRIPTION
…and commit

This is needed to be able to cache things efficiently on the client.
As a side-effect, it makes Irmin_http.Make functor signature nice, e.g
now it's just  Irmin.S -> Irmin.S, which makes senses: the client just
proxy write/read operations to the server, the rest should be unchanged.