### PR TITLE
Relicense ppx_irmin under ISC

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -3,7 +3,7 @@ maintainer: "Craig Ferguson <craig@tarides.com>"
 author: "Craig Ferguson <craig@tarides.com>"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
-license: "BSD-2"
+license: "ISC"
 dev-repo: "git+https://github.com/mirage/irmin.git"
 
 build: [


### PR DESCRIPTION
To be consistent with the other packages in this repository. ISC is
functionally identical to BSD-2 (the original license).

See https://github.com/mirage/irmin/pull/952#issue-381486598.