### PR TITLE
irmin-pack: instantiate index once

### DIFF
--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -257,14 +257,15 @@ let ( // ) = Filename.concat
 
 let with_cache ~v ~clear file =
   let files = Hashtbl.create 13 in
-  fun ?(fresh = false) ?(shared = true) ?(readonly = false) root ->
+  let cached_constructor extra_args ?(fresh = false) ?(shared = true)
+      ?(readonly = false) root =
     let file = root // file in
     if fresh && readonly then raise RO_Not_Allowed;
     if not shared then (
       Log.debug (fun l ->
           l "[%s] v fresh=%b shared=%b readonly=%b" (Filename.basename file)
             fresh shared readonly );
-      let t = v ~fresh ~shared ~readonly file in
+      let t = v extra_args ~fresh ~shared ~readonly file in
       if fresh then clear t;
       t )
     else
@@ -283,7 +284,9 @@ let with_cache ~v ~clear file =
         Log.debug (fun l ->
             l "[%s] v fresh=%b shared=%b readonly=%b" (Filename.basename file)
               fresh shared readonly );
-        let t = v ~fresh ~shared ~readonly file in
+        let t = v extra_args ~fresh ~shared ~readonly file in
         if fresh then clear t;
         Hashtbl.add files file t;
         t
+  in
+  `Staged cached_constructor

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -45,11 +45,8 @@ end
 module Unix : S
 
 val with_cache :
-  v:(fresh:bool -> shared:bool -> readonly:bool -> string -> 'a) ->
-  clear:('a -> unit) ->
+  v:('a -> fresh:bool -> shared:bool -> readonly:bool -> string -> 'b) ->
+  clear:('b -> unit) ->
   string ->
-  ?fresh:bool ->
-  ?shared:bool ->
-  ?readonly:bool ->
-  string ->
-  'a
+  [ `Staged of
+    'a -> ?fresh:bool -> ?shared:bool -> ?readonly:bool -> string -> 'b ]

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -98,4 +98,6 @@ let v_no_cache ~fresh ~shared:_ ~readonly file =
   refill ~from:0L t;
   t
 
-let v = with_cache ~clear ~v:v_no_cache "store.dict"
+let v =
+  let (`Staged v) = with_cache ~clear ~v:(fun () -> v_no_cache) "store.dict" in
+  v ()

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -38,11 +38,14 @@ end
 module type S = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
 
+  type index
+
   val v :
     ?fresh:bool ->
     ?shared:bool ->
     ?readonly:bool ->
     ?lru_size:int ->
+    index:index ->
     string ->
     [ `Read ] t Lwt.t
 
@@ -60,15 +63,17 @@ end
 module type MAKER = sig
   type key
 
+  type index
+
   (** Save multiple kind of values in the same pack file. Values will
       be distinguished using [V.magic], so they have to all be
       different. *)
   module Make (V : ELT with type hash := key) :
-    S with type key = key and type value = V.t
+    S with type key = key and type value = V.t and type index = index
 end
 
 module File (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
-  MAKER with type key = K.t
+  MAKER with type key = K.t and type index = Index.t
 
 type stats = {
   pack_cache_misses : float;

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -104,9 +104,14 @@ module H = Irmin.Hash.SHA1
 module I = Irmin_pack.Index.Make (H)
 module P = Irmin_pack.Pack.File (I) (H)
 module Pack = P.Make (S)
+module Index = Irmin_pack.Index.Make (Irmin.Hash.SHA1)
+
+let get_index = Index.v ~log_size:10_000_000 ~fan_out_size:16
 
 let test_pack _switch () =
-  Pack.v ~fresh:true ~lru_size:0 test_file >>= fun t ->
+  let root = Filename.dirname test_file in
+  let index = get_index ~fresh:true root in
+  Pack.v ~fresh:true ~lru_size:0 ~index test_file >>= fun t ->
   let x1 = "foo" in
   let x2 = "bar" in
   let x3 = "otoo" in
@@ -131,11 +136,15 @@ let test_pack _switch () =
     Alcotest.(check string) "x4" x4 y4;
     Lwt.return ()
   in
-  test t >>= fun () -> Pack.v ~fresh:false test_file >>= test
+  test t >>= fun () -> Pack.v ~fresh:false ~index test_file >>= test
 
 let test_readonly_pack _switch () =
-  Pack.v ~fresh:true test_file >>= fun w ->
-  Pack.v ~fresh:false ~shared:false ~readonly:true test_file >>= fun r ->
+  let root = Filename.dirname test_file in
+  let index = get_index ~fresh:true root in
+  Pack.v ~fresh:true ~index test_file >>= fun w ->
+  let index = get_index ~fresh:false ~shared:false ~readonly:true root in
+  Pack.v ~fresh:false ~shared:false ~readonly:true ~index test_file
+  >>= fun r ->
   let adds l = List.iter (fun (k, v) -> Pack.unsafe_append w k v) l in
   let x1 = "foo" in
   let x2 = "bar" in


### PR DESCRIPTION
This pulls out instantiation of the Index.t from the `Pack` functor and makes it a compulsory argument to the construction of any `Pack` index, making sharing of the index more explicit. Previously, the behaviour relied on the sharing properties of the Index library:

https://github.com/mirage/irmin/pull/799#discussion_r303423708

N.B. there's at least one bug in this currently. Not to be merged.