### PR TITLE
irmin-test: fix flaky test

### DIFF
--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1656,7 +1656,7 @@ module Make (S : S) = struct
         let ry = Lwt_mvar.create_empty () in
         let wy = Lwt_mvar.create_empty () in
         S.set_exn t ~info:(infof "init") [ "a" ] "0" >>= fun () ->
-        Lwt.choose
+        Lwt.join
           [ update [ "a" ] ~retries:0 `Set rx wx;
             update [ "a" ] ~retries:0 `Set ry wy;
             ( Lwt_mvar.put rx "1" >>= fun () ->
@@ -1677,7 +1677,7 @@ module Make (S : S) = struct
         let rz = Lwt_mvar.create_empty () in
         let wz = Lwt_mvar.create_empty () in
         S.set_exn t ~info:(infof "init") [ "a" ] "0" >>= fun () ->
-        Lwt.choose
+        Lwt.join
           [ update [ "a" ] ~retries:0 `Test_and_set rx wx;
             update [ "a" ] ~retries:0 `Test_and_set ry wy;
             update [ "a" ] ~retries:1 `Test_and_set rz wz;
@@ -1707,7 +1707,7 @@ module Make (S : S) = struct
         let rz = Lwt_mvar.create_empty () in
         let wz = Lwt_mvar.create_empty () in
         S.set_exn t ~info:(infof "init") [ "a" ] "0" >>= fun () ->
-        Lwt.choose
+        Lwt.join
           [ update [ "a" ] ~retries:0 `Merge rx wx;
             update [ "a" ] ~retries:0 `Merge ry wy;
             update [ "a" ] ~retries:1 `Merge rz wz;


### PR DESCRIPTION
In some cases, the next test will start before all the threads were complete --
for some reasons, it causes the next thread to be very confused and fail.