### PR TITLE
irmin: update README to 2.0 interface

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,0 +1,1 @@
+examples/readme.ml

--- a/README.md
+++ b/README.md
@@ -81,19 +81,14 @@ let main =
 let () = Lwt_main.run main
 ```
 
-To compile the example above, save it to a file called `example.ml` and run:
+The example is contained in `examples/readme.ml`. It can be compiled and executed with dune:
 
 ```bash
-$ ocamlfind ocamlopt example.ml -o example -package irmin-unix,lwt.unix -linkpkg
-$ ./example
+$ dune build examples/readme.exe
+$ dune exec examples/readme.exe
 foo/bar => 'testing 123'
 ```
-The `examples` directory contains some more advanced examples. The build them, run:
-
-```bash
-$ dune build examples/trees.exe
-$ dune exec examples/trees.exe
-```
+The `examples/` directory also contains more advanced examples, which can be executed in the same way.
 
 ### Command-line
 The same thing can also be accomplished using `irmin`, the command-line application installed with `irmin-unix`, by running:

--- a/examples/dune
+++ b/examples/dune
@@ -1,14 +1,14 @@
 (executables
-  (names trees sync process deploy irmin_git_store custom_merge push)
+  (names readme trees sync process deploy irmin_git_store custom_merge push)
   (libraries checkseum.c digestif.c irmin irmin-unix))
 
 (alias
  (name examples)
- (deps trees.exe sync.exe process.exe deploy.exe push.exe
+ (deps readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
        irmin_git_store.exe custom_merge.exe))
 
 (alias
  (name    runtest)
  (package irmin-unix)
- (deps    trees.exe sync.exe process.exe deploy.exe push.exe
+ (deps    readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
           irmin_git_store.exe custom_merge.exe))

--- a/examples/readme.ml
+++ b/examples/readme.ml
@@ -1,0 +1,30 @@
+open Lwt.Infix
+
+(* Irmin store with string contents *)
+module Store = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+
+(* Database configuration *)
+let config = Irmin_git.config ~bare:true "/tmp/irmin/test"
+
+(* Commit author *)
+let author = "Example <example@example.com>"
+
+(* Commit information *)
+let info fmt = Irmin_unix.info ~author fmt
+
+let main =
+    (* Open the repo *)
+    Store.Repo.v config >>=
+
+    (* Load the master branch *)
+    Store.master >>= fun t ->
+
+    (* Set key "foo/bar" to "testing 123" *)
+    Store.set_exn t ~info:(info "Updating foo/bar") ["foo"; "bar"] "testing 123" >>= fun () ->
+
+    (* Get key "foo/bar" and print it to stdout *)
+    Store.get t ["foo"; "bar"] >|= fun x ->
+    Printf.printf "foo/bar => '%s'\n" x
+
+(* Run the program *)
+let () = Lwt_main.run main


### PR DESCRIPTION
This fixes #830. 

The README example is also copied to the `examples/` directory to discourage this from happening again.