### PR TITLE
Improved default GraphQL presentation

### DIFF
--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -509,6 +509,40 @@ module Type : sig
 
     val t : t ty
   end
+
+  module type MAPPER = sig
+    type 'a t
+    type 'a field
+    type 'a case
+
+    val unit : unit -> unit t
+    val bool : unit -> bool t
+    val char : unit -> char t
+    val int : unit -> int t
+    val int32 : unit -> int32 t
+    val int64 : unit -> int64 t
+    val float : unit -> float t
+    val string : len -> string t
+    val bytes : len -> bytes t
+
+    val map : 'a t -> ('b -> 'a) -> 'b t
+    val list : 'a t -> len -> 'a list t
+    val array : 'a t -> len -> 'a array t
+    val pair : 'a t -> 'b t -> ('a * 'b) t
+    val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+    val option : 'a t -> 'a option t
+
+    val record_field : string -> 'a t -> ('b -> 'a) -> 'b field
+    val record : string -> 'a field list -> 'a t
+
+    val variant_case0 : string -> 'a -> 'a case
+    val variant_case1 : string -> 'b t -> ('b -> 'a) -> 'a case
+    val variant : string -> 'a case list -> 'a t
+  end
+
+  module Mapper (M : MAPPER) : sig
+    val map : 'a t -> 'a M.t
+  end
 end
 
 (** Commit info are used to keep track of the origin of write

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -515,6 +515,8 @@ module Type : sig
     type 'a field
     type 'a case
 
+    val exception_handler : 'a ty -> exn -> 'a t
+
     val unit : unit -> unit t
     val bool : unit -> bool t
     val char : unit -> char t
@@ -525,6 +527,7 @@ module Type : sig
     val string : len -> string t
     val bytes : len -> bytes t
 
+    val custom : 'a ty -> 'a t
     val map : 'a t -> ('b -> 'a) -> 'b t
     val list : 'a t -> len -> 'a list t
     val array : 'a t -> len -> 'a array t
@@ -536,7 +539,7 @@ module Type : sig
     val record : string -> 'a field list -> 'a t
 
     val variant_case0 : string -> 'a -> 'a case
-    val variant_case1 : string -> 'b t -> ('b -> 'a) -> 'a case
+    val variant_case1 : string -> 'b t -> ('a -> 'b option) -> 'a case
     val variant : string -> 'a case list -> 'a t
   end
 

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -216,6 +216,8 @@ module type MAPPER = sig
   type 'a field
   type 'a case
 
+  val exception_handler : 'a ty -> exn -> 'a t
+
   val unit : unit -> unit t
   val bool : unit -> bool t
   val char : unit -> char t
@@ -226,6 +228,7 @@ module type MAPPER = sig
   val string : len -> string t
   val bytes : len -> bytes t
 
+  val custom : 'a ty -> 'a t
   val map : 'a t -> ('b -> 'a) -> 'b t
   val list : 'a t -> len -> 'a list t
   val array : 'a t -> len -> 'a array t
@@ -237,7 +240,7 @@ module type MAPPER = sig
   val record : string -> 'a field list -> 'a t
 
   val variant_case0 : string -> 'a -> 'a case
-  val variant_case1 : string -> 'b t -> ('b -> 'a) -> 'a case
+  val variant_case1 : string -> 'b t -> ('a -> 'b option) -> 'a case
   val variant : string -> 'a case list -> 'a t
 end
 

--- a/src/irmin/type.mli
+++ b/src/irmin/type.mli
@@ -210,3 +210,37 @@ module type S = sig
 
   val t : t ty
 end
+
+module type MAPPER = sig
+  type 'a t
+  type 'a field
+  type 'a case
+
+  val unit : unit -> unit t
+  val bool : unit -> bool t
+  val char : unit -> char t
+  val int : unit -> int t
+  val int32 : unit -> int32 t
+  val int64 : unit -> int64 t
+  val float : unit -> float t
+  val string : len -> string t
+  val bytes : len -> bytes t
+
+  val map : 'a t -> ('b -> 'a) -> 'b t
+  val list : 'a t -> len -> 'a list t
+  val array : 'a t -> len -> 'a array t
+  val pair : 'a t -> 'b t -> ('a * 'b) t
+  val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+  val option : 'a t -> 'a option t
+
+  val record_field : string -> 'a t -> ('b -> 'a) -> 'b field
+  val record : string -> 'a field list -> 'a t
+
+  val variant_case0 : string -> 'a -> 'a case
+  val variant_case1 : string -> 'b t -> ('b -> 'a) -> 'a case
+  val variant : string -> 'a case list -> 'a t
+end
+
+module Mapper (M : MAPPER) : sig
+  val map : 'a t -> 'a M.t
+end


### PR DESCRIPTION
This PR is a proof-of-concept for a much improved default presentation of values in the GraphQL API (improvement on top of https://github.com/mirage/irmin/pull/643). Rather than just present `Contents.t` as serialized to a JSON string, this PR will try to map the value to a proper JSON structure and will also allow the GraphQL API consumer to introspect this structure.

Assume an Irmin store with the following `content` type:

```ocaml
type contact = {
  name : string;
  phone : string option;
  email : string option;
}
```

The current default presentation of such a value via the GraphQL API is the serialized string:

```json
"{\"name\":\"John Doe\","\phone\":null,\"email\":\"john.doe@email.org\"}"
```

With this PR, it would be presented as a proper JSON object by default:

```json
{
  "name": "John Doe",
  "phone": null,
  "email": "john.doe@email.org"
}
```

Further, clients would be aware of this structure and only fetch the desired fields.

I've been toying around with this idea for a while, so I thought I'd share progress and see if anyone else has clever ideas to solve the blockers.

There are two parts to achieving this:

- 3996c2d introduces `Irmin.Type.Mapper`, which allows mapping over an `'a Irmin.Type.t` to create some other `'a t`. This is possibly of general interest.
- c7b2d64 uses `Irmin.Type.Mapper` to map from `'a Irmin.Type.t` to `(unit, 'a option) Graphql_lwt.Schema.typ` in `Irmin_graphql.Server.Default_presentation`.

When going over the code, (almost) all the calls to `failwith` are essentially blockers I've run into and not been able to solve. In particular:

- `Irmin.Type.Custom` can inherently not be mapped over.
- It does not make sense for the `Contents.t` to be an option type, i.e. `'a option Irmin.Type.t`.
- `unit Irmin.Type.t` cannot be converted because GraphQL does not have a unit type. A dummy type could be introduced.
- Any `'a option option Irmin.Type.t` cannot be converted to GraphQL, as doubly-optional types does not exist. Maybe it could be flattened on the Irmin side using `Irmin.Type.map`?
- Converting a value using `Irmin.Type.Map` is currently not possible since you cannot map over a `Graphql_lwt.Schema.typ` -- this could be introduced.
- Variants are tricky:
  - Variants using only `case0` can be converted to GraphQL enums.
  - Variants using only `case1` should be convertible to GraphQL unions, but I haven't worked out how yet.
  - I have not come up with a way to represent variants using both `case0` and `case1` in GraphQL.