### PR TITLE
Add CLI options for setting the hash function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,3 @@
-
-
 ### Unreleased
 
 #### Added
@@ -13,6 +11,12 @@
 - **irmin**:
   - Added `Irmin.Hash.Make_BLAKE2B` and `Irmin.Hash.Make_BLAKE2S` functors for
     customizing the bit-length of these hash functions. (#898, @craigfe)
+
+#### Changed
+
+- **irmin-pack**:
+  - Changed the bit-length of serialized hashes from 60 to 30. (#897,
+    @icristescu)
 
 ### 2.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+
+
+### Unreleased
+
+#### Added
+
+- **irmin-unix**:
+  - Added a `--hash` parameter to the command-line interface, allowing the hash
+    function to be specified. For BLAKE2b and BLAKE2s, the bit-length may be
+    specified with a trailing slash, as in `--hash=blake2b/16`. The `hash`
+    function may also be specified in the configuration file. (#898, @craigfe)
+ 
+- **irmin**:
+  - Added `Irmin.Hash.Make_BLAKE2B` and `Irmin.Hash.Make_BLAKE2S` functors for
+    customizing the bit-length of these hash functions. (#898, @craigfe)
+
 ### 2.0.0
 
 #### Added

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -54,6 +54,12 @@ module Store : sig
      contains: the store implementation a creator of store's state and
      endpoint. *)
 
+  (** The type of constructors of a store configuration. Depending on the
+      backend, a store may require a hash function. *)
+  type store_functor =
+    | Fixed_hash of (contents -> t)
+    | Variable_hash of (hash -> contents -> t)
+
   type remote_fn = ?headers:Cohttp.Header.t -> string -> Irmin.remote
 
   val v : ?remote:remote_fn -> (module Irmin.S) -> t
@@ -66,9 +72,9 @@ module Store : sig
 
   val git : contents -> t
 
-  val find : string -> hash -> contents -> t
+  val find : string -> store_functor
 
-  val add : string -> ?default:bool -> (hash -> contents -> t) -> unit
+  val add : string -> ?default:bool -> store_functor -> unit
 end
 
 type Irmin.remote += R of Cohttp.Header.t option * string

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -20,6 +20,19 @@ val global_option_section : string
 
 val branch : string option Cmdliner.Term.t
 
+(** {1 Hash} *)
+module Hash : sig
+  type t = (module Irmin.Hash.S)
+
+  val add : string -> ?default:bool -> (module Irmin.Hash.S) -> unit
+
+  val find : string -> t
+
+  val term : string option Cmdliner.Term.t
+end
+
+type hash = Hash.t
+
 (** {1 Contents} *)
 module Contents : sig
   type t = (module Irmin.Contents.S)
@@ -45,17 +58,17 @@ module Store : sig
 
   val v : ?remote:remote_fn -> (module Irmin.S) -> t
 
-  val mem : contents -> t
+  val mem : hash -> contents -> t
 
-  val irf : contents -> t
+  val irf : hash -> contents -> t
 
   val http : t -> t
 
   val git : contents -> t
 
-  val find : string -> contents -> t
+  val find : string -> hash -> contents -> t
 
-  val add : string -> ?default:bool -> (contents -> t) -> unit
+  val add : string -> ?default:bool -> (hash -> contents -> t) -> unit
 end
 
 type Irmin.remote += R of Cohttp.Header.t option * string

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -28,7 +28,7 @@ module Hash : sig
 
   val find : string -> t
 
-  val term : string option Cmdliner.Term.t
+  val term : t option Cmdliner.Term.t
 end
 
 type hash = Hash.t

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -38,6 +38,14 @@ module Make (H : Digestif.S) = struct
   let hash s = H.digesti_string s
 end
 
+module Make_BLAKE2B (D : sig
+  val digest_size : int
+end) =
+  Make (Digestif.Make_BLAKE2B (D))
+module Make_BLAKE2S (D : sig
+  val digest_size : int
+end) =
+  Make (Digestif.Make_BLAKE2S (D))
 module SHA1 = Make (Digestif.SHA1)
 module RMD160 = Make (Digestif.RMD160)
 module SHA224 = Make (Digestif.SHA224)

--- a/src/irmin/hash.mli
+++ b/src/irmin/hash.mli
@@ -18,6 +18,14 @@
 
 module Make (H : Digestif.S) : S.HASH with type t = H.t
 
+module Make_BLAKE2B (D : sig
+  val digest_size : int
+end) : S.HASH
+
+module Make_BLAKE2S (D : sig
+  val digest_size : int
+end) : S.HASH
+
 module SHA1 : S.HASH
 
 module RMD160 : S.HASH

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1076,6 +1076,14 @@ module Hash : sig
   module Make (H : Digestif.S) : S with type t = H.t
   (** Digestif hashes. *)
 
+  module Make_BLAKE2B (D : sig
+    val digest_size : int
+  end) : S
+
+  module Make_BLAKE2S (D : sig
+    val digest_size : int
+  end) : S
+
   module SHA1 : S
 
   module RMD160 : S


### PR DESCRIPTION
Closes #896.

- Adds new `Make_BLAKE2X` functors to `Irmin.Hash` (matching those in `Digestif`), which allow the user to set the bit-length of these hash functions. The original `BLAKE2B` and `BLAKE2S` modules have been kept as sensible defaults.

- Add a `--hash` parameter to the `irmin` binary, allowing the hash function to be specified. For BLAKE2b and BLAKE2s, the bit-length may be specified with a trailing slash, as in `--hash=blake2b/16`. This behaviour is documented in the `--help` and manpages.

- Generally improves the documentation produced by `Cmdliner` (e.g. by exposing the various store / content types as enum values).

~~__TODO__: add an error when attempting to set the hash function in combination with a Git-compatible backend (for which the hash function must be `SHA1`). At the moment, the hash parameter is simply ignored in these cases.~~