### PR TITLE
Constrain Alcotest to pre-1.0

### DIFF
--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"    {>= "4.02.3"}
   "dune"     {>= "1.8.0"}
   "irmin"    {>= "2.0.0"}
-  "alcotest"
+  "alcotest" {< "1.0.0"}
   "mtime"    {>= "1.0.0"}
   "metrics-unix"
 ]


### PR DESCRIPTION
A quick fix to the development environment while we wait for the Alcotest 1.0.1 release to make it to the CI (after which point https://github.com/mirage/irmin/pull/942 can be merged).

CC. @icristescu