### PR TITLE
Update cli commands from set->write and get->read

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ The same thing can also be accomplished using `irmin`, the command-line applicat
 ```bash
 $ echo "root: ." > irmin.yml
 $ irmin init
-$ irmin set foo/bar "testing 123"
-$ irmin get foo/bar
+$ irmin write foo/bar "testing 123"
+$ irmin read foo/bar
 ```
 
 `irmin.yml` allows for `irmin` flags to be set on a per-directory basis. You can also set flags globally using `$HOME/.irmin/config.yml`. Run `irmin help irmin.yml` for further details.


### PR DESCRIPTION
Seems like readme on master is no longer up to date with version 1.4.0 (i installed using `opam install irmin-unix`)