### PR TITLE
irmin-pack: minor cleanup in Dict

### DIFF
--- a/src/irmin-pack/pack_dict.mli
+++ b/src/irmin-pack/pack_dict.mli
@@ -10,12 +10,7 @@
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
-include Dict.Make (IO.Unix)
+include Dict.S
 
-(* Add IO caching around Dict.v *)
-let (`Staged v) =
-  let v_no_cache ~fresh ~shared:_ ~readonly = v ~fresh ~readonly in
-  IO.with_cache ~clear ~v:(fun capacity -> v_no_cache ~capacity) "store.dict"
-
-let v ?fresh ?shared ?readonly ?(capacity = 100_000) root =
-  v capacity ?fresh ?shared ?readonly root
+val v :
+  ?fresh:bool -> ?shared:bool -> ?readonly:bool -> ?capacity:int -> string -> t


### PR DESCRIPTION
Takes care of a few loose ends in https://github.com/mirage/irmin/pull/828:
- ~~removes a redundant `shared` argument in the constructor of `Dict`~~
- adds missing copyright header / `.mli` file for `Dict`