### PR TITLE
Use autoformatting for dune files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 1.8)
 (name irmin)
-(using fmt 1.0)
+(using fmt 1.2)

--- a/examples/dune
+++ b/examples/dune
@@ -1,14 +1,15 @@
 (executables
-  (names readme trees sync process deploy irmin_git_store custom_merge push custom_graphql)
-  (libraries checkseum.c digestif.c irmin irmin-unix))
+ (names readme trees sync process deploy irmin_git_store custom_merge push
+   custom_graphql)
+ (libraries checkseum.c digestif.c irmin irmin-unix))
 
 (alias
  (name examples)
  (deps readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
-       irmin_git_store.exe custom_merge.exe custom_graphql))
+   irmin_git_store.exe custom_merge.exe custom_graphql))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-unix)
- (deps    readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
-          irmin_git_store.exe custom_merge.exe))
+ (deps readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
+   irmin_git_store.exe custom_merge.exe))

--- a/src/irmin-chunk/dune
+++ b/src/irmin-chunk/dune
@@ -1,4 +1,4 @@
 (library
- (name        irmin_chunk)
+ (name irmin_chunk)
  (public_name irmin-chunk)
- (libraries   irmin))
+ (libraries irmin))

--- a/src/irmin-fs/dune
+++ b/src/irmin-fs/dune
@@ -1,4 +1,4 @@
 (library
- (name        irmin_fs)
+ (name irmin_fs)
  (public_name irmin-fs)
- (libraries   irmin))
+ (libraries irmin))

--- a/src/irmin-git/dune
+++ b/src/irmin-git/dune
@@ -1,4 +1,4 @@
 (library
- (name        irmin_git)
+ (name irmin_git)
  (public_name irmin-git)
- (libraries   irmin git))
+ (libraries irmin git))

--- a/src/irmin-graphql/dune
+++ b/src/irmin-graphql/dune
@@ -1,4 +1,4 @@
 (library
-  (name irmin_graphql)
-  (public_name irmin-graphql)
-  (libraries graphql-lwt graphql-cohttp cohttp-lwt irmin))
+ (name irmin_graphql)
+ (public_name irmin-graphql)
+ (libraries graphql-lwt graphql-cohttp cohttp-lwt irmin))

--- a/src/irmin-http/dune
+++ b/src/irmin-http/dune
@@ -1,4 +1,4 @@
 (library
- (name        irmin_http)
+ (name irmin_http)
  (public_name irmin-http)
- (libraries   irmin cohttp-lwt webmachine))
+ (libraries irmin cohttp-lwt webmachine))

--- a/src/irmin-mem/dune
+++ b/src/irmin-mem/dune
@@ -1,4 +1,4 @@
 (library
- (name        irmin_mem)
+ (name irmin_mem)
  (public_name irmin-mem)
- (libraries   irmin))
+ (libraries irmin))

--- a/src/irmin-mirage/dune
+++ b/src/irmin-mirage/dune
@@ -1,4 +1,4 @@
 (library
- (name        irmin_mirage)
+ (name irmin_mirage)
  (public_name irmin-mirage)
- (libraries   irmin irmin-mem ptime mirage-clock))
+ (libraries irmin irmin-mem ptime mirage-clock))

--- a/src/irmin-mirage/git/dune
+++ b/src/irmin-mirage/git/dune
@@ -1,4 +1,4 @@
 (library
-  (name irmin_mirage_git)
-  (public_name irmin-mirage-git)
-  (libraries irmin-mirage irmin-git git-mirage mirage-kv))
+ (name irmin_mirage_git)
+ (public_name irmin-mirage-git)
+ (libraries irmin-mirage irmin-git git-mirage mirage-kv))

