### PR TITLE
Change the JSON representation of 'a option and unit to avoid ambiguity.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
        the variant with the same arity have the same name;
      - `Irmin.Type.enum` will now raise `Invalid_argument` if two cases of
        the enum have the same name.
+  - Changed the JSON encoding of options to avoid ambiguity (#967, @liautaud):
+    - `None` is now encoded as `[]`;
+    - `Some x` is now encoded as `[x]`;
+    - Fields of records which have value `None` are still omitted;
+    - Fields of records which have value `Some x` are still unboxed into `x`.
 
 ### 2.1.0 (2020-02-01)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,11 @@
        the variant with the same arity have the same name;
      - `Irmin.Type.enum` will now raise `Invalid_argument` if two cases of
        the enum have the same name.
-  - Changed the JSON encoding of options to avoid ambiguity (#967, @liautaud):
-    - `None` is now encoded as `[]`;
-    - `Some x` is now encoded as `[x]`;
+  - Changed the JSON encoding of options and unit to avoid ambiguous cases
+    (#967, @liautaud):
+    - `()` is now encoded as `{}`;
+    - `None` is now encoded as `null`;
+    - `Some x` is now encoded as `{"some": x}`;
     - Fields of records which have value `None` are still omitted;
     - Fields of records which have value `Some x` are still unboxed into `x`.
 

--- a/src/irmin/type/irmin_type.mli
+++ b/src/irmin/type/irmin_type.mli
@@ -358,14 +358,17 @@ val encode_json : 'a t -> Jsonm.encoder -> 'a -> unit
     relatively straightforward translation of the OCaml structure into JSON. The
     main highlights are:
 
-    - OCaml [ints] are translated into JSON floats.
+    - The unit value [()] is translated into the empty object [{}].
+    - OCaml ints are translated into JSON floats.
     - OCaml strings are translated into JSON strings. You must then ensure that
       the OCaml strings contains only valid UTF-8 characters.
-    - OCaml record fields of type ['a option] are automatically unboxed in their
-      JSON representation. If the value if [None], the field is removed from the
-      JSON object.
-    - variant cases built using {!case0} are represented as strings.
-    - variant cases built using {!case1} are represented as a record with one
+    - OCaml options are translated differently depending on context: record
+      fields with a value of [None] are removed from the JSON object; record
+      fields with a value of [Some x] are automatically unboxed into x; and
+      outside of records, [None] is translated into [null] and [Some x] into
+      [{"some": x'}] with [x'] the JSON encoding of [x].
+    - Variant cases built using {!case0} are represented as strings.
+    - Variant cases built using {!case1} are represented as a record with one
       field; the field name is the name of the variant.
 
     {b NOTE:} this can be used to encode JSON fragments. It's the responsibility

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -84,13 +84,12 @@ module Encode = struct
     lexeme e `Ae
 
   let boxed_option o e = function
-    | None ->
-        lexeme e `As;
-        lexeme e `Ae
+    | None -> lexeme e `Null
     | Some x ->
-        lexeme e `As;
+        lexeme e `Os;
+        lexeme e (`Name "some");
         o e x;
-        lexeme e `Ae
+        lexeme e `Oe
 
   let rec t : type a. a t -> a encode_json =
    fun ty e ->
@@ -282,13 +281,13 @@ module Decode = struct
         o e >|= fun v -> Some v
 
   let boxed_option o e =
-    expect_lexeme e `As >>= fun () ->
     lexeme e >>= function
-    | `Ae -> Ok None
-    | lex ->
-        Json.rewind e lex;
+    | `Null -> Ok None
+    | `Os ->
+        expect_lexeme e (`Name "some") >>= fun () ->
         o e >>= fun v ->
-        expect_lexeme e `Ae >|= fun () -> Some v
+        expect_lexeme e `Oe >|= fun () -> Some v
+    | l -> error e l "`Option-contents"
 
   let rec t : type a. a t -> a decode_json =
    fun ty d ->

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -273,12 +273,7 @@ module Decode = struct
     c e >>= fun z ->
     expect_lexeme e `Ae >|= fun () -> (x, y, z)
 
-  let unboxed_option o e =
-    lexeme e >>= function
-    | `Null -> Ok None
-    | lex ->
-        Json.rewind e lex;
-        o e >|= fun v -> Some v
+  let unboxed_option o e = o e >|= fun v -> Some v
 
   let boxed_option o e =
     lexeme e >>= function

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -29,7 +29,9 @@ let is_valid_utf8 str =
 module Encode = struct
   let lexeme e l = ignore (Jsonm.encode e (`Lexeme l))
 
-  let unit e () = lexeme e `Null
+  let unit e () =
+    lexeme e `Os;
+    lexeme e `Oe
 
   let base64 e s =
     let x = Base64.encode_exn s in
@@ -198,7 +200,7 @@ module Decode = struct
     in
     aux () >|= fun () -> List.rev !lexemes
 
-  let unit e = expect_lexeme e `Null
+  let unit e = expect_lexeme e `Os >>= fun () -> expect_lexeme e `Oe
 
   let get_base64_value e =
     match lexeme e with

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -141,6 +141,11 @@ let test_json_option () =
   Alcotest.(check (ok testable_t))
     "Decode nested option 3"
     (Ok { c = None; d = Some (Some 1) })
+    x;
+  let x = of_json_string t "{\"d\":null}" in
+  Alcotest.(check (ok testable_t))
+    "Decode nested option 4"
+    (Ok { c = None; d = Some None })
     x
 
 let l =

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -18,7 +18,9 @@ let test_base () =
   let s = T.to_bin_string T.int 42 in
   Alcotest.(check string) "binary int" "*" s;
   let s = T.to_string T.int 42 in
-  Alcotest.(check string) "CLI string" "42" s
+  Alcotest.(check string) "CLI string" "42" s;
+  let s = T.to_json_string T.unit () in
+  Alcotest.(check string) "JSON unit" "{}" s
 
 let id x = x
 

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1,6 +1,6 @@
 module T = Irmin.Type
 
-type dummy_record_2 = { c : int option; d : int option option }
+type bar = { c : int option; d : int option option }
 
 let test_base () =
   let s = T.to_json_string T.string "foo" in
@@ -82,20 +82,25 @@ let test_json () =
   Alcotest.(check (ok string))
     "JSON string with chars larger than 127"
     (T.of_json_string T.string x)
-    (Ok "\128\129a")
+    (Ok "\128\129a");
+  let x = T.of_json_string T.unit "{}" in
+  Alcotest.(check (ok unit)) "JSON of unit" (Ok ()) x
 
 let test_json_option () =
   let open T in
+  (* Test JSON encoding. *)
   let x = to_json_string (option int) (Some 1) in
-  Alcotest.(check string) "Option outside of record 1" "[1]" x;
+  Alcotest.(check string) "Option outside of record 1" "{\"some\":1}" x;
   let x = to_json_string (option int) None in
-  Alcotest.(check string) "Option outside of record 2" "[]" x;
+  Alcotest.(check string) "Option outside of record 2" "null" x;
   let x = to_json_string (option (option int)) (Some (Some 1)) in
-  Alcotest.(check string) "Nested option outside of record 1" "[[1]]" x;
+  Alcotest.(check string)
+    "Nested option outside of record 1" "{\"some\":{\"some\":1}}" x;
   let x = to_json_string (option (option int)) (Some None) in
-  Alcotest.(check string) "Nested option outside of record 2" "[[]]" x;
+  Alcotest.(check string)
+    "Nested option outside of record 2" "{\"some\":null}" x;
   let x = to_json_string (option (option int)) None in
-  Alcotest.(check string) "Nested option outside of record 3" "[]" x;
+  Alcotest.(check string) "Nested option outside of record 3" "null" x;
   let t =
     record "foo" (fun c d -> { c; d })
     |+ field "c" (option int) (fun r -> r.c)
@@ -107,9 +112,36 @@ let test_json_option () =
   let x = to_json_string t { c = Some 1; d = None } in
   Alcotest.(check string) "Nested option within record 2" "{\"c\":1}" x;
   let x = to_json_string t { c = None; d = Some (Some 1) } in
-  Alcotest.(check string) "Nested option within record 2" "{\"d\":[1]}" x;
+  Alcotest.(check string)
+    "Nested option within record 2" "{\"d\":{\"some\":1}}" x;
   let x = to_json_string t { c = None; d = Some None } in
-  Alcotest.(check string) "Nested option within record 3" "{\"d\":[]}" x
+  Alcotest.(check string) "Nested option within record 3" "{\"d\":null}" x;
+
+  (* Test JSON decoding. *)
+  let x = of_json_string (option int) "null" in
+  Alcotest.(check (ok (option int))) "Decode null option" (Ok None) x;
+  let x = of_json_string (option int) "{\"some\":1}" in
+  Alcotest.(check (ok (option int))) "Decode some option" (Ok (Some 1)) x;
+  let x = of_json_string (option (option int)) "{\"some\":null}" in
+  Alcotest.(check (ok (option (option int))))
+    "Decode nested null option" (Ok (Some None)) x;
+
+  let testable_t = Alcotest.testable (T.pp t) (T.equal t) in
+  let x = of_json_string t "{}" in
+  Alcotest.(check (ok testable_t))
+    "Decode nested option"
+    (Ok { c = None; d = None })
+    x;
+  let x = of_json_string t "{\"c\":1}" in
+  Alcotest.(check (ok testable_t))
+    "Decode nested option 2"
+    (Ok { c = Some 1; d = None })
+    x;
+  let x = of_json_string t "{\"d\":{\"some\":1}}" in
+  Alcotest.(check (ok testable_t))
+    "Decode nested option 3"
+    (Ok { c = None; d = Some (Some 1) })
+    x
 
 let l =
   let hex = T.map (T.string_of (`Fixed 3)) ~cli:(pp_hex, of_hex_string) id id in


### PR DESCRIPTION
Last one for the day: when [fuzz testing the JSON encoder of `Irmin.Type`](https://github.com/pascutto/irmin/pull/1), I also discovered that we are using an ambiguous representation of `'a option`, where `None` is represented as `null` and `Some x` is unboxed into `x` directly.

This causes–admittedly unlikely–issues when trying to encode nested option types, since e.g. `None` and `Some None` would both turn into `null`.

To avoid these issues, this pull request changes the representation of options to lists: 
- `None` is now encoded as `[]` in general;
- `Some x` is now encoded as `[x]` in general.

However, to maintain backwards-compatibility with most use-cases (as suggested by @samoht):
- Fields of records with the value `None` are still omitted altogether;
- Fields of records with the value `Some x` are still unboxed into `x`.