### PR TITLE
Allow values to define a custom hash functions

### DIFF
--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -409,7 +409,7 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
       module Key = struct
         include S.Hash
 
-        let digest v = digest (Irmin.Type.pre_digest Val.t v)
+        let hash v = hash (Irmin.Type.pre_hash Val.t v)
       end
 
       include AO (Client) (S.Hash) (Val)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1144,7 +1144,7 @@ module Make (S : S) = struct
       (* Test caching (makesure that no tree is lying in scope) *)
       ( S.Tree.Cache.trim ();
         Gc.full_major ();
-        let v0 = S.Tree.shallow repo (P.Contents.Key.digest "foo") in
+        let v0 = S.Tree.shallow repo (P.Contents.Key.hash "foo") in
         check_cache "empty" 0 0;
         let foo = "foo-x" in
         S.Tree.add v0 [ "foo" ] foo >>= fun v0 ->
@@ -1165,7 +1165,7 @@ module Make (S : S) = struct
           ()
         in
         S.Tree.Cache.trim ();
-        let v0 = S.Tree.shallow repo (P.Contents.Key.digest "bar") in
+        let v0 = S.Tree.shallow repo (P.Contents.Key.hash "bar") in
         let xxx = "xxx" in
         let yyy = "yyy" in
         let zzz = "zzz" in
@@ -1751,8 +1751,8 @@ module Make (S : S) = struct
 
   let test_shallow_objects x () =
     let test repo =
-      let foo_k = S.Private.Contents.Key.digest "foo" in
-      let bar_k = S.Private.Contents.Key.digest "bar" in
+      let foo_k = S.Private.Contents.Key.hash "foo" in
+      let bar_k = S.Private.Contents.Key.hash "bar" in
       let tree_1 = S.Tree.shallow repo foo_k in
       let tree_2 = S.Tree.shallow repo bar_k in
       let node_3 =

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -121,7 +121,7 @@ struct
 
   let merge t ~info = Merge.(option (v S.Key.t (merge_commit info t)))
 
-  module Key = Hash.With_digest (S.Key) (S.Val)
+  module Key = Hash.With_hash (S.Key) (S.Val)
   module Val = S.Val
 end
 
@@ -188,7 +188,7 @@ module History (S : S.COMMIT_STORE) = struct
 
     let compare = Type.compare S.Key.t
 
-    let hash = S.Key.hash
+    let hash = S.Key.short_hash
 
     let equal = Type.equal S.Key.t
   end
@@ -511,6 +511,7 @@ module V1 (C : S.COMMIT) = struct
   type t = { parents : hash list; c : C.t }
 
   let import c = { c; parents = C.parents c }
+
   let export t = t.c
 
   let node t = C.node t.c

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -272,7 +272,7 @@ module Store (S : sig
   module Val : S.CONTENTS with type t = value
 end) =
 struct
-  module Key = Hash.With_digest (S.Key) (S.Val)
+  module Key = Hash.With_hash (S.Key) (S.Val)
   module Val = S.Val
 
   type 'a t = 'a S.t

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -19,11 +19,11 @@ module Make (H : Digestif.S) = struct
 
   external get_64 : string -> int -> int64 = "%caml_string_get64u"
 
-  let hash c = Int64.to_int (get_64 (H.to_raw_string c) 0)
+  let short_hash c = Int64.to_int (get_64 (H.to_raw_string c) 0)
 
-  let digest_size = H.digest_size
+  let hash_size = H.digest_size
 
-  let digest x = H.digest_string x
+  let hash x = H.digest_string x
 
   let of_hex s =
     match H.consistent_of_hex s with
@@ -34,7 +34,7 @@ module Make (H : Digestif.S) = struct
 
   let t =
     Type.map ~cli:(pp_hex, of_hex)
-      Type.(string_of (`Fixed digest_size))
+      Type.(string_of (`Fixed hash_size))
       H.of_raw_string H.to_raw_string
 end
 
@@ -47,10 +47,10 @@ module SHA512 = Make (Digestif.SHA512)
 module BLAKE2B = Make (Digestif.BLAKE2B)
 module BLAKE2S = Make (Digestif.BLAKE2S)
 
-module With_digest (K : S.HASH) (V : Type.S) = struct
+module With_hash (K : S.HASH) (V : Type.S) = struct
   include K
 
-  let digest v = K.digest (Type.pre_digest V.t v)
+  let hash v = K.hash (Type.pre_hash V.t v)
 end
 
 module V1 (K : S.HASH) : S.HASH with type t = K.t = struct
@@ -58,9 +58,9 @@ module V1 (K : S.HASH) : S.HASH with type t = K.t = struct
 
   let hash = K.hash
 
-  let digest = K.digest
+  let short_hash = K.short_hash
 
-  let digest_size = K.digest_size
+  let hash_size = K.hash_size
 
   let h = Type.string_of `Int64
 

--- a/src/irmin/hash.mli
+++ b/src/irmin/hash.mli
@@ -34,10 +34,10 @@ module BLAKE2B : S.HASH
 
 module BLAKE2S : S.HASH
 
-module With_digest (K : S.HASH) (V : Type.S) : sig
+module With_hash (K : S.HASH) (V : Type.S) : sig
   include S.HASH with type t = K.t
 
-  val digest : V.t -> t
+  val hash : V.t -> t
 end
 
 module V1 (H : S.HASH) : S.HASH with type t = H.t

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -17,6 +17,7 @@
 open Lwt.Infix
 module Type = Type
 module Diff = Diff
+module Content_addressable = Store.Content_addressable
 
 module Contents = struct
   include Contents
@@ -43,60 +44,14 @@ module Hash = struct
   include Hash
 
   module type S = S.HASH
+
+  module type HASHABLE = S.HASHABLE
 end
 
 module Path = struct
   include Path
 
   module type S = S.PATH
-end
-
-module type APPEND_ONLY_STORE = sig
-  type 'a t
-
-  type key
-
-  type value
-
-  val mem : [> `Read ] t -> key -> bool Lwt.t
-
-  val find : [> `Read ] t -> key -> value option Lwt.t
-
-  val add : [> `Write ] t -> key -> value -> unit Lwt.t
-end
-
-module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
-  include APPEND_ONLY_STORE with type key = K.t and type value = V.t
-
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
-  val v : Conf.t -> [ `Read ] t Lwt.t
-end
-
-module Content_addressable
-    (AO : APPEND_ONLY_STORE_MAKER)
-    (K : S.HASH)
-    (V : Type.S) =
-struct
-  include AO (K) (V)
-
-  let pp_key = Type.pp K.t
-
-  let digest v = K.digest (Type.pre_digest V.t v)
-
-  let find t k =
-    find t k >>= function
-    | None -> Lwt.return None
-    | Some v as r ->
-        let k' = digest v in
-        if Type.equal K.t k k' then Lwt.return r
-        else
-          Fmt.kstrf Lwt.fail_invalid_arg
-            "corrupted value: got %a, expecting %a" pp_key k' pp_key k
-
-  let add t v =
-    let k = digest v in
-    add t k v >|= fun () -> k
 end
 
 module Make_ext
@@ -116,10 +71,21 @@ struct
   module X = struct
     module Hash = H
 
+    module With_hash (V : Type.S) = struct
+      let hash t = Hash.hash (Type.pre_hash V.t t)
+    end
+
     module Contents = struct
       module CA = struct
-        module Val = C
         module Key = Hash
+
+        module Val = struct
+          type hash = Hash.t
+
+          include C
+          include With_hash (C)
+        end
+
         include CA (Key) (Val)
       end
 
@@ -128,8 +94,13 @@ struct
 
     module Node = struct
       module CA = struct
-        module Val = N
         module Key = Hash
+
+        module Val = struct
+          include N
+          include With_hash (N)
+        end
+
         include CA (Key) (Val)
       end
 
@@ -138,8 +109,13 @@ struct
 
     module Commit = struct
       module CA = struct
-        module Val = CT
         module Key = Hash
+
+        module Val = struct
+          include CT
+          include With_hash (CT)
+        end
+
         include CA (Key) (Val)
       end
 
@@ -213,6 +189,8 @@ module Of_private = Store.Make
 
 module type CONTENT_ADDRESSABLE_STORE = S.CONTENT_ADDRESSABLE_STORE
 
+module type APPEND_ONLY_STORE = S.APPEND_ONLY_STORE
+
 module type ATOMIC_WRITE_STORE = S.ATOMIC_WRITE_STORE
 
 module type TREE = S.TREE
@@ -224,6 +202,8 @@ type config = Conf.t
 type 'a diff = 'a Diff.t
 
 module type CONTENT_ADDRESSABLE_STORE_MAKER = S.CONTENT_ADDRESSABLE_STORE_MAKER
+
+module type APPEND_ONLY_STORE_MAKER = S.APPEND_ONLY_STORE_MAKER
 
 module type ATOMIC_WRITE_STORE_MAKER = S.ATOMIC_WRITE_STORE_MAKER
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -318,7 +318,7 @@ module Type : sig
   val compare : 'a t -> 'a -> 'a -> int
   (** [compare t] compares values of type [t]. *)
 
-  val hash : 'a t -> ?seed:int -> 'a -> int
+  val short_hash : 'a t -> ?seed:int -> 'a -> int
   (** [hash t x] is a short hash of [x] of type [t]. *)
 
   (** The type for pretty-printers for CLI arguments. *)
@@ -440,8 +440,8 @@ module Type : sig
   (** The type for size function related to binary encoder/decoders. *)
   type 'a size_of = ?headers:bool -> 'a -> int option
 
-  val pre_digest : 'a t -> 'a -> string
-  (** [pre_digest t x] is the string representation of [x], of type
+  val pre_hash : 'a t -> 'a -> string
+  (** [pre_hash t x] is the string representation of [x], of type
       [t], which will be used to compute the digest of the value. By
       default it's [to_bin_string t x] but it can be overriden by {!v},
       {!like} and {!map} operators. *)
@@ -480,8 +480,8 @@ module Type : sig
     bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     equal:('a -> 'a -> bool) ->
     compare:('a -> 'a -> int) ->
-    hash:(?seed:int -> 'a -> int) ->
-    pre_digest:('a -> string) ->
+    short_hash:(?seed:int -> 'a -> int) ->
+    pre_hash:('a -> string) ->
     'a t
 
   val like :
@@ -490,8 +490,8 @@ module Type : sig
     ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?equal:('a -> 'a -> bool) ->
     ?compare:('a -> 'a -> int) ->
-    ?hash:('a -> int) ->
-    ?pre_digest:('a -> string) ->
+    ?short_hash:('a -> int) ->
+    ?pre_hash:('a -> string) ->
     'a t ->
     'a t
 
@@ -501,8 +501,8 @@ module Type : sig
     ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?equal:('a -> 'a -> bool) ->
     ?compare:('a -> 'a -> int) ->
-    ?hash:('a -> int) ->
-    ?pre_digest:('a -> string) ->
+    ?short_hash:('a -> int) ->
+    ?pre_hash:('a -> string) ->
     'b t ->
     ('b -> 'a) ->
     ('a -> 'b) ->
@@ -1037,15 +1037,15 @@ module Hash : sig
     (** The type for digest hashes. *)
     type t
 
-    val digest : string -> t
+    val hash : string -> t
     (** Compute a deterministic store key from a string. *)
 
-    val hash : t -> int
-    (** [hash h] is a small hash of [h], to be used for instance as
+    val short_hash : t -> int
+    (** [short_hash h] is a small hash of [h], to be used for instance as
        the `hash` function of an OCaml [Hashtbl]. *)
 
-    val digest_size : int
-    (** [digest_size] is the size of hash results, in bytes. *)
+    val hash_size : int
+    (** [hash_size] is the size of hash results, in bytes. *)
 
     (** {1 Value Types} *)
 
@@ -1074,6 +1074,14 @@ module Hash : sig
 
   (** v1 serialisation *)
   module V1 (H : S) : S with type t = H.t
+
+  module type HASHABLE = sig
+    include Type.S
+
+    type hash
+
+    val hash : t -> hash
+  end
 end
 
 (** [Metadata] defines metadata that is attached to contents but stored in
@@ -1178,7 +1186,7 @@ module Contents : sig
     module Key : sig
       include Hash.S with type t = key
 
-      val digest : value -> key
+      val hash : value -> key
     end
 
     (** [Val] provides base functions for user-defined contents values. *)
@@ -1604,7 +1612,7 @@ module Private : sig
       module Key : sig
         include Hash.S with type t = key
 
-        val digest : value -> key
+        val hash : value -> key
       end
 
       (** [Metadata] provides base functions for node metadata. *)
@@ -1809,7 +1817,7 @@ module Private : sig
       module Key : sig
         include Hash.S with type t = key
 
-        val digest : value -> key
+        val hash : value -> key
       end
 
       (** [Val] provides functions for commit values. *)
@@ -3547,7 +3555,7 @@ end
     and [V] is the implementation of values. *)
 module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   (K : Hash.S)
-  (V : Type.S)
+  (V : Hash.HASHABLE with type hash = K.t)
   -> sig
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
 
@@ -3562,8 +3570,8 @@ end
 
 module Content_addressable
     (S : APPEND_ONLY_STORE_MAKER)
-    (K : Hash.S)
-    (V : Type.S) : sig
+    (K : Type.S)
+    (V : Hash.HASHABLE with type hash = K.t) : sig
   include
     CONTENT_ADDRESSABLE_STORE
     with type 'a t = 'a S(K)(V).t

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -152,7 +152,7 @@ module Store
     end) =
 struct
   module Contents = C
-  module Key = Hash.With_digest (S.Key) (S.Val)
+  module Key = Hash.With_hash (S.Key) (S.Val)
   module Path = P
   module Metadata = M
 

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -106,10 +106,10 @@ struct
        are good enough to be used as short hashes. *)
     let hash (t : t) : int =
       match t with
-      | `Contents (c, _) -> Type.hash Contents.t c
-      | `Node n -> Type.hash Node.t n
-      | `Commit c -> Type.hash Commit.t c
-      | `Branch b -> Type.hash Branch.t b
+      | `Contents (c, _) -> Type.short_hash Contents.t c
+      | `Node n -> Type.short_hash Node.t n
+      | `Commit c -> Type.short_hash Commit.t c
+      | `Branch b -> Type.short_hash Branch.t b
   end
 
   module G = Graph.Imperative.Digraph.ConcreteBidirectional (X)

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -45,11 +45,11 @@ end
 module type HASH = sig
   type t
 
-  val digest : string -> t
+  val hash : string -> t
 
-  val hash : t -> int
+  val short_hash : t -> int
 
-  val digest_size : int
+  val hash_size : int
 
   val t : t Type.t
 end
@@ -74,11 +74,41 @@ module type CONTENT_ADDRESSABLE_STORE = sig
   val add : [> `Write ] t -> value -> key Lwt.t
 end
 
