### PR TITLE
Add OCaml-CI status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Irmin - A distributed database built on the same principles as Git
-[![Build Status](https://travis-ci.org/mirage/irmin.svg)](https://travis-ci.org/mirage/irmin)
+[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Firmin%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/mirage/irmin)
+[![Travis-CI Build Status](https://travis-ci.org/mirage/irmin.svg)](https://travis-ci.org/mirage/irmin)
 [![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/irmin/)
 
 Irmin is an OCaml library for building mergeable, branchable distributed data stores.


### PR DESCRIPTION
Now that https://github.com/ocurrent/ocaml-ci/pull/100 has been merged, we have access to new badges for OCaml-CI.