### PR TITLE
Allow custom value GraphQL input type for irmin-graphql

### DIFF
--- a/examples/custom_graphql.ml
+++ b/examples/custom_graphql.ml
@@ -1,0 +1,158 @@
+open Lwt.Infix
+
+module Car = struct
+  type color =
+    | Black
+    | White
+    | Other of string
+
+  type t = {
+    license: string;
+    year: int32;
+    make_and_model: string * string;
+    color: color;
+    owner: string;
+  }
+
+  let color =
+    let open Irmin.Type in
+    variant "color" (fun black white other -> function
+        | Black -> black
+        | White -> white
+        | Other color -> other color)
+    |~ case0 "Black" Black
+    |~ case0 "White" White
+    |~ case1 "Other" string (fun s -> Other s)
+    |> sealv
+
+  let t =
+    let open Irmin.Type in
+    record "car" (fun license year make_and_model color owner ->
+        {license; year; make_and_model; color; owner})
+    |+ field "license" string (fun t -> t.license)
+    |+ field "year" int32 (fun t -> t.year)
+    |+ field "make_and_model" (pair string string) (fun t -> t.make_and_model)
+    |+ field "color" color (fun t -> t.color)
+    |+ field "owner" string (fun t -> t.owner)
+    |> sealr
+
+  let merge = Irmin.Merge.(option (idempotent t))
+end
+
+module Store = Irmin_unix.Git.Mem.KV (Car)
+
+module Presentation = struct
+  module Defaults = Irmin_graphql.Server.Default_presentation (Store)
+
+  module Metadata = Defaults.Metadata
+
+  module Contents = struct
+    open Graphql_lwt
+
+    type src = Car.t
+
+    let to_src _tree _key contact = contact
+
+    let color_values = Schema.[
+      enum_value "BLACK" ~value:Car.Black;
+      enum_value "WHITE" ~value:Car.White;
+    ]
+
+    let schema_typ = Schema.(obj "Car"
+      ~fields:(fun _ -> [
+        field "license"
+          ~typ:(non_null string)
+          ~args:[]
+          ~resolve:(fun _ car ->
+            car.Car.license
+          )
+        ;
+        field "year"
+          ~typ:(non_null string)
+          ~args:[]
+          ~resolve:(fun _ car ->
+            car.Car.license
+          )
+        ;
+        field "make"
+          ~typ:(non_null string)
+          ~args:[]
+          ~resolve:(fun _ car ->
+            fst car.Car.make_and_model
+          )
+        ;
+        field "model"
+          ~typ:(non_null string)
+          ~args:[]
+          ~resolve:(fun _ car ->
+            snd car.Car.make_and_model
+          )
+        ;
+        field "color"
+          ~typ:(non_null string)
+          ~args:[]
+          ~resolve:(fun _ car ->
+            car.Car.license
+          )
+        ;
+        field "owner"
+          ~typ:(non_null string)
+          ~args:[]
+          ~resolve:(fun _ car ->
+            car.Car.owner
+          )
+        ;
+      ])
+    )
+  end
+end
+
+module Input = struct
+  open Graphql_lwt
+
+  let color = Schema.Arg.enum "Color" ~values:Presentation.Contents.color_values
+
+  let arg_typ = Schema.Arg.(obj "CarInput"
+    ~fields:[
+      arg "license" ~typ:(non_null string);
+      arg "year" ~typ:(non_null int);
+      arg "make" ~typ:(non_null string);
+      arg "model" ~typ:(non_null string);
+      arg "color" ~typ:(non_null color);
+      arg "owner" ~typ:(non_null string);
+    ]
+    ~coerce:(fun license year make model color owner ->
+      { Car.license; year = Int32.of_int year; make_and_model = (make, model); color; owner }
+    )
+  )
+end
+
+module Remote = struct
+  let remote = Some Store.remote
+end
+
+module Server =
+  Irmin_unix.Graphql.Server.Make_ext
+    (Store)
+    (Remote)
+    (Presentation)
+    (Input)
+
+let main () =
+  Config.init ();
+  let config = Irmin_git.config Config.root in
+  Store.Repo.v config >>= fun repo ->
+  let server = Server.v repo in
+  let src = "localhost" in
+  let port = 9876 in
+  Conduit_lwt_unix.init ~src () >>= fun ctx ->
+  let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
+  let on_exn exn =
+    Printf.printf "on_exn: %s" (Printexc.to_string exn)
+  in
+  Printf.printf "Visit GraphiQL @ http://%s:%d/graphql\n%!" src port;
+  Cohttp_lwt_unix.Server.create ~on_exn ~ctx
+    ~mode:(`TCP (`Port port))
+    server
+
+let () = Lwt_main.run (main ())

