### PR TITLE
Make slice iter blocking

### DIFF
--- a/src/irmin/slice.ml
+++ b/src/irmin/slice.ml
@@ -59,7 +59,7 @@ struct
         Lwt.return_unit
 
   let iter t f =
-    Lwt.choose
+    Lwt.join
       [
         Lwt_list.iter_p (fun c -> f (`Contents c)) t.contents;
         Lwt_list.iter_p (fun n -> f (`Node n)) t.nodes;


### PR DESCRIPTION
This behaviour also is closer to the one of `Lwt_list.iter_p`: wait for all iter functions to resolve before returning. 