### PR TITLE
Use tree-structured inodes instead of flat lists to represent tree nodes

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -204,6 +204,8 @@ struct
 
       type t = G.Value.Tree.t
 
+      type inode = t
+
       type metadata = Metadata.t
 
       type hash = Key.t
@@ -308,7 +310,7 @@ struct
                 (to_step name, mk_c node perm) :: acc )
           [] (G.Value.Tree.to_list t)
 
-      module N = Irmin.Private.Node.Make (H) (P) (Metadata)
+      module N = Irmin.Private.Node.Flat (H) (P) (Metadata)
 
       let to_n t = N.v (alist t)
 
@@ -337,6 +339,12 @@ struct
 
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
+
+      let inode_t = t
+
+      let load ~find h = find h
+
+      let save ~add t = add t
     end
 
     include Content_addressable (struct

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -56,7 +56,7 @@ module Append_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
   include Read_only (K) (V)
 
   let add t key value =
-    Log.debug (fun f -> f "add -> %a" pp_key key);
+    Log.debug (fun f -> f "add %a -> %a" Irmin.Type.(pp V.t) value pp_key key);
     t.t <- KMap.add key value t.t;
     Lwt.return ()
 end

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -511,6 +511,7 @@ module V1 (C : S.COMMIT) = struct
   type t = { parents : hash list; c : C.t }
 
   let import c = { c; parents = C.parents c }
+
   let export t = t.c
 
   let node t = C.node t.c

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -130,7 +130,14 @@ struct
       module CA = struct
         module Val = N
         module Key = Hash
-        include CA (Key) (Val)
+
+        module Inode = struct
+          type t = Val.inode
+
+          let t = Val.inode_t
+        end
+
+        include CA (Key) (Inode)
       end
 
       include Node.Store (Contents) (P) (M) (CA)
@@ -204,7 +211,13 @@ module Make
     (B : S.BRANCH)
     (H : S.HASH) =
 struct
-  module N = Node.Make (H) (P) (M)
+  module Conf = struct
+    let max_inodes = 32
+
+    let max_values = 32
+  end
+
+  module N = Node.Tree (Conf) (H) (P) (M)
   module CT = Commit.Make (H)
   include Make_ext (CA) (AW) (M) (C) (P) (B) (H) (N) (CT)
 end

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -110,6 +110,8 @@ end
 module type NODE = sig
   type t
 
+  type inode
+
   type metadata
 
   type hash
@@ -132,7 +134,13 @@ module type NODE = sig
 
   val remove : t -> step -> t
 
+  val load : find:(hash -> inode option Lwt.t) -> hash -> t option Lwt.t
+
+  val save : add:(inode -> hash Lwt.t) -> t -> hash Lwt.t
+
   val t : t Type.t
+
+  val inode_t : inode Type.t
 
   val default : metadata
 

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -1,4 +1,4 @@
 (test
  (name      test)
  (package   irmin)
- (libraries digestif.c irmin alcotest hex))
+ (libraries digestif.c irmin alcotest hex lwt.unix))


### PR DESCRIPTION
This should improve the size of nodes on disk. This doesn't change the hash of tree nodes if the number of nodes is smaller than a user-defined limit.

Note however that the inodes tree are entirely read everytime a node is loaded. Lazy read of inodes can come later, if I/O is really an issue.