--- a/src/irmin-mirage/graphql/dune
+++ b/src/irmin-mirage/graphql/dune
@@ -1,4 +1,4 @@
 (library
-  (name irmin_mirage_graphql)
-  (public_name irmin-mirage-graphql)
-  (libraries irmin-mirage irmin-graphql git-mirage mirage-clock))
+ (name irmin_mirage_graphql)
+ (public_name irmin-mirage-graphql)
+ (libraries irmin-mirage irmin-graphql git-mirage mirage-clock))

--- a/src/irmin-pack/dune
+++ b/src/irmin-pack/dune
@@ -1,4 +1,4 @@
 (library
-  (public_name irmin-pack)
-  (name        irmin_pack)
-  (libraries   irmin logs lwt.unix index.unix))
+ (public_name irmin-pack)
+ (name irmin_pack)
+ (libraries irmin logs lwt.unix index.unix))

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -1,13 +1,13 @@
 (library
-  (name        irmin_test)
-  (public_name irmin-test)
-  (modules     Irmin_test Store Common)
-  (libraries   irmin mtime mtime.clock.os alcotest lwt.unix logs.fmt))
+ (name irmin_test)
+ (public_name irmin-test)
+ (modules Irmin_test Store Common)
+ (libraries irmin mtime mtime.clock.os alcotest lwt.unix logs.fmt))
 
 (library
-  (name        irmin_bench)
-  (public_name irmin-test.bench)
-  (modules     Irmin_bench Rusage)
-  (c_names     rusage_stubs)
-  (libraries   lwt.unix irmin logs.fmt cmdliner fmt.cli fmt.tty logs.cli
-               metrics metrics-unix))
+ (name irmin_bench)
+ (public_name irmin-test.bench)
+ (modules Irmin_bench Rusage)
+ (c_names rusage_stubs)
+ (libraries lwt.unix irmin logs.fmt cmdliner fmt.cli fmt.tty logs.cli metrics
+   metrics-unix))

--- a/src/irmin-unix/bin/dune
+++ b/src/irmin-unix/bin/dune
@@ -1,5 +1,5 @@
 (executable
-  (name         main)
-  (public_name irmin)
-  (package     irmin-unix)
-  (libraries   checkseum.c digestif.c irmin-unix))
+ (name main)
+ (public_name irmin)
+ (package irmin-unix)
+ (libraries checkseum.c digestif.c irmin-unix))

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -1,6 +1,6 @@
 (library
- (name        irmin_unix)
+ (name irmin_unix)
  (public_name irmin-unix)
- (libraries   irmin irmin-fs irmin-git irmin-http git-unix irmin-mem
-              irmin-graphql irmin-pack
-              irmin-watcher yaml cmdliner logs.fmt logs.cli fmt.cli fmt.tty))
+ (libraries irmin irmin-fs irmin-git irmin-http git-unix irmin-mem
+   irmin-graphql irmin-pack irmin-watcher yaml cmdliner logs.fmt logs.cli
+   fmt.cli fmt.tty))

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,4 +1,5 @@
 (library
- (name        irmin)
+ (name irmin)
  (public_name irmin)
- (libraries   fmt uri jsonm lwt ocamlgraph logs astring base64 digestif irmin_type))
+ (libraries fmt uri jsonm lwt ocamlgraph logs astring base64 digestif
+   irmin_type))

--- a/test/irmin-chunk/dune
+++ b/test/irmin-chunk/dune
@@ -1,14 +1,15 @@
 (library
- (name      test_chunk)
- (modules   test_chunk)
+ (name test_chunk)
+ (modules test_chunk)
  (libraries irmin-test irmin-chunk irmin-mem))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries digestif.c test_chunk))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-chunk)
- (action  (run ./test.exe -q --color=always)))
+ (action
+  (run ./test.exe -q --color=always)))

--- a/test/irmin-fs/dune
+++ b/test/irmin-fs/dune
@@ -1,14 +1,15 @@
 (library
- (name      test_fs)
- (modules   test_fs)
+ (name test_fs)
+ (modules test_fs)
  (libraries irmin-fs irmin-test))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries digestif.c test_fs))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-fs)
