### PR TITLE
Iter on closure

### DIFF
--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -1740,6 +1740,17 @@ module Private : sig
 
           {b Note:} Both [min] and [max] are subsets of [c].*)
 
+      val iter_on_closure :
+        [> `Read ] t ->
+        min:node list ->
+        max:node list ->
+        f_nodes:(node -> unit Lwt.t) ->
+        f_edges:(node -> node list -> unit Lwt.t) ->
+        unit Lwt.t
+      (** [iter_on_closure min max pred f_nodes f_edges ()] is the same as
+          closure except that it applies [f_nodes] on the nodes and [f_edges] on
+          the edges of the closure graph while traversing it. *)
+
       (** {1 Value Types} *)
 
       val metadata_t : metadata Type.t

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -291,21 +291,40 @@ module Graph (S : S.NODE_STORE) = struct
 
   let pp_path = Type.pp S.Path.t
 
+  let pred t = function
+    | `Node k -> ( S.find t k >|= function None -> [] | Some v -> edges v )
+    | _ -> Lwt.return_nil
+
   let closure t ~min ~max =
     Log.debug (fun f -> f "closure min=%a max=%a" pp_keys min pp_keys max);
-    let pred = function
-      | `Node k -> ( S.find t k >|= function None -> [] | Some v -> edges v )
-      | _ -> Lwt.return_nil
-    in
     let min = List.rev_map (fun x -> `Node x) min in
     let max = List.rev_map (fun x -> `Node x) max in
-    Graph.closure ~pred ~min ~max () >>= fun g ->
+    Graph.closure ~pred:(pred t) ~min ~max () >>= fun g ->
     let keys =
       List.fold_left
         (fun acc -> function `Node x -> x :: acc | _ -> acc)
         [] (Graph.vertex g)
     in
     Lwt.return keys
+
+  let iter_on_closure t ~min ~max ~f_nodes ~f_edges =
+    Log.debug (fun f ->
+        f "iter on closure min=%a max=%a" pp_keys min pp_keys max);
+    let min = List.rev_map (fun x -> `Node x) min in
+    let max = List.rev_map (fun x -> `Node x) max in
+    let f_nodes = function `Node x -> f_nodes x | _ -> Lwt.return_unit in
+    let f_edges n nls =
+      match n with
+      | `Node x ->
+          let ls =
+            List.fold_left
+              (fun acc -> function `Node x -> x :: acc | _ -> acc)
+              [] nls
+          in
+          f_edges x ls
+      | _ -> Lwt.return_unit
+    in
+    Graph.iter_on_closure ~pred:(pred t) ~min ~max ~f_nodes ~f_edges ()
 
   let v t xs = S.add t (S.Val.v xs)
 

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -45,6 +45,19 @@ module type S = sig
       using the precedence relation [pred]. The closure will not
       contain any keys before the the one specified in [min]. *)
 
+  val iter_on_closure :
+    ?depth:int ->
+    pred:(vertex -> vertex list Lwt.t) ->
+    min:vertex list ->
+    max:vertex list ->
+    f_nodes:(vertex -> unit Lwt.t) ->
+    f_edges:(vertex -> vertex list -> unit Lwt.t) ->
+    unit ->
+    unit Lwt.t
+  (** [iter_on_closure min max pred f_nodes f_edges ()] is the same as closure
+      except that it applies [f_nodes] on the nodes and [f_edges] on the edges
+      of the closure graph *)
+
   val output :
     Format.formatter ->
     (vertex * Graph.Graphviz.DotAttributes.vertex list) list ->

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -213,6 +213,14 @@ module type NODE_GRAPH = sig
   val closure :
     [> `Read ] t -> min:node list -> max:node list -> node list Lwt.t
 
+  val iter_on_closure :
+    [> `Read ] t ->
+    min:node list ->
+    max:node list ->
+    f_nodes:(node -> unit Lwt.t) ->
+    f_edges:(node -> node list -> unit Lwt.t) ->
+    unit Lwt.t
+
   val metadata_t : metadata Type.t
 
   val contents_t : contents Type.t


### PR DESCRIPTION
In order to make https://github.com/mirage/irmin/pull/882 more manageable I'll make a few smaller PRs which introduce some modifications for 882 but not strictly related to the layered store. 

This PR introduces an `iter_on_closure` operation which applies a function to the nodes and the edges of the closure graph as it traverse it. This way the closure graph is not be returned (and need not be in memory). 

`iter_on_closure` duplicates code from `closure` because I'm worried that resolving unit promises for every node and every edge in the closure graphs introduces performance overhead for `closure`.  

`iter_on_closure` is introduced for object_graph and the node store (this is what I need for the layered store), but for consistency I could also introduce it for the commit store. 