### PR TITLE
Add missing type equalities to irmin-git

### DIFF
--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -16,7 +16,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "irmin"    {>= "1.3.0"}
-  "git"      {>= "1.11.0"}
+  "git"      {>= "1.11.0" & < "1.12.0"}
   "alcotest" {test}
   "git-unix" {test & >= "1.11.4"}
   "mtime"    {test & >= "1.0.0"}

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -55,15 +55,19 @@ module Irmin_value_store
   module Contents: Irmin.Contents.STORE
     with type key = Irmin.Hash.SHA1.t
      and type value = C.t
+     and type t = G.t
 
   module Node: Irmin.Private.Node.STORE
     with type key = Irmin.Hash.SHA1.t
      and type Val.contents = Contents.key
+     and type t = Contents.t * G.t
      and module Metadata = Metadata
+     and module Path = P
 
   module Commit: Irmin.Private.Commit.STORE
     with type key = Irmin.Hash.SHA1.t
      and type Val.node = Node.key
+     and type t = Node.t * G.t
 end
 
 module AO (G: Git.Store.S) (V: Irmin.Contents.Conv) : Irmin.AO


### PR DESCRIPTION
`Irmin_value_store` doesn't provide any constructors for its various stores and doesn't expose the stores' types either, so it appears to be impossible to construct them. The changes in this PR would allow building irmin-indexeddb without any pins.