### PR TITLE
Use `Index.find_all`

### DIFF
--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -92,11 +92,13 @@ module S = struct
 
   let hash = H.hash
 
-  let encode_bin ~dict:_ ~offset:_ x _k =
-    Irmin.Type.encode_bin ~headers:false t x
+  let encode_bin ~dict:_ ~offset:_ x k =
+    Irmin.Type.(encode_bin ~headers:false (pair H.t t) (k, x))
 
   let decode_bin ~dict:_ ~hash:_ x off =
-    let _, v = Irmin.Type.decode_bin ~headers:false t x off in
+    let _, (_, v) =
+      Irmin.Type.(decode_bin ~headers:false (pair H.t t) x off)
+    in
     v
 end
 


### PR DESCRIPTION
https://github.com/mirage/index/pull/14 will allow to add duplicate keys in the index (e.g. shorter hashes) and get them using `find_all`.
This PR reflects the API change. It does not use shorter hashes, a separate PR might be better for that.