### PR TITLE
adapt to mirage 3.7.0 API changes

### DIFF
--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -17,8 +17,8 @@ depends: [
   "dune"       {>= "1.1.0"}
   "irmin-mirage"
   "irmin-git"  {>= "1.3.0"}
-  "git-mirage" {>= "2.1.1"}
-  "mirage-kv-lwt" {>= "2.0.0"}
+  "git-mirage" {>= "2.2.0"}
+  "mirage-kv" {>= "3.0.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/irmin-mirage.opam
+++ b/irmin-mirage.opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"      {=version}
   "irmin-mem"  {=version}
   "ptime"
-  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/src/irmin-mirage/git/dune
+++ b/src/irmin-mirage/git/dune
@@ -1,4 +1,4 @@
 (library
   (name irmin_mirage_git)
   (public_name irmin-mirage-git)
-  (libraries irmin-mirage irmin-git git-mirage mirage-kv-lwt))
+  (libraries irmin-mirage irmin-git git-mirage mirage-kv))

--- a/src/irmin-mirage/git/irmin_mirage_git.mli
+++ b/src/irmin-mirage/git/irmin_mirage_git.mli
@@ -48,7 +48,7 @@ module Ref : REF_MAKER
 module type KV_RO = sig
   type git
 
-  include Mirage_kv_lwt.RO
+  include Mirage_kv.RO
 
   val connect :
     ?depth:int ->
@@ -74,9 +74,7 @@ module KV_RO (G : Irmin_git.G) : KV_RO with type git := G.t
 module type KV_RW = sig
   type git
 
-  type clock
-
-  include Mirage_kv_lwt.RW
+  include Mirage_kv.RW
 
   val connect :
     ?depth:int ->
@@ -88,7 +86,6 @@ module type KV_RW = sig
     ?author:string ->
     ?msg:([ `Set of key | `Remove of key | `Batch ] -> string) ->
     git ->
-    clock ->
     string ->
     t Lwt.t
   (** [connect ?depth ?branch ?path ?author ?msg g c uri] clones
@@ -105,7 +102,7 @@ end
 (** Functor to create a MirageOS' KV_RW store from a Git
     repository. *)
 module KV_RW (G : Irmin_git.G) (C : Mirage_clock.PCLOCK) :
-  KV_RW with type git := G.t and type clock = C.t
+  KV_RW with type git := G.t
 
 (** Embed an Irmin store into an in-memory Git repository. *)
 module Mem : sig
@@ -140,5 +137,5 @@ module Mem : sig
   module KV_RO : KV_RO with type git := G.t
 
   module KV_RW (C : Mirage_clock.PCLOCK) :
-    KV_RW with type git := G.t and type clock := C.t
+    KV_RW with type git := G.t
 end

--- a/src/irmin-mirage/graphql/dune
+++ b/src/irmin-mirage/graphql/dune
@@ -1,4 +1,4 @@
 (library
   (name irmin_mirage_graphql)
   (public_name irmin-mirage-graphql)
-  (libraries irmin-mirage irmin-graphql git-mirage mirage-clock-lwt))
+  (libraries irmin-mirage irmin-graphql git-mirage mirage-clock))

--- a/src/irmin-mirage/irmin_mirage.ml
+++ b/src/irmin-mirage/irmin_mirage.ml
@@ -15,10 +15,10 @@
  *)
 
 module Info (C : Mirage_clock.PCLOCK) = struct
-  let f ~author c fmt =
+  let f ~author fmt =
     Fmt.kstrf
       (fun msg () ->
-        C.now_d_ps c |> Ptime.v |> Ptime.to_float_s |> Int64.of_float
+        C.now_d_ps () |> Ptime.v |> Ptime.to_float_s |> Int64.of_float
         |> fun date -> Irmin.Info.v ~date ~author msg)
       fmt
 end

--- a/src/irmin-mirage/irmin_mirage.mli
+++ b/src/irmin-mirage/irmin_mirage.mli
@@ -23,10 +23,9 @@ module Info (C : Mirage_clock.PCLOCK) : sig
 
   val f :
     author:string ->
-    C.t ->
     ('a, Format.formatter, unit, Irmin.Info.f) format4 ->
     'a
-  (** [f c ~author msg] is a new commit info with [author] as commit
-      author, [C.now_d_ps c] as commit date and [msg] as commit
+  (** [f ~author msg] is a new commit info with [author] as commit
+      author, [C.now_d_ps ()] as commit date and [msg] as commit
       message.*)
 end


### PR DESCRIPTION
awaits a release of git (see mirage/ocaml-git#376), is then ready for mirage 3.7 :D