### PR TITLE
irmin-pack: avoid writes of size 0

### DIFF
--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -63,7 +63,7 @@ module Unix : S = struct
     let really_write fd buf =
       let rec aux off len =
         let w = Unix.write fd buf off len in
-        if w = 0 then () else (aux [@tailcall]) (off + w) (len - w)
+        if w = 0 || w = len then () else (aux [@tailcall]) (off + w) (len - w)
       in
       (aux [@tailcall]) 0 (Bytes.length buf)
 


### PR DESCRIPTION
See https://github.com/mirage/index/pull/131 for a similar fix in index.