### PR TITLE
Change default hash to BLAKE2b

### DIFF
--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -314,7 +314,7 @@ module Make (IO : IO) = Make_ext (IO) (Obj) (Ref)
 module KV (IO : IO) (C : Irmin.Contents.S) =
   Make (IO) (Irmin.Metadata.None) (C) (Irmin.Path.String_list)
     (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+    (Irmin.Hash.BLAKE2B)
 
 module IO_mem = struct
   type t = {

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -131,4 +131,4 @@ module Make =
   Irmin.Make (Irmin.Content_addressable (Append_only)) (Atomic_write)
 module KV (C : Irmin.Contents.S) =
   Make (Irmin.Metadata.None) (C) (Irmin.Path.String_list) (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+    (Irmin.Hash.BLAKE2B)

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -398,7 +398,7 @@ struct
   include Irmin.Of_private (X)
 end
 
-module Hash = Irmin.Hash.SHA1
+module Hash = Irmin.Hash.BLAKE2B
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
 

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -127,7 +127,7 @@ module Store = struct
     let module S =
       S (Irmin.Metadata.None) (C) (Irmin.Path.String_list)
         (Irmin.Branch.String)
-        (Irmin.Hash.SHA1)
+        (Irmin.Hash.BLAKE2B)
     in
     T ((module S), None)
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1019,12 +1019,12 @@ end
 
 (** Hashing functions.
 
-    [Hash] provides user-defined hash function to digest serialized
+    [Hash] provides user-defined hash functions to digest serialized
     contents. Some {{!backend}backends} might be parameterized by such
     hash functions, others might work with a fixed one (for instance,
     the Git format uses only {{!Hash.SHA1}SHA1}).
 
-    An {{!Hash.SHA1}SHA1} implementation is available to pass to the
+    A {{!Hash.SHA1}SHA1} implementation is available to pass to the
     backends. *)
 module Hash : sig
   (** {1 Contents Hashing} *)

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -89,9 +89,9 @@ let l =
 let tl = Alcotest.testable (T.pp l) (T.equal l)
 
 let hash =
-  Alcotest.testable (T.pp Irmin.Hash.SHA1.t) (T.equal Irmin.Hash.SHA1.t)
+  Alcotest.testable (T.pp Irmin.Hash.BLAKE2B.t) (T.equal Irmin.Hash.BLAKE2B.t)
 
-let sha1 x = Irmin.Hash.SHA1.hash (fun l -> l x)
+let sha1 x = Irmin.Hash.BLAKE2B.hash (fun l -> l x)
 
 let test_bin () =
   let s = T.to_string l [ "foo"; "foo" ] in
@@ -111,16 +111,16 @@ let test_bin () =
   Alcotest.(check string) "foo 1" (Buffer.contents buf) "foo";
   let buf = Buffer.create 10 in
   let h = sha1 "foo" in
-  T.encode_bin ~headers:false Irmin.Hash.SHA1.t h (Buffer.add_string buf);
+  T.encode_bin ~headers:false Irmin.Hash.BLAKE2B.t h (Buffer.add_string buf);
   let x = Buffer.contents buf in
   let buf = Bytes.create 100 in
   Bytes.blit_string x 0 buf 0 (String.length x);
   let n, v =
-    T.decode_bin ~headers:false Irmin.Hash.SHA1.t
+    T.decode_bin ~headers:false Irmin.Hash.BLAKE2B.t
       (Bytes.unsafe_to_string buf)
       0
   in
-  Alcotest.(check int) "hash size" n Irmin.Hash.SHA1.hash_size;
+  Alcotest.(check int) "hash size" n Irmin.Hash.BLAKE2B.hash_size;
   Alcotest.(check hash) "hash" v h
 
 let x = T.like ~compare:(fun x y -> y - x - 1) T.int


### PR DESCRIPTION
This is a candidate solution for #727.

[SHA-1 has been broken](https://shattered.io/), and so is no longer a sensible default.