### PR TITLE
irmin-http: use a separate route to handle tree merges

### DIFF
--- a/src/irmin-http/irmin_http_common.ml
+++ b/src/irmin-http/irmin_http_common.ml
@@ -41,3 +41,13 @@ let init_t k x =
   let open Irmin.Type in
   record "init" (fun k v -> (k, v))
   |+ field "branch" k fst |+ field "commit" x snd |> sealr
+
+type 'a merge = { old : 'a; left : 'a; right : 'a }
+
+let merge_t h =
+  let open Irmin.Type in
+  record "merge" (fun old left right -> { old; left; right })
+  |+ field "old" h (fun t -> t.old)
+  |+ field "left" h (fun t -> t.left)
+  |+ field "right" h (fun t -> t.right)
+  |> sealr

--- a/src/irmin-http/irmin_http_common.mli
+++ b/src/irmin-http/irmin_http_common.mli
@@ -28,3 +28,7 @@ val event_t :
   'a Irmin.Type.t -> 'b Irmin.Type.t -> ('a * 'b Irmin.Diff.t) Irmin.Type.t
 
 val init_t : 'a Irmin.Type.t -> 'b Irmin.Type.t -> ('a * 'b) Irmin.Type.t
+
+type 'a merge = { old : 'a; left : 'a; right : 'a }
+
+val merge_t : 'a Irmin.Type.t -> 'a merge Irmin.Type.t


### PR DESCRIPTION
This avoid having to recode all the merge logics on the client side.