### PR TITLE
Standardise usage of pre-provided Lwt promises

### DIFF
--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -214,19 +214,19 @@ struct
 
   let find_leaves t key =
     AO.find t.db key >>= function
-    | None -> Lwt.return None (* shallow objects *)
+    | None -> Lwt.return_none (* shallow objects *)
     | Some x -> Tree.find_leaves t x >|= fun v -> Some v
 
   let check_hash k v =
     let k' = K.hash (fun f -> f v) in
-    if Irmin.Type.equal K.t k k' then Lwt.return ()
+    if Irmin.Type.equal K.t k k' then Lwt.return_unit
     else
       Fmt.kstrf Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
         pp_key k' pp_key k
 
   let find t key =
     find_leaves t key >>= function
-    | None -> Lwt.return None
+    | None -> Lwt.return_none
     | Some bufs -> (
         let buf = String.concat "" bufs in
         check_hash key buf >|= fun () ->

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -375,7 +375,7 @@ module IO_mem = struct
   let read_file file =
     try
       let buf = Hashtbl.find t.files file in
-      Lwt.return (Some buf)
+      Lwt.return_some buf
     with Not_found -> Lwt.return_none
 
   let write_file ?temp_dir:_ ?lock file v =

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -743,7 +743,7 @@ struct
             | None ->
                 Store.watch t (fun diff ->
                     push (Some diff);
-                    Lwt.return ())
+                    Lwt.return_unit)
                 >|= fun watch -> Ok (stream, destroy_stream watch)
             | Some key ->
                 Store.watch_key t key (function diff ->
@@ -754,7 +754,7 @@ struct
                             ~removed:(fun (c, _) -> c)
                             ~updated:(fun (before, _) (after, _) ->
                               (before, after))));
-                    Lwt.return ())
+                    Lwt.return_unit)
                 >|= fun watch -> Ok (stream, destroy_stream watch));
       ]
 

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -89,7 +89,7 @@ let json_stream (stream : string Lwt_stream.t) : Jsonm.lexeme list Lwt_stream.t
         | `Ae -> decr arrs
         | `Name _ | `Null | `Bool _ | `String _ | `Float _ -> ()
       in
-      if !objs > 0 || !arrs > 0 then aux () else Lwt.return ()
+      if !objs > 0 || !arrs > 0 then aux () else Lwt.return_unit
     in
     aux () >|= fun () -> List.rev !lexemes
   in
@@ -300,8 +300,8 @@ struct
     let value = { v = None; set; test } in
     let body = to_json (set_t V.t) value in
     put t [ RO.item t.t; key_str key ] ~body (of_json status_t) >>= function
-    | "true" -> Lwt.return true
-    | "false" -> Lwt.return false
+    | "true" -> Lwt.return_true
+    | "false" -> Lwt.return_false
     | e -> Lwt.fail_with e
 
   let remove t key =

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -45,7 +45,7 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
 
   let find { t; _ } key =
     Log.debug (fun f -> f "find %a" pp_key key);
-    try Lwt.return (Some (KMap.find key t)) with Not_found -> Lwt.return_none
+    try Lwt.return_some (KMap.find key t) with Not_found -> Lwt.return_none
 
   let mem { t; _ } key =
     Log.debug (fun f -> f "mem %a" pp_key key);
@@ -58,7 +58,7 @@ module Append_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
   let add t key value =
     Log.debug (fun f -> f "add -> %a" pp_key key);
     t.t <- KMap.add key value t.t;
-    Lwt.return ()
+    Lwt.return_unit
 end
 
 module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
@@ -118,8 +118,8 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
             | None -> t.t.RO.t <- RO.KMap.remove key t.t.RO.t
             | Some v -> t.t.RO.t <- RO.KMap.add key v t.t.RO.t
           in
-          Lwt.return true
-        else Lwt.return false)
+          Lwt.return_true
+        else Lwt.return_false)
     >>= fun updated ->
     (if updated then W.notify t.w key set else Lwt.return_unit) >>= fun () ->
     Lwt.return updated

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -780,7 +780,7 @@ struct
   let unsafe_add t k v =
     check_hash k (hash v);
     save t v.Val.v;
