### PR TITLE
irmin.tree: optimise tree.export

### DIFF
--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1312,7 +1312,11 @@ module Make (P : S.PRIVATE) = struct
             >>= function
             | true -> k ()
             | false ->
-                Stack.push (add_node_map n x) todo;
+                let () =
+                  match Node.value n with
+                  | None -> Stack.push (add_node_map n x) todo
+                  | Some v -> Stack.push (add_node n v) todo
+                in
                 let contents = ref [] in
                 let nodes = ref [] in
                 StepMap.iter


### PR DESCRIPTION
Divide by 2 the number of times we call `Node.Val.list` in Tree.export. This was found using the new tree perf counters + pack_bench.