### PR TITLE
Move irmin-git test repository to _build/ directory

### DIFF
--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -16,7 +16,7 @@
 
 open Lwt.Infix
 
-let test_db = "test_db_git"
+let test_db = Filename.concat "_build" "test-db-git"
 
 let config =
   let head = Git.Reference.of_string "refs/heads/test" in


### PR DESCRIPTION
This test instance was polluting the main test/ directory, causing
issues with `git` believing it to be a submodule (e.g. erroring
on `git add .`).