### PR TITLE
ppx_irmin: strengthen the tests to compile and run the output

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
   "ppxlib" {= "0.12.0"}
+  "irmin" {with-test & >= "2.0.0"}
 ]
 
 synopsis: "PPX deriver for Irmin generics"

--- a/src/ppx_irmin/lib/attributes.ml
+++ b/src/ppx_irmin/lib/attributes.ml
@@ -16,7 +16,7 @@
 
 open Ppxlib
 
-let namespace = "ppx_irmin"
+let namespace = "irmin"
 
 let generic =
   Attribute.declare

--- a/test/ppx_irmin/deriver/bugs/json_module.expected
+++ b/test/ppx_irmin/deriver/bugs/json_module.expected
@@ -1,0 +1,10 @@
+module Json = struct type t = string
+                     let t = Irmin.Type.string end
+type foo = {
+  contents: Json.t }[@@deriving irmin]
+let foo_t =
+  let open Irmin.Type in
+    ((record "foo" (fun contents -> { contents })) |+
+       (field "contents" Json.t (fun t -> t.contents)))
+      |> sealr
+let (_ : foo Irmin.Type.t) = foo_t

--- a/test/ppx_irmin/deriver/bugs/json_module.ml
+++ b/test/ppx_irmin/deriver/bugs/json_module.ml
@@ -1,0 +1,14 @@
+(* Ensure that the [Json] module in [Irmin.Type] doesn't shadow references to
+   types contained in a different [Json] module.
+
+   Disabled due to https://github.com/mirage/irmin/issues/923. *)
+
+module Json = struct
+  type t = string
+
+  let t = Irmin.Type.string
+end
+
+type foo = { contents : Json.t } [@@deriving irmin]
+
+let (_ : foo Irmin.Type.t) = foo_t

--- a/test/ppx_irmin/deriver/errors/dune.inc
+++ b/test/ppx_irmin/deriver/errors/dune.inc
@@ -4,126 +4,161 @@
    (OCAML_ERROR_STYLE "short")
    (OCAML_COLOR "never"))))
 
+; -------- Test: `lib_invalid.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets lib_invalid.actual)
  (deps
   (:pp pp.exe)
   (:input lib_invalid.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff lib_invalid.expected lib_invalid.actual)))
 
+; -------- Test: `nobuiltin_nonempty.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets nobuiltin_nonempty.actual)
  (deps
   (:pp pp.exe)
   (:input nobuiltin_nonempty.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff nobuiltin_nonempty.expected nobuiltin_nonempty.actual)))
 
+; -------- Test: `unsupported_tuple_size.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_tuple_size.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_tuple_size.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_tuple_size.expected unsupported_tuple_size.actual)))
 
+; -------- Test: `unsupported_type_arrow.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_arrow.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_arrow.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_type_arrow.expected unsupported_type_arrow.actual)))
 
+; -------- Test: `unsupported_type_extension.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_extension.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_extension.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_type_extension.expected unsupported_type_extension.actual)))
 
+; -------- Test: `unsupported_type_open.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_open.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_open.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_type_open.expected unsupported_type_open.actual)))
 
+; -------- Test: `unsupported_type_open_polyvariant.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_open_polyvariant.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_open_polyvariant.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
@@ -131,57 +166,73 @@
   (diff unsupported_type_open_polyvariant.expected
     unsupported_type_open_polyvariant.actual)))
 
+; -------- Test: `unsupported_type_package.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_package.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_package.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_type_package.expected unsupported_type_package.actual)))
 