- (action (run ./test.exe -q --color=always)))
+ (action
+  (run ./test.exe -q --color=always)))

--- a/test/irmin-git/dune
+++ b/test/irmin-git/dune
@@ -1,14 +1,15 @@
 (library
- (name      test_git)
- (modules   test_git)
+ (name test_git)
+ (modules test_git)
  (libraries irmin-test irmin-mem irmin-git git-unix))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries checkseum.c digestif.c irmin test_git))
 
 (alias
  (name runtest)
  (package irmin-git)
- (action (run ./test.exe -q --color=always)))
+ (action
+  (run ./test.exe -q --color=always)))

--- a/test/irmin-http/dune
+++ b/test/irmin-http/dune
@@ -1,15 +1,18 @@
 (library
- (name      test_http)
- (modules   test_http)
+ (name test_http)
+ (modules test_http)
  (libraries irmin-test test_mem test_git irmin-http))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries checkseum.c digestif.c test_http))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-http)
- (locks   ../http)
- (action  (chdir %{workspace_root} (run %{exe:test.exe} -q --color=always))))
+ (locks ../http)
+ (action
+  (chdir
+   %{workspace_root}
+   (run %{exe:test.exe} -q --color=always))))

--- a/test/irmin-mem/dune
+++ b/test/irmin-mem/dune
@@ -1,23 +1,25 @@
 (library
- (name      test_mem)
- (modules   test_mem)
+ (name test_mem)
+ (modules test_mem)
  (libraries irmin-test irmin-mem))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries digestif.ocaml test_mem))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-mem)
- (action  (run ./test.exe -q --color=always)))
+ (action
+  (run ./test.exe -q --color=always)))
 
 (executable
- (name      bench)
- (modules   bench)
+ (name bench)
+ (modules bench)
  (libraries irmin-mem irmin-test.bench))
 
 (alias
- (name   bench)
- (action (run ./bench.exe)))
+ (name bench)
+ (action
+  (run ./bench.exe)))

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -1,28 +1,30 @@
 (library
- (name      test_pack)
- (modules   test_pack multiple_instances)
+ (name test_pack)
+ (modules test_pack multiple_instances)
  (libraries irmin-test irmin-pack alcotest-lwt common))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries digestif.ocaml test_pack))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-pack)
- (action  (run ./test.exe -q --color=always)))
+ (action
+  (run ./test.exe -q --color=always)))
 
 (executable
- (name      bench)
- (modules   bench)
+ (name bench)
+ (modules bench)
  (libraries irmin_pack irmin-test.bench))
 
 (alias
- (name   bench)
- (action (run ./bench.exe)))
+ (name bench)
+ (action
+  (run ./bench.exe)))
 
 (library
- (name      common)
- (modules   common)
+ (name common)
+ (modules common)
  (libraries irmin-test irmin-pack))

--- a/test/irmin-unix/dune
+++ b/test/irmin-unix/dune
@@ -1,15 +1,18 @@
 (library
- (name      test_unix)
- (modules   test_unix)
+ (name test_unix)
+ (modules test_unix)
  (libraries irmin-test test_fs test_git test_http irmin-unix))
 
 (executable
- (name      test)
- (modules   test)
+ (name test)
+ (modules test)
  (libraries checkseum.c digestif.c test_unix))
 
 (alias
- (name    runtest)
+ (name runtest)
  (package irmin-unix)
- (locks   ../http)
- (action  (chdir %{workspace_root} (run %{exe:test.exe} -q --color=always))))
+ (locks ../http)
+ (action
+  (chdir
+   %{workspace_root}
+   (run %{exe:test.exe} -q --color=always))))

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -1,4 +1,4 @@
 (test
- (name      test)
- (package   irmin)
+ (name test)
+ (package irmin)
  (libraries digestif.c irmin alcotest hex))


### PR DESCRIPTION
I suggest we shift to Dune's autoformatter for `dune` files.

The formatting is not ideal, but I'd rather have it than not.