--- a/examples/dune
+++ b/examples/dune
@@ -1,11 +1,11 @@
 (executables
-  (names readme trees sync process deploy irmin_git_store custom_merge push)
+  (names readme trees sync process deploy irmin_git_store custom_merge push custom_graphql)
   (libraries checkseum.c digestif.c irmin irmin-unix))
 
 (alias
  (name examples)
  (deps readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
-       irmin_git_store.exe custom_merge.exe))
+       irmin_git_store.exe custom_merge.exe custom_graphql))
 
 (alias
  (name    runtest)

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -42,74 +42,96 @@ module type CONFIG = sig
     ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
 end
 
-module type PRESENTER = sig
+module type CUSTOM_TYPE = sig
   type t
 
-  type key
+  val schema_typ : (unit, t option) Schema.typ
 
-  type tree
-
-  type src
-
-  val to_src : tree -> key -> t -> src
-
-  val schema_typ : (unit, src option) Schema.typ
+  val arg_typ : t option Schema.Arg.arg_typ
 end
 
-module type PRESENTATION = sig
-  type tree
-
+module type CUSTOM_TYPES = sig
   type key
-
-  type contents
 
   type metadata
 
-  module Contents :
-    PRESENTER with type tree := tree and type key := key and type t := contents
-
-  module Metadata :
-    PRESENTER with type tree := tree and type key := key and type t := metadata
-end
-
-module Default_presenter (T : Irmin.Type.S) = struct
-  type src = string
-
-  let to_src _tree _key = Irmin.Type.to_string T.t
-
-  let schema_typ = Schema.string
-end
-
-module Default_presentation (S : Irmin.S) = struct
-  module Contents = Default_presenter (S.Contents)
-  module Metadata = Default_presenter (S.Metadata)
-end
-
-module type INPUT = sig
   type contents
 
-  val arg_typ : contents option Schema.Arg.arg_typ
+  type hash
+
+  type branch
+
+  module Key : CUSTOM_TYPE with type t := key
+
+  module Metadata : CUSTOM_TYPE with type t := metadata
+
+  module Contents : CUSTOM_TYPE with type t := contents
+
+  module Hash : CUSTOM_TYPE with type t := hash
+
+  module Branch : CUSTOM_TYPE with type t := branch
 end
 
-module Default_input (T : Irmin.Type.S) = struct
-  let coerce = function
-    | `String s -> of_irmin_result (Irmin.Type.of_string T.t s)
-    | _ -> Error "invalid value encoding"
+module Default_type (T : sig
+  include Irmin.Type.S
 
-  let arg_typ = Schema.Arg.scalar "Value" ~coerce
+  val name : string
+end) =
+struct
+  let schema_typ =
+    let coerce t = `String (Irmin.Type.to_string T.t t) in
+    Schema.scalar T.name ~coerce
+
+  let arg_typ =
+    let coerce = function
+      | `String s -> of_irmin_result (Irmin.Type.of_string T.t s)
+      | _ -> Error "Invalid input value"
+    in
+    Schema.Arg.scalar T.name ~coerce
+end
+
+module Default_types (S : Irmin.S) = struct
+  module Key = Default_type (struct
+    include S.Key
+
+    let name = "Key"
+  end)
+
+  module Metadata = Default_type (struct
+    include S.Metadata
+
+    let name = "Metadata"
+  end)
+
+  module Contents = Default_type (struct
+    include S.Contents
+
+    let name = "Contents"
+  end)
+
+  module Hash = Default_type (struct
+    include S.Hash
+
+    let name = "Hash"
+  end)
+
+  module Branch = Default_type (struct
+    include S.Branch
+
+    let name = "Branch"
+  end)
 end
 
 module Make_ext
     (Server : Cohttp_lwt.S.Server)
     (Config : CONFIG)
     (Store : Irmin.S)
-    (Presentation : PRESENTATION
-                      with type contents := Store.contents
-                       and type metadata := Store.metadata
-                       and type tree := Store.tree
-                       and type key := Store.key)
-    (Input : INPUT
-               with type contents := Store.contents) =
+    (Types : CUSTOM_TYPES
+               with type key := Store.key
+                and type metadata := Store.metadata
+                and type contents := Store.contents
+                and type hash := Store.hash
+                and type branch := Store.branch) =
 struct
   module IO = Server.IO
   module Sync = Irmin.Sync (Store)
@@ -168,40 +190,24 @@ struct
     | Some (step, key'') -> concat_key (Store.Key.cons step key) key''
 
   module Input = struct
-    let coerce_key = function
-      | `String s -> of_irmin_result (Irmin.Type.of_string Store.key_t s)
-      | _ -> Error "invalid key encoding"
-
-    let coerce_metadata = function
-      | `String s -> of_irmin_result (Irmin.Type.of_string Store.metadata_t s)
-      | _ -> Error "invalid metadata encoding"
-
-    let coerce_branch = function
-      | `String s -> of_irmin_result @@ Irmin.Type.of_string Store.branch_t s
-      | _ -> Error "invalid branch encoding"
-
     let coerce_remote = function
       | `String s -> (
           match Config.remote with
           | Some remote -> Ok (remote s)
           | None -> Error "sync is not available" )
-      | _ -> Error "invalid remote encoding"
-
-    let coerce_hash = function
-      | `String s -> of_irmin_result @@ Irmin.Type.of_string Store.Hash.t s
-      | _ -> Error "invalid hash encoding"
-
-    let key = Schema.Arg.(scalar "Key" ~coerce:coerce_key)
-
-    let commit_hash = Schema.Arg.(scalar "CommitHash" ~coerce:coerce_hash)
-
-    let branch = Schema.Arg.(scalar "BranchName" ~coerce:coerce_branch)
+      | _ -> Error "Invalid input value"
 
     let remote = Schema.Arg.(scalar "Remote" ~coerce:coerce_remote)
 
-    let value = Input.arg_typ
+    let key = Types.Key.arg_typ
 
-    let metadata = Schema.Arg.(scalar "Metadata" ~coerce:coerce_metadata)
+    let commit_hash = Types.Hash.arg_typ
+
+    let branch = Types.Branch.arg_typ
+
+    let value = Types.Contents.arg_typ
+
+    let metadata = Types.Metadata.arg_typ
 
     let info =
       Schema.Arg.(
@@ -241,17 +247,15 @@ struct
                 ~args:[]
                 ~resolve:(fun _ c -> (Store.Commit.tree c, Store.Key.empty));
               field "parents"
-                ~typ:(non_null (list (non_null string)))
+                ~typ:(non_null (list (non_null Types.Hash.schema_typ)))
                 ~args:[]
-                ~resolve:(fun _ c ->
-                  let parents = Store.Commit.parents c in
-                  List.map (Irmin.Type.to_string Store.Hash.t) parents);
+                ~resolve:(fun _ c -> Store.Commit.parents c);
               field "info"
                 ~typ:(non_null Lazy.(force info))
                 ~args:[]
                 ~resolve:(fun _ c -> Store.Commit.info c);
-              field "hash" ~typ:(non_null string) ~args:[] ~resolve:(fun _ c ->
-                  Irmin.Type.to_string Store.Hash.t (Store.Commit.hash c));
+              field "hash" ~typ:(non_null Types.Hash.schema_typ) ~args:[]
+                ~resolve:(fun _ c -> Store.Commit.hash c);
             ]))
 
   and info : ('ctx, Irmin.Info.t option) Schema.typ Lazy.t =
@@ -272,16 +276,13 @@ struct
       Schema.(
         obj "Tree" ~fields:(fun _ ->
             [
-              field "key" ~typ:(non_null string) ~args:[]
-                ~resolve:(fun _ (_, key) ->
-                  Irmin.Type.to_string Store.key_t key);
+              field "key" ~typ:(non_null Types.Key.schema_typ) ~args:[]
+                ~resolve:(fun _ (_, key) -> key);
               io_field "get"
                 ~args:Arg.[ arg "key" ~typ:(non_null Input.key) ]
-                ~typ:Presentation.Contents.schema_typ
+                ~typ:Types.Contents.schema_typ
                 ~resolve:(fun _ (tree, _) key ->
-                  Store.Tree.find tree key
-                  >|= Option.map (Presentation.Contents.to_src tree key)
-                  >|= Result.ok);
+                  Store.Tree.find tree key >|= Result.ok);
               io_field "get_contents"
                 ~args:Arg.[ arg "key" ~typ:(non_null Input.key) ]
                 ~typ:Lazy.(force contents)
@@ -289,7 +290,7 @@ struct
                   Store.Tree.find_all tree key
                   >|= Option.map (fun (c, m) ->
                           let key' = concat_key tree_key key in
-                          (tree, c, m, key'))
+                          (c, m, key'))
                   >|= Result.ok);
               io_field "get_tree"
                 ~args:Arg.[ arg "key" ~typ:(non_null Input.key) ]
@@ -305,7 +306,7 @@ struct
                 ~resolve:(fun _ (tree, key) ->
                   let rec tree_list ?(acc = []) concrete_tree key =
                     match concrete_tree with
-                    | `Contents (c, m) -> (tree, c, m, key) :: acc
+                    | `Contents (c, m) -> (c, m, key) :: acc
                     | `Tree l ->
                         List.fold_left
                           (fun acc (step, t) ->
@@ -316,10 +317,8 @@ struct
                   in
                   Store.Tree.to_concrete tree >|= fun concrete_tree ->
                   Ok (tree_list concrete_tree key));
-              field "hash" ~typ:(non_null string) ~args:[]
-                ~resolve:(fun _ (tree, _) ->
-                  let hash = Store.Tree.hash tree in
-                  Irmin.Type.to_string Store.Hash.t hash);
+              field "hash" ~typ:(non_null Types.Hash.schema_typ) ~args:[]
+                ~resolve:(fun _ (tree, _) -> Store.Tree.hash tree);
               io_field "list"
                 ~typ:(non_null (list (non_null node)))
                 ~args:[]
@@ -333,8 +332,7 @@ struct
                               Store.Tree.get_all tree relative_key
                               >|= fun (c, m) ->
                               Lazy.(
-                                force contents_as_node
-                                  (tree, c, m, absolute_key))
+                                force contents_as_node (c, m, absolute_key))
                           | `Node ->
                               Store.Tree.get_tree tree relative_key
                               >|= fun t ->
@@ -347,9 +345,8 @@ struct
       Schema.(
         obj "Branch" ~fields:(fun _branch ->
             [
-              field "name" ~typ:(non_null string) ~args:[]
-                ~resolve:(fun _ (_, b) ->
-                  Irmin.Type.to_string Store.branch_t b);
+              field "name" ~typ:(non_null Types.Branch.schema_typ) ~args:[]
+                ~resolve:(fun _ (_, b) -> b);
               io_field "head" ~args:[] ~typ:(Lazy.force commit)
                 ~resolve:(fun _ (t, _) -> Store.Head.find t >>= Lwt.return_ok);
               io_field "tree" ~args:[]
@@ -372,27 +369,21 @@ struct
             ]))
 
   and contents :
-      ( 'ctx,
-        (Store.tree * Store.contents * Store.metadata * Store.key) option )
-      Schema.typ
+      ('ctx, (Store.contents * Store.metadata * Store.key) option) Schema.typ
       Lazy.t =
     lazy
       Schema.(
         obj "Contents" ~fields:(fun _contents ->
             [
-              field "key" ~typ:(non_null string) ~args:[]
-                ~resolve:(fun _ (_, _, _, key) ->
-                  Irmin.Type.to_string Store.key_t key);
-              field "metadata" ~typ:(non_null Presentation.Metadata.schema_typ)
-                ~args:[] ~resolve:(fun _ (tree, _, metadata, key) ->
-                  Presentation.Metadata.to_src tree key metadata);
-              field "value" ~typ:(non_null Presentation.Contents.schema_typ)
-                ~args:[] ~resolve:(fun _ (tree, contents, _, key) ->
-                  Presentation.Contents.to_src tree key contents);
-              field "hash" ~typ:(non_null string) ~args:[]
-                ~resolve:(fun _ (_, contents, _, _) ->
-                  let hash = Store.Contents.hash contents in
-                  Irmin.Type.to_string Store.Hash.t hash);
+              field "key" ~typ:(non_null Types.Key.schema_typ) ~args:[]
+                ~resolve:(fun _ (_, _, key) -> key);
+              field "metadata" ~typ:(non_null Types.Metadata.schema_typ)
+                ~args:[] ~resolve:(fun _ (_, metadata, _) -> metadata);
+              field "value" ~typ:(non_null Types.Contents.schema_typ) ~args:[]
+                ~resolve:(fun _ (contents, _, _) -> contents);
+              field "hash" ~typ:(non_null Types.Hash.schema_typ) ~args:[]
+                ~resolve:(fun _ (contents, _, _) ->
+                  Store.Contents.hash contents);
             ]))
 
   and node = Schema.union "Node"
@@ -613,7 +604,7 @@ struct
             >>= function
             | Ok () -> Store.Head.find t >>= Lwt.return_ok
             | Error e -> err_write e);
-        io_field "merge" ~typ:string
+        io_field "merge" ~typ:Types.Hash.schema_typ
           ~args:
             Arg.
               [
@@ -628,14 +619,7 @@ struct
             txn_args s info >>= fun (info, retries, allow_empty, parents) ->
             Store.merge t key ~info ?retries ?allow_empty ?parents ~old value
             >>= function
-            | Ok _ ->
-                Store.hash t key
-                >>= (function
-                      | Some hash ->
-                          Lwt.return_some
-                            (Irmin.Type.to_string Store.Hash.t hash)
-                      | None -> Lwt.return_none)
-                >>= Lwt.return_ok
+            | Ok _ -> Store.hash t key >>= Lwt.return_ok
             | Error e ->
                 Lwt.return_error (Irmin.Type.to_string Store.write_error_t e));
         io_field "merge_tree" ~typ:(Lazy.force commit)
@@ -809,7 +793,6 @@ end
 
 module Make (Server : Cohttp_lwt.S.Server) (Config : CONFIG) (Store : Irmin.S) =
 struct
-  module Presentation = Default_presentation (Store)
-  module Input' = Default_input (Store.Contents)
-  include Make_ext (Server) (Config) (Store) (Presentation) (Input')
+  module Types = Default_types (Store)
+  include Make_ext (Server) (Config) (Store) (Types)
 end

--- a/src/irmin-graphql/server.mli
+++ b/src/irmin-graphql/server.mli
@@ -66,6 +66,15 @@ module Default_presentation (S : Irmin.S) :
      and type tree := S.tree
      and type key := S.key
 
+module type INPUT = sig
+  type contents
+
+  val arg_typ : contents option Schema.Arg.arg_typ
+end
+
+module Default_input (T : Irmin.Type.S) :
+  INPUT with type contents := T.t
+
 module Make (Server : Cohttp_lwt.S.Server) (Config : CONFIG) (Store : Irmin.S) :
   S with type repo = Store.repo and type server = Server.t
 
@@ -77,5 +86,7 @@ module Make_ext
                       with type contents := Store.contents
                        and type metadata := Store.metadata
                        and type tree := Store.tree
-                       and type key := Store.key) :
+                       and type key := Store.key)
+    (Input : INPUT
+               with type contents := Store.contents) :
   S with type repo = Store.repo and type server = Server.t

--- a/src/irmin-graphql/server.mli
+++ b/src/irmin-graphql/server.mli
@@ -1,5 +1,6 @@
 module Schema = Graphql_lwt.Schema
 
+(** GraphQL server *)
 module type S = sig
   module IO : Cohttp_lwt.S.IO
 
@@ -22,6 +23,7 @@ module type S = sig
   val v : repo -> server
 end
 
+(** GraphQL server config *)
 module type CONFIG = sig
   val remote : (?headers:Cohttp.Header.t -> string -> Irmin.remote) option
 
@@ -29,64 +31,60 @@ module type CONFIG = sig
     ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
 end
 
-module type PRESENTER = sig
+(** Custom GraphQL schema type and argument type for [type t]. *)
+module type CUSTOM_TYPE = sig
   type t
 
-  type key
+  val schema_typ : (unit, t option) Schema.typ
 
-  type tree
-
-  type src
-
-  val to_src : tree -> key -> t -> src
-
-  val schema_typ : (unit, src option) Schema.typ
+  val arg_typ : t option Schema.Arg.arg_typ
 end
 
-module type PRESENTATION = sig
-  type tree
-
+(** GraphQL types for Irmin concepts (key, metadata, contents, hash and branch). *)
+module type CUSTOM_TYPES = sig
   type key
-
-  type contents
 
   type metadata
 
-  module Contents :
-    PRESENTER with type tree := tree and type key := key and type t := contents
-
-  module Metadata :
-    PRESENTER with type tree := tree and type key := key and type t := metadata
-end
-
-module Default_presentation (S : Irmin.S) :
-  PRESENTATION
-    with type contents := S.contents
-     and type metadata := S.metadata
-     and type tree := S.tree
-     and type key := S.key
-
-module type INPUT = sig
   type contents
 
-  val arg_typ : contents option Schema.Arg.arg_typ
+  type hash
+
+  type branch
+
+  module Key : CUSTOM_TYPE with type t := key
+
+  module Metadata : CUSTOM_TYPE with type t := metadata
+
+  module Contents : CUSTOM_TYPE with type t := contents
+
+  module Hash : CUSTOM_TYPE with type t := hash
+
+  module Branch : CUSTOM_TYPE with type t := branch
 end
 
-module Default_input (T : Irmin.Type.S) :
-  INPUT with type contents := T.t
+(** Default GraphQL types for the Irmin store [S]. *)
+module Default_types (S : Irmin.S) :
+  CUSTOM_TYPES
+    with type key := S.key
+     and type metadata := S.metadata
+     and type contents := S.contents
+     and type hash := S.hash
+     and type branch := S.branch
 
+(** Create a GraphQL server with default GraphQL types for [S]. *)
 module Make (Server : Cohttp_lwt.S.Server) (Config : CONFIG) (Store : Irmin.S) :
   S with type repo = Store.repo and type server = Server.t
 
+(** Create a GraphQL server with custom GraphQL types. *)
 module Make_ext
     (Server : Cohttp_lwt.S.Server)
     (Config : CONFIG)
     (Store : Irmin.S)
-    (Presentation : PRESENTATION
-                      with type contents := Store.contents
-                       and type metadata := Store.metadata
-                       and type tree := Store.tree
-                       and type key := Store.key)
-    (Input : INPUT
-               with type contents := Store.contents) :
+    (Types : CUSTOM_TYPES
+               with type key := Store.key
+                and type metadata := Store.metadata
+                and type contents := Store.contents
+                and type hash := Store.hash
+                and type branch := Store.branch) :
   S with type repo = Store.repo and type server = Server.t

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -13,7 +13,9 @@ module Server = struct
              with type contents := S.contents
               and type metadata := S.metadata
               and type tree := S.tree
-              and type key := S.key) =
+              and type key := S.key)
+      (I : Irmin_graphql.Server.INPUT
+             with type contents := S.contents) =
     Irmin_graphql.Server.Make_ext
       (Cohttp_lwt_unix.Server)
       (struct
@@ -23,6 +25,7 @@ module Server = struct
       end)
       (S)
       (P)
+      (I)
 
   module Make
       (S : Irmin.S) (Remote : sig

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -9,13 +9,12 @@ module Server = struct
       (S : Irmin.S) (Remote : sig
         val remote : Resolver.Store.remote_fn option
       end)
-      (P : Irmin_graphql.Server.PRESENTATION
-             with type contents := S.contents
+      (T : Irmin_graphql.Server.CUSTOM_TYPES
+             with type key := S.key
               and type metadata := S.metadata
-              and type tree := S.tree
-              and type key := S.key)
-      (I : Irmin_graphql.Server.INPUT
-             with type contents := S.contents) =
+              and type contents := S.contents
+              and type hash := S.hash
+              and type branch := S.branch) =
     Irmin_graphql.Server.Make_ext
       (Cohttp_lwt_unix.Server)
       (struct
@@ -24,8 +23,7 @@ module Server = struct
         let remote = Remote.remote
       end)
       (S)
-      (P)
-      (I)
+      (T)
 
   module Make
       (S : Irmin.S) (Remote : sig

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -21,7 +21,9 @@ module Server : sig
              with type contents := S.contents
               and type metadata := S.metadata
               and type tree := S.tree
-              and type key := S.key) :
+              and type key := S.key)
+      (I : Irmin_graphql.Server.INPUT
+             with type contents := S.contents) :
     Irmin_graphql.Server.S
       with type repo = S.repo
        and type server = Cohttp_lwt_unix.Server.t

--- a/src/irmin-unix/graphql.mli
+++ b/src/irmin-unix/graphql.mli
@@ -17,13 +17,12 @@ module Server : sig
       (S : Irmin.S) (Remote : sig
         val remote : Resolver.Store.remote_fn option
       end)
-      (P : Irmin_graphql.Server.PRESENTATION
-             with type contents := S.contents
+      (T : Irmin_graphql.Server.CUSTOM_TYPES
+             with type key := S.key
               and type metadata := S.metadata
-              and type tree := S.tree
-              and type key := S.key)
-      (I : Irmin_graphql.Server.INPUT
-             with type contents := S.contents) :
+              and type contents := S.contents
+              and type hash := S.hash
+              and type branch := S.branch) :
     Irmin_graphql.Server.S
       with type repo = S.repo
        and type server = Cohttp_lwt_unix.Server.t


### PR DESCRIPTION
When mutating values via `irmin-graphql`, the caller is currently required to provide the serialized version of values. As an example, consider the custom content type `Car` from the Irmin tutorial ([link](https://zshipko.github.io/irmin-tutorial/Contents.html#record)). Before this PR, the caller would be required to make a GraphQL request such as the following to set a value:

```graphql
mutation {
  set(key: "foo", value: "{\"license\":\"AB123456\",\"year\":1955,\"make_and_model\":[\"Ford\",\"Thunderbird\"],\"color\":\"White\",\"owner\":\"John Doe\"}") {
    # ...
  }
}
```

This is clearly not great, and breaks symmetry with the ability to provide a custom GraphQL presenter (https://github.com/mirage/irmin/pull/643).

This PR allows providing a custom value GraphQL input  type for `irmin-graphql`, such as the following:

```ocaml
module Store =
  (* ... some store with type contents = Car.t from Irmin tutorial *)

module Input = struct
  open Graphql_lwt

  let color_values = Schema.[
    enum_value "BLACK" ~value:Car.Black;
    enum_value "WHITE" ~value:Car.White;
  ]

  let color = Schema.Arg.enum "Color" ~values:color_values

  let arg_typ = Graphql_lwt.Schema.Arg.(obj "Car"
    ~fields:[
      arg "license" ~typ:(non_null string);
      arg "year" ~typ:(non_null int);
      arg "make" ~typ:(non_null string);
      arg "model" ~typ:(non_null string);
      arg "color" ~typ:(non_null color);
      arg "owner" ~typ:(non_null string);
    ]
    ~coerce:(fun license year make model color owner ->
      { Car.license; year = Int32.of_int year; make_and_model = (make, model); color; owner }
    )
  )
end

module Presentation = Irmin_graphql.Server.Default_presentation (Store)
module Remote = struct
  (* dummy implementation *)
  let remote  = None
end

module GQL = Irmin_unix.Graphql.Server.Make_ext (Store) (Remote) (Presentation) (Input)
```

With this in hand, a GraphQL query with the same intent as above looks like the following:

```graphql
mutation SetFoo {
  set(key: "foo", value: {owner: "John Doe", color: White, model: "Thunderbird", make: "Ford", year: 1955, license: "AB123456"}) {
    # ...
  }
}
```

The functor `Irmin_graphql.Server.Make_ext` has been extended with a new parameter `Input`. This is a breaking change. I'm open to naming suggestions if anyone has bright ideas (especially such that the names for customising input and output match each other).

This feature could potentially be made more powerful by allowing a function to process the input value (possibly even allowing asynchronous operations).

Thanks to @icristescu for bringing up this issue!