### PR TITLE
test: use a lock to avoid races between irmin-unix and irmin-http tests

### DIFF
--- a/test/irmin-http/dune
+++ b/test/irmin-http/dune
@@ -11,4 +11,5 @@
 (alias
  (name    runtest)
  (package irmin-http)
+ (locks   http)
  (action  (chdir %{workspace_root} (run %{exe:test.exe} -q --color=always))))

--- a/test/irmin-unix/dune
+++ b/test/irmin-unix/dune
@@ -11,4 +11,5 @@
 (alias
  (name    runtest)
  (package irmin-unix)
+ (locks   http)
  (action  (chdir %{workspace_root} (run %{exe:test.exe} -q --color=always))))


### PR DESCRIPTION
/cc @CraigFe 

Will hopefully fix #847 