+module type HASHABLE = sig
+  type hash
+
+  include Type.S
+
+  val hash : t -> hash
+end
+
 module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   (K : HASH)
-  (V : Type.S)
+  (V : HASHABLE with type hash = K.t)
   -> sig
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
+
+  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
+
+  val v : Conf.t -> [ `Read ] t Lwt.t
+end
+
+module type APPEND_ONLY_STORE = sig
+  type 'a t
+
+  type key
+
+  type value
+
+  val mem : [> `Read ] t -> key -> bool Lwt.t
+
+  val find : [> `Read ] t -> key -> value option Lwt.t
+
+  val add : [> `Write ] t -> key -> value -> unit Lwt.t
+end
+
+module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
+  include APPEND_ONLY_STORE with type key = K.t and type value = V.t
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 
@@ -101,7 +131,7 @@ module type CONTENTS_STORE = sig
   module Key : sig
     include HASH with type t = key
 
-    val digest : value -> t
+    val hash : value -> t
   end
 
   module Val : CONTENTS with type t = value
@@ -198,7 +228,7 @@ module type NODE_STORE = sig
   module Key : sig
     include HASH with type t = key
 
-    val digest : value -> t
+    val hash : value -> t
   end
 
   module Metadata : METADATA
@@ -243,7 +273,7 @@ module type COMMIT_STORE = sig
   module Key : sig
     include HASH with type t = key
 
