### PR TITLE
Fix irmin-git -> irmin constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ The following packages have been made available on `opam`:
 
 For more information about an individual package consult the [online documentation](https://mirage.github.io/irmin).
 
+#### Development version
+
+To install the development version of Irmin, clone this repository and `opam install` the packages inside:
+
+    git clone https://github.com/mirage/irmin
+    cd irmin/
+    opam install .
+
 ### Examples
 Below is a simple example of setting a key and getting the value out of a Git based, filesystem-backed store.
 

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "1.8.0"}
-  "irmin"      {= version}
+  "irmin"      {>= "2.0.0"}
   "git"        {>= "2.1.1"}
   "digestif"   {>= "0.7.3"}
   "irmin-test" {with-test & >= "2.0.0"}


### PR DESCRIPTION
... and add installation instructions to the README for installing Irmin from `master`.

I'm sure I've mentioned this before, but I feel that issues with `opam install .` should be caught by the CI.

Resolves https://github.com/mirage/irmin/issues/972.