### PR TITLE
Add reverse traversal to iter

### DIFF
--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -310,7 +310,7 @@ module Graph (S : S.NODE_STORE) = struct
   let ignore_lwt _ = Lwt.return_unit
 
   let iter t ~min ~max ?(node = ignore_lwt) ?(edge = fun _ -> ignore_lwt)
-      ?(skip = fun _ -> Lwt.return_false) () =
+      ?(skip = fun _ -> Lwt.return_false) ?(rev = true) () =
     Log.debug (fun f ->
         f "iter on closure min=%a max=%a" pp_keys min pp_keys max);
     let min = List.rev_map (fun x -> `Node x) min in
@@ -322,7 +322,7 @@ module Graph (S : S.NODE_STORE) = struct
       | _ -> Lwt.return_unit
     in
     let skip = function `Node x -> skip x | _ -> Lwt.return_false in
-    Graph.iter ~pred:(pred t) ~min ~max ~node ~edge ~skip ()
+    Graph.iter ~pred:(pred t) ~min ~max ~node ~edge ~skip ~rev ()
 
   let v t xs = S.add t (S.Val.v xs)
 

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -53,12 +53,21 @@ module type S = sig
     node:(vertex -> unit Lwt.t) ->
     edge:(vertex -> vertex -> unit Lwt.t) ->
     skip:(vertex -> bool Lwt.t) ->
+    rev:bool ->
     unit ->
     unit Lwt.t
-  (** [iter depth min max pred node edge skip] is the same as closure except
-      that it applies three functions while traversing the closure graph: [node]
-      on the nodes of the graph; [edge node predecessor] on the directed edges
-      of the graph and [skip] to not visit a node. *)
+  (** [iter depth min max node edge skip rev ()] iterates in topological order
+      over the closure graph starting with the [max] nodes and bounded by the
+      [min] nodes and by [depth].
+
+      It applies three functions while traversing the graph: [node] on the
+      nodes; [edge n predecessor_of_n] on the directed edges and [skip n] to not
+      include a node [n], its predecessors and the outgoing edges of [n].
+
+      If [rev] is true (the default) then the graph is traversed in the reverse
+      order: [node n] is applied only after it was applied on all its
+      predecessors; [edge n p] is applied after [node n]. Note that [edge n p]
+      is applied even if [p] is skipped. *)
 
   val output :
     Format.formatter ->

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -366,12 +366,21 @@ module type NODE_GRAPH = sig
     ?node:(node -> unit Lwt.t) ->
     ?edge:(node -> node -> unit Lwt.t) ->
     ?skip:(node -> bool Lwt.t) ->
+    ?rev:bool ->
     unit ->
     unit Lwt.t
-  (** [iter min max node edge skip ()] is the same as closure except that it
-      applies three functions while traversing the closure graph: [node] on the
-      nodes of the graph; [edge node predecessor] on the directed edges of the
-      graph and [skip] to not visit a node. *)
+  (** [iter min max node edge skip rev ()] iterates in topological order
+      over the closure graph from the [max] nodes and bounded by the [min]
+      nodes.
+
+      It applies three functions while traversing the graph: [node] on the
+      nodes; [edge n predecessor_of_n] on the directed edges and [skip n] to not
+      include a node [n], its predecessors and the outgoing edges of [n].
+
+      If [rev] is true (the default) then the graph is traversed in the reverse
+      order: [node n] is applied only after it was applied on all its
+      predecessors; [edge n p] is applied after [node n]. Note that [edge n p]
+      is applied even if [p] is skipped. *)
 
   (** {1 Value Types} *)
 


### PR DESCRIPTION
Replaced bfs with dfs in `iter` in order to support traversal of the closure graph in both direction: when `rev = false` then a node (and the edges to its predecessors) is treated when it is first visited. Otherwise a node is treated only after all of its predecessors have been treated first. `skip` and `level` are verified when first visiting each node.