-    Lwt.return ()
+    Lwt.return_unit
 
   let batch = Inode.batch
 

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -145,14 +145,14 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
 
   let unsafe_find t k =
     Log.debug (fun l -> l "[branches] find %a" pp_branch k);
-    try Lwt.return (Some (Tbl.find t.cache k))
-    with Not_found -> Lwt.return None
+    try Lwt.return_some (Tbl.find t.cache k)
+    with Not_found -> Lwt.return_none
 
   let find t k = Lwt_mutex.with_lock t.lock (fun () -> unsafe_find t k)
 
   let unsafe_mem t k =
     Log.debug (fun l -> l "[branches] mem %a" pp_branch k);
-    try Lwt.return (Tbl.mem t.cache k) with Not_found -> Lwt.return false
+    try Lwt.return (Tbl.mem t.cache k) with Not_found -> Lwt.return_false
 
   let mem t v = Lwt_mutex.with_lock t.lock (fun () -> unsafe_mem t v)
 
@@ -172,7 +172,7 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Log.debug (fun l -> l "[branches] remove %a" pp_branch k);
     Lwt_mutex.with_lock t.lock (fun () ->
         unsafe_remove t k;
-        Lwt.return ())
+        Lwt.return_unit)
     >>= fun () -> W.notify t.w k None
 
   let unsafe_clear t =
@@ -237,14 +237,14 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Log.debug (fun l -> l "[branches] set %a" pp_branch k);
     Lwt_mutex.with_lock t.lock (fun () ->
         unsafe_set t k v;
-        Lwt.return ())
+        Lwt.return_unit)
     >>= fun () -> W.notify t.w k (Some v)
 
   let unsafe_test_and_set t k ~test ~set =
     let v = try Some (Tbl.find t.cache k) with Not_found -> None in
-    if not (Irmin.Type.(equal (option V.t)) v test) then Lwt.return false
+    if not (Irmin.Type.(equal (option V.t)) v test) then Lwt.return_false
     else
-      let return () = Lwt.return true in
+      let return () = Lwt.return_true in
       match set with
       | None -> unsafe_remove t k |> return
       | Some v -> unsafe_set t k v |> return
@@ -254,7 +254,7 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Lwt_mutex.with_lock t.lock (fun () -> unsafe_test_and_set t k ~test ~set)
     >>= function
     | true -> W.notify t.w k set >|= fun () -> true
-    | false -> Lwt.return false
+    | false -> Lwt.return_false
 
   let list t =
     Log.debug (fun l -> l "[branches] list");

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -313,7 +313,7 @@ struct
     let append t k v =
       Lwt_mutex.with_lock t.pack.lock (fun () ->
           unsafe_append t k v;
-          Lwt.return ())
+          Lwt.return_unit)
 
     let add t v =
       let k = V.hash v in

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -171,7 +171,7 @@ module Make (S : S) = struct
     in
     aux 0
 
-  let old k () = Lwt.return (Ok (Some k))
+  let old k () = Lwt.return_ok (Some k)
 
   let test_contents x () =
     let test repo =
@@ -1259,7 +1259,7 @@ module Make (S : S) = struct
       S.Tree.Cache.clear ~depth:3 ();
       S.Tree.Cache.clear ~depth:2 ();
       S.Tree.Cache.clear ~depth:1 ();
-      Lwt.return ()
+      Lwt.return_unit
     in
     run x test
 
@@ -1865,7 +1865,7 @@ module Make (S : S) = struct
       S.set_tree_exn t [ "3" ] ~parents:[ commit ] tree_3 ~info >>= fun () ->
       S.find_tree t [ "1" ] >>= fun t1 ->
       Alcotest.(check (option tree_t)) "shallow tree" (Some tree_1) t1;
-      Lwt.return ()
+      Lwt.return_unit
     in
     run x test
 end

--- a/src/irmin-unix/fs.ml
+++ b/src/irmin-unix/fs.ml
@@ -83,7 +83,7 @@ module IO = struct
           if s.Unix.st_mtime < 1.0 (* ??? *) then false
           else Unix.gettimeofday () -. s.Unix.st_mtime > max_age)
         (function
-          | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return false
+          | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return_false
           | e -> Lwt.fail e)
 
     let unlock file = Lwt_unix.unlink file
@@ -288,7 +288,7 @@ module IO = struct
           | Some x, Some y -> String.equal x y
           | _ -> false
         in
