### PR TITLE
Temporarily disable Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,8 @@
+# Appveyor CI temporarily disabled. See https://github.com/mirage/irmin/issues/963.
+branches:
+  only:
+  - explicitly-test-appveyor
+
 platform:
   - x86
 


### PR DESCRIPTION
Appveyor is adding a lot of noise to our PRs, and we've stopped paying any attention to it when merging. I suggest we disable it until someone has time to debug it.

An eventual fix is tracked by: https://github.com/mirage/irmin/issues/963.