### PR TITLE
Close repo in tests

### DIFF
--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -83,7 +83,8 @@ let config = Irmin_chunk.config ()
 let clean () =
   let (module S : Irmin_test.S) = store in
   S.Repo.v config >>= fun repo ->
-  S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo)
+  S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo) >>= fun () ->
+  S.Repo.close repo
 
 let suite =
   { Irmin_test.name = "CHUNK"; init; store; config; clean; stats = None }

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -24,7 +24,8 @@ let config = Irmin_mem.config ()
 let clean () =
   let (module S : Irmin_test.S) = store in
   S.Repo.v config >>= fun repo ->
-  S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo)
+  S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo) >>= fun () ->
+  S.Repo.close repo
 
 let init () = Lwt.return_unit
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -45,6 +45,7 @@ let suite =
     let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_dir in
     S.Repo.v config >>= fun repo ->
     S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo)
+    >>= fun () -> S.Repo.close repo
   in
   let stats = None in
   { Irmin_test.name = "PACK"; init; clean; config; store; stats }


### PR DESCRIPTION
The `clean` function, run after a test, sometimes re-opens the store. In Irmin-pack this leads to many fd in use during tests. 