-        if not equal then Lwt.return false
+        if not equal then Lwt.return_false
         else
           ( match set with
           | None -> remove_file file

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -101,7 +101,7 @@ struct
       (old () >>= function
        | Error (`Conflict msg) ->
            Log.debug (fun f -> f "old: conflict %s" msg);
-           Lwt.return None
+           Lwt.return_none
        | Ok o -> Lwt.return o)
       >>= fun old ->
       if equal_opt_keys old (Some k1) then Merge.ok k2
@@ -233,7 +233,7 @@ module History (S : S.COMMIT_STORE) = struct
     KSet.iter (add_todo 0) init;
     let rec aux seen =
       match check () with
-      | (`Too_many_lcas | `Max_depth_reached) as x -> Lwt.return (Error x)
+      | (`Too_many_lcas | `Max_depth_reached) as x -> Lwt.return_error x
       | `Stop -> return ()
       | `Continue -> (
           match unqueue todo seen with
@@ -416,15 +416,15 @@ module History (S : S.COMMIT_STORE) = struct
 
   let lcas t ?(max_depth = max_int) ?(n = max_int) c1 c2 =
     incr lca_calls;
-    if max_depth < 0 then Lwt.return (Error `Max_depth_reached)
-    else if n <= 0 then Lwt.return (Error `Too_many_lcas)
-    else if equal_keys c1 c2 then Lwt.return (Ok [ c1 ])
+    if max_depth < 0 then Lwt.return_error `Max_depth_reached
+    else if n <= 0 then Lwt.return_error `Too_many_lcas
+    else if equal_keys c1 c2 then Lwt.return_ok [ c1 ]
     else
       let init = KSet.of_list [ c1; c2 ] in
       let s = empty_state c1 c2 in
       let check () = check ~max_depth ~n s in
       let pp () = pp_state s in
-      let return () = Lwt.return (Ok (lcas s)) in
+      let return () = Lwt.return_ok (lcas s) in
       let t0 = Sys.time () in
       Lwt.finalize
         (fun () ->

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -294,7 +294,7 @@ struct
 
   let add_opt t = function
     | None -> Lwt.return_none
-    | Some v -> add t v >>= fun k -> Lwt.return (Some k)
+    | Some v -> add t v >>= fun k -> Lwt.return_some k
 
   let merge t =
     Merge.like_lwt Type.(option Key.t) Val.merge (read_opt t) (add_opt t)

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -240,7 +240,7 @@ struct
     in
     let add v =
       if S.Val.is_empty v then Lwt.return_none
-      else add t v >>= fun k -> Lwt.return (Some k)
+      else add t v >>= fun k -> Lwt.return_some k
     in
     Merge.like_lwt Type.(option S.Key.t) merge read add
 
@@ -317,7 +317,7 @@ module Graph (S : S.NODE_STORE) = struct
     Log.debug (fun f -> f "read_node_exn %a %a" pp_key node pp_path path);
     let rec aux node path =
       match Path.decons path with
-      | None -> Lwt.return (Some (`Node node))
+      | None -> Lwt.return_some (`Node node)
       | Some (h, tl) -> (
           find_step t node h >>= function
           | (None | Some (`Contents _)) as x -> Lwt.return x

--- a/src/irmin/sync.ml
+++ b/src/irmin/sync.ml
@@ -17,7 +17,7 @@
 module None (H : Type.S) (R : Type.S) = struct
   type t = unit
 
-  let v _ = Lwt.return ()
+  let v _ = Lwt.return_unit
 
   type endpoint = unit
 

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -172,17 +172,17 @@ module Make (S : S.STORE) = struct
             convert_slice (module S.Private) (module R.Private) s_slice
             >>= fun r_slice ->
             R.Repo.import (R.repo r) r_slice >>= function
