### PR TITLE
Use digestif default variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@
     let _ = <begin loop> ... encode_bin foo ... <end loop>
     ```
   - Added a `clear` function for stores (#1071, @icristescu, @CraigFe)
+  - Requires digestif>=0.9 to use digestif's default variants
+    (#873, @pascutto, @samoht)
 
 - **irmin-pack**:
   - Added `index_throttle` option to `Irmin_pack.config`, which exposes the

--- a/examples/dune
+++ b/examples/dune
@@ -1,8 +1,7 @@
 (executables
  (names readme trees sync process deploy irmin_git_store custom_merge push
    custom_graphql)
- (libraries astring checkseum.c cohttp digestif.c fmt git irmin irmin-git
-   irmin-unix lwt lwt.unix))
+ (libraries astring cohttp fmt git irmin irmin-git irmin-unix lwt lwt.unix))
 
 (alias
  (name examples)

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.5.1"}
   "irmin"      {>= "2.0.0"}
   "git"        {>= "2.1.1"}
-  "digestif"   {>= "0.7.3"}
+  "digestif"   {>= "0.9.0"}
   "astring"
   "fpath"
   "logs"

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -24,7 +24,7 @@ depends: [
   "irmin-mem"  {with-test & >= "2.0.0"}
   "irmin-test" {with-test & >= "2.0.0"}
   "git-unix"   {with-test}
-  "digestif"   {with-test & >= "0.6.1"}
+  "digestif"   {with-test & >= "0.9.0"}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -24,7 +24,7 @@ depends: [
   "irmin-pack"    {>= "2.0.0"}
   "irmin-graphql"
   "git-unix"      {>= "1.11.4"}
-  "digestif"      {>= "0.6.1"}
+  "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "0.1.0"}
   "astring"

--- a/irmin.opam
+++ b/irmin.opam
@@ -22,7 +22,7 @@ depends: [
   "jsonm"   {>= "1.0.0"}
   "lwt"     {>= "2.4.7"}
   "base64"  {>= "2.0.0"}
-  "digestif"
+  "digestif" {>= "0.9.0"}
   "ocamlgraph"
   "logs"    {>= "0.5.0"}
   "astring"

--- a/src/irmin-git/dune
+++ b/src/irmin-git/dune
@@ -1,4 +1,4 @@
 (library
  (name irmin_git)
  (public_name irmin-git)
- (libraries astring cstruct digestif fmt fpath git irmin logs lwt uri))
+ (libraries astring cstruct fmt fpath git irmin logs lwt uri))

--- a/src/irmin-unix/bin/dune
+++ b/src/irmin-unix/bin/dune
@@ -2,4 +2,4 @@
  (name main)
  (public_name irmin)
  (package irmin-unix)
- (libraries checkseum.c digestif.c irmin-unix))
+ (libraries irmin-unix))

--- a/test/irmin-chunk/dune
+++ b/test/irmin-chunk/dune
@@ -6,7 +6,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest digestif.c fmt irmin irmin-test lwt lwt.unix test_chunk))
+ (libraries alcotest fmt irmin irmin-test lwt lwt.unix test_chunk))
 
 (rule
  (alias runtest)

--- a/test/irmin-fs/dune
+++ b/test/irmin-fs/dune
@@ -6,7 +6,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest digestif.c irmin irmin-test test_fs))
+ (libraries alcotest irmin irmin-test test_fs))
 
 (rule
  (alias runtest)

--- a/test/irmin-git/dune
+++ b/test/irmin-git/dune
@@ -7,7 +7,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest checkseum.c digestif.c irmin irmin-test test_git))
+ (libraries alcotest irmin irmin-test test_git))
 
 (rule
  (alias runtest)

--- a/test/irmin-http/dune
+++ b/test/irmin-http/dune
@@ -7,7 +7,7 @@
 (executable
  (name test)
  (modules test)
- (libraries checkseum.c digestif.c irmin-test test_http))
+ (libraries irmin-test test_http))
 
 (rule
  (alias runtest)

--- a/test/irmin-mem/dune
+++ b/test/irmin-mem/dune
@@ -6,7 +6,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest digestif.ocaml irmin-test test_mem))
+ (libraries alcotest irmin-test test_mem))
 
 (rule
  (alias runtest)

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -7,7 +7,7 @@
 (executable
  (name test)
  (modules test test_utils)
- (libraries alcotest astring digestif.ocaml irmin irmin-test test_pack))
+ (libraries alcotest astring irmin irmin-test test_pack))
 
 (rule
  (alias runtest)

--- a/test/irmin-unix/dune
+++ b/test/irmin-unix/dune
@@ -7,8 +7,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest checkseum.c digestif.c irmin-test test_git test_http
-   test_unix))
+ (libraries alcotest irmin-test test_git test_http test_unix))
 
 (rule
  (alias runtest)

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -3,4 +3,4 @@
  (package irmin)
  (preprocess
   (pps ppx_irmin))
- (libraries digestif.c irmin irmin-mem alcotest alcotest-lwt lwt hex))
+ (libraries irmin irmin-mem alcotest alcotest-lwt lwt hex))


### PR DESCRIPTION
Using `digestif.0.8.0` allows to use `digestif.c` as the default variant and thus does not require a specific mention in the `dune` files anymore.