### PR TITLE
update opam files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: bash -ex .travis-docker.sh
 env:
   global:
   - ALCOTEST_SHOW_ERRORS=1
-  - PINS="irmin.dev:. irmin-mem.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:."
+  - PINS="irmin.dev:. irmin-mem.dev:. irmin-pack.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:."
   - DISTRO=debian-stable
   matrix:
   - OCAML_VERSION=4.08 PACKAGE="irmin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - PINS="irmin.dev:. irmin-mem.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:."
   - DISTRO=debian-stable
   matrix:
+  - OCAML_VERSION=4.08 PACKAGE="irmin"
   - OCAML_VERSION=4.07 PACKAGE="irmin"
   - OCAML_VERSION=4.05 PACKAGE="irmin-fs"
   - OCAML_VERSION=4.06 PACKAGE="irmin-mem"

--- a/irmin-chunk.opam
+++ b/irmin-chunk.opam
@@ -13,12 +13,12 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.01.0"}
-  "dune"       {build  & >= "1.1.0"}
-  "irmin"      {>= "1.3.0"}
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {=version}
   "lwt"
-  "irmin-mem"  {with-test & >= "1.3.0"}
-  "irmin-test" {with-test}
+  "irmin-mem"  {with-test & =version}
+  "irmin-test" {with-test & =version}
 ]
 
 synopsis: "Irmin backend which allow to store values into chunks"

--- a/irmin-fs.opam
+++ b/irmin-fs.opam
@@ -15,9 +15,9 @@ build: [
 
 depends: [
   "ocaml"      {>= "4.03.0"}
-  "dune"       {build & >= "1.1.0"}
-  "irmin"      {>= "1.3.0"}
-  "irmin-test" {with-test}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {=version}
+  "irmin-test" {with-test & =version}
 ]
 
 synopsis: "Generic file-system backend for Irmin"

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -14,20 +14,15 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.01.0"}
-  "dune"       {build  & >= "1.1.0"}
-  "irmin"      {>= "1.3.0"}
-  "git"        {>= "1.11.0"}
-  "digestif"   {>= "0.6.1"}
-  "irmin-test" {with-test}
-  "irmin-mem"  {with-test}
-  "git-unix"   {with-test & >= "1.11.4"}
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {= version}
+  "git"        {>= "2.1.0"}
+  "digestif"   {>= "0.7.3"}
+  "irmin-test" {with-test & =version}
+  "irmin-mem"  {with-test & =version}
+  "git-unix"   {with-test & >= "2.1.0"}
   "mtime"      {with-test & >= "1.0.0"}
-]
-
-pin-depends: [
-  ["git.dev" "git+https://github.com/mirage/ocaml-git"]
-  ["git-http.dev" "git+https://github.com/mirage/ocaml-git"]
 ]
 
 synopsis: "Git backend for Irmin"

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -15,8 +15,8 @@ build: [
 
 depends: [
   "ocaml"   {>= "4.03.0"}
-  "dune"    {build}
-  "irmin"
+  "dune"    {>= "1.1.0"}
+  "irmin"   {=version}
   "graphql" {>= "0.9"}
   "graphql-lwt" {>= "0.9"}
   "graphql-cohttp" {>= "0.12.1"}

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -14,16 +14,16 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.01.0"}
-  "dune"       {build & >= "1.1.0"}
-  "crunch"
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
+  "crunch"     {>= "2.2.0"}
   "webmachine" {>= "0.6.0"}
-  "irmin"      {>= "1.3.0"}
+  "irmin"      {=version}
   "cohttp-lwt" {>= "1.0.0"}
-  "irmin-git"  {with-test & >= "1.3.0"}
-  "irmin-mem"  {with-test & >= "1.3.0"}
+  "irmin-git"  {with-test & =version}
+  "irmin-mem"  {with-test & =version}
+  "irmin-test" {with-test & =version}
   "git-unix"   {with-test}
-  "irmin-test" {with-test}
   "digestif"   {with-test & >= "0.6.1"}
 ]
 

--- a/irmin-mirage.opam
+++ b/irmin-mirage.opam
@@ -13,11 +13,11 @@ build: [
 ]
 
 depends: [
-  "dune"       {build & >= "1.1.0"}
-  "irmin"      {>= "1.3.0"}
-  "irmin-mem"  {>= "1.3.0"}
+  "dune"       {>= "1.1.0"}
+  "irmin"      {=version}
+  "irmin-mem"  {=version}
   "ptime"
-  "mirage-clock"
+  "mirage-clock" {>= "2.0.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -13,13 +13,13 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.01.0"}
-  "dune"       {build  & >= "1.1.0"}
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "1.1.0"}
   "bloomf"
-  "irmin"      {>= "1.3.0"}
+  "irmin"      {=version}
   "index"
   "lwt"
-  "irmin-test" {with-test}
+  "irmin-test" {with-test & =version}
   "alcotest-lwt" {with-test}
 ]
 

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -13,9 +13,9 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.01.0"}
-  "dune"     {build & >= "1.1.0"}
-  "irmin"    {>= "1.3.0"}
+  "ocaml"    {>= "4.02.3"}
+  "dune"     {>= "1.1.0"}
+  "irmin"    {=version}
   "alcotest"
   "mtime"    {>= "1.0.0"}
   "metrics-unix"

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -16,17 +16,17 @@ build: [
 depends: [
   "ocaml"         {>= "4.01.0"}
   "dune"          {build & >= "1.1.0"}
-  "irmin"         {>= "1.3.0"}
-  "irmin-mem"     {>= "1.3.0"}
-  "irmin-git"     {>= "1.3.0"}
-  "irmin-http"    {>= "1.3.0"}
-  "irmin-fs"      {>= "1.3.0"}
+  "irmin"         {=version}
+  "irmin-mem"     {=version}
+  "irmin-git"     {=version}
+  "irmin-http"    {=version}
+  "irmin-fs"      {=version}
   "irmin-graphql"
   "git-unix"      {>= "1.11.4"}
   "digestif"      {>= "0.6.1"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "0.1.0"}
-  "irmin-test"    {with-test}
+  "irmin-test"    {with-test & =version}
 ]
 
 synopsis: "Unix backends for Irmin"


### PR DESCRIPTION
This updates the opam files to ensure that the various irmin packages depend on the same version that is released from the repo. This is certainly required for irmin 2, but can be relaxed in the future as minor versions are released.

Also remove pin-depends on git 2.1.0 since that is now released.