### PR TITLE
Clarify closures and exports of commit graph 

### DIFF
--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -671,14 +671,15 @@ module type S = sig
       ?full:bool ->
       ?depth:int ->
       ?min:commit list ->
-      ?max:commit list ->
+      ?max:[ `Head | `Max of commit list ] ->
       t ->
       slice Lwt.t
-    (** [export t ~depth ~min ~max] exports the store slice between [min] and
-        [max], using at most [depth] history depth (starting from the max).
+    (** [export t ~full ~depth ~min ~max] exports the store slice between [min]
+        and [max], using at most [depth] history depth (starting from the max).
 
-        If [max] is not specified, use the current [heads]. If [min] is not
-        specified, use an unbound past (but can still be limited by [depth]).
+        If [max] is `Head (also the default value), use the current [heads]. If
+        [min] is not specified, use an unbound past (but can still be limited by
+        [depth]).
 
         [depth] is used to limit the depth of the commit history. [None] here
         means no limitation.
@@ -1433,8 +1434,8 @@ module type S = sig
   val history :
     ?depth:int -> ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
   (** [history ?depth ?min ?max t] is a view of the history of the store [t], of
-      depth at most [depth], starting from the [max] (or from the [t]'s head if
-      the list of heads is empty) and stopping at [min] if specified. *)
+      depth at most [depth], starting from the [t]'s head (or from [max] if the
+      head is not set) and stopping at [min] if specified. *)
 
   val last_modified : ?depth:int -> ?n:int -> t -> key -> commit list Lwt.t
   (** [last_modified ?number c k] is the list of the last [number] commits that

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -299,13 +299,10 @@ module Graph (S : S.NODE_STORE) = struct
     Log.debug (fun f -> f "closure min=%a max=%a" pp_keys min pp_keys max);
     let min = List.rev_map (fun x -> `Node x) min in
     let max = List.rev_map (fun x -> `Node x) max in
-    Graph.closure ~pred:(pred t) ~min ~max () >>= fun g ->
-    let keys =
-      List.fold_left
-        (fun acc -> function `Node x -> x :: acc | _ -> acc)
-        [] (Graph.vertex g)
-    in
-    Lwt.return keys
+    Graph.closure ~pred:(pred t) ~min ~max () >|= fun g ->
+    List.fold_left
+      (fun acc -> function `Node x -> x :: acc | _ -> acc)
+      [] (Graph.vertex g)
 
   let ignore_lwt _ = Lwt.return_unit
 

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt
+open Lwt.Infix
 
 let src = Logs.Src.create "irmin.graph" ~doc:"Irmin graph support"
 
@@ -167,11 +167,11 @@ struct
       visit ()
     and visit () =
       match Stack.top todo with
-      | exception Stack.Empty -> return_unit
+      | exception Stack.Empty -> Lwt.return_unit
       | key, level -> (
           if level >= depth then pop key level
           else if has_mark key then (
-            (if rev then treat key else return_unit) >>= fun () ->
+            (if rev then treat key else Lwt.return_unit) >>= fun () ->
             ignore (Stack.pop todo);
             visit () )
           else
@@ -179,7 +179,7 @@ struct
             | true -> pop key level
             | false ->
                 Log.debug (fun f -> f "VISIT %a %d" Type.(pp X.t) key level);
-                (if not rev then treat key else return_unit) >>= fun () ->
+                (if not rev then treat key else Lwt.return_unit) >>= fun () ->
                 mark key level;
                 if List.mem key min then visit ()
                 else

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -23,7 +23,7 @@ module type S = sig
   include Graph.Oper.S with type g := t
   (** Basic operations. *)
 
-  (** Topoogical traversal *)
+  (** Topological traversal *)
   module Topological : sig
     val fold : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
   end
@@ -41,9 +41,11 @@ module type S = sig
     max:vertex list ->
     unit ->
     t Lwt.t
-  (** [closure min max pred] creates the clansitive closure of [max] using the
-      precedence relation [pred]. The closure will not contain any keys before
-      the the one specified in [min]. *)
+  (** [closure depth pred min max ()] creates the transitive closure graph of
+      [max] using the predecessor relation [pred]. The graph is bounded by the
+      [min] nodes and by [depth].
+
+      {b Note:} Both [min] and [max] are subsets of [n]. *)
 
   val iter :
     ?depth:int ->

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -349,15 +349,11 @@ module type NODE_GRAPH = sig
 
   val closure :
     [> `Read ] t -> min:node list -> max:node list -> node list Lwt.t
-  (** [closure t ~min ~max] is the transitive closure [c] of [t]'s nodes such
-      that:
+  (** [closure t min max] is the unordered list of nodes [n] reachable from a
+      node of [max] along a path which: (i) either contains no [min] or (ii) it
+      ends with a [min].
 
-      - There is a path in [t] from any nodes in [min] to nodes in [c]. If [min]
-        is empty, that condition is always true.
-      - There is a path in [t] from any nodes in [c] to nodes in [max]. If [max]
-        is empty, that condition is always false.
-
-      {b Note:} Both [min] and [max] are subsets of [c].*)
+      {b Note:} Both [min] and [max] are subsets of [n]. *)
 
   val iter :
     [> `Read ] t ->
@@ -370,7 +366,8 @@ module type NODE_GRAPH = sig
     unit ->
     unit Lwt.t
   (** [iter min max node edge skip rev ()] iterates in topological order over
-      the closure graph from the [max] nodes and bounded by the [min] nodes.
+      the closure of [t] as specified by {{!Private.Node.GRAPH.closure}
+      GRAPH.closure}.
 
       It applies three functions while traversing the graph: [node] on the
       nodes; [edge n predecessor_of_n] on the directed edges and [skip n] to not
@@ -952,7 +949,7 @@ module type STORE = sig
       ?full:bool ->
       ?depth:int ->
       ?min:commit list ->
-      ?max:commit list ->
+      ?max:[ `Head | `Max of commit list ] ->
       t ->
       slice Lwt.t
 

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -94,7 +94,8 @@ module Make (S : S.STORE) = struct
         R.Head.find r >>= function
         | None -> Lwt.return_ok `Empty
         | Some h -> (
-            R.Repo.export (R.repo r) ?depth ~min ~max:[ h ] >>= fun r_slice ->
+            R.Repo.export (R.repo r) ?depth ~min ~max:(`Max [ h ])
+            >>= fun r_slice ->
             convert_slice (module R.Private) (module S.Private) r_slice
             >>= fun s_slice ->
             S.Repo.import s_repo s_slice >|= function


### PR DESCRIPTION
`closure` on the commit graph need at least one node in the `max` list, since the graph is directed. Functions that compute closures on the commit graph now return an error when `max` is empty.  If there are nodes in `min` that are not connected to at least one `max` node an error is returned as well. 

`export` is similar to `closure` but is defined at the level of a store and therefore can retrieve the current head. Functions that compute exports therefore use head whenever `max` is empty and only return an error for a disconnected min node.  