+; -------- Test: `unsupported_type_poly.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_poly.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_poly.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_type_poly.expected unsupported_type_poly.actual)))
 
+; -------- Test: `unsupported_type_variable.ml` --------
 
 
+
+; Run the PPX on the `.ml` file
 (rule
  (targets unsupported_type_variable.actual)
  (deps
   (:pp pp.exe)
   (:input unsupported_type_variable.ml))
  (action
+  ; expect the process to fail, capturing stderr
   (with-stderr-to
    %{targets}
    (bash "! ./%{pp} -no-color --impl %{input}"))))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff unsupported_type_variable.expected unsupported_type_variable.actual)))
+
 

--- a/test/ppx_irmin/deriver/gen_dune_rules.ml
+++ b/test/ppx_irmin/deriver/gen_dune_rules.ml
@@ -5,6 +5,7 @@ let global_stanzas () =
   (env-vars
    (OCAML_ERROR_STYLE "short")
    (OCAML_COLOR "never"))))
+
 |}
 
 let output_stanzas ~expect_failure filename =
@@ -12,7 +13,8 @@ let output_stanzas ~expect_failure filename =
   let pp_library ppf base =
     if not expect_failure then
       Format.fprintf ppf
-        "@[<v 1>(executable@ (name %s)@ (modules %s)@ (preprocess (pps \
+        "; The PPX-dependent executable under test@,\
+         @[<v 1>(executable@ (name %s)@ (modules %s)@ (preprocess (pps \
          ppx_irmin))@ (libraries irmin))@]"
         base base
     else ()
@@ -21,7 +23,8 @@ let output_stanzas ~expect_failure filename =
     let pp_action ppf expect_failure =
       Format.fprintf ppf
         ( if expect_failure then
-          "@[<v 1>(with-stderr-to@,\
+          "; expect the process to fail, capturing stderr@,\
+           @[<v 1>(with-stderr-to@,\
            %%{targets}@,\
            (bash \"! ./%%{pp} -no-color --impl %%{input}\"))@]"
         else
@@ -29,7 +32,8 @@ let output_stanzas ~expect_failure filename =
            %%{targets})" )
     in
     Format.fprintf ppf
-      "@[<v 1>(rule@,\
+      "; Run the PPX on the `.ml` file@,\
+       @[<v 1>(rule@,\
        (targets %s.actual)@,\
        @[<v 1>(deps@,\
        (:pp pp.exe)@,\
@@ -40,7 +44,8 @@ let output_stanzas ~expect_failure filename =
   in
   let pp_diff_alias ppf base =
     Format.fprintf ppf
-      "@[<v 1>(alias@,\
+      "; Compare the post-processed output to the .expected file@,\
+       @[<v 1>(alias@,\
        (name runtest)@,\
        (package ppx_irmin)@,\
        @[<v 1>(action@,\
@@ -53,6 +58,7 @@ let output_stanzas ~expect_failure filename =
       Format.fprintf ppf
         "@,\
          @,\
+         ; Ensure that the post-processed executable runs correctly@,\
          @[<v 1>(alias@,\
          (name runtest)@,\
          (package ppx_irmin)@,\
@@ -61,8 +67,9 @@ let output_stanzas ~expect_failure filename =
     else ()
   in
   Format.set_margin 80;
-  Format.printf "@[<v 0>@,%a@,@,%a@,@,%a%a@]@." pp_library base pp_rule base
-    pp_diff_alias base pp_run_alias base
+  Format.printf
+    "@[<v 0>; -------- Test: `%s.ml` --------@,@,%a@,@,%a@,@,%a%a@,@]@." base
+    pp_library base pp_rule base pp_diff_alias base pp_run_alias base
 
 let is_error_test = function
   | "pp.ml" -> false

--- a/test/ppx_irmin/deriver/gen_dune_rules.ml
+++ b/test/ppx_irmin/deriver/gen_dune_rules.ml
@@ -1,4 +1,6 @@
-let global_stanzas () =
+(* Global configuration for tests in which the PPX fails (for consistency with
+   various compiler versions / platforms). *)
+let ppx_fail_global_stanzas () =
   Format.printf
     {|(env
  (_
@@ -11,6 +13,7 @@ let global_stanzas () =
 let output_stanzas ~expect_failure filename =
   let base = Filename.remove_extension filename in
   let pp_library ppf base =
+    (* If the PPX will fail, we don't need to declare the file as executable *)
     if not expect_failure then
       Format.fprintf ppf
         "; The PPX-dependent executable under test@,\
@@ -82,10 +85,11 @@ let is_error_test = function
 let () =
   let expect_failure =
     match Array.to_list Sys.argv with
-    | _ :: "--expect-failure" :: _ -> true
-    | _ -> false
+    | [ _; "--expect-failure" ] -> true
+    | [ _ ] -> false
+    | _ -> failwith "Unsupported option passed"
   in
-  global_stanzas ();
+  if expect_failure then ppx_fail_global_stanzas ();
   Sys.readdir "."
   |> Array.to_list
   |> List.sort String.compare

--- a/test/ppx_irmin/deriver/gen_dune_rules.ml
+++ b/test/ppx_irmin/deriver/gen_dune_rules.ml
@@ -11,7 +11,10 @@ let output_stanzas ~expect_failure filename =
   let base = Filename.remove_extension filename in
   let pp_library ppf base =
     if not expect_failure then
-      Format.fprintf ppf "@[<v 1>(library@ (name %s)@ (modules %s))@]" base base
+      Format.fprintf ppf
+        "@[<v 1>(executable@ (name %s)@ (modules %s)@ (preprocess (pps \
+         ppx_irmin))@ (libraries irmin))@]"
+        base base
     else ()
   in
   let pp_rule ppf base =
@@ -35,7 +38,7 @@ let output_stanzas ~expect_failure filename =
        %a))@]@]"
       base base pp_action expect_failure
   in
-  let pp_alias ppf base =
+  let pp_diff_alias ppf base =
     Format.fprintf ppf
       "@[<v 1>(alias@,\
        (name runtest)@,\
@@ -43,14 +46,31 @@ let output_stanzas ~expect_failure filename =
        @[<v 1>(action@,\
        @[<hov 2>(diff@ %s.expected@ %s.actual)@])@])@]" base base
   in
+  let pp_run_alias ppf base =
+    (* If we expect the derivation to succeed, then we should be able to compile
+       the output. *)
+    if not expect_failure then
+      Format.fprintf ppf
+        "@,\
+         @,\
+         @[<v 1>(alias@,\
+         (name runtest)@,\
+         (package ppx_irmin)@,\
+         @[<v 1>(action@,\
+         @[<hov 2>(run@ ./%s.exe)@])@])@]" base
+    else ()
+  in
   Format.set_margin 80;
-  Format.printf "@[<v 0>@,%a@,@,%a@,@,%a@]@." pp_library base pp_rule base
-    pp_alias base
+  Format.printf "@[<v 0>@,%a@,@,%a@,@,%a%a@]@." pp_library base pp_rule base
+    pp_diff_alias base pp_run_alias base
 
 let is_error_test = function
   | "pp.ml" -> false
   | "gen_dune_rules.ml" -> false
-  | filename -> Filename.check_suffix filename ".ml"
+  | filename ->
+      Filename.check_suffix filename ".ml"
+      (* Avoid capturing post-PPX files *)
+      && not (Filename.check_suffix filename ".pp.ml")
 
 let () =
   let expect_failure =

--- a/test/ppx_irmin/deriver/passing/alias.expected
+++ b/test/ppx_irmin/deriver/passing/alias.expected
@@ -7,3 +7,6 @@ include struct let t_alias_t = test_result_t end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
 type t = t_alias[@@deriving irmin]
 include struct let t = t_alias_t end[@@ocaml.doc "@inline"][@@merlin.hide ]
+let (_ : test_result Irmin.Type.t) = test_result_t
+let (_ : t_alias Irmin.Type.t) = t_alias_t
+let (_ : t Irmin.Type.t) = t

--- a/test/ppx_irmin/deriver/passing/alias.ml
+++ b/test/ppx_irmin/deriver/passing/alias.ml
@@ -4,3 +4,9 @@ type test_result = (int, string) result [@@deriving irmin]
 type t_alias = test_result [@@deriving irmin]
 
 type t = t_alias [@@deriving irmin]
+
+let (_ : test_result Irmin.Type.t) = test_result_t
+
+let (_ : t_alias Irmin.Type.t) = t_alias_t
+
+let (_ : t Irmin.Type.t) = t

--- a/test/ppx_irmin/deriver/passing/arguments.expected
+++ b/test/ppx_irmin/deriver/passing/arguments.expected
@@ -1,9 +1,11 @@
 type c = string[@@deriving irmin { name = "c_wit" }]
 include struct let c_wit = Irmin.Type.string end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
+let (_ : c Irmin.Type.t) = c_wit
 type d = int[@@deriving irmin { name = "generic_for_d" }]
 include struct let generic_for_d = Irmin.Type.int end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
+let (_ : d Irmin.Type.t) = generic_for_d
 type point_elsewhere1 = ((c)[@generic c_wit])[@@deriving irmin]
 include struct let point_elsewhere1_t = c_wit end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
@@ -45,3 +47,7 @@ include
            |+ (field "sit" generic_for_d (fun t -> t.sit)))
           |> sealr
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+let (_ : point_elsewhere1 Irmin.Type.t) = point_elsewhere1_t
+let (_ : point_elsewhere2 Irmin.Type.t) = point_elsewhere2_t
+let (_ : point_elsewhere3 Irmin.Type.t) = point_elsewhere3_t
+let (_ : point_elsewhere4 Irmin.Type.t) = point_elsewhere4_t

--- a/test/ppx_irmin/deriver/passing/arguments.ml
+++ b/test/ppx_irmin/deriver/passing/arguments.ml
@@ -1,7 +1,11 @@
 (* Tests of the arguments/attributes *)
 type c = string [@@deriving irmin { name = "c_wit" }]
 
+let (_ : c Irmin.Type.t) = c_wit
+
 type d = int [@@deriving irmin { name = "generic_for_d" }]
+
+let (_ : d Irmin.Type.t) = generic_for_d
 
 type point_elsewhere1 = (c[@generic c_wit]) [@@deriving irmin]
 
@@ -19,3 +23,11 @@ type point_elsewhere4 = {
   sit : (d[@generic generic_for_d]);
 }
 [@@deriving irmin]
+
+let (_ : point_elsewhere1 Irmin.Type.t) = point_elsewhere1_t
+
+let (_ : point_elsewhere2 Irmin.Type.t) = point_elsewhere2_t
+
+let (_ : point_elsewhere3 Irmin.Type.t) = point_elsewhere3_t
+
+let (_ : point_elsewhere4 Irmin.Type.t) = point_elsewhere4_t

--- a/test/ppx_irmin/deriver/passing/composite.expected
+++ b/test/ppx_irmin/deriver/passing/composite.expected
@@ -24,3 +24,10 @@ type test_result = (int32, string) result[@@deriving irmin]
 include
   struct let test_result_t = let open Irmin.Type in result int32 string end
 [@@ocaml.doc "@inline"][@@merlin.hide ]
+let (_ : test_list1 Irmin.Type.t) = test_list1_t
+let (_ : test_list2 Irmin.Type.t) = test_list2_t
+let (_ : test_array Irmin.Type.t) = test_array_t
+let (_ : test_option Irmin.Type.t) = test_option_t
+let (_ : test_pair Irmin.Type.t) = test_pair_t
+let (_ : test_triple Irmin.Type.t) = test_triple_t
+let (_ : test_result Irmin.Type.t) = test_result_t

--- a/test/ppx_irmin/deriver/passing/composite.ml
+++ b/test/ppx_irmin/deriver/passing/composite.ml
@@ -12,3 +12,17 @@ type test_pair = string * int32 [@@deriving irmin]
 type test_triple = string * int32 * bool [@@deriving irmin]
 
 type test_result = (int32, string) result [@@deriving irmin]
+
+let (_ : test_list1 Irmin.Type.t) = test_list1_t
+
+let (_ : test_list2 Irmin.Type.t) = test_list2_t
+
+let (_ : test_array Irmin.Type.t) = test_array_t
+
+let (_ : test_option Irmin.Type.t) = test_option_t
+
+let (_ : test_pair Irmin.Type.t) = test_pair_t
+
+let (_ : test_triple Irmin.Type.t) = test_triple_t
+
+let (_ : test_result Irmin.Type.t) = test_result_t

--- a/test/ppx_irmin/deriver/passing/dune.inc
+++ b/test/ppx_irmin/deriver/passing/dune.inc
@@ -4,9 +4,11 @@
    (OCAML_ERROR_STYLE "short")
    (OCAML_COLOR "never"))))
 
-(library
+(executable
  (name alias)
- (modules alias))
+ (modules alias)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets alias.actual)
@@ -22,9 +24,17 @@
  (action
   (diff alias.expected alias.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./alias.exe)))
+
+(executable
  (name arguments)
- (modules arguments))
+ (modules arguments)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets arguments.actual)
@@ -40,9 +50,17 @@
  (action
   (diff arguments.expected arguments.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./arguments.exe)))
+
+(executable
  (name basic)
- (modules basic))
+ (modules basic)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets basic.actual)
@@ -58,9 +76,17 @@
  (action
   (diff basic.expected basic.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./basic.exe)))
+
+(executable
  (name composite)
- (modules composite))
+ (modules composite)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets composite.actual)
@@ -76,9 +102,17 @@
  (action
   (diff composite.expected composite.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./composite.exe)))
+
+(executable
  (name lib_relocated)
- (modules lib_relocated))
+ (modules lib_relocated)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets lib_relocated.actual)
@@ -94,9 +128,17 @@
  (action
   (diff lib_relocated.expected lib_relocated.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./lib_relocated.exe)))
+
+(executable
  (name module)
- (modules module))
+ (modules module)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets module.actual)
@@ -112,9 +154,17 @@
  (action
   (diff module.expected module.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./module.exe)))
+
+(executable
  (name nobuiltin)
- (modules nobuiltin))
+ (modules nobuiltin)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets nobuiltin.actual)
@@ -130,9 +180,17 @@
  (action
   (diff nobuiltin.expected nobuiltin.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./nobuiltin.exe)))
+
+(executable
  (name nonrec)
- (modules nonrec))
+ (modules nonrec)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets nonrec.actual)
@@ -148,9 +206,17 @@
  (action
   (diff nonrec.expected nonrec.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./nonrec.exe)))
+
+(executable
  (name polyvariant)
- (modules polyvariant))
+ (modules polyvariant)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets polyvariant.actual)
@@ -166,9 +232,17 @@
  (action
   (diff polyvariant.expected polyvariant.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./polyvariant.exe)))
+
+(executable
  (name record)
- (modules record))
+ (modules record)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets record.actual)
@@ -184,9 +258,17 @@
  (action
   (diff record.expected record.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./record.exe)))
+
+(executable
  (name signature)
- (modules signature))
+ (modules signature)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets signature.actual)
@@ -202,9 +284,17 @@
  (action
   (diff signature.expected signature.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./signature.exe)))
+
+(executable
  (name tuple_deep)
- (modules tuple_deep))
+ (modules tuple_deep)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets tuple_deep.actual)
@@ -220,9 +310,17 @@
  (action
   (diff tuple_deep.expected tuple_deep.actual)))
 
-(library
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./tuple_deep.exe)))
+
+(executable
  (name variant)
- (modules variant))
+ (modules variant)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
 
 (rule
  (targets variant.actual)
@@ -237,4 +335,10 @@
  (package ppx_irmin)
  (action
   (diff variant.expected variant.actual)))
+
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (run ./variant.exe)))
 

--- a/test/ppx_irmin/deriver/passing/dune.inc
+++ b/test/ppx_irmin/deriver/passing/dune.inc
@@ -4,12 +4,16 @@
    (OCAML_ERROR_STYLE "short")
    (OCAML_COLOR "never"))))
 
+; -------- Test: `alias.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name alias)
  (modules alias)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets alias.actual)
  (deps
@@ -18,24 +22,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff alias.expected alias.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./alias.exe)))
 
