### PR TITLE
Forbid duplicate field and case names in `Irmin.Type`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+### Unreleased
+
+#### Changed
+
+- **irmin**:
+  - Add sanity checks when creating `Irmin.Type` records, variants and enums
+    (#956, @liautaud):
+     - `Irmin.Type.sealr` will now raise `Invalid_argument` if two fields of
+       the record have the same name;
+     - `Irmin.Type.sealv` will now raise `Invalid_argument` if two cases of
+       the variant with the same arity have the same name;
+     - `Irmin.Type.enum` will now raise `Invalid_argument` if two cases of
+       the enum have the same name.
+
 ### 2.1.0 (2020-02-01)
 
 #### Added

--- a/src/irmin/type/irmin_type.ml
+++ b/src/irmin/type/irmin_type.ml
@@ -140,7 +140,7 @@ let check_unique f =
 let check_unique_field_names rname rfields =
   let names = List.map (fun (Field { fname; _ }) -> fname) rfields in
   let failure fname =
-    Fmt.failwith "The name %s was used for two or more fields in record %s."
+    Fmt.invalid_arg "The name %s was used for two or more fields in record %s."
       fname rname
   in
   check_unique failure names
@@ -190,13 +190,13 @@ let check_unique_case_names vname vcases =
   in
   check_unique
     (fun cname ->
-      Fmt.failwith
+      Fmt.invalid_arg
         "The name %s was used for two or more case0 in variant or enum %s."
         cname vname)
     names0;
   check_unique
     (fun cname ->
-      Fmt.failwith
+      Fmt.invalid_arg
         "The name %s was used for two or more case1 in variant or enum %s."
         cname vname)
     names1

--- a/src/irmin/type/irmin_type.ml
+++ b/src/irmin/type/irmin_type.ml
@@ -140,9 +140,8 @@ let check_unique f =
 let check_unique_field_names rname rfields =
   let names = List.map (fun (Field { fname; _ }) -> fname) rfields in
   let failure fname =
-    failwith
-    @@ Format.sprintf
-         "The name %s was used for two or more fields in record %s." fname rname
+    Fmt.failwith "The name %s was used for two or more fields in record %s."
+      fname rname
   in
   check_unique failure names
 
@@ -179,7 +178,7 @@ let app v c cs =
   let c, f = c (List.length cs) in
   (n, fc f, c :: cs)
 
-let check_unique_case_names ?(source = "variant") vname vcases =
+let check_unique_case_names vname vcases =
   let n0, n1 =
     List.partition (function C0 _ -> true | C1 _ -> false) vcases
   in
@@ -191,15 +190,15 @@ let check_unique_case_names ?(source = "variant") vname vcases =
   in
   check_unique
     (fun cname ->
-      failwith
-        (Format.sprintf "The name %s was used for two or more case0 in %s %s."
-           cname source vname))
+      Fmt.failwith
+        "The name %s was used for two or more case0 in variant or enum %s."
+        cname vname)
     names0;
   check_unique
     (fun cname ->
-      failwith
-        (Format.sprintf "The name %s was used for two or more case1 in %s %s."
-           cname source vname))
+      Fmt.failwith
+        "The name %s was used for two or more case1 in variant or enum %s."
+        cname vname)
     names1
 
 let sealv v =
@@ -220,7 +219,7 @@ let enum vname l =
         (ctag0 + 1, C0 c :: cases, (v, CV0 c) :: mk))
       (0, [], []) l
   in
-  check_unique_case_names ~source:"enum" vname vcases;
+  check_unique_case_names vname vcases;
   let vcases = Array.of_list (List.rev vcases) in
   Variant { vwit; vname; vcases; vget = (fun x -> List.assq x mk) }
 

