### PR TITLE
irmin: expose additional pretty-printers

### DIFF
--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -3258,8 +3258,8 @@ val remote_store : (module S with type t = 'a) -> 'a -> remote
     synchronization using {!Store.remote} but it works for all
     backends. *)
 
-(** [SYNC] provides functions to synchronization an Irmin store with
-    local and remote Irmin stores. *)
+(** [SYNC] provides functions to synchronize an Irmin store with local
+    and remote Irmin stores. *)
 module type SYNC = sig
   (** {1 Native Synchronization} *)
 
@@ -3269,7 +3269,14 @@ module type SYNC = sig
   (** The type for store heads. *)
   type commit
 
+  (** The type for remote status. *)
   type status = [ `Empty | `Head of commit ]
+
+  val status_t : db -> status Type.t
+  (** [status_t db] is the value type for {!status} of remote [db]. *)
+
+  val pp_status : status Fmt.t
+  (** [pp_status] pretty-prints return statuses. *)
 
   val fetch :
     db -> ?depth:int -> remote -> (status, [ `Msg of string ]) result Lwt.t
@@ -3282,7 +3289,11 @@ module type SYNC = sig
   (** Same as {!fetch} but raise [Invalid_argument] if either the
       local or remote store do not have a valid head. *)
 
+  (** The type for pull errors. *)
   type pull_error = [ `Msg of string | Merge.conflict ]
+
+  val pp_pull_error : pull_error Fmt.t
+  (** [pp_push_error] pretty-prints pull errors. *)
 
   val pull :
     db ->

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -1119,10 +1119,16 @@ module type SYNC_STORE = sig
 
   type status = [ `Empty | `Head of commit ]
 
+  val status_t : db -> status Type.t
+
+  val pp_status : status Fmt.t
+
   val fetch :
     db -> ?depth:int -> remote -> (status, [ `Msg of string ]) result Lwt.t
 
   val fetch_exn : db -> ?depth:int -> remote -> status Lwt.t
+
+  val pp_pull_error : pull_error Fmt.t
 
   val pull :
     db ->

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -71,6 +71,18 @@ module Make (S : S.STORE) = struct
 
   type status = [ `Empty | `Head of commit ]
 
+  let pp_status ppf = function
+    | `Empty -> Fmt.string ppf "empty"
+    | `Head c -> Type.pp S.Hash.t ppf (S.Commit.hash c)
+
+  let status_t t =
+    let open Type in
+    variant "status" (fun empty head -> function
+      | `Empty -> empty | `Head c -> head c )
+    |~ case0 "empty" `Empty
+    |~ case1 "head" S.(commit_t @@ repo t) (fun c -> `Head c)
+    |> sealv
+
   let fetch t ?depth remote =
     match remote with
     | Store ((module R), r) -> (


### PR DESCRIPTION
This is a candidate solution for #755.

There may be a more elegant solution unifying local and remote status types, but this avoids changing either type for now.