### PR TITLE
irmin-pack: improve Dict module abstraction

### DIFF
--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -14,10 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-exception RO_Not_Allowed
-
 module type S = sig
   type t
+
+  exception RO_Not_Allowed
 
   val v : fresh:bool -> version:string -> readonly:bool -> string -> t
 

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -23,86 +23,88 @@ let current_version = "00000001"
 
 let ( -- ) = Int64.sub
 
-let with_cache = IO.with_cache
+module type S = sig
+  type t
 
-exception RO_Not_Allowed = IO.RO_Not_Allowed
+  val find : t -> int -> string option
 
-module IO = IO.Unix
+  val index : t -> string -> int option
 
-type t = {
-  capacity : int;
-  cache : (string, int) Hashtbl.t;
-  index : (int, string) Hashtbl.t;
-  io : IO.t
-}
+  val sync : t -> unit
 
-let io t = t.io
+  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 
-let append_string t v =
-  let len = Int32.of_int (String.length v) in
-  let buf = Irmin.Type.(to_bin_string int32 len) ^ v in
-  IO.append t.io buf
+  val clear : t -> unit
+end
 
-let refill ~from t =
-  let len = Int64.to_int (IO.offset t.io -- from) in
-  let raw = Bytes.create len in
-  let n = IO.read t.io ~off:from raw in
-  assert (n = len);
-  let raw = Bytes.unsafe_to_string raw in
-  let rec aux n offset =
-    if offset >= len then ()
-    else
-      let _, v = Irmin.Type.(decode_bin int32) raw offset in
-      let len = Int32.to_int v in
-      let v = String.sub raw (offset + 4) len in
-      Hashtbl.add t.cache v n;
-      Hashtbl.add t.index n v;
-      (aux [@tailcall]) (n + 1) (offset + 4 + len)
-  in
-  (aux [@tailcall]) (Hashtbl.length t.cache) 0
+module Make (IO : IO.S) : S = struct
+  type t = {
+    capacity : int;
+    cache : (string, int) Hashtbl.t;
+    index : (int, string) Hashtbl.t;
+    io : IO.t
+  }
 
-let sync_offset t =
-  let former_log_offset = IO.offset t.io in
-  let log_offset = IO.force_offset t.io in
-  if log_offset > former_log_offset then refill ~from:former_log_offset t
+  let append_string t v =
+    let len = Int32.of_int (String.length v) in
+    let buf = Irmin.Type.(to_bin_string int32 len) ^ v in
+    IO.append t.io buf
 
-let sync t = IO.sync t.io
+  let refill ~from t =
+    let len = Int64.to_int (IO.offset t.io -- from) in
+    let raw = Bytes.create len in
+    let n = IO.read t.io ~off:from raw in
+    assert (n = len);
+    let raw = Bytes.unsafe_to_string raw in
+    let rec aux n offset =
+      if offset >= len then ()
+      else
+        let _, v = Irmin.Type.(decode_bin int32) raw offset in
+        let len = Int32.to_int v in
+        let v = String.sub raw (offset + 4) len in
+        Hashtbl.add t.cache v n;
+        Hashtbl.add t.index n v;
+        (aux [@tailcall]) (n + 1) (offset + 4 + len)
+    in
+    (aux [@tailcall]) (Hashtbl.length t.cache) 0
 
-let index t v =
-  Log.debug (fun l -> l "[dict] index %S" v);
-  if IO.readonly t.io then sync_offset t;
-  try Some (Hashtbl.find t.cache v)
-  with Not_found ->
-    let id = Hashtbl.length t.cache in
-    if id > t.capacity then None
-    else (
-      if IO.readonly t.io then raise RO_Not_Allowed;
-      append_string t v;
-      Hashtbl.add t.cache v id;
-      Hashtbl.add t.index id v;
-      Some id )
+  let sync_offset t =
+    let former_log_offset = IO.offset t.io in
+    let log_offset = IO.force_offset t.io in
+    if log_offset > former_log_offset then refill ~from:former_log_offset t
 
-let find t id =
-  if IO.readonly t.io then sync_offset t;
-  Log.debug (fun l -> l "[dict] find %d" id);
-  let v = try Some (Hashtbl.find t.index id) with Not_found -> None in
-  v
+  let sync t = IO.sync t.io
 
