### PR TITLE
Set hash size to Tezos's default one

### DIFF
--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -28,7 +28,7 @@ module Make (K : Irmin.Hash.S) = struct
 
     let hash t = Irmin.Type.short_hash K.t t
 
-    let hash_size = 60
+    let hash_size = 30
 
     let equal x y = Irmin.Type.equal K.t x y
 


### PR DESCRIPTION
This is already used by Tezos (https://gitlab.com/tezos/tezos/blob/zeronet/vendors/irmin-pack/pack_index.ml#L31) 