### PR TITLE
irmin-graphql: Expose Schema as alias of Graphql_lwt.Schema

### DIFF
--- a/src/irmin-graphql/server.mli
+++ b/src/irmin-graphql/server.mli
@@ -1,4 +1,4 @@
-module Schema : Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
+module Schema = Graphql_lwt.Schema
 
 module type S = sig
   module IO : Cohttp_lwt.S.IO


### PR DESCRIPTION
This PR exposes `Irmin_graphql.Server.Schema` as an alias of `Graphql_lwt.Schema`, which there's really no reason in hiding and makes things simpler as a user of `Irmin_graphql.Server`.

/cc @zshipko 