--- a/src/irmin/type/irmin_type.mli
+++ b/src/irmin/type/irmin_type.mli
@@ -108,7 +108,7 @@ val field : string -> 'a t -> ('b -> 'a) -> ('b, 'a) field
 (** [field n t g] is the representation of the field [n] of type [t] with getter
     [g].
 
-    The name [n] must be unique to the field.
+    The name [n] must not be used by any other [field] in the record.
 
     For instance:
 
@@ -163,6 +163,8 @@ val case0 : string -> 'a -> ('a, 'a case_p) case
 (** [case0 n v] is a representation of a variant constructor [v] with no
     arguments and name [n]. e.g.
 
+    The name [n] must not by used by any other [case0] in the record.
+
     {[
       type t = Foo
 
@@ -172,6 +174,8 @@ val case0 : string -> 'a -> ('a, 'a case_p) case
 val case1 : string -> 'b t -> ('b -> 'a) -> ('a, 'b -> 'a case_p) case
 (** [case1 n t c] is a representation of a variant constructor [c] with an
     argument of type [t] and name [n]. e.g.
+
+    The name [n] must not by used by any other [case1] in the record.
 
     {[
       type t = Foo of string
@@ -184,7 +188,8 @@ val ( |~ ) :
 (** [v |~ c] is the open variant [v] augmented with the case [c]. *)
 
 val sealv : ('a, 'b, 'a -> 'a case_p) open_variant -> 'a t
-(** [sealv v] seals the open variant [v]. *)
+(** [sealv v] seals the open variant [v]. {b Raises.} [Failure] if two or more
+    cases of same arity share the same name. *)
 
 (** Putting all together:
 
@@ -206,7 +211,9 @@ val enum : string -> (string * 'a) list -> 'a t
       type t = Foo | Bar | Toto
 
       let t = enum "t" [ ("Foo", Foo); ("Bar", Bar); ("Toto", Toto) ]
-    ]} *)
+    ]}
+
+    {b Raises.} [Failure] if two or more cases share the same name. *)
 
 (** {1:recursive Recursive definitions}
 

--- a/src/irmin/type/irmin_type.mli
+++ b/src/irmin/type/irmin_type.mli
@@ -123,8 +123,8 @@ val ( |+ ) :
 (** [r |+ f] is the open record [r] augmented with the field [f]. *)
 
 val sealr : ('a, 'b, 'a) open_record -> 'a t
-(** [sealr r] seals the open record [r]. {b Raises.} [Failure] if two or more
-    fields share the same name. *)
+(** [sealr r] seals the open record [r]. {b Raises.} [Invalid_argument] if two
+    or more fields share the same name. *)
 
 (** Putting all together:
 
@@ -188,8 +188,8 @@ val ( |~ ) :
 (** [v |~ c] is the open variant [v] augmented with the case [c]. *)
 
 val sealv : ('a, 'b, 'a -> 'a case_p) open_variant -> 'a t
-(** [sealv v] seals the open variant [v]. {b Raises.} [Failure] if two or more
-    cases of same arity share the same name. *)
+(** [sealv v] seals the open variant [v]. {b Raises.} [Invalid_argument] if two
+    or more cases of same arity share the same name. *)
 
 (** Putting all together:
 
@@ -213,7 +213,7 @@ val enum : string -> (string * 'a) list -> 'a t
       let t = enum "t" [ ("Foo", Foo); ("Bar", Bar); ("Toto", Toto) ]
     ]}
 
-    {b Raises.} [Failure] if two or more cases share the same name. *)
+    {b Raises.} [Invalid_argument] if two or more cases share the same name. *)
 
 (** {1:recursive Recursive definitions}
 

--- a/src/irmin/type/irmin_type.mli
+++ b/src/irmin/type/irmin_type.mli
@@ -108,6 +108,8 @@ val field : string -> 'a t -> ('b -> 'a) -> ('b, 'a) field
 (** [field n t g] is the representation of the field [n] of type [t] with getter
     [g].
 
+    The name [n] must be unique to the field.
+
     For instance:
 
     {[
@@ -121,7 +123,8 @@ val ( |+ ) :
 (** [r |+ f] is the open record [r] augmented with the field [f]. *)
 
 val sealr : ('a, 'b, 'a) open_record -> 'a t
-(** [sealr r] seals the open record [r]. *)
+(** [sealr r] seals the open record [r]. {b Raises.} [Failure] if two or more
+    fields share the same name. *)
 
 (** Putting all together:
 

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1102,47 +1102,44 @@ type dummy_record = { a : int; b : int }
 
 (* Test that reusing the same name for different fields raises. *)
 let test_duplicate_names () =
-  let ( |+ ) = Irmin.Type.( |+ ) in
-  let ( |~ ) = Irmin.Type.( |~ ) in
-
+  let open Irmin.Type in
   Alcotest.check_raises "Two record fields with the same name."
     (Failure "The name foo was used for two or more fields in record bar.")
     (fun () ->
       ignore
-        ( Irmin.Type.record "bar" (fun a b -> { a; b })
-        |+ Irmin.Type.field "foo" Irmin.Type.int (fun r -> r.a)
-        |+ Irmin.Type.field "foo" Irmin.Type.int (fun r -> r.b)
-        |> Irmin.Type.sealr ));
+        ( record "bar" (fun a b -> { a; b })
+        |+ field "foo" int (fun r -> r.a)
+        |+ field "foo" int (fun r -> r.b)
+        |> sealr ));
 
   Alcotest.check_raises "Two variant case0 with the same name."
     (Failure "The name Foo was used for two or more case0 in variant bar.")
     (fun () ->
       ignore
-        ( Irmin.Type.variant "bar" (fun a b -> function `A -> a | `B -> b)
-        |~ Irmin.Type.case0 "Foo" `A
-        |~ Irmin.Type.case0 "Foo" `B
-        |> Irmin.Type.sealv ));
+        ( variant "bar" (fun a b -> function `A -> a | `B -> b)
+        |~ case0 "Foo" `A
+        |~ case0 "Foo" `B
+        |> sealv ));
 
   Alcotest.check_raises "Two variant case1 with the same name."
     (Failure "The name Foo was used for two or more case1 in variant bar.")
     (fun () ->
       ignore
-        ( Irmin.Type.variant "bar" (fun a b ->
-            function `A i -> a i | `B i -> b i)
-        |~ Irmin.Type.case1 "Foo" Irmin.Type.int (fun i -> `A i)
-        |~ Irmin.Type.case1 "Foo" Irmin.Type.int (fun i -> `B i)
-        |> Irmin.Type.sealv ));
+        ( variant "bar" (fun a b -> function `A i -> a i | `B i -> b i)
+        |~ case1 "Foo" int (fun i -> `A i)
+        |~ case1 "Foo" int (fun i -> `B i)
+        |> sealv ));
 
   (* Check that we don't raise when two cases have the same name but different arity. *)
   ignore
-    ( Irmin.Type.variant "bar" (fun a b -> function `A -> a | `B i -> b i)
-    |~ Irmin.Type.case0 "Foo" `A
-    |~ Irmin.Type.case1 "Foo" Irmin.Type.int (fun i -> `B i)
-    |> Irmin.Type.sealv );
+    ( variant "bar" (fun a b -> function `A -> a | `B i -> b i)
+    |~ case0 "Foo" `A
+    |~ case1 "Foo" int (fun i -> `B i)
+    |> sealv );
 
   Alcotest.check_raises "Two enum cases with the same name."
     (Failure "The name Foo was used for two or more case0 in enum bar.")
-    (fun () -> ignore (Irmin.Type.enum "bar" [ ("Foo", `A); ("Foo", `B) ]))
+    (fun () -> ignore (enum "bar" [ ("Foo", `A); ("Foo", `B) ]))
 
 let suite =
   [

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1104,8 +1104,8 @@ type dummy_record = { a : int; b : int }
 let test_duplicate_names () =
   let open Irmin.Type in
   Alcotest.check_raises "Two record fields with the same name."
-    (Failure "The name foo was used for two or more fields in record bar.")
-    (fun () ->
+    (Invalid_argument
+       "The name foo was used for two or more fields in record bar.") (fun () ->
       ignore
         ( record "bar" (fun a b -> { a; b })
         |+ field "foo" int (fun r -> r.a)
@@ -1113,7 +1113,8 @@ let test_duplicate_names () =
         |> sealr ));
 
   Alcotest.check_raises "Two variant case0 with the same name."
-    (Failure "The name Foo was used for two or more case0 in variant bar.")
+    (Invalid_argument
+       "The name Foo was used for two or more case0 in variant or enum bar.")
     (fun () ->
       ignore
         ( variant "bar" (fun a b -> function `A -> a | `B -> b)
@@ -1122,7 +1123,8 @@ let test_duplicate_names () =
         |> sealv ));
 
   Alcotest.check_raises "Two variant case1 with the same name."
-    (Failure "The name Foo was used for two or more case1 in variant bar.")
+    (Invalid_argument
+       "The name Foo was used for two or more case1 in variant or enum bar.")
     (fun () ->
       ignore
         ( variant "bar" (fun a b -> function `A i -> a i | `B i -> b i)
@@ -1138,7 +1140,8 @@ let test_duplicate_names () =
     |> sealv );
 
   Alcotest.check_raises "Two enum cases with the same name."
-    (Failure "The name Foo was used for two or more case0 in enum bar.")
+    (Invalid_argument
+       "The name Foo was used for two or more case0 in variant or enum bar.")
     (fun () -> ignore (enum "bar" [ ("Foo", `A); ("Foo", `B) ]))
 
 let suite =

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1098,6 +1098,21 @@ let test_variants () =
   test (`X259 1024);
   test (`X259 (1024 * 1024))
 
+type silly_record = { a : int; b : int }
+
+(* Test that reusing the same name for different fields raises. *)
+let test_duplicate_names () =
+  let ( |+ ) = Irmin.Type.( |+ ) in
+
+  Alcotest.check_raises "Two record fields with the same name."
+    (Failure "The name foo was used for two or more fields in record bar.")
+    (fun () ->
+      ignore
+        ( Irmin.Type.record "bar" (fun a b -> { a; b })
+        |+ Irmin.Type.field "foo" Irmin.Type.int (fun r -> r.a)
+        |+ Irmin.Type.field "foo" Irmin.Type.int (fun r -> r.b)
+        |> Irmin.Type.sealr ))
+
 let suite =
   [
     ( "type",
@@ -1112,6 +1127,7 @@ let suite =
         ("size_of", `Quick, test_size);
         ("test_hashes", `Quick, test_hashes);
         ("test_variants", `Quick, test_variants);
+        ("test_duplicate_names", `Quick, test_duplicate_names);
       ] );
   ]
 


### PR DESCRIPTION
As part of the ongoing [fuzz testing of `Irmin.Type`](https://github.com/pascutto/irmin/pull/1), I discovered that we currently allow the declaration of records, variants and enums for which two fields or cases share the same name.

While this this isn't a problem in most use cases, it might create some problems when dealing with JSON encoding and decoding (since `decode_json` relies on the user-provided names to uniquely identify each field or case).

This pull request solves the problem by enforcing that:
- No two fields of a record have the same name (otherwise `sealr` will raise);
- No two cases __of the same arity__ of a variant have the same name (otherwise `sealv` will raise);
- No two cases of an enum have the same name (otherwise `enum` will raise).

Note that __two cases of a variant with different arities are still allowed to share a common name__.  Although this is a debatable choice, it is strict enough to avoid any JSON-related bugs (since `case0` and `case1` have a distinct and unambiguous JSON representation). More importantly, [`Tree.kind`](https://github.com/mirage/irmin/blob/master/src/irmin/node.ml#L54) relies on this assumption, so we don't have much choice if we want the JSON representation of `Tree.kind` to remain backwards-compatible.