### PR TITLE
RO opens pack before RW

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - **irmin-pack**
   - Fix a performance regression where all caches where always cleaned by
     `Store.sync` when using the V1 format (#1360, @samoht)
+  - Allow RO instances to be opened before an RW one. (#955, @icristescu)
 
 ### Added
 

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -237,12 +237,12 @@ module Unix : S = struct
           | false ->
               Some
                 (raw
-                   ~flags:[ O_CREAT; mode; O_CLOEXEC ]
+                   ~flags:[ O_CREAT; O_EXCL; O_RDWR; O_CLOEXEC ]
                    ~version ~offset:Int63.zero ~generation:Int63.zero file)
         in
         v ~offset:Int63.zero ~version ~generation:Int63.zero raw
     | true -> (
-        let x = Unix.openfile file Unix.[ O_EXCL; mode; O_CLOEXEC ] 0o644 in
+        let x = Unix.openfile file Unix.[ mode; O_CLOEXEC ] 0o644 in
         let raw = Raw.v x in
         if fresh then (
           let version = get_version () in

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -16,11 +16,10 @@
 
 open! Import
 
-type headers = { offset : int63; generation : int63 }
-
 module type S = sig
   type t
   type path := string
+  type headers = { offset : int63; generation : int63 }
 
   val v : version:Version.t option -> fresh:bool -> readonly:bool -> path -> t
   val name : t -> string

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -100,6 +100,7 @@ module Make (M : Maker) = struct
           let io =
             IO.v ~fresh:false ~readonly:true ~version:(Some version) path
           in
+          ignore (IO.force_headers io : IO.headers);
           Fun.protect ~finally:(fun () -> IO.close io) (fun () -> Some (f io))
 
     let detect_version ~root =
@@ -243,6 +244,7 @@ module Make (M : Maker) = struct
     let run_versioned_store ~root ~heads (module Store : Versioned_store) =
       let conf = conf root in
       let* repo = Store.Repo.v conf in
+      Store.sync repo;
       let* heads =
         match heads with
         | None -> Store.Repo.heads repo

--- a/src/irmin-pack/content_addressable.ml
+++ b/src/irmin-pack/content_addressable.ml
@@ -305,6 +305,7 @@ struct
           IO.v ~fresh:false ~version:(Some V.version) ~readonly:true
             (IO.name t.pack.block)
         in
+        ignore (IO.force_headers block : IO.headers);
         t.pack.block <- block;
         Dict.sync t.pack.dict;
         Index.sync t.pack.index)

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -62,6 +62,7 @@ module Make (V : Version.S) (IO : IO.S) : S = struct
         IO.v ~fresh:false ~readonly:true ~version:(Some V.version)
           (IO.name t.io)
       in
+      ignore (IO.force_headers io : IO.headers);
       t.io <- io;
       Hashtbl.clear t.cache;
       Hashtbl.clear t.index;
@@ -105,7 +106,7 @@ module Make (V : Version.S) (IO : IO.S) : S = struct
     let cache = Hashtbl.create 997 in
     let index = Hashtbl.create 997 in
     let t = { capacity; index; cache; io; open_instances = 1 } in
-    refill ~from:Int63.zero t;
+    if not readonly then refill ~from:Int63.zero t;
     t
 
   let close t =

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -288,12 +288,12 @@ struct
                 pack_file
             in
             let dict = Dict.v ~fresh:false ~readonly:true root in
-            let total = IO.offset pack in
+            let h = IO.force_headers pack in
             let bar, progress =
-              Utils.Progress.counter ~total ~sampling_interval:100
+              Utils.Progress.counter ~total:h.offset ~sampling_interval:100
                 ~message:"Reconstructing index" ~pp_count:Utils.pp_bytes ()
             in
-            decode_buffer ~progress ~total pack dict index;
+            decode_buffer ~progress ~total:h.offset pack dict index;
             Index.close index;
             IO.close pack;
             Dict.close dict;

--- a/src/irmin-pack/layered/checks.ml
+++ b/src/irmin-pack/layered/checks.ml
@@ -173,6 +173,7 @@ module Make (M : Maker) (Store : S.Store) = struct
 
     let check_store ~root ~heads (module S : S.Store) =
       let* repo = S.Repo.v (conf root) in
+      S.sync repo;
       let* heads =
         match heads with
         | None -> S.Repo.heads repo

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -17,6 +17,7 @@
 open! Import
 
 exception RO_not_allowed
+exception File_not_found
 
 module type Checkable = sig
   type 'a t

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -386,6 +386,7 @@ module Test = struct
         (config ~fresh:false ~readonly:true
            (Filename.concat ctxt.index.root Conf.lower_root))
     in
+    StoreSimple.sync repo;
     let* () =
       StoreSimple.Commit.of_hash repo hash1 >>= function
       | None -> Alcotest.fail "checkout block1"


### PR DESCRIPTION
Type raw in the Io module is now of type option raw. When a RO instance is opened first and there are no files on disks, then its raw field is set to `None`. RO will try to open the file only the first time it needs to read it.

RO instances do not refill their memory caches for Dict and the branch store when opened, but instead only when the first read occurs. To ensure this, the offset is set to `0` when a file is opened.
