### PR TITLE
Use hash-consing for tree nodes and contents.

### DIFF
--- a/src/irmin-http/irmin_http_server.ml
+++ b/src/irmin-http/irmin_http_server.ml
@@ -106,7 +106,7 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
               let str = Irmin.Type.to_string V.t in
               S.find db key >>= function
               | Some value -> Wm.continue (`String (str value)) rd
-              | None -> assert false )
+              | None -> Wm.respond 404 rd )
 
         method! allowed_methods rd = Wm.continue [ `GET; `HEAD ] rd
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -125,6 +125,7 @@ module Make (S : S) = struct
     try
       Lwt_main.run
         ( x.init () >>= fun () ->
+          S.Tree.Cache.trim ();
           S.Repo.v x.config >>= fun repo -> test repo >>= x.clean )
     with e ->
       Lwt_main.run (x.clean ());
@@ -1283,12 +1284,13 @@ module Make (S : S) = struct
       let px = [ "x"; "y"; "z" ] in
       S.set_exn tt ~info:(infof "update") px vx >>= fun () ->
       S.get_tree tt [] >>= fun tree ->
-      S.Tree.clear_caches tree;
+      S.Tree.clear tree;
       S.Tree.stats tree >>= fun s ->
       Alcotest.(check stats_t)
         "lazy stats"
         { S.Tree.nodes = 0; leafs = 0; skips = 1; depth = 0; width = 0 }
         s;
+      S.Tree.clear tree;
       S.Tree.stats ~force:true tree >>= fun s ->
       Alcotest.(check stats_t)
         "forced stats"

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -2580,7 +2580,7 @@ module type S = sig
     module Cache : sig
       val length : unit -> [ `Contents of int ] * [ `Nodes of int ]
 
-      val trim : unit -> unit
+      val trim : ?depth:int -> unit -> unit
 
       val dump : unit Fmt.t
     end

--- a/src/irmin/lock.ml
+++ b/src/irmin/lock.ml
@@ -24,6 +24,8 @@ module type S = sig
   val v : unit -> t
 
   val with_lock : t -> key -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+  val stats : t -> int
 end
 
 module Make (K : Type.S) = struct
@@ -42,6 +44,8 @@ module Make (K : Type.S) = struct
   type t = { global : Lwt_mutex.t; locks : Lwt_mutex.t KHashtbl.t }
 
   let v () = { global = Lwt_mutex.create (); locks = KHashtbl.create 1024 }
+
+  let stats t = KHashtbl.length t.locks
 
   let lock t key () =
     let lock =

--- a/src/irmin/lock.mli
+++ b/src/irmin/lock.mli
@@ -22,6 +22,8 @@ module type S = sig
   val v : unit -> t
 
   val with_lock : t -> key -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+  val stats : t -> int
 end
 
 module Make (K : Type.S) : S with type key = K.t

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -554,7 +554,7 @@ module type TREE = sig
   module Cache : sig
     val length : unit -> [ `Contents of int ] * [ `Nodes of int ]
 
-    val trim : unit -> unit
+    val trim : ?depth:int -> unit -> unit
 
     val dump : unit Fmt.t
   end

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -510,8 +510,6 @@ module type TREE = sig
 
   val merge : tree Merge.t
 
-  val clear_caches : tree -> unit
-
   type marks
 
   val empty_marks : unit -> marks
@@ -550,6 +548,16 @@ module type TREE = sig
   val of_concrete : concrete -> tree
 
   val to_concrete : tree -> concrete Lwt.t
+
+  val clear : tree -> unit
+
+  module Cache : sig
+    val length : unit -> [ `Contents of int ] * [ `Nodes of int ]
+
+    val trim : unit -> unit
+
+    val dump : unit Fmt.t
+  end
 end
 
 module type STORE = sig
@@ -1023,6 +1031,7 @@ module type STORE = sig
   val save_contents : [> `Write ] Private.Contents.t -> contents -> hash Lwt.t
 
   val save_tree :
+    ?clear:bool ->
     repo ->
     [> `Write ] Private.Contents.t ->
     [> `Write ] Private.Node.t ->

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -65,10 +65,10 @@ module Make (P : S.PRIVATE) = struct
 
   let save_contents b c = P.Contents.add b c
 
-  let save_tree r x y (tr : Tree.tree) =
+  let save_tree ?(clear = true) r x y (tr : Tree.tree) =
     match tr with
     | `Contents (c, _) -> save_contents x c
-    | `Node n -> Tree.export r x y n
+    | `Node n -> Tree.export ~clear r x y n
 
   type node = Tree.node
 

--- a/src/irmin/tree.mli
+++ b/src/irmin/tree.mli
@@ -28,6 +28,7 @@ module Make (P : S.PRIVATE) : sig
   val import_no_check : P.Repo.t -> P.Node.key -> node
 
   val export :
+    ?clear:bool ->
     P.Repo.t ->
     [> `Write ] P.Contents.t ->
     [> `Write ] P.Node.t ->


### PR DESCRIPTION
Every tree node/contents/hash has an associated info field stored in an
ephemeron. We try to alway keep alive only one version of similar values.