-            | Error e -> Lwt.return (Error (e :> push_error))
+            | Error e -> Lwt.return_error (e :> push_error)
             | Ok () -> (
                 match conv S.(commit_t s_repo) R.(commit_t r_repo) h with
-                | Error e -> Lwt.return (Error (e :> push_error))
+                | Error e -> Lwt.return_error (e :> push_error)
                 | Ok h ->
                     R.Head.set r h >>= fun () ->
                     S.Head.get t >|= fun head -> Ok (`Head head) ) ) )
     | S.E e -> (
         match S.status t with
         | `Empty -> Lwt.return_ok `Empty
-        | `Commit _ -> Lwt.return (Error `Detached_head)
+        | `Commit _ -> Lwt.return_error `Detached_head
         | `Branch br -> (
             S.of_branch (S.repo t) br >>= S.Head.get >>= fun head ->
             B.v (S.repo t) >>= fun g ->

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -64,7 +64,7 @@ module Mem (C : Irmin.Contents.S) = struct
   let init () =
     Git.v (Fpath.v test_db) >>= function
     | Ok t -> S.Git.reset t >|= fun _ -> ()
-    | _ -> Lwt.return ()
+    | _ -> Lwt.return_unit
 end
 
 module Generic (C : Irmin.Contents.S) = struct
@@ -129,7 +129,7 @@ let test_sort_order (module S : S) =
   S.set_exn master ~info [ "foo" ] "foo" >>= fun () ->
   ls master >>= fun items ->
   Alcotest.(check (list string)) "Sort order" [ "foo"; "foo.c"; "foo1" ] items;
-  Lwt.return ()
+  Lwt.return_unit
 
 module Ref (S : Irmin_git.G) =
   Irmin_git.Ref (S) (Git_unix.Sync (S)) (Irmin.Contents.String)
@@ -203,7 +203,7 @@ let test_blobs (module S : S) =
   >>= fun k2 ->
   let hash = Irmin_test.testable X.Hash.t in
   Alcotest.(check hash) "blob" k1 k2;
-  Lwt.return ()
+  Lwt.return_unit
 
 let test_import_export (module S : S) =
   let module Generic = Generic (Irmin.Contents.String) in

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -86,7 +86,7 @@ let serve servers n =
     let spec = HTTP.v repo ~strict:false in
     Lwt.catch
       (fun () -> Lwt_unix.unlink socket)
-      (function Unix.Unix_error _ -> Lwt.return () | e -> Lwt.fail e)
+      (function Unix.Unix_error _ -> Lwt.return_unit | e -> Lwt.fail e)
     >>= fun () ->
     let mode = `Unix_domain_socket (`File socket) in
     Conduit_lwt_unix.set_max_active 100;

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -137,7 +137,7 @@ let test_pack _switch () =
     Alcotest.(check string) "x2" x2 y2;
     Pack.find t h4 >|= get >>= fun y4 ->
     Alcotest.(check string) "x4" x4 y4;
-    Lwt.return ()
+    Lwt.return_unit
   in
   test t >>= fun () -> Pack.v ~fresh:false ~index test_dir >>= test
 
@@ -167,7 +167,7 @@ let test_readonly_pack _switch () =
   Alcotest.(check (option string)) "y2" (Some x2) y2;
   Pack.find r h3 >>= fun y3 ->
   Alcotest.(check (option string)) "y3" (Some x3) y3;
-  Lwt.return ()
+  Lwt.return_unit
 
 let test_readonly_dict () =
   let ignore_int (_ : int option) = () in
@@ -239,7 +239,7 @@ let test_branch _switch () =
     "branches"
     (List.filter (( <> ) "foo") branches)
     br;
-  Lwt.return ()
+  Lwt.return_unit
 
 let misc =
   ( "misc",

--- a/test/irmin-unix/test_unix.ml
+++ b/test/irmin-unix/test_unix.ml
@@ -57,7 +57,7 @@ module Git = struct
     ( if Sys.file_exists test_db then
       Git_unix.Store.v (Fpath.v test_db) >>= function
       | Ok t -> Git_unix.Store.reset t >|= fun _ -> ()
-      | Error _ -> Lwt.return ()
+      | Error _ -> Lwt.return_unit
     else Lwt.return_unit )
     >|= fun () -> Irmin_unix.set_listen_dir_hook ()
 


### PR DESCRIPTION
Replaces all instances of `Lwt.replace` in the codebase with a specialised `Lwt.return_*` form when this is possible.
-  For constant values, this [avoids a minor allocation](https://ocsigen.org/lwt/3.2.1/api/Lwt#3_Preallocatedpromises).
- In other cases (`Some`, `Ok`, `Error`), there is no associated optimisation, but it seems worth being consistent anyway.