### PR TITLE
irmin-pack: adapt to latest change in index (no more fan_out_size)

### DIFF
--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -392,9 +392,7 @@ struct
         let readonly = readonly config in
         let shared = shared config in
         let log_size = index_log_size config in
-        let index =
-          Index.v ~fresh ~shared ~readonly ~log_size ~fan_out_size:16 root
-        in
+        let index = Index.v ~fresh ~shared ~readonly ~log_size root in
         Contents.CA.v ~fresh ~shared ~readonly ~lru_size ~index root
         >>= fun contents ->
         Node.CA.v ~fresh ~shared ~readonly ~lru_size ~index root

--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -22,7 +22,6 @@ module type S = sig
     ?readonly:bool ->
     ?shared:bool ->
     log_size:int ->
-    fan_out_size:int ->
     string ->
     t
 

--- a/src/irmin-pack/pack_index.mli
+++ b/src/irmin-pack/pack_index.mli
@@ -22,7 +22,6 @@ module type S = sig
     ?readonly:bool ->
     ?shared:bool ->
     log_size:int ->
-    fan_out_size:int ->
     string ->
     t
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -110,7 +110,7 @@ module P = Irmin_pack.Pack.File (I) (H)
 module Pack = P.Make (S)
 module Index = Irmin_pack.Index.Make (Irmin.Hash.SHA1)
 
-let get_index = Index.v ~log_size:10_000_000 ~fan_out_size:16
+let get_index = Index.v ~log_size:10_000_000
 
 let test_pack _switch () =
   let index = get_index ~fresh:true test_dir in


### PR DESCRIPTION
See https://github.com/mirage/index/pull/32