-    val digest : value -> t
+    val hash : value -> t
   end
 
   module Val : COMMIT with type t = value and type hash = key

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -21,6 +21,31 @@ let src = Logs.Src.create "irmin" ~doc:"Irmin branch-consistent store"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+module Content_addressable
+    (AO : S.APPEND_ONLY_STORE_MAKER)
+    (K : Type.S)
+    (V : S.HASHABLE with type hash = K.t) =
+struct
+  include AO (K) (V)
+  open Lwt.Infix
+
+  let pp_key = Type.pp K.t
+
+  let find t k =
+    find t k >>= function
+    | None -> Lwt.return None
+    | Some v as r ->
+        let k' = V.hash v in
+        if Type.equal K.t k k' then Lwt.return r
+        else
+          Fmt.kstrf Lwt.fail_invalid_arg
+            "corrupted value: got %a, expecting %a" pp_key k' pp_key k
+
+  let add t v =
+    let k = V.hash v in
+    add t k v >|= fun () -> k
+end
+
 module Make (P : S.PRIVATE) = struct
   module Branch_store = P.Branch
 
@@ -48,7 +73,7 @@ module Make (P : S.PRIVATE) = struct
 
     let of_hash r h = P.Contents.find (P.Repo.contents_t r) h
 
-    let hash c = P.Contents.Key.digest c
+    let hash c = P.Contents.Key.hash c
   end
 
   module Tree = struct
