### PR TITLE
Ensure unique default GraphQL type names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@
   - Changed the bit-length of serialized hashes from 60 to 30. (#897,
     @icristescu)
 
+- **irmin-graphql**:
+  - Changed default GraphQL type names to ensure uniqueness. (#944, @andreas)
+
 ### 2.0.0
 
 #### Added

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -106,7 +106,7 @@ module Default_types (S : Irmin.S) = struct
   module Contents = Default_type (struct
     include S.Contents
 
-    let name = "Contents"
+    let name = "Value"
   end)
 
   module Hash = Default_type (struct
@@ -118,7 +118,7 @@ module Default_types (S : Irmin.S) = struct
   module Branch = Default_type (struct
     include S.Branch
 
-    let name = "Branch"
+    let name = "BranchName"
   end)
 end
 


### PR DESCRIPTION
@voodoos raised the issue that introspection was broken with GraphiQL for `irmin-graphq`. The issue turns out to be due to duplicate GraphQL type names 🤦‍♂ The duplicate names were introduced in https://github.com/mirage/irmin/pull/867, which allowed users to customize more of the GraphQL types exposed by `irmin-graphql`.

In this PR, I have simply renamed the two offending cases. A better solution would be https://github.com/mirage/irmin/pull/771, such that new scalar types are not introduced needlessly. As an example, a branch name is often a string, and the built-in GraphQL scalar `String` would be perfectly suitable to reuse, rather than introduce a new scalar `BranchName`, which is a string under the hood anyway.