+; -------- Test: `arguments.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name arguments)
  (modules arguments)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets arguments.actual)
  (deps
@@ -44,24 +54,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff arguments.expected arguments.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./arguments.exe)))
 
+; -------- Test: `basic.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name basic)
  (modules basic)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets basic.actual)
  (deps
@@ -70,24 +86,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff basic.expected basic.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./basic.exe)))
 
+; -------- Test: `composite.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name composite)
  (modules composite)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets composite.actual)
  (deps
@@ -96,24 +118,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff composite.expected composite.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./composite.exe)))
 
+; -------- Test: `lib_relocated.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name lib_relocated)
  (modules lib_relocated)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets lib_relocated.actual)
  (deps
@@ -122,24 +150,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff lib_relocated.expected lib_relocated.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./lib_relocated.exe)))
 
+; -------- Test: `module.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name module)
  (modules module)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets module.actual)
  (deps
@@ -148,24 +182,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff module.expected module.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./module.exe)))
 
+; -------- Test: `nobuiltin.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name nobuiltin)
  (modules nobuiltin)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets nobuiltin.actual)
  (deps
@@ -174,24 +214,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff nobuiltin.expected nobuiltin.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./nobuiltin.exe)))
 
+; -------- Test: `nonrec.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name nonrec)
  (modules nonrec)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets nonrec.actual)
  (deps
@@ -200,24 +246,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff nonrec.expected nonrec.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./nonrec.exe)))
 
+; -------- Test: `polyvariant.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name polyvariant)
  (modules polyvariant)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets polyvariant.actual)
  (deps
@@ -226,24 +278,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff polyvariant.expected polyvariant.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./polyvariant.exe)))
 
