### PR TITLE
irmin-mirage-git: KV_RW provide 'author' delayed (unit -> string) instead of string

### DIFF
--- a/src/irmin-mirage/git/irmin_mirage_git.mli
+++ b/src/irmin-mirage/git/irmin_mirage_git.mli
@@ -83,7 +83,7 @@ module type KV_RW = sig
     ?conduit:Conduit_mirage.t ->
     ?resolver:Resolver_lwt.t ->
     ?headers:Cohttp.Header.t ->
-    ?author:string ->
+    ?author:(unit -> string) ->
     ?msg:([ `Set of key | `Remove of key | `Batch ] -> string) ->
     git ->
     string ->
@@ -94,7 +94,7 @@ module type KV_RW = sig
         [branch] is master, [depth] is [1] and [path] is empty,
         ie. reads will be relative to the root of the repository.
         [author], [msg] and [c] are used to create new commit info
-        values on every update.  By defaut [author] is ["irmin"
+        values on every update.  By defaut [author] is [fun () -> "irmin"
         <irmin@mirage.io>] and [msg] returns basic information about
         the kind of operations performed. *)
 end


### PR DESCRIPTION
What I try to accomplish?

I have a web service which interacts via HTTP to user(s). Its data is stored via a Mirage_kv.RW in a key-value store. Now, an (potentially authenticated) web client may use HTTP to modify data in the store. The web service itself does the KV (and git) interaction, but I'd appreciate to embed the (HTTP-authenticated) user name in the git commit (i.e. "Author: alice via my-web-service"), which is radically more useful than "Author: my-web-service", especially for triaging issues and auditing changes.

Now, the control and data flow is already a bit intricate, thus this PR only uses `unit -> string` for the `author` to be used (similarly to `msg: op -> string`). I.e. the author name to be provided from something more globally known (for me, dynamically bound (and unfortunately deprecated with no clear upgrade path) Lwt [implicit callback arguments](http://ocsigen.org/lwt/4.1.0/api/Lwt#3_Implicitcallbackarguments)).

Fundamentally: the code which uses the Mirage_kv.RW interface does not know anything about git/irmin. (well, we could modify the kv.RW set&remove signature to accomodate git/irmin, but this would complicate other implementors (such as mirage-kv-unix)). This PR is the simplest solution I could come up with, please let me know if there are other ways to achieve this (in a different development where I stick to irmin+git directly, I use `Sync` manually, but in the above example I really like to use the Mirage_kv.RW interface only).