### PR TITLE
Fix dune locks used in the HTTP tests

### DIFF
--- a/test/irmin-http/dune
+++ b/test/irmin-http/dune
@@ -11,5 +11,5 @@
 (alias
  (name    runtest)
  (package irmin-http)
- (locks   http)
+ (locks   ../http)
  (action  (chdir %{workspace_root} (run %{exe:test.exe} -q --color=always))))

--- a/test/irmin-unix/dune
+++ b/test/irmin-unix/dune
@@ -11,5 +11,5 @@
 (alias
  (name    runtest)
  (package irmin-unix)
- (locks   http)
+ (locks   ../http)
  (action  (chdir %{workspace_root} (run %{exe:test.exe} -q --color=always))))


### PR DESCRIPTION
Lock names are interpreted as file names, and so the irmin-{http,unix}
test suites were holding _different_ `http` locks in their respective
directories. This fixes the tests to run mutually exclusively by holding
an `http` lock in the shared parent directory.