### PR TITLE
Reflect API change in index

### DIFF
--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -137,7 +137,7 @@ module File (K : Irmin.Hash.S) = struct
     let root = Filename.dirname file in
     let lock = Lwt_mutex.create () in
     let index =
-      Index.v ~fresh ~shared ~readonly ~log_size:10_000_000 ~fan_out_size:64
+      Index.v ~fresh ~shared ~readonly ~log_size:10_000_000 ~fan_out_size:16
         root
     in
     let dict = Dict.v ~fresh ~readonly root in

--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -18,6 +18,8 @@ module Make (K : Irmin.Hash.S) = struct
 
     let hash = K.short_hash
 
+    let hash_size = 63
+
     let equal = Irmin.Type.equal K.t
 
     let encode = Irmin.Type.to_bin_string K.t


### PR DESCRIPTION
- `fan_out_size` is now a number of bits
- the `Key` module requires the size of the hash