### PR TITLE
Introduce (de-)serialization of contents depending on key

### DIFF
--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -116,7 +116,7 @@ module Content_addressable
     (V : Irmin.Type.S) =
 struct
   module Chunk = Chunk (K)
-  module AO = S (K) (Chunk)
+  module AO = S (K) (Chunk) (Irmin.Serialize.Default (K) (Chunk))
   module CA = Irmin.Content_addressable (S) (K) (Chunk)
 
   type key = CA.key

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -157,7 +157,8 @@ module Make_ext
     (S : Git.Sync.S with module Store := G)
     (C : Irmin.Contents.S)
     (P : Irmin.Path.S)
-    (B : BRANCH) :
+    (B : BRANCH)
+    (Z : Irmin.Serialize.S with type t = C.t and type key = P.t) :
   S
     with type key = P.t
      and type step = P.step

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -56,7 +56,7 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
     Lwt.return (KMap.mem key t)
 end
 
-module Append_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
+module Append_only (K : Irmin.Type.S) (V : Irmin.Type.S) (Z : Irmin.Serialize.S with type t = V.t and type key = K.t) = struct
   include Read_only (K) (V)
 
   let add t key value =
@@ -65,7 +65,7 @@ module Append_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
     Lwt.return_unit
 end
 
-module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
+module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) (Z : Irmin.Serialize.S with type t = V.t and type key = K.t) = struct
   module RO = Read_only (K) (V)
   module W = Irmin.Private.Watch.Make (K) (V)
   module L = Irmin.Private.Lock.Make (K)

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -74,6 +74,15 @@ module type CONTENTS = sig
   val merge : t option Merge.t
 end
 
+module type SERIALIZE = sig
+  type t
+  type key
+
+  val encode_bin : key -> t Type.encode_bin
+  val decode_bin : key -> t Type.decode_bin
+  val size_of : key -> t Type.size_of
+end
+
 module type CONTENT_ADDRESSABLE_STORE = sig
   type 'a t
 
@@ -117,7 +126,7 @@ module type APPEND_ONLY_STORE = sig
   val add : [> `Write ] t -> key -> value -> unit Lwt.t
 end
 
-module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
+module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) (S : SERIALIZE with type t = V.t and type key = K.t) -> sig
   include APPEND_ONLY_STORE with type key = K.t and type value = V.t
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
@@ -403,7 +412,7 @@ module type ATOMIC_WRITE_STORE = sig
   val unwatch : t -> watch -> unit Lwt.t
 end
 
-module type ATOMIC_WRITE_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
+module type ATOMIC_WRITE_STORE_MAKER = functor (K : Type.S) (V : Type.S) (Z : SERIALIZE with type t = V.t and type key = K.t) -> sig
   include ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
   val v : Conf.t -> t Lwt.t

--- a/src/irmin/serialize.ml
+++ b/src/irmin/serialize.ml
@@ -1,0 +1,26 @@
+type ('a, 'b) t = (module S.SERIALIZE with type key = 'a and type t = 'b)
+
+module Default (K : Type.S) (V : Type.S) : S.SERIALIZE with type t = V.t and type key = K.t = struct
+  type t = V.t
+  type key = K.t
+
+  let encode_bin (_key : K.t) = Type.encode_bin V.t
+  let decode_bin (_key : K.t) = Type.decode_bin V.t
+  let size_of (_key : K.t) = Type.size_of V.t
+end
+
+let to_bin_string (type a b) (t : (a, b) t) (key : a) (x : b) =
+  let (module T) = t in
+  let seq = T.encode_bin key x in
+  let len =
+    match T.size_of key x with None -> 1024 | Some n -> n
+  in
+  let buf = Buffer.create len in
+  seq (Buffer.add_string buf);
+  Buffer.contents buf
+
+let of_bin_string (type a b) (t : (a, b) t) (key : a) buf : (b, [`Msg of string]) result =
+  let (module T) = t in
+  let last, v = T.decode_bin key buf 0 in
+  assert (last = String.length buf);
+  Ok v

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -26,7 +26,7 @@ module Content_addressable
     (K : S.HASH)
     (V : Type.S) =
 struct
-  include AO (K) (V)
+  include AO (K) (V) (Serialize.Default (K) (V))
   open Lwt.Infix
   module H = Hash.Typed (K) (V)
 

--- a/src/irmin/store.mli
+++ b/src/irmin/store.mli
@@ -36,7 +36,7 @@ module Content_addressable
     (V : Type.S) : sig
   include
     S.CONTENT_ADDRESSABLE_STORE
-      with type 'a t = 'a X(K)(V).t
+      with type 'a t = 'a X(K)(V)(Serialize.Default(K)(V)).t
        and type key = K.t
        and type value = V.t
 


### PR DESCRIPTION
⚠️ The current implementation is not complete -- more input needed! 🚧

When the `content` type of an Irmin store is a variant, you currently need to serialize it to a string such that the members can be discerned just from looking at this string. This PR is an attempt to allow serialization and deserialization of content values to also depend on the key. This means you don't need to include additional data in the serialized string to discern between members. This is a particular benefit when interacting with contents of an Irmin store outside of Irmin, e.g. via Git.

This PR introduces a new signature `Irmin.Serializer.S`, which captures serializing and deserializing a value while depending on a key:

```
module Serialize : sig
  module type S = sig
    type t
    type key

    val encode_bin : key -> t Type.encode_bin
    val decode_bin : key -> t Type.decode_bin
    val size_of : key -> t Type.size_of
  end
end
```

An additional argument with this type has been added to the functors `APPEND_ONLY_STORE_MAKER` and `ATOMIC_WRITE_STORE_MAKER`, as well as `Irmin.Store.Make_ext`. Existing implementations of these signatures have been updated.

Everything compiles, but the current patch does not have the desired effect. This is because the serializer is only passed to append-only stores and atomic write stores, but not content addressable stores (`CONTENT_ADDRESSABLE_STORE`). Content adressable stores don't care about keys, only values, so it does not really make sense to provide a `Serialise.S` for a content adressable store. However, the actual content is stored in a content adressable store ([here](https://github.com/mirage/irmin/blob/master/src/irmin/irmin.ml#L196)). Further, the contents store is currently keyed by a hash, not the path of the store, and is not aware of the path at all.

I'm currently investigating different approaches on how to solve this, but would appreciate any input. I'll try update this PR as I learn more.