### PR TITLE
Forbid non-UTF8 names for record fields and variant cases.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,21 @@
 
 - **irmin**:
   - Add sanity checks when creating `Irmin.Type` records, variants and enums
-    (#956, @liautaud):
+    (#956 and #966, @liautaud):
      - `Irmin.Type.sealr` will now raise `Invalid_argument` if two fields of
        the record have the same name;
      - `Irmin.Type.sealv` will now raise `Invalid_argument` if two cases of
        the variant with the same arity have the same name;
      - `Irmin.Type.enum` will now raise `Invalid_argument` if two cases of
        the enum have the same name.
+     - `Irmin.Type.field` will now raise `Invalid_argument` if the name of
+       the field is not a valid UTF-8 string.
+     - `Irmin.Type.case0` will now raise `Invalid_argument` if the name of
+       the case is not a valid UTF-8 string.
+     - `Irmin.Type.case1` will now raise `Invalid_argument` if the name of
+       the case is not a valid UTF-8 string.
+     - `Irmin.Type.enum` will now raise `Invalid_argument` if the name of
+       any of the tags is not a valid UTF-8 string.
   - Changed the JSON encoding of options and unit to avoid ambiguous cases
     (#967, @liautaud):
     - `()` is now encoded as `{}`;

--- a/src/irmin/type/irmin_type.ml
+++ b/src/irmin/type/irmin_type.ml
@@ -163,15 +163,17 @@ type 'a case_p = 'a case_v
 
 type ('a, 'b) case = int -> 'a a_case * 'b
 
-let case0 cname0 c0 ctag0 =
+let case0 cname0 c0 =
   check_valid_utf8 cname0;
-  let c = { ctag0; cname0; c0 } in
-  (C0 c, CV0 c)
+  fun ctag0 ->
+    let c = { ctag0; cname0; c0 } in
+    (C0 c, CV0 c)
 
-let case1 cname1 ctype1 c1 ctag1 =
+let case1 cname1 ctype1 c1 =
   check_valid_utf8 cname1;
-  let c = { ctag1; cname1; ctype1; c1 } in
-  (C1 c, fun v -> CV1 (c, v))
+  fun ctag1 ->
+    let c = { ctag1; cname1; ctype1; c1 } in
+    (C1 c, fun v -> CV1 (c, v))
 
 type ('a, 'b, 'c) open_variant = 'a a_case list -> string * 'c * 'a a_case list
 

--- a/src/irmin/type/irmin_type.ml
+++ b/src/irmin/type/irmin_type.ml
@@ -112,7 +112,9 @@ let mu2 : type a b. (a t -> b t -> a t * b t) -> a t * b t =
 
 type ('a, 'b, 'c) open_record = ('a, 'c) fields -> string * 'b * ('a, 'b) fields
 
-let field fname ftype fget = { fname; ftype; fget }
+let field fname ftype fget =
+  check_valid_utf8 fname;
+  { fname; ftype; fget }
 
 let record : string -> 'b -> ('a, 'b, 'b) open_record = fun n c fs -> (n, c, fs)
 
@@ -162,10 +164,12 @@ type 'a case_p = 'a case_v
 type ('a, 'b) case = int -> 'a a_case * 'b
 
 let case0 cname0 c0 ctag0 =
+  check_valid_utf8 cname0;
   let c = { ctag0; cname0; c0 } in
   (C0 c, CV0 c)
 
 let case1 cname1 ctype1 c1 ctag1 =
+  check_valid_utf8 cname1;
   let c = { ctag1; cname1; ctype1; c1 } in
   (C1 c, fun v -> CV1 (c, v))
 
@@ -215,6 +219,7 @@ let enum vname l =
   let _, vcases, mk =
     List.fold_left
       (fun (ctag0, cases, mk) (n, v) ->
+        check_valid_utf8 n;
         let c = { ctag0; cname0 = n; c0 = v } in
         (ctag0 + 1, C0 c :: cases, (v, CV0 c) :: mk))
       (0, [], []) l

--- a/src/irmin/type/irmin_type.mli
+++ b/src/irmin/type/irmin_type.mli
@@ -33,6 +33,9 @@ type 'a t
 type len = [ `Int | `Int8 | `Int16 | `Int32 | `Int64 | `Fixed of int ]
 (** The type of integer used to store buffers, list or array lengths. *)
 
+exception Not_utf8
+(** Raised when a field or case name is not valid UTF-8. *)
+
 (** {1:primitives Primitives} *)
 
 val unit : unit t
@@ -106,7 +109,7 @@ type ('a, 'b) field
 
 val field : string -> 'a t -> ('b -> 'a) -> ('b, 'a) field
 (** [field n t g] is the representation of the field [n] of type [t] with getter
-    [g].
+    [g]. {b Raises.} [Not_utf8] if [n] is not valid UTF-8.
 
     The name [n] must not be used by any other [field] in the record.
 
@@ -161,9 +164,11 @@ type 'a case_p
 
 val case0 : string -> 'a -> ('a, 'a case_p) case
 (** [case0 n v] is a representation of a variant constructor [v] with no
-    arguments and name [n]. e.g.
+    arguments and name [n]. {b Raises.} [Not_utf8] if [n] is not valid UTF-8.
 
     The name [n] must not by used by any other [case0] in the record.
+
+    For instance:
 
     {[
       type t = Foo
@@ -173,9 +178,12 @@ val case0 : string -> 'a -> ('a, 'a case_p) case
 
 val case1 : string -> 'b t -> ('b -> 'a) -> ('a, 'b -> 'a case_p) case
 (** [case1 n t c] is a representation of a variant constructor [c] with an
-    argument of type [t] and name [n]. e.g.
+    argument of type [t] and name [n]. {b Raises.} [Not_utf8] if [n] is not
+    valid UTF-8.
 
     The name [n] must not by used by any other [case1] in the record.
+
+    For instance:
 
     {[
       type t = Foo of string

--- a/src/irmin/type/irmin_type.mli
+++ b/src/irmin/type/irmin_type.mli
@@ -33,9 +33,6 @@ type 'a t
 type len = [ `Int | `Int8 | `Int16 | `Int32 | `Int64 | `Fixed of int ]
 (** The type of integer used to store buffers, list or array lengths. *)
 
-exception Not_utf8
-(** Raised when a field or case name is not valid UTF-8. *)
-
 (** {1:primitives Primitives} *)
 
 val unit : unit t
@@ -109,7 +106,7 @@ type ('a, 'b) field
 
 val field : string -> 'a t -> ('b -> 'a) -> ('b, 'a) field
 (** [field n t g] is the representation of the field [n] of type [t] with getter
-    [g]. {b Raises.} [Not_utf8] if [n] is not valid UTF-8.
+    [g]. {b Raises.} [Invalid_argument] if [n] is not valid UTF-8.
 
     The name [n] must not be used by any other [field] in the record.
 
@@ -164,7 +161,8 @@ type 'a case_p
 
 val case0 : string -> 'a -> ('a, 'a case_p) case
 (** [case0 n v] is a representation of a variant constructor [v] with no
-    arguments and name [n]. {b Raises.} [Not_utf8] if [n] is not valid UTF-8.
+    arguments and name [n]. {b Raises.} [Invalid_argument] if [n] is not valid
+    UTF-8.
 
     The name [n] must not by used by any other [case0] in the record.
 
@@ -178,8 +176,8 @@ val case0 : string -> 'a -> ('a, 'a case_p) case
 
 val case1 : string -> 'b t -> ('b -> 'a) -> ('a, 'b -> 'a case_p) case
 (** [case1 n t c] is a representation of a variant constructor [c] with an
-    argument of type [t] and name [n]. {b Raises.} [Not_utf8] if [n] is not
-    valid UTF-8.
+    argument of type [t] and name [n]. {b Raises.} [Invalid_argument] if [n] is
+    not valid UTF-8.
 
     The name [n] must not by used by any other [case1] in the record.
 

--- a/src/irmin/type/type_core.ml
+++ b/src/irmin/type/type_core.ml
@@ -14,6 +14,19 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+exception Not_utf8
+
+let check_valid_utf8 str =
+  Uutf.String.fold_utf_8
+    (fun _ _ -> function `Malformed _ -> raise Not_utf8 | _ -> ())
+    () str
+
+let is_valid_utf8 str =
+  try
+    check_valid_utf8 str;
+    true
+  with Not_utf8 -> false
+
 module Json = struct
   type decoder = { mutable lexemes : Jsonm.lexeme list; d : Jsonm.decoder }
 

--- a/src/irmin/type/type_core.ml
+++ b/src/irmin/type/type_core.ml
@@ -14,18 +14,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-exception Not_utf8
-
 let check_valid_utf8 str =
   Uutf.String.fold_utf_8
-    (fun _ _ -> function `Malformed _ -> raise Not_utf8 | _ -> ())
+    (fun _ _ -> function `Malformed _ -> invalid_arg "Malformed UTF-8"
+      | _ -> ())
     () str
 
 let is_valid_utf8 str =
   try
     check_valid_utf8 str;
     true
-  with Not_utf8 -> false
+  with Invalid_argument _ -> false
 
 module Json = struct
   type decoder = { mutable lexemes : Jsonm.lexeme list; d : Jsonm.decoder }

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -16,16 +16,6 @@
 
 open Type_core
 
-exception Not_utf8
-
-let is_valid_utf8 str =
-  try
-    Uutf.String.fold_utf_8
-      (fun _ _ -> function `Malformed _ -> raise Not_utf8 | _ -> ())
-      () str;
-    true
-  with Not_utf8 -> false
-
 module Encode = struct
   let lexeme e l = ignore (Jsonm.encode e (`Lexeme l))
 


### PR DESCRIPTION
As part of the ongoing [fuzz testing of `Irmin.Type`](https://github.com/pascutto/irmin/pull/1), and particularly of the encoding and decoding of Irmin values into JSON, I discovered a nasty edge case that would crash the JSON decoder whenever the name of a record field or a variant case was not proper UTF-8.

Here is a minimal example:
```ocaml
open Irmin.Type

let e = enum "e" ["\128\255\255\r\012\247\r\r\r\r\r\r\003\r\r\r\r\r\rl", `Weird]
let v = `Weird
let json = to_json_string e v
let oops = of_json_string e json
```

The last line raises an OOB which can be traced back to `src/irmin/type/type_json.ml:364`.

In short, what happens is that:
- Irmin encodes nullary constructors as strings (the name of the constructor), and unary constructors as objects (which map the name of the constructor to its value). Then, when decoding the case, it eagerly checks if the first token it encounters is a string (in which case it assumes a `case0`) or the start of an object (in which case it tries to decode a `case1`). 
- However, when a case name is not valid UTF-8 (therefore can't be represented in JSON directly), Irmin works around the problem by representing the string as `{"base64": "..."}`. In our example, `json` becomes `{"base64":"gP//DQz3DQ0NDQ0NAw0NDQ0NDWw="}`, but this confuses the decoder which sees a `{` and starts looking for a `case1` with the constructor `base64`.

Although this particular issue can be solved by either changing the JSON representation of variants or patching the decoder in some way or another, my (and @samoht's) view is that it would make more sense to forbid non-UTF8 names entirely when defining records, variants and enums.

This pull request enforces and documents the condition in `field`, `case0`, `case1` and `enum`.