@@ -122,7 +147,7 @@ module Make (P : S.PRIVATE) = struct
     let to_private_commit t = t.v
 
     let of_private_commit r v =
-      let h = P.Commit.Key.digest v in
+      let h = P.Commit.Key.hash v in
       { r; h; v }
 
     let equal_opt x y =
@@ -866,7 +891,7 @@ module Make (P : S.PRIVATE) = struct
   module History = OCamlGraph.Persistent.Digraph.ConcreteBidirectional (struct
     type t = commit
 
-    let hash h = P.Commit.Key.hash h.Commit.h
+    let hash h = P.Commit.Key.short_hash h.Commit.h
 
     let compare x y = Type.compare P.Commit.Key.t x.Commit.h y.Commit.h
 

--- a/src/irmin/store.mli
+++ b/src/irmin/store.mli
@@ -29,3 +29,18 @@ module Make (P : S.PRIVATE) :
    and module Key = P.Node.Path
    and type repo = P.Repo.t
    and module Private = P
+
+module Content_addressable
+    (X : S.APPEND_ONLY_STORE_MAKER)
+    (K : Type.S)
+    (V : S.HASHABLE with type hash = K.t) : sig
+  include
+    S.CONTENT_ADDRESSABLE_STORE
+    with type 'a t = 'a X(K)(V).t
+     and type key = K.t
+     and type value = V.t
+
+  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
+
+  val v : Conf.t -> [ `Read ] t Lwt.t
+end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -66,7 +66,7 @@ end = struct
 
     let equal (x : t) (y : t) = Type.equal K.t x y
 
-    let hash (x : t) = Type.hash K.t x
+    let hash (x : t) = Type.short_hash K.t x
   end)
 end
 
@@ -105,7 +105,7 @@ module Make (P : S.PRIVATE) = struct
   module Hashes = Hashtbl.Make (struct
     type t = hash
 
-    let hash = P.Hash.hash
+    let hash = P.Hash.short_hash
 
     let equal = Type.equal P.Hash.t
   end)
@@ -243,7 +243,7 @@ module Make (P : S.PRIVATE) = struct
         match value c with
         | None -> assert false
         | Some v ->
-            let k = P.Contents.Key.digest v in
+            let k = P.Contents.Key.hash v in
             let () =
               match Cache.find cache k with
               | i ->
@@ -590,7 +590,7 @@ module Make (P : S.PRIVATE) = struct
       | _ -> ()
 
     let hash_of_value t v =
-      let k = P.Node.Key.digest v in
+      let k = P.Node.Key.hash v in
       let () =
         match Cache.find cache k with
         | i ->
@@ -1435,7 +1435,7 @@ module Make (P : S.PRIVATE) = struct
   let hash (t : tree) =
     match t with
     | `Node n -> `Node (Node.to_hash n)
-    | `Contents (c, m) -> `Contents (P.Contents.Key.digest c, m)
+    | `Contents (c, m) -> `Contents (P.Contents.Key.hash c, m)
 
   module Cache = struct
     let length () =

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -94,7 +94,7 @@ val equal : 'a t -> 'a -> 'a -> bool
 
 val compare : 'a t -> 'a -> 'a -> int
 
-val hash : 'a t -> ?seed:int -> 'a -> int
+val short_hash : 'a t -> ?seed:int -> 'a -> int
 
 (* CLI *)
 
@@ -144,8 +144,8 @@ val v :
   bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   equal:('a -> 'a -> bool) ->
   compare:('a -> 'a -> int) ->
-  hash:(?seed:int -> 'a -> int) ->
-  pre_digest:('a -> string) ->
+  short_hash:(?seed:int -> 'a -> int) ->
+  pre_hash:('a -> string) ->
   'a t
 
 val like :
@@ -154,8 +154,8 @@ val like :
   ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?equal:('a -> 'a -> bool) ->
   ?compare:('a -> 'a -> int) ->
-  ?hash:('a -> int) ->
-  ?pre_digest:('a -> string) ->
+  ?short_hash:('a -> int) ->
+  ?pre_hash:('a -> string) ->
   'a t ->
   'a t
 
@@ -165,8 +165,8 @@ val map :
   ?bin:'b encode_bin * 'b decode_bin * 'b size_of ->
   ?equal:('b -> 'b -> bool) ->
   ?compare:('b -> 'b -> int) ->
-  ?hash:('b -> int) ->
-  ?pre_digest:('b -> string) ->
+  ?short_hash:('b -> int) ->
+  ?pre_hash:('b -> string) ->
   'a t ->
   ('a -> 'b) ->
   ('b -> 'a) ->
@@ -178,7 +178,7 @@ val to_string : 'a t -> 'a -> string
 
 val pp_json : ?minify:bool -> 'a t -> 'a Fmt.t
 
-val pre_digest : 'a t -> 'a -> string
+val pre_hash : 'a t -> 'a -> string
 
 val encode_json : 'a t -> Jsonm.encoder -> 'a -> unit
 

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -36,9 +36,8 @@ let test_add_read ?(stable = false) (module AO : Test_chunk.S) () =
     AO.batch t (fun t -> AO.add t v) >>= fun k ->
     ( if stable then
       let str = Irmin.Type.to_bin_string Test_chunk.Value.t v in
-      Alcotest.(check key_t)
-        (name ^ " is stable") k
-        (Test_chunk.Key.digest str) );
+      Alcotest.(check key_t) (name ^ " is stable") k (Test_chunk.Key.hash str)
+    );
     AO.find t k >|= fun v' ->
     Alcotest.(check @@ option value_t) name (Some v) v'
   in

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -32,6 +32,10 @@ module Value = struct
   let pp = Fmt.string
 
   let equal = String.equal
+
+  type hash = Key.t
+
+  let hash x = Key.hash (Irmin.Type.pre_hash t x)
 end
 
 module type S = sig

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -177,15 +177,15 @@ let test_list_refs (module S : G) =
 let bin_string = Alcotest.testable (Fmt.fmt "%S") ( = )
 
 let test_blobs (module S : S) =
-  let str = Irmin.Type.pre_digest S.Contents.t "foo" in
+  let str = Irmin.Type.pre_hash S.Contents.t "foo" in
   Alcotest.(check bin_string) "blob foo" "blob 3\000foo" str;
-  let str = Irmin.Type.pre_digest S.Contents.t "" in
+  let str = Irmin.Type.pre_hash S.Contents.t "" in
   Alcotest.(check bin_string) "blob ''" "blob 0\000" str;
   let module X = Mem (X) in
-  let str = Irmin.Type.pre_digest X.Contents.t (Y [ "foo"; "bar" ]) in
+  let str = Irmin.Type.pre_hash X.Contents.t (Y [ "foo"; "bar" ]) in
   Alcotest.(check bin_string)
     "blob foo" "blob 19\000{\"y\":[\"foo\",\"bar\"]}" str;
-  let str = Irmin.Type.pre_digest X.Contents.t (X (1, 2)) in
+  let str = Irmin.Type.pre_hash X.Contents.t (X (1, 2)) in
   Alcotest.(check bin_string) "blob ''" "blob 11\000{\"x\":[1,2]}" str;
   let t = X.Tree.empty in
   X.Tree.add t [ "foo" ] (X (1, 2)) >>= fun t ->

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -108,7 +108,7 @@ let test_bin () =
   T.encode_bin ~headers:false T.string buf "foo";
   Alcotest.(check string) "foo 1" (Buffer.contents buf) "foo";
   let buf = Buffer.create 10 in
-  let h = Irmin.Hash.SHA1.digest "foo" in
+  let h = Irmin.Hash.SHA1.hash "foo" in
   T.encode_bin ~headers:false Irmin.Hash.SHA1.t buf h;
   let x = Buffer.contents buf in
   let buf = Bytes.create 100 in
@@ -118,7 +118,7 @@ let test_bin () =
       (Bytes.unsafe_to_string buf)
       0
   in
-  Alcotest.(check int) "hash size" n Irmin.Hash.SHA1.digest_size;
+  Alcotest.(check int) "hash size" n Irmin.Hash.SHA1.hash_size;
   Alcotest.(check sha1) "hash" v h
 
 let x = T.like ~compare:(fun x y -> y - x - 1) T.int
@@ -234,16 +234,15 @@ module Commit = Irmin.Private.Commit.Make (Hash)
 module Commit_v1 = Irmin.Private.Commit.V1 (Commit)
 module Hash_v1 = Irmin.Hash.V1 (Hash)
 
-let hash c = Hash.digest (Irmin.Type.pre_digest Irmin.Contents.String.t c)
+let hash c = Hash.hash (Irmin.Type.pre_hash Irmin.Contents.String.t c)
 
-let hash_v1 c =
-  Hash_v1.digest (Irmin.Type.pre_digest Irmin.Contents.V1.String.t c)
+let hash_v1 c = Hash_v1.hash (Irmin.Type.pre_hash Irmin.Contents.V1.String.t c)
 
 let test_hashes () =
   let digest t x =
     let s = Irmin.Type.to_bin_string t x in
     Printf.eprintf "to_bin_string: %S\n" s;
-    Irmin.Type.to_string Hash.t (Hash.digest s)
+    Irmin.Type.to_string Hash.t (Hash.hash s)
   in
   Alcotest.(check string)
     "empty contents" "da39a3ee5e6b4b0d3255bfef95601890afd80709"


### PR DESCRIPTION
This hash will be used as key when storing the data in the backend.

Also rename a few digest -> hash to be more consistent through the codebase.