### PR TITLE
irmin-pack: track offset/hash append ratio in stats

### DIFF
--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -104,7 +104,9 @@ type stats = {
   pack_page_faults : float;
   index_page_faults : float;
   pack_cache_misses : float;
-  search_steps : float
+  search_steps : float;
+  offset_ratio : float;
+  offset_significance : int;
 }
 
 val reset_stats : unit -> unit


### PR DESCRIPTION
This adds two new `stats` fields to track the proportion of appended hashes that are encoded as offsets for compression purposes, making it possible to determine the space-efficiency of a bulk import mechanism w.r.t. the offset compression.