### PR TITLE
Fix shared buffer clear

### DIFF
--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -209,10 +209,7 @@ module Unix : S = struct
   let buffers = Hashtbl.create 256
 
   let buffer file =
-    try
-      let buf = Hashtbl.find buffers file in
-      Buffer.clear buf;
-      buf
+    try Hashtbl.find buffers file
     with Not_found ->
       let buf = Buffer.create (4 * 1024) in
       Hashtbl.add buffers file buf;

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -5,6 +5,13 @@ let get = function Some x -> x | None -> Alcotest.fail "None"
 
 let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
 
+let rm_dir root =
+  if Sys.file_exists root then (
+    let cmd = Printf.sprintf "rm -rf %s" root in
+    Logs.info (fun l -> l "exec: %s\n%!" cmd);
+    let _ = Sys.command cmd in
+    () )
+
 module S = struct
   include Irmin.Contents.String
 

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -39,3 +39,5 @@ end
 val get : 'a option -> 'a
 
 val sha1 : string -> H.t
+
+val rm_dir : string -> unit

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -1,6 +1,6 @@
 (library
  (name      test_pack)
- (modules   test_pack)
+ (modules   test_pack multiple_instances)
  (libraries irmin-test irmin-pack alcotest-lwt common))
 
 (executable

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -1,0 +1,52 @@
+open Lwt.Infix
+open Common
+
+let root = Filename.concat "_build" "test-instances"
+
+let src = Logs.Src.create "tests.instances" ~doc:"Tests"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let index_log_size = Some 1_000
+
+module Conf = struct
+  let entries = 32
+
+  let stable_hash = 256
+end
+
+module Hash = Irmin.Hash.SHA1
+module S =
+  Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+    (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Hash)
+
+let config ?(readonly = false) ?(fresh = true) root =
+  Irmin_pack.config ~readonly ?index_log_size ~fresh root
+
+let info () = Irmin.Info.empty
+
+let open_ro_after_rw_closed () =
+  rm_dir root;
+  S.Repo.v (config ~readonly:false ~fresh:true root) >>= fun rw ->
+  S.master rw >>= fun t ->
+  S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
+  S.set_tree_exn ~parents:[] ~info t [] tree >>= fun () ->
+  S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
+  S.Repo.close rw >>= fun () ->
+  S.master ro >>= fun t ->
+  S.Head.get t >>= fun c ->
+  S.Commit.of_hash ro (S.Commit.hash c) >>= function
+  | None -> Alcotest.fail "no hash"
+  | Some commit ->
+      let tree = S.Commit.tree commit in
+      S.Tree.find tree [ "a" ] >>= fun x ->
+      Alcotest.(check (option string)) "RO find" (Some "x") x;
+      S.Repo.close ro
+
+let tests =
+  [
+    Alcotest.test_case "Test open ro after rw closed" `Quick (fun () ->
+        Lwt_main.run (open_ro_after_rw_closed ()));
+  ]

--- a/test/irmin-pack/multiple_instances.mli
+++ b/test/irmin-pack/multiple_instances.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -377,4 +377,5 @@ module Branch = struct
     ]
 end
 
-let misc = ("misc", Dict.tests @ Pack.tests @ Branch.tests)
+let misc =
+  ("misc", Dict.tests @ Pack.tests @ Branch.tests @ Multiple_instances.tests)


### PR DESCRIPTION
This is similar to [commit on index](https://github.com/mirage/index/commit/5551cf2d879bd46e14d2a8b73317f43a36916cec): when a RO instance of pack is opened it should not clear the buffers it shares with RW instances. 