### PR TITLE
Do not fail when inode not found

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -364,7 +364,11 @@ struct
 
       let rec list_entry ~find acc = function
         | Empty -> acc
-        | Inode i -> list_values ~find acc (get_tree ~find i)
+        | Inode i -> (
+            try
+              let x = get_tree ~find i in
+              list_values ~find acc x
+            with Failure _ -> acc )
 
       and list_inodes ~find acc t =
         Array.fold_left (list_entry ~find) acc t.entries


### PR DESCRIPTION
Inodes cache `find t`, where `t` is the node store on which a particular inode is created. This means that if an inode points to a node from another store, it will not find it. 

This is problematic in the case of layered store, where some parts of the tree are stored in a different layer. 
The test that exposes this is [here](https://github.com/mirage/irmin/pull/882/files#diff-b56185e41c37edf135113ac297cf1727R453). The problem is when iterating over the graph, the predecessor relation has to [list all neighbours of a node](https://github.com/mirage/irmin/blob/master/src/irmin/node.ml#L286). In the case of an inode, it entails an extra test to check that the neighbour is indeed in the store.   

My fix is to simply not fail when an inode is not found in the expected store, but there are maybe more clever solutions. 