+; -------- Test: `record.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name record)
  (modules record)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets record.actual)
  (deps
@@ -252,24 +310,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff record.expected record.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./record.exe)))
 
+; -------- Test: `signature.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name signature)
  (modules signature)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets signature.actual)
  (deps
@@ -278,24 +342,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff signature.expected signature.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./signature.exe)))
 
+; -------- Test: `tuple_deep.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name tuple_deep)
  (modules tuple_deep)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets tuple_deep.actual)
  (deps
@@ -304,24 +374,30 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff tuple_deep.expected tuple_deep.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./tuple_deep.exe)))
 
+; -------- Test: `variant.ml` --------
+
+; The PPX-dependent executable under test
 (executable
  (name variant)
  (modules variant)
  (preprocess (pps ppx_irmin))
  (libraries irmin))
 
+; Run the PPX on the `.ml` file
 (rule
  (targets variant.actual)
  (deps
@@ -330,15 +406,18 @@
  (action
   (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
 
+; Compare the post-processed output to the .expected file
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (diff variant.expected variant.actual)))
 
+; Ensure that the post-processed executable runs correctly
 (alias
  (name runtest)
  (package ppx_irmin)
  (action
   (run ./variant.exe)))
+
 

--- a/test/ppx_irmin/deriver/passing/dune.inc
+++ b/test/ppx_irmin/deriver/passing/dune.inc
@@ -1,9 +1,3 @@
-(env
- (_
-  (env-vars
-   (OCAML_ERROR_STYLE "short")
-   (OCAML_COLOR "never"))))
-
 ; -------- Test: `alias.ml` --------
 
 ; The PPX-dependent executable under test

--- a/test/ppx_irmin/deriver/passing/lib_relocated.expected
+++ b/test/ppx_irmin/deriver/passing/lib_relocated.expected
@@ -1,9 +1,12 @@
 module Elsewhere :
   sig
+    module Foo : module type of Irmin.Type
     type t[@@deriving irmin { lib = (Some "Foo") }]
     include sig val t : t Foo.t end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end =
   struct
+    module Foo = Irmin.Type
+    module Irmin = struct  end
     type t = (unit * unit)[@@deriving irmin { lib = (Some "Foo") }]
     include struct let t = let open Foo in pair unit unit end[@@ocaml.doc
                                                                "@inline"]
@@ -11,10 +14,13 @@ module Elsewhere :
   end 
 module Locally_avaliable :
   sig
+    type 'a ty
     type t[@@deriving irmin { lib = None }]
     include sig val t : t ty end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end =
   struct
+    include Irmin.Type
+    module Irmin = struct  end
     type t = (unit * unit)[@@deriving irmin { lib = None }]
     include struct let t = pair unit unit end[@@ocaml.doc "@inline"][@@merlin.hide
                                                                     ]

--- a/test/ppx_irmin/deriver/passing/lib_relocated.expected
+++ b/test/ppx_irmin/deriver/passing/lib_relocated.expected
@@ -19,7 +19,8 @@ module Locally_avaliable :
     include sig val t : t ty end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end =
   struct
-    include Irmin.Type
+    let (pair, unit) = let open Irmin.Type in (pair, unit)
+    type 'a ty = 'a Irmin.Type.ty
     module Irmin = struct  end
     type t = (unit * unit)[@@deriving irmin { lib = None }]
     include struct let t = pair unit unit end[@@ocaml.doc "@inline"][@@merlin.hide

--- a/test/ppx_irmin/deriver/passing/lib_relocated.ml
+++ b/test/ppx_irmin/deriver/passing/lib_relocated.ml
@@ -1,19 +1,23 @@
 module Elsewhere : sig
+  module Foo : module type of Irmin.Type
+
   type t [@@deriving irmin { lib = Some "Foo" }]
 end = struct
-  (* module Foo = Irmin.Type
-   * 
-   * module Irmin = struct end *)
+  module Foo = Irmin.Type
+
+  module Irmin = struct end
 
   type t = unit * unit [@@deriving irmin { lib = Some "Foo" }]
 end
 
 module Locally_avaliable : sig
+  type 'a ty
+
   type t [@@deriving irmin { lib = None }]
 end = struct
-  (* open Irmin.Type
-   * 
-   * module Irmin = struct end *)
+  include Irmin.Type
+
+  module Irmin = struct end
 
   type t = unit * unit [@@deriving irmin { lib = None }]
 end

--- a/test/ppx_irmin/deriver/passing/lib_relocated.ml
+++ b/test/ppx_irmin/deriver/passing/lib_relocated.ml
@@ -15,7 +15,9 @@ module Locally_avaliable : sig
 
   type t [@@deriving irmin { lib = None }]
 end = struct
-  include Irmin.Type
+  let pair, unit = Irmin.Type.(pair, unit)
+
+  type 'a ty = 'a Irmin.Type.ty
 
   module Irmin = struct end
 

--- a/test/ppx_irmin/deriver/passing/nobuiltin.expected
+++ b/test/ppx_irmin/deriver/passing/nobuiltin.expected
@@ -1,12 +1,28 @@
 type unit = string[@@deriving irmin]
 include struct let unit_t = Irmin.Type.string end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
-let result _some _opt = assert false
-type t = ((unit)[@nobuiltin ])[@@deriving irmin]
-include struct let t = unit_t end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type u = (((unit, unit) result)[@nobuiltin ])[@@deriving irmin]
-include struct let u_t = let open Irmin.Type in result_t unit unit end
-[@@ocaml.doc "@inline"][@@merlin.hide ]
-type foo = ((unit)[@irmin.nobuiltin ])[@@deriving irmin]
-include struct let foo_t = Irmin.Type.unit end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
+module Nobuiltin_t =
+  struct
+    type t = ((unit)[@nobuiltin ])[@@deriving irmin]
+    include struct let t = unit_t end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    let (_ : string Irmin.Type.t) = t
+  end
+module Nobuiltin_foo =
+  struct
+    type foo = ((unit)[@irmin.nobuiltin ])[@@deriving irmin]
+    include struct let foo_t = unit_t end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                  ]
+    let (_ : string Irmin.Type.t) = foo_t
+  end
+module Nobuiltin_operator =
+  struct
+    let result_t a b = Irmin.Type.pair a b
+    let int32_t = Irmin.Type.int
+    let int64_t = Irmin.Type.bool
+    type u = (((((int32)[@nobuiltin ]), int64) result)[@nobuiltin ])[@@deriving
+                                                                    irmin]
+    include
+      struct let u_t = let open Irmin.Type in result_t int32_t int64 end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
+    let (_ : (int * int64) Irmin.Type.t) = u_t
+  end

--- a/test/ppx_irmin/deriver/passing/nobuiltin.ml
+++ b/test/ppx_irmin/deriver/passing/nobuiltin.ml
@@ -4,17 +4,30 @@
 
 type unit = string [@@deriving irmin]
 
-let result _some _opt = assert false
+(* Shadow [Stdlib.unit] *)
+module Nobuiltin_t = struct
+  type t = (unit[@nobuiltin]) [@@deriving irmin]
 
-type t = (unit[@nobuiltin]) [@@deriving irmin]
+  (* [t]'s repr should be for strings. *)
+  let (_ : string Irmin.Type.t) = t
+end
 
-type u = ((unit, unit) result[@nobuiltin]) [@@deriving irmin]
+module Nobuiltin_foo = struct
+  type foo = (unit[@irmin.nobuiltin]) [@@deriving irmin]
 
-(* Should work as "irmin.nobuiltin" too *)
-type foo = (unit[@irmin.nobuiltin]) [@@deriving irmin]
+  (* [foo]'s repr should be for strings too. *)
+  let (_ : string Irmin.Type.t) = foo_t
+end
 
-(* TODO: uncomment once https://github.com/mirage/irmin/pull/970 is merged *)
+module Nobuiltin_operator = struct
+  (* Define our own representation of [result]. *)
+  let result_t a b = Irmin.Type.pair a b
 
-(* let (_ : unit_t Irmin.Type.t) = t
- * 
- * let (_ : unit_t Irmin.Type.t) = foo_t *)
+  let int32_t = Irmin.Type.int
+
+  let int64_t = Irmin.Type.bool
+
+  type u = (((int32[@nobuiltin]), int64) result[@nobuiltin]) [@@deriving irmin]
+
+  let (_ : (int * int64) Irmin.Type.t) = u_t
+end

--- a/test/ppx_irmin/deriver/passing/nonrec.expected
+++ b/test/ppx_irmin/deriver/passing/nonrec.expected
@@ -1,5 +1,7 @@
-type t = unit
-type t_alias = unit
+type t = unit[@@deriving irmin]
+let t = Irmin.Type.unit
+type t_alias = unit[@@deriving irmin]
+let t_alias_t = Irmin.Type.unit
 module S1 :
   sig
     type nonrec t = t list[@@deriving irmin]

--- a/test/ppx_irmin/deriver/passing/nonrec.expected
+++ b/test/ppx_irmin/deriver/passing/nonrec.expected
@@ -1,7 +1,9 @@
 type t = unit[@@deriving irmin]
-let t = Irmin.Type.unit
+include struct let t = Irmin.Type.unit end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                   ]
 type t_alias = unit[@@deriving irmin]
-let t_alias_t = Irmin.Type.unit
+include struct let t_alias_t = Irmin.Type.unit end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 module S1 :
   sig
     type nonrec t = t list[@@deriving irmin]

--- a/test/ppx_irmin/deriver/passing/nonrec.ml
+++ b/test/ppx_irmin/deriver/passing/nonrec.ml
@@ -1,6 +1,6 @@
-type t = unit
+type t = unit [@@deriving irmin]
 
-type t_alias = unit
+type t_alias = unit [@@deriving irmin]
 
 (* Ensure that 'nonrec' assertions are respected *)
 module S1 : sig

--- a/test/ppx_irmin/deriver/passing/tuple_deep.expected
+++ b/test/ppx_irmin/deriver/passing/tuple_deep.expected
@@ -8,3 +8,4 @@ include
         triple (triple (triple (pair int32 int32) int32 int32) int32 int32)
           int32 int32
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+let (_ : deep_tuple Irmin.Type.t) = deep_tuple_t

--- a/test/ppx_irmin/deriver/passing/tuple_deep.ml
+++ b/test/ppx_irmin/deriver/passing/tuple_deep.ml
@@ -2,3 +2,5 @@
 type deep_tuple =
   (((int32 * int32) * int32 * int32) * int32 * int32) * int32 * int32
 [@@deriving irmin]
+
+let (_ : deep_tuple Irmin.Type.t) = deep_tuple_t


### PR DESCRIPTION
... and use this to catch a bug in the `passing/nonrec.ml` test.

Also adds a (broken) test case witnessing the bug described by https://github.com/mirage/irmin/issues/923 (cc. @pascutto). I couldn't find an easy way to assert that this bug exists as part of `dune runtest` (doing so would likely require something like [janestreet/toplevel_expect_test](https://github.com/janestreet/toplevel_expect_test)).