### PR TITLE
irmin-pack: support for large inodes

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -45,6 +45,8 @@ end
 
 module type CONFIG = sig
   val entries : int
+
+  val stable_hash : int
 end
 
 module Make
@@ -53,8 +55,15 @@ module Make
     (H : Irmin.Hash.S with type t = Pack.key)
     (Node : Irmin.Private.Node.S with type hash = H.t) =
 struct
-  module Inode = struct
-    type hash = Node.hash
+  module Node = struct
+    include Node
+    module H = Irmin.Hash.Typed (H) (Node)
+
+    let hash = H.hash
+  end
+
+  module T = struct
+    type hash = H.t
 
     type step = Node.step
 
@@ -62,313 +71,549 @@ struct
 
     let step_t = Node.step_t
 
-    let hash_t = Node.hash_t
+    let hash_t = H.t
 
     let metadata_t = Node.metadata_t
 
-    type 'a item = { magic : char; hash : hash; v : 'a }
+    let default = Node.default
 
-    let item a =
-      let open Irmin.Type in
-      record "value" (fun hash magic v -> { magic; hash; v })
-      |+ field "hash" hash_t (fun v -> v.hash)
-      |+ field "magic" char (fun v -> v.magic)
-      |+ field "v" a (fun v -> v.v)
-      |> sealr
+    type value = Node.value
 
-    module Val = struct
-      type entry =
-        | Node of { name : step; node : hash }
-        | Contents of { metadata : metadata; name : step; node : hash }
-        | Inode of { index : int; node : hash }
+    let value_t = Node.value_t
 
-      let entry : entry Irmin.Type.t =
+    let pp_hash = Irmin.Type.(pp hash_t)
+  end
+
+  module Inode = struct
+    module StepMap = struct
+      include Map.Make (struct
+        type t = T.step
+
+        let compare = Irmin.Type.compare T.step_t
+      end)
+
+      let of_list l = List.fold_left (fun acc (k, v) -> add k v acc) empty l
+
+      let t a =
         let open Irmin.Type in
-        variant "Inode.entry" (fun node contents inode -> function
-          | Node n -> node (n.name, n.node)
-          | Contents c -> contents (c.metadata, c.name, c.node)
-          | Inode i -> inode (i.index, i.node) )
-        |~ case1 "Node" (pair step_t hash_t) (fun (name, node) ->
-               Node { name; node } )
-        |~ case1 "Contents" (triple metadata_t step_t hash_t)
-             (fun (metadata, name, node) -> Contents { metadata; name; node })
-        |~ case1 "Inode" (pair int hash_t) (fun (index, node) ->
-               Inode { index; node } )
-        |> sealv
-
-      (* hash is the hash of the corresponding sub-node *)
-      type t = entry list item
-
-      module H = Irmin.Hash.Typed (H) (Node)
-
-      let hash = H.hash
-
-      let magic = 'T'
-
-      let empty = { magic; hash = hash Node.empty; v = [] }
-
-      let v ~hash v = { magic; hash; v }
-
-      let t = item (Irmin.Type.list entry)
-
-      let entry_of_value name v =
-        match v with
-        | `Node node -> Node { name; node }
-        | `Contents (node, metadata) -> Contents { metadata; name; node }
-
-      let entries_of_values l =
-        let v =
-          List.fold_left
-            (fun acc (s, v) -> entry_of_value s v :: acc)
-            [] (List.rev l)
-        in
-        let hash = hash (Node.v l) in
-        { magic; hash; v }
-
-      let entry_of_inode index node = Inode { index; node }
+        map (list (pair T.step_t a)) of_list bindings
     end
 
-    module Tree = struct
-      module StepMap = struct
-        include Map.Make (struct
-          type t = step
+    (* Binary representation, useful to compute hashes *)
+    module Bin = struct
+      open T
 
-          let compare = Irmin.Type.compare step_t
-        end)
+      type inode = { index : int; hash : H.t }
 
-        let of_list l = List.fold_left (fun acc (k, v) -> add k v acc) empty l
-      end
+      type inodes = { seed : int; length : int; entries : inode list }
 
-      type t = Values of Node.value StepMap.t | Nodes of t array | Empty
+      type v = Values of (step * value) list | Inodes of inodes
 
-      let empty : t = Empty
+      let inode : inode Irmin.Type.t =
+        let open Irmin.Type in
+        record "Bin.inode" (fun index hash -> { index; hash })
+        |+ field "index" int (fun t -> t.index)
+        |+ field "hash" H.t (fun (t : inode) -> t.hash)
+        |> sealr
 
-      let list (t : t) =
-        let rec aux acc = function
-          | Empty -> acc
-          | Values t ->
-              List.fold_left (fun acc e -> e :: acc) acc (StepMap.bindings t)
-          | Nodes n -> Array.fold_left aux acc n
-        in
-        aux [] t
+      let inodes : inodes Irmin.Type.t =
+        let open Irmin.Type in
+        record "Bin.inodes" (fun seed length entries ->
+            { seed; length; entries } )
+        |+ field "seed" int (fun t -> t.seed)
+        |+ field "length" int (fun t -> t.length)
+        |+ field "entries" (list inode) (fun t -> t.entries)
+        |> sealr
 
-      module H_entries =
+      let v_t : v Irmin.Type.t =
+        let open Irmin.Type in
+        variant "Bin.v" (fun values inodes -> function
+          | Values l -> values l | Inodes i -> inodes i )
+        |~ case1 "Values" (list (pair step_t value_t)) (fun t -> Values t)
+        |~ case1 "Inodes" inodes (fun t -> Inodes t)
+        |> sealv
+
+      module V =
         Irmin.Hash.Typed
           (H)
           (struct
-            type t = Val.entry list
+            type t = v
 
-            let t = Irmin.Type.list Val.entry
+            let t = v_t
           end)
 
-      let hash_entries = H_entries.hash
+      type t = { hash : H.t Lazy.t; stable : bool; v : v }
 
-      let index ~seed k =
-        abs (Irmin.Type.short_hash step_t ~seed k) mod Conf.entries
+      let t : t Irmin.Type.t =
+        let open Irmin.Type in
+        let pre_hash x = Irmin.Type.pre_hash v_t x.v in
+        record "Bin.t" (fun hash stable v -> { hash = lazy hash; stable; v })
+        |+ field "hash" H.t (fun t -> Lazy.force t.hash)
+        |+ field "stable" bool (fun t -> t.stable)
+        |+ field "v" v_t (fun t -> t.v)
+        |> sealr |> like ~pre_hash
 
-      let singleton s v = Values (StepMap.singleton s v)
+      let node ~hash v = { stable = true; hash; v }
 
-      let rec add_values : type a. seed:_ -> _ -> _ -> _ -> _ -> (t -> a) -> a
-          =
-       fun ~seed t vs s v k ->
-        let values = StepMap.add s v vs in
-        if values == vs then k t
-        else if StepMap.cardinal values <= Conf.entries then k (Values values)
-        else (nodes_of_values [@tailcall]) ~seed values @@ fun n -> k (Nodes n)
+      let inode ~hash v = { stable = false; hash; v }
 
-      and nodes_of_values : type a. seed:_ -> _ -> (t array -> a) -> a =
-       fun ~seed entries k ->
-        let n = Array.make Conf.entries empty in
-        StepMap.iter
-          (fun s e -> (update_nodes [@tailcall]) ~seed n s e)
-          entries;
-        k n
-
-      and with_node : type a.
-          seed:_ -> copy:_ -> _ -> _ -> _ -> (int -> t -> t -> a) -> a =
-       fun ~seed ~copy n s v k ->
-        let i = index ~seed s in
-        let x = n.(i) in
-        match x with
-        | Empty -> k i x (singleton s v)
-        | Values vs ->
-            (add_values [@tailcall]) ~seed:(seed + 1) x vs s v @@ fun y ->
-            k i x y
-        | Nodes n ->
-            (add_nodes [@tailcall]) ~seed:(seed + 1) ~copy x n s v @@ fun y ->
-            k i x y
-
-      and update_nodes ~seed n s e =
-        with_node ~seed ~copy:false n s e @@ fun i x y ->
-        if x != y then n.(i) <- y
-
-      and add_nodes : type a.
-          seed:_ -> copy:_ -> t -> _ -> _ -> _ -> (t -> a) -> a =
-       fun ~seed ~copy t n s e k ->
-        with_node ~seed ~copy n s e @@ fun i x y ->
-        if x == y then k t
-        else
-          let n = if copy then Array.copy n else n in
-          n.(i) <- y;
-          k (Nodes n)
-
-      let values l = Values (StepMap.of_list l)
-
-      let v l : t =
-        if List.length l < Conf.entries then values l
-        else
-          let aux t (s, v) =
-            match t with
-            | Empty -> singleton s v
-            | Values vs ->
-                (add_values [@tailcall]) ~seed:0 t vs s v (fun x -> x)
-            | Nodes n ->
-                (add_nodes [@tailcall]) ~seed:0 ~copy:false t n s v (fun x -> x)
-          in
-          List.fold_left aux empty l
-
-      let fold f t ~hash init =
-        let rec inode t k =
-          match t with
-          | Empty -> k Val.empty
-          | Values vs ->
-              let values = StepMap.bindings vs in
-              assert (List.length values <= Conf.entries);
-              k (Val.entries_of_values values)
-          | Nodes n ->
-              (inodes [@tailcall]) n 0 @@ fun entries ->
-              let hash = hash_entries entries in
-              k (Val.v ~hash entries)
-        and inodes n i k =
-          if i >= Array.length n then k []
-          else
-            match n.(i) with
-            | Empty -> inodes n (i + 1) k
-            | Values es when StepMap.cardinal es = 1 ->
-                let s, v = StepMap.choose es in
-                (inodes [@tailcall]) n (i + 1) @@ fun entries ->
-                let entries = Val.entry_of_value s v :: entries in
-                k entries
-            | _ ->
-                (inode [@tailcall]) n.(i) @@ fun t ->
-                f t.hash t @@ fun () ->
-                (inodes [@tailcall]) n (i + 1) @@ fun entries ->
-                let entries = Val.entry_of_inode i t.hash :: entries in
-                k entries
-        in
-        inode t (fun v ->
-            let v = { v with hash } in
-            init hash v )
-
-      let save ~add t =
-        fold (fun k v f -> add k v >>= f) t (fun k v -> add k v >|= fun () -> k)
-
-      let load ~find h =
-        let rec inode ~seed h k =
-          find h >>= function
-          | None -> k None
-          | Some { v = []; _ } -> k (Some empty)
-          | Some { v = i; _ } ->
-              let vs, is =
-                List.fold_left
-                  (fun (vs, is) -> function
-                    | Val.Node n -> (StepMap.add n.name (`Node n.node) vs, is)
-                    | Contents c ->
-                        ( StepMap.add c.name (`Contents (c.node, c.metadata)) vs,
-                          is ) | Inode i -> (vs, (i.index, i.node) :: is) )
-                  (StepMap.empty, []) i
-              in
-              if is = [] then
-                let t = Values vs in
-                k (Some t)
-              else
-                (nodes_of_values [@tailcall]) ~seed vs @@ fun n ->
-                (inodes [@tailcall]) ~seed n is @@ fun n -> k (Some (Nodes n))
-        and inodes ~seed n l k =
-          match l with
-          | [] -> k n
-          | (i, h) :: t -> (
-              (inode [@tailcall]) ~seed:(seed + 1) h @@ fun v ->
-              (inodes [@tailcall]) ~seed n t @@ fun n ->
-              match v with
-              | None -> k n
-              | Some v ->
-                  assert (i < Conf.entries);
-                  assert (n.(i) = Empty);
-                  n.(i) <- v;
-                  k n )
-        in
-        inode ~seed:0 h (function
-          | None -> Lwt.return None
-          | Some x -> Lwt.return (Some x) )
+      let hash t = Lazy.force t.hash
     end
 
+    (* Compressed binary representation *)
     module Compress = struct
+      open T
+
       type name = Indirect of int | Direct of step
 
       type address = Indirect of int64 | Direct of H.t
 
-      type entry =
+      let address : address Irmin.Type.t =
+        let open Irmin.Type in
+        variant "Compress.address" (fun i d -> function
+          | Indirect x -> i x | Direct x -> d x )
+        |~ case1 "Indirect" int64 (fun x -> Indirect x)
+        |~ case1 "Direct" H.t (fun x -> Direct x)
+        |> sealv
+
+      type inode = { index : int; hash : address }
+
+      let inode : inode Irmin.Type.t =
+        let open Irmin.Type in
+        record "Compress.inode" (fun index hash -> { index; hash })
+        |+ field "index" int (fun t -> t.index)
+        |+ field "hash" address (fun t -> t.hash)
+        |> sealr
+
+      type inodes = { seed : int; length : int; entries : inode list }
+
+      let inodes : inodes Irmin.Type.t =
+        let open Irmin.Type in
+        record "Compress.inodes" (fun seed length entries ->
+            { seed; length; entries } )
+        |+ field "seed" int (fun t -> t.seed)
+        |+ field "length" int (fun t -> t.length)
+        |+ field "entries" (list inode) (fun t -> t.entries)
+        |> sealr
+
+      type value =
         | Contents of name * address * metadata
         | Node of name * address
-        | Inode of int * address
 
-      let entry : entry Irmin.Type.t =
+      let is_default = Irmin.Type.equal T.metadata_t T.default
+
+      let value : value Irmin.Type.t =
         let open Irmin.Type in
-        variant "Compress.entry"
+        variant "Compress.value"
           (fun contents_ii
+          contents_x_ii
           node_ii
-          inode_i
           contents_id
+          contents_x_id
           node_id
-          inode_d
           contents_di
+          contents_x_di
           node_di
           contents_dd
+          contents_x_dd
           node_dd
           -> function
-          | Contents (Indirect n, Indirect h, m) -> contents_ii (n, h, m)
+          | Contents (Indirect n, Indirect h, m) ->
+              if is_default m then contents_ii (n, h)
+              else contents_x_ii (n, h, m)
           | Node (Indirect n, Indirect h) -> node_ii (n, h)
-          | Inode (n, Indirect h) -> inode_i (n, h)
-          | Contents (Indirect n, Direct h, m) -> contents_id (n, h, m)
+          | Contents (Indirect n, Direct h, m) ->
+              if is_default m then contents_id (n, h)
+              else contents_x_id (n, h, m)
           | Node (Indirect n, Direct h) -> node_id (n, h)
-          | Inode (n, Direct h) -> inode_d (n, h)
-          | Contents (Direct n, Indirect h, m) -> contents_di (n, h, m)
+          | Contents (Direct n, Indirect h, m) ->
+              if is_default m then contents_di (n, h)
+              else contents_x_di (n, h, m)
           | Node (Direct n, Indirect h) -> node_di (n, h)
-          | Contents (Direct n, Direct h, m) -> contents_dd (n, h, m)
+          | Contents (Direct n, Direct h, m) ->
+              if is_default m then contents_dd (n, h)
+              else contents_x_dd (n, h, m)
           | Node (Direct n, Direct h) -> node_dd (n, h) )
-        |~ case1 "contents-ii" (triple int int64 metadata_t) (fun (n, i, m) ->
-               Contents (Indirect n, Indirect i, m) )
+        |~ case1 "contents-ii" (pair int int64) (fun (n, i) ->
+               Contents (Indirect n, Indirect i, T.default) )
+        |~ case1 "contents-x-ii" (triple int int64 metadata_t)
+             (fun (n, i, m) -> Contents (Indirect n, Indirect i, m))
         |~ case1 "node-ii" (pair int int64) (fun (n, i) ->
                Node (Indirect n, Indirect i) )
-        |~ case1 "inode-i" (pair int int64) (fun (n, i) -> Inode (n, Indirect i))
-        |~ case1 "contents-id" (triple int H.t metadata_t) (fun (n, h, m) ->
+        |~ case1 "contents-id" (pair int H.t) (fun (n, h) ->
+               Contents (Indirect n, Direct h, T.default) )
+        |~ case1 "contents-x-id" (triple int H.t metadata_t) (fun (n, h, m) ->
                Contents (Indirect n, Direct h, m) )
         |~ case1 "node-id" (pair int H.t) (fun (n, h) ->
                Node (Indirect n, Direct h) )
-        |~ case1 "inode-d" (pair int H.t) (fun (n, h) -> Inode (n, Direct h))
-        |~ case1 "contents-di" (triple step_t int64 metadata_t)
+        |~ case1 "contents-di" (pair step_t int64) (fun (n, i) ->
+               Contents (Direct n, Indirect i, T.default) )
+        |~ case1 "contents-x-di" (triple step_t int64 metadata_t)
              (fun (n, i, m) -> Contents (Direct n, Indirect i, m))
         |~ case1 "node-di" (pair step_t int64) (fun (n, i) ->
                Node (Direct n, Indirect i) )
-        |~ case1 "contents-dd" (triple step_t H.t metadata_t) (fun (n, i, m) ->
-               Contents (Direct n, Direct i, m) )
+        |~ case1 "contents-dd" (pair step_t H.t) (fun (n, i) ->
+               Contents (Direct n, Direct i, T.default) )
+        |~ case1 "contents-x-dd" (triple step_t H.t metadata_t)
+             (fun (n, i, m) -> Contents (Direct n, Direct i, m))
         |~ case1 "node-dd" (pair step_t H.t) (fun (n, i) ->
                Node (Direct n, Direct i) )
         |> sealv
 
-      let t = item (Irmin.Type.list entry)
+      type v = Values of value list | Inodes of inodes
+
+      let v_t : v Irmin.Type.t =
+        let open Irmin.Type in
+        variant "Compress.v" (fun values inodes -> function
+          | Values x -> values x | Inodes x -> inodes x )
+        |~ case1 "Values" (list value) (fun x -> Values x)
+        |~ case1 "Inodes" inodes (fun x -> Inodes x)
+        |> sealv
+
+      type t = { hash : H.t; stable : bool; v : v }
+
+      let node ~hash v = { hash; stable = true; v }
+
+      let inode ~hash v = { hash; stable = false; v }
+
+      let magic_node = 'N'
+
+      let magic_inode = 'I'
+
+      let stable : bool Irmin.Type.t =
+        Irmin.Type.(map char)
+          (fun n -> n = magic_node)
+          (function true -> magic_node | false -> magic_inode)
+
+      let t =
+        let open Irmin.Type in
+        record "Compress.t" (fun hash stable v -> { hash; stable; v })
+        |+ field "hash" H.t (fun t -> t.hash)
+        |+ field "stable" stable (fun t -> t.stable)
+        |+ field "v" v_t (fun t -> t.v)
+        |> sealr
+    end
+
+    module Val = struct
+      open T
+
+      type inode = { i_hash : hash Lazy.t; mutable tree : t option }
+
+      and entry = Empty | Inode of inode
+
+      and inodes = { seed : int; length : int; entries : entry array }
+
+      and v = Values of value StepMap.t | Inodes of inodes
+
+      and t = { hash : hash Lazy.t; stable : bool; v : v }
+
+      let hash_of_inode (i : inode) = Lazy.force i.i_hash
+
+      let inode_t t : inode Irmin.Type.t =
+        let same_hash x y =
+          Irmin.Type.equal hash_t (hash_of_inode x) (hash_of_inode y)
+        in
+        let open Irmin.Type in
+        record "Node.inode" (fun hash tree -> { i_hash = lazy hash; tree })
+        |+ field "hash" hash_t (fun t -> Lazy.force t.i_hash)
+        |+ field "tree" (option t) (fun t -> t.tree)
+        |> sealr |> like ~equal:same_hash
+
+      let entry_t inode : entry Irmin.Type.t =
+        let open Irmin.Type in
+        variant "Node.entry" (fun empty inode -> function
+          | Empty -> empty | Inode i -> inode i )
+        |~ case0 "Empty" Empty
+        |~ case1 "Inode" inode (fun i -> Inode i)
+        |> sealv
+
+      let inodes entry : inodes Irmin.Type.t =
+        let open Irmin.Type in
+        record "Node.entries" (fun seed length entries ->
+            { seed; length; entries } )
+        |+ field "seed" int (fun t -> t.seed)
+        |+ field "length" int (fun t -> t.length)
+        |+ field "entries" (array entry) (fun t -> t.entries)
+        |> sealr
+
+      let length t =
+        match t.v with
+        | Values vs -> StepMap.cardinal vs
+        | Inodes vs -> vs.length
+
+      let get_tree ~find t =
+        match t.tree with
+        | Some t -> t
+        | None -> (
+            let h = hash_of_inode t in
+            match find h with
+            | None -> Fmt.failwith "%a: unknown key" pp_hash h
+            | Some x ->
+                t.tree <- Some x;
+                x )
+
+      let rec list_entry ~find acc = function
+        | Empty -> acc
+        | Inode i -> list_values ~find acc (get_tree ~find i)
+
+      and list_inodes ~find acc t =
+        Array.fold_left (list_entry ~find) acc t.entries
+
+      and list_values ~find acc t =
+        match t.v with
+        | Values vs -> StepMap.bindings vs @ acc
+        | Inodes t -> list_inodes ~find acc t
+
+      let compare_step a b = Irmin.Type.compare step_t a b
+
+      let compare_entry x y = compare_step (fst x) (fst y)
+
+      let list ~find t =
+        let entries = list_values ~find [] t in
+        List.fast_sort compare_entry entries
+
+      let to_bin_v = function
+        | Values vs ->
+            let vs = StepMap.bindings vs in
+            Bin.Values vs
+        | Inodes t ->
+            let _, entries =
+              Array.fold_left
+                (fun (i, acc) -> function Empty -> (i + 1, acc)
+                  | Inode inode ->
+                      let hash = hash_of_inode inode in
+                      (i + 1, { Bin.index = i; hash } :: acc) )
+                (0, []) t.entries
+            in
+            let entries = List.rev entries in
+            Bin.Inodes { seed = t.seed; length = t.length; entries }
+
+      let to_bin t =
+        let v = to_bin_v t.v in
+        if t.stable then Bin.node ~hash:t.hash v else Bin.inode ~hash:t.hash v
+
+      let hash t = Lazy.force t.hash
+
+      let stabilize ~find t =
+        if t.stable then t
+        else
+          let n = length t in
+          if n > Conf.stable_hash then t
+          else
+            let hash =
+              lazy
+                (let vs = list ~find t in
+                 Node.hash (Node.v vs))
+            in
+            { hash; stable = true; v = t.v }
+
+      let index ~seed k =
+        abs (Irmin.Type.short_hash step_t ~seed k) mod Conf.entries
+
+      let inode ?tree i_hash = Inode { tree; i_hash }
+
+      let of_bin t =
+        let v =
+          match t.Bin.v with
+          | Bin.Values vs ->
+              let vs = StepMap.of_list vs in
+              Values vs
+          | Inodes t ->
+              let entries = Array.make Conf.entries Empty in
+              List.iter
+                (fun { Bin.index; hash } ->
+                  entries.(index) <- inode (lazy hash) )
+                t.entries;
+              Inodes { seed = t.Bin.seed; length = t.length; entries }
+        in
+        { hash = t.Bin.hash; stable = t.Bin.stable; v }
+
+      let v_t t : v Irmin.Type.t =
+        let open Irmin.Type in
+        let pre_hash x = pre_hash Bin.v_t (to_bin_v x) in
+        let entry = entry_t (inode_t t) in
+        variant "Inode.t" (fun values inodes -> function
+          | Values v -> values v | Inodes i -> inodes i )
+        |~ case1 "Values" (StepMap.t value_t) (fun t -> Values t)
+        |~ case1 "Inodes" (inodes entry) (fun t -> Inodes t)
+        |> sealv |> like ~pre_hash
+
+      let t : t Irmin.Type.t =
+        let open Irmin.Type in
+        mu @@ fun t ->
+        let v = v_t t in
+        let t =
+          record "hash" (fun hash stable v -> { hash = lazy hash; stable; v })
+          |+ field "hash" H.t (fun t -> Lazy.force t.hash)
+          |+ field "stable" bool (fun t -> t.stable)
+          |+ field "v" v (fun t -> t.v)
+          |> sealr
+        in
+        let pre_hash x = Irmin.Type.pre_hash v x.v in
+        like ~pre_hash t
+
+      let empty =
+        let hash = lazy (Node.hash Node.empty) in
+        { stable = true; hash; v = Values StepMap.empty }
+
+      let values vs =
+        let length = StepMap.cardinal vs in
+        if length = 0 then empty
+        else
+          let v = Values vs in
+          let hash = lazy (Bin.V.hash (to_bin_v v)) in
+          { hash; stable = false; v }
+
+      let inodes is =
+        let v = Inodes is in
+        let hash = lazy (Bin.V.hash (to_bin_v v)) in
+        { hash; stable = false; v }
+
+      let of_values l = values (StepMap.of_list l)
+
+      let is_empty t =
+        match t.v with Values vs -> StepMap.is_empty vs | Inodes _ -> false
+
+      let find_value ~seed ~find t s =
+        let rec aux ~seed = function
+          | Values vs -> (
+            try Some (StepMap.find s vs) with Not_found -> None )
+          | Inodes t -> (
+              let i = index ~seed s in
+              let x = t.entries.(i) in
+              match x with
+              | Empty -> None
+              | Inode i -> aux ~seed:(seed + 1) (get_tree ~find i).v )
+        in
+        aux ~seed t.v
+
+      let find ~find t s = find_value ~seed:0 ~find t s
+
+      let rec add ~seed ~find ~copy t s v k =
+        match find_value ~seed ~find t s with
+        | Some v' when Irmin.Type.equal value_t v v' -> k t
+        | v' -> (
+          match t.v with
+          | Values vs ->
+              let length =
+                match v' with
+                | None -> StepMap.cardinal vs + 1
+                | Some _ -> StepMap.cardinal vs
+              in
+              let t =
+                if length <= Conf.entries then values (StepMap.add s v vs)
+                else
+                  let vs = StepMap.bindings (StepMap.add s v vs) in
+                  let empty =
+                    inodes
+                      { length = 0;
+                        seed;
+                        entries = Array.make Conf.entries Empty
+                      }
+                  in
+                  let aux t (s, v) =
+                    (add [@tailcall]) ~seed ~find ~copy:false t s v (fun x -> x)
+                  in
+                  List.fold_left aux empty vs
+              in
+              k t
+          | Inodes t -> (
+              let length =
+                match v' with None -> t.length + 1 | Some _ -> t.length
+              in
+              let entries = if copy then Array.copy t.entries else t.entries in
+              let i = index ~seed s in
+              match entries.(i) with
+              | Empty ->
+                  let tree = values (StepMap.singleton s v) in
+                  entries.(i) <- inode ~tree tree.hash;
+                  let t = inodes { seed; length; entries } in
+                  k t
+              | Inode n ->
+                  let t = get_tree ~find n in
+                  add ~seed:(seed + 1) ~find ~copy t s v @@ fun tree ->
+                  let inode = inode ~tree tree.hash in
+                  entries.(i) <- inode;
+                  let t = inodes { seed; length; entries } in
+                  k t ) )
+
+      let add ~find ~copy t s v =
+        add ~seed:0 ~find ~copy t s v (stabilize ~find)
+
+      let rec remove ~seed ~find t s k =
+        match find_value ~seed ~find t s with
+        | None -> k t
+        | Some _ -> (
+          match t.v with
+          | Values vs ->
+              let t = values (StepMap.remove s vs) in
+              k t
+          | Inodes t -> (
+              let length = t.length - 1 in
+              if length <= Conf.entries then
+                let vs = list_inodes ~find [] t in
+                let vs = StepMap.of_list vs in
+                let vs = StepMap.remove s vs in
+                let t = values vs in
+                k t
+              else
+                let entries = Array.copy t.entries in
+                let i = index ~seed s in
+                match entries.(i) with
+                | Empty -> assert false
+                | Inode t ->
+                    let t = get_tree ~find t in
+                    remove ~seed:(seed + 1) ~find t s @@ fun tree ->
+                    entries.(i) <- inode ~tree (lazy (hash tree));
+                    let t = inodes { seed; length; entries } in
+                    k t ) )
+
+      let remove ~find t s = remove ~find ~seed:0 t s (stabilize ~find)
+
+      let v l : t =
+        let len = List.length l in
+        let find _ = assert false in
+        let t =
+          if len <= Conf.entries then of_values l
+          else
+            let aux acc (s, v) = add ~find ~copy:false acc s v in
+            List.fold_left aux empty l
+        in
+        stabilize ~find t
+
+      let add ~find t s v = add ~find ~copy:true t s v
+
+      let save ~add ~mem t =
+        let rec aux ~seed t =
+          Log.debug (fun l -> l "save seed:%d" seed);
+          match t.v with
+          | Values _ -> add (Lazy.force t.hash) (to_bin t)
+          | Inodes n ->
+              Array.iter
+                (function
+                  | Empty | Inode { tree = None; _ } -> ()
+                  | Inode ({ tree = Some t; _ } as i) ->
+                      let hash = hash_of_inode i in
+                      if mem hash then () else aux ~seed:(seed + 1) t )
+                n.entries;
+              add (Lazy.force t.hash) (to_bin t)
+        in
+        aux ~seed:0 t
     end
 
     include Pack.Make (struct
-      include Val
+      type t = Bin.t
 
-      let hash t = t.hash
+      let t = Bin.t
+
+      let magic (t : t) =
+        if t.stable then Compress.magic_node else Compress.magic_inode
+
+      let hash t = Bin.hash t
 
       let encode_bin ~dict ~offset (t : t) k =
-        assert (Irmin.Type.equal H.t k t.hash);
         let step s : Compress.name =
-          let str = Irmin.Type.to_bin_string step_t s in
+          let str = Irmin.Type.to_bin_string T.step_t s in
           if String.length str <= 4 then Direct s
           else
             let s = dict str in
@@ -379,34 +624,45 @@ struct
           | None -> Compress.Direct h
           | Some off -> Compress.Indirect off
         in
-        let inode : entry -> Compress.entry = function
-          | Contents c ->
-              let s = step c.name in
-              let v = hash c.node in
-              Compress.Contents (s, v, c.metadata)
-          | Node n ->
-              let s = step n.name in
-              let v = hash n.node in
+        let inode : Bin.inode -> Compress.inode =
+         fun n ->
+          let hash = hash n.hash in
+          { index = n.index; hash }
+        in
+        let value : T.step * T.value -> Compress.value = function
+          | s, `Contents (c, m) ->
+              let s = step s in
+              let v = hash c in
+              Compress.Contents (s, v, m)
+          | s, `Node n ->
+              let s = step s in
+              let v = hash n in
               Compress.Node (s, v)
-          | Inode i ->
-              let v = hash i.node in
-              Compress.Inode (i.index, v)
         in
         (* List.map is fine here as the number of entries is small *)
-        let inodes = List.map inode t.v in
-        Irmin.Type.encode_bin Compress.t (Val.v ~hash:k inodes)
+        let v : Bin.v -> Compress.v = function
+          | Values vs -> Values (List.map value vs)
+          | Inodes { seed; length; entries } ->
+              let entries = List.map inode entries in
+              Inodes { Compress.seed; length; entries }
+        in
+        let t =
+          if t.stable then Compress.node ~hash:k (v t.v)
+          else Compress.inode ~hash:k (v t.v)
+        in
+        Irmin.Type.encode_bin Compress.t t
 
       exception Exit of [ `Msg of string ]
 
       let decode_bin ~dict ~hash t off : t =
         let _, i = Irmin.Type.decode_bin ~headers:false Compress.t t off in
-        let step : Compress.name -> step = function
+        let step : Compress.name -> T.step = function
           | Direct n -> n
           | Indirect s -> (
             match dict s with
             | None -> raise_notrace (Exit (`Msg "dict"))
             | Some s -> (
-              match Irmin.Type.of_bin_string step_t s with
+              match Irmin.Type.of_bin_string T.step_t s with
               | Error e -> raise_notrace (Exit e)
               | Ok v -> v ) )
         in
@@ -414,28 +670,68 @@ struct
           | Indirect off -> hash off
           | Direct n -> n
         in
-        let inode : Compress.entry -> entry = function
+        let inode : Compress.inode -> Bin.inode =
+         fun n ->
+          let hash = hash n.hash in
+          { index = n.index; hash }
+        in
+        let value : Compress.value -> T.step * T.value = function
           | Contents (n, h, metadata) ->
               let name = step n in
               let node = hash h in
-              Contents { name; node; metadata }
+              (name, `Contents (node, metadata))
           | Node (n, h) ->
               let name = step n in
               let node = hash h in
-              Node { name; node }
-          | Inode (index, h) ->
-              let node = hash h in
-              Inode { index; node }
+              (name, `Node node)
         in
-        try
-          (* List.map is fine here as the number of inodes is small. *)
-          let entries = List.map inode i.v in
-          Val.v ~hash:i.hash entries
-        with Exit (`Msg e) -> failwith e
+        let t : Compress.v -> Bin.v = function
+          | Values vs -> Values (List.map value vs)
+          | Inodes { seed; length; entries } ->
+              let entries = List.map inode entries in
+              Inodes { seed; length; entries }
+        in
+        if i.stable then Bin.node ~hash:(lazy i.hash) (t i.v)
+        else Bin.inode ~hash:(lazy i.hash) (t i.v)
     end)
   end
 
-  module Val = Node
+  module Val = struct
+    include T
+    module I = Inode.Val
+
+    type t = { mutable find : H.t -> I.t option; v : I.t }
+
+    let niet _ = assert false
+
+    let v l = { find = niet; v = I.v l }
+
+    let list t = I.list ~find:t.find t.v
+
+    let empty = { find = niet; v = Inode.Val.empty }
+
+    let is_empty t = I.is_empty t.v
+
+    let find t s = I.find ~find:t.find t.v s
+
+    let add t s v =
+      let v = I.add ~find:t.find t.v s v in
+      if v == t.v then t else { find = t.find; v }
+
+    let remove t s =
+      let v = I.remove ~find:t.find t.v s in
+      if v == t.v then t else { find = t.find; v }
+
+    let t : t Irmin.Type.t =
+      let pre_hash x =
+        if not x.v.stable then Irmin.Type.pre_hash I.t x.v
+        else
+          let vs = list x in
+          Irmin.Type.pre_hash Node.t (Node.v vs)
+      in
+      Irmin.Type.map I.t ~pre_hash (fun v -> { find = niet; v }) (fun t -> t.v)
+  end
+
   module Key = H
 
   type 'a t = 'a Inode.t
@@ -446,39 +742,41 @@ struct
 
   let mem t k = Inode.mem t k
 
-  let find t k =
-    Inode.Tree.load
-      ~find:(fun k ->
-        let v = Inode.unsafe_find t k in
-        Lwt.return v )
-      k
-    >|= function
+  let unsafe_find t k =
+    match Inode.unsafe_find t k with
     | None -> None
-    | Some t -> Some (Val.v (Inode.Tree.list t))
+    | Some v ->
+        let v = Inode.Val.of_bin v in
+        Some v
 
-  module H_node = Irmin.Hash.Typed (H) (Val)
+  let find t k =
+    Inode.find t k >|= function
+    | None -> None
+    | Some v ->
+        let v = Inode.Val.of_bin v in
+        let find = unsafe_find t in
+        Some { Val.find; v }
 
-  let hash_node = H_node.hash
+  let save t v =
+    let add k v = Inode.unsafe_append t k v in
+    Inode.Val.save ~add ~mem:(Inode.unsafe_mem t) v
+
+  let hash v = Lazy.force v.Val.v.Inode.Val.hash
 
   let add t v =
-    let n = Val.list v in
-    let hash = hash_node v in
-    let v = Inode.Tree.v n in
-    Inode.Tree.save ~hash
-      ~add:(fun k v ->
-        Inode.unsafe_append t k v;
-        Lwt.return () )
-      v
+    save t v.Val.v;
+    Lwt.return (hash v)
+
+  let check_hash expected got =
+    if Irmin.Type.equal H.t expected got then ()
+    else
+      Fmt.invalid_arg "corrupted value: got %a, expecting %a" T.pp_hash
+        expected T.pp_hash got
 
   let unsafe_add t k v =
-    let n = Val.list v in
-    let v = Inode.Tree.v n in
-    Inode.Tree.save ~hash:k
-      ~add:(fun k v ->
-        Inode.unsafe_append t k v;
-        Lwt.return () )
-      v
-    >|= fun _ -> ()
+    check_hash k (hash v);
+    save t v.Val.v;
+    Lwt.return ()
 
   let batch = Inode.batch
 

--- a/src/irmin-pack/inode.mli
+++ b/src/irmin-pack/inode.mli
@@ -16,6 +16,8 @@
 
 module type CONFIG = sig
   val entries : int
+
+  val stable_hash : int
 end
 
 module type S = sig

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -298,6 +298,8 @@ struct
           let decode_bin ~dict:_ ~hash:_ s off =
             let _, t = Irmin.Type.decode_bin ~headers:false value s off in
             t.v
+
+          let magic _ = magic
         end)
       end
 
@@ -330,6 +332,8 @@ struct
           let decode_bin ~dict:_ ~hash:_ s off =
             let _, v = Irmin.Type.decode_bin ~headers:false value s off in
             v.v
+
+          let magic _ = magic
         end)
       end
 

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -29,6 +29,8 @@ exception RO_Not_Allowed
 
 module type CONFIG = sig
   val entries : int
+
+  val stable_hash : int
 end
 
 module Make_ext

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -52,7 +52,7 @@ module type ELT = sig
 
   val hash : t -> hash
 
-  val magic : char
+  val magic : t -> char
 
   val encode_bin :
     dict:(string -> int) ->
@@ -301,7 +301,7 @@ module File (K : Irmin.Hash.S) = struct
           let off = IO.offset t.pack.block in
           V.encode_bin ~offset ~dict v k (IO.append t.pack.block);
           let len = Int64.to_int (IO.offset t.pack.block -- off) in
-          Index.replace t.pack.index k (off, len, V.magic);
+          Index.replace t.pack.index k (off, len, V.magic v);
           if Tbl.length t.staging >= auto_flush then sync t
           else Tbl.add t.staging k v;
           Lru.add t.lru k v

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -21,7 +21,7 @@ module type ELT = sig
 
   val hash : t -> hash
 
-  val magic : char
+  val magic : t -> char
 
   val encode_bin :
     dict:(string -> int) ->

--- a/test/irmin-pack/bench.ml
+++ b/test/irmin-pack/bench.ml
@@ -18,6 +18,8 @@ let config ~root = Irmin_pack.config ~fresh:false root
 
 module Config = struct
   let entries = 2
+
+  let stable_hash = 3
 end
 
 module KV = Irmin_pack.KV (Config) (Irmin.Contents.String)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -18,6 +18,8 @@ open Lwt.Infix
 
 module Config = struct
   let entries = 2
+
+  let stable_hash = 3
 end
 
 let store =
@@ -84,7 +86,7 @@ let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
 module S = struct
   include Irmin.Contents.String
 
-  let magic = 'S'
+  let magic _ = 'S'
 
   module H = Irmin.Hash.Typed (Irmin.Hash.SHA1) (Irmin.Contents.String)
 


### PR DESCRIPTION
There is now two modes of operations for inodes:
- small inodes (#children <= Conf.stable_hash) have their hashes identical to
  what would flat nodes do.
- large inodes (#children > Conf.stable_hash) would have a more optimised hash,
  which can be computed whithout having to read the full children first.