### PR TITLE
Add quotes on hashes when generating dot files

### DIFF
--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -186,7 +186,7 @@ struct
     let default_edge_attributes _ = []
 
     let vertex_name k =
-      let str t v = Type.to_string t v in
+      let str t v = "\"" ^ Type.to_string t v ^ "\"" in
       match k with
       | `Node n -> str Node.t n
       | `Commit c -> str Commit.t c


### PR DESCRIPTION
Hashes are read as numerical value and confuse Graphviz. This leads to a
warning: syntax ambiguity - badly delimited number; and to weird png
files. The fix is to enquote the vertex name.