-let clear t =
-  IO.clear t.io;
-  Hashtbl.clear t.cache;
-  Hashtbl.clear t.index
+  let index t v =
+    Log.debug (fun l -> l "[dict] index %S" v);
+    if IO.readonly t.io then sync_offset t;
+    try Some (Hashtbl.find t.cache v)
+    with Not_found ->
+      let id = Hashtbl.length t.cache in
+      if id > t.capacity then None
+      else (
+        if IO.readonly t.io then raise IO.RO_Not_Allowed;
+        append_string t v;
+        Hashtbl.add t.cache v id;
+        Hashtbl.add t.index id v;
+        Some id )
 
-let v_no_cache ~capacity ~fresh ~shared:_ ~readonly file =
-  let io = IO.v ~fresh ~version:current_version ~readonly file in
-  let cache = Hashtbl.create 997 in
-  let index = Hashtbl.create 997 in
-  let t = { capacity; index; cache; io } in
-  refill ~from:0L t;
-  t
+  let find t id =
+    if IO.readonly t.io then sync_offset t;
+    Log.debug (fun l -> l "[dict] find %d" id);
+    let v = try Some (Hashtbl.find t.index id) with Not_found -> None in
+    v
 
-let (`Staged v) =
-  with_cache ~clear ~v:(fun capacity -> v_no_cache ~capacity) "store.dict"
+  let clear t =
+    IO.clear t.io;
+    Hashtbl.clear t.cache;
+    Hashtbl.clear t.index
 
-let v ?fresh ?shared ?readonly ?(capacity = 100_000) root =
-  v capacity ?fresh ?shared ?readonly root
+  let v ?(fresh = true) ?(readonly = false) ?(capacity = 100_000) file =
+    let io = IO.v ~fresh ~version:current_version ~readonly file in
+    let cache = Hashtbl.create 997 in
+    let index = Hashtbl.create 997 in
+    let t = { capacity; index; cache; io } in
+    refill ~from:0L t;
+    t
+end

--- a/src/irmin-pack/dict.mli
+++ b/src/irmin-pack/dict.mli
@@ -14,17 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type t
+module type S = sig
+  type t
 
-val find : t -> int -> string option
+  val find : t -> int -> string option
 
-val index : t -> string -> int option
+  val index : t -> string -> int option
 
-val sync : t -> unit
+  val sync : t -> unit
 
-val v :
-  ?fresh:bool -> ?shared:bool -> ?readonly:bool -> ?capacity:int -> string -> t
+  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 
-val clear : t -> unit
+  val clear : t -> unit
+end
 
-val io : t -> IO.Unix.t
+module Make (IO : IO.S) : S

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -78,13 +78,12 @@ let ( ++ ) = Int64.add
 let with_cache = IO.with_cache
 
 open Lwt.Infix
-
-exception RO_Not_Allowed = IO.RO_Not_Allowed
-
-module Dict = Dict
 module Pack = Pack
+module Dict = Pack_dict
 module Index = Pack_index
 module IO = IO.Unix
+
+exception RO_Not_Allowed = IO.RO_Not_Allowed
 
 module Table (K : Irmin.Type.S) = Hashtbl.Make (struct
   type t = K.t

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -23,8 +23,8 @@ val config :
   string ->
   Irmin.config
 
-module Dict = Dict
 module Pack = Pack
+module Dict = Pack_dict
 module Index = Pack_index
 
 exception RO_Not_Allowed

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -125,6 +125,7 @@ module IO = IO.Unix
 module File (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) =
 struct
   module Tbl = Table (K)
+  module Dict = Pack_dict
 
   type index = Index.t
 
@@ -288,7 +289,7 @@ struct
     let cast t = (t :> [ `Read | `Write ] t)
 
     let sync t =
-      IO.sync (Dict.io t.pack.dict);
+      Dict.sync t.pack.dict;
       Index.flush t.pack.index;
       IO.sync t.pack.block;
       Tbl.clear t.staging;

--- a/src/irmin-pack/pack_dict.ml
+++ b/src/irmin-pack/pack_dict.ml
@@ -1,0 +1,9 @@
+include Dict.Make (IO.Unix)
+
+(* Add IO caching around Dict.v *)
+let (`Staged v) =
+  let v_no_cache ~fresh ~shared:_ ~readonly = v ~fresh ~readonly in
+  IO.with_cache ~clear ~v:(fun capacity -> v_no_cache ~capacity) "store.dict"
+
+let v ?fresh ?readonly ?shared ?(capacity = 100_000) root =
+  v capacity ?fresh ?shared ?readonly root


### PR DESCRIPTION
- extracts the caching of `Dict` constructions to a separate `Pack_dict` module;
- parameterises `Dict` on an arbitrary `IO` module, and hides the internal IO instance (this was only being used to do `IO.sync`, which is already exposed via `Dict.sync`).

These changes will aid potential future extraction of the `Dict` functionality.