### PR TITLE
irmin-pack: fix an issue with the offset/hash decompression function

### DIFF
--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -965,9 +965,9 @@ struct
 
     let value a =
       let open Irmin.Type in
-      record "value" (fun magic hash v -> { magic; hash; v })
-      |+ field "magic" char (fun v -> v.magic)
+      record "value" (fun hash magic v -> { magic; hash; v })
       |+ field "hash" H.t (fun v -> v.hash)
+      |+ field "magic" char (fun v -> v.magic)
       |+ field "v" a (fun v -> v.v)
       |> sealr
 

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -24,7 +24,13 @@ let fresh_key =
   Irmin.Private.Conf.key ~doc:"Start with a fresh disk." "fresh"
     Irmin.Private.Conf.bool false
 
+let lru_size_key =
+  Irmin.Private.Conf.key ~doc:"Size of the LRU cache for pack entries."
+    "lru-size" Irmin.Private.Conf.int 10_000
+
 let fresh config = Irmin.Private.Conf.get config fresh_key
+
+let lru_size config = Irmin.Private.Conf.get config lru_size_key
 
 let root_key = Irmin.Private.Conf.root
 
@@ -33,10 +39,11 @@ let root config =
   | None -> failwith "no root set"
   | Some r -> r
 
-let config ?(fresh = false) root =
+let config ?(fresh = false) ?(lru_size = 10_000) root =
   let config = Irmin.Private.Conf.empty in
   let config = Irmin.Private.Conf.add config fresh_key fresh in
   let config = Irmin.Private.Conf.add config root_key (Some root) in
+  let config = Irmin.Private.Conf.add config lru_size_key lru_size in
   config
 
 let ( // ) = Filename.concat
@@ -383,12 +390,14 @@ module Lru (H : Hashtbl.HashedType) = struct
     with Not_found -> ()
 
   let add t k v =
-    remove t k;
-    let n = Q.node (k, v) in
-    t.w <- t.w + 1;
-    if weight t > t.cap then drop_lru t;
-    HT.add t.ht k n;
-    Q.append t.q n
+    if t.w = 0 then ()
+    else (
+      remove t k;
+      let n = Q.node (k, v) in
+      t.w <- t.w + 1;
+      if weight t > t.cap then drop_lru t;
+      HT.add t.ht k n;
+      Q.append t.q n )
 
   let promote t k =
     try
@@ -604,7 +613,7 @@ module Pack (K : Irmin.Hash.S) = struct
     include
       Irmin.CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
 
-    val v : ?fresh:bool -> string -> [ `Read ] t Lwt.t
+    val v : ?fresh:bool -> ?lru_size:int -> string -> [ `Read ] t Lwt.t
 
     val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 
@@ -629,7 +638,7 @@ module Pack (K : Irmin.Hash.S) = struct
 
     let create = Lwt_mutex.create ()
 
-    let unsafe_v ?(fresh = false) root =
+    let unsafe_v ?(fresh = false) ?(lru_size = 10_000) root =
       Log.debug (fun l -> l "[pack] v fresh=%b root=%s" fresh root);
       try
         let t = Hashtbl.find files root in
@@ -637,14 +646,14 @@ module Pack (K : Irmin.Hash.S) = struct
       with Not_found ->
         v ~fresh root >>= fun pack ->
         let staging = Tbl.create 127 in
-        let lru = Lru.create 10_000 in
+        let lru = Lru.create lru_size in
         let t = { staging; lru; pack } in
         (if fresh then clear t else Lwt.return ()) >|= fun () ->
         Hashtbl.add files root t;
         t
 
-    let v ?fresh root =
-      Lwt_mutex.with_lock create (fun () -> unsafe_v ?fresh root)
+    let v ?fresh ?lru_size root =
+      Lwt_mutex.with_lock create (fun () -> unsafe_v ?fresh ?lru_size root)
 
     let pp_hash = Irmin.Type.pp K.t
 
@@ -1486,9 +1495,10 @@ struct
       let v config =
         let root = root config in
         let fresh = fresh config in
-        Contents.CA.v ~fresh root >>= fun contents ->
-        Node.CA.v ~fresh root >>= fun node ->
-        Commit.CA.v ~fresh root >>= fun commit ->
+        let lru_size = lru_size config in
+        Contents.CA.v ~fresh ~lru_size root >>= fun contents ->
+        Node.CA.v ~fresh ~lru_size root >>= fun node ->
+        Commit.CA.v ~fresh ~lru_size root >>= fun commit ->
         Branch.v ~fresh root >|= fun branch ->
         { contents; node; commit; branch; config }
     end

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val config : ?fresh:bool -> string -> Irmin.config
+val config : ?fresh:bool -> ?lru_size:int -> string -> Irmin.config
 
 module Make_ext
     (Metadata : Irmin.Metadata.S)
@@ -81,7 +81,7 @@ module Pack (K : Irmin.Hash.S) : sig
   module Make (V : S with type hash = K.t) : sig
     type 'a t
 
-    val v : ?fresh:bool -> string -> [ `Read ] t Lwt.t
+    val v : ?fresh:bool -> ?lru_size:int -> string -> [ `Read ] t Lwt.t
 
     val find : [> `Read ] t -> K.t -> V.t option Lwt.t
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -213,6 +213,12 @@ module Make (S : S) = struct
       with_node repo (fun g -> Graph.v g [ ("x", normal kv1) ]) >>= fun k1' ->
       check_key "k1.1" k1 k1';
       P.Node.find n k1 >>= fun t1 ->
+      let k' = P.Node.Val.find (get t1) "x" in
+      check
+        (Irmin.Type.option P.Node.Val.value_t)
+        "find x"
+        (Some (normal kv1))
+        k';
       with_node repo (fun n -> P.Node.add n (get t1)) >>= fun k1'' ->
       check_key "k1.2" k1 k1'';
       (* Create the node  t2 -b-> t1 -x-> (v1) *)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -21,11 +21,11 @@ let store =
 
 let test_file = Filename.concat "_build" "test-db-pack"
 
-let config = Irmin_pack.config ~fresh:false test_file
+let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_file
 
 let clean () =
   let (module S : Irmin_test.S) = store in
-  let config = Irmin_pack.config ~fresh:true test_file in
+  let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_file in
   S.Repo.v config >>= fun repo ->
   S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo)
 
@@ -97,7 +97,7 @@ module P = Irmin_pack.Pack (Irmin.Hash.SHA1)
 module Pack = P.Make (S)
 
 let test_pack _switch () =
-  Pack.v ~fresh:true test_file >>= fun t ->
+  Pack.v ~fresh:true ~lru_size:0 test_file >>= fun t ->
   let x1 = "foo" in
   let x2 = "bar" in
   let x3 = "otoo" in


### PR DESCRIPTION
This is built on top of #790 and see 9f6ff49 for more explanation on the bug.