### PR TITLE
irmin-pack: fix a small race when updating the pack file

### DIFF
--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -301,8 +301,8 @@ struct
 
     let sync t =
       Dict.sync t.pack.dict;
-      Index.flush t.pack.index;
       IO.sync t.pack.block;
+      Index.flush t.pack.index;
       Tbl.clear t.staging
 
     let integrity_check ~offset ~length k t =


### PR DESCRIPTION
The index file is the source of truth regarding which objects are present
in the pack file or not, so it should be updated last.