### PR TITLE
irmin-pack: do not duplicate the creation of the Index module

### DIFF
--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -74,6 +74,7 @@ exception RO_Not_Allowed = IO.RO_Not_Allowed
 
 module Dict = Dict
 module Pack = Pack
+module Index = Pack_index
 module IO = IO.Unix
 
 module Table (K : Irmin.Type.S) = Hashtbl.Make (struct
@@ -261,8 +262,8 @@ module Make_ext
              and type step = P.step)
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
-  module Pack = Pack.File (H)
   module Index = Pack_index.Make (H)
+  module Pack = Pack.File (Index) (H)
 
   module X = struct
     module Hash = H

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -24,6 +24,7 @@ val config :
 
 module Dict = Dict
 module Pack = Pack
+module Index = Pack_index
 
 exception RO_Not_Allowed
 

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -117,9 +117,9 @@ let with_cache = IO.with_cache
 
 module IO = IO.Unix
 
-module File (K : Irmin.Hash.S) = struct
+module File (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) =
+struct
   module Tbl = Table (K)
-  module Index = Pack_index.Make (K)
 
   type 'a t = {
     block : IO.t;

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -67,7 +67,8 @@ module type MAKER = sig
     S with type key = key and type value = V.t
 end
 
-module File (K : Irmin.Hash.S) : MAKER with type key = K.t
+module File (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
+  MAKER with type key = K.t
 
 type stats = {
   pack_cache_misses : float;

--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -10,6 +10,8 @@
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
+module type S = Index.S with type value = int64 * int * char
+
 module Make (K : Irmin.Hash.S) = struct
   module Key = struct
     type t = K.t

--- a/src/irmin-pack/pack_index.mli
+++ b/src/irmin-pack/pack_index.mli
@@ -10,5 +10,6 @@
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
-module Make (K : Irmin.Hash.S) :
-  Index.S with type key = K.t and type value = int64 * int * char
+module type S = Index.S with type value = int64 * int * char
+
+module Make (K : Irmin.Hash.S) : S with type key = K.t

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -100,7 +100,9 @@ module S = struct
     v
 end
 
-module P = Irmin_pack.Pack.File (Irmin.Hash.SHA1)
+module H = Irmin.Hash.SHA1
+module I = Irmin_pack.Index.Make (H)
+module P = Irmin_pack.Pack.File (I) (H)
 module Pack = P.Make (S)
 
 let test_pack _switch () =


### PR DESCRIPTION
This will probably conflict with #805 but with a different aim/goal. The goal here is to make sure we are calling `Pack_index.Make` only once.

/cc @CraigFe 