### PR TITLE
ppx_irmin: upgrade to Ppxlib 0.12.0

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -16,7 +16,7 @@ depends: [
   "dune"
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
-  "ppxlib" {= "0.9.0"}
+  "ppxlib" {= "0.12.0"}
 ]
 
 synopsis: "PPX deriver for Irmin generics"

--- a/test/ppx_irmin/deriver/passing/alias.expected
+++ b/test/ppx_irmin/deriver/passing/alias.expected
@@ -1,6 +1,9 @@
 type test_result = (int, string) result[@@deriving irmin]
-let test_result_t = let open Irmin.Type in result int string
+include
+  struct let test_result_t = let open Irmin.Type in result int string end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t_alias = test_result[@@deriving irmin]
-let t_alias_t = test_result_t
+include struct let t_alias_t = test_result_t end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type t = t_alias[@@deriving irmin]
-let t = t_alias_t
+include struct let t = t_alias_t end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/arguments.expected
+++ b/test/ppx_irmin/deriver/passing/arguments.expected
@@ -1,36 +1,47 @@
 type c = string[@@deriving irmin { name = "c_wit" }]
-let c_wit = Irmin.Type.string
+include struct let c_wit = Irmin.Type.string end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type d = int[@@deriving irmin { name = "generic_for_d" }]
-let generic_for_d = Irmin.Type.int
+include struct let generic_for_d = Irmin.Type.int end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type point_elsewhere1 = ((c)[@generic c_wit])[@@deriving irmin]
-let point_elsewhere1_t = c_wit
+include struct let point_elsewhere1_t = c_wit end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type point_elsewhere2 = (int * ((c)[@generic c_wit]))[@@deriving irmin]
-let point_elsewhere2_t = let open Irmin.Type in pair int c_wit
+include
+  struct let point_elsewhere2_t = let open Irmin.Type in pair int c_wit end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
 type point_elsewhere3 =
   | A of int * ((c)[@generic c_wit]) 
   | B of ((c)[@generic c_wit]) [@@deriving irmin]
-let point_elsewhere3_t =
-  let open Irmin.Type in
-    (((variant "point_elsewhere3"
-         (fun a ->
-            fun b -> function | A (x1, x2) -> a (x1, x2) | B x1 -> b x1))
-        |~ (case1 "A" (pair int c_wit) (fun (x1, x2) -> A (x1, x2))))
-       |~ (case1 "B" c_wit (fun x1 -> B x1)))
-      |> sealv
+include
+  struct
+    let point_elsewhere3_t =
+      let open Irmin.Type in
+        (((variant "point_elsewhere3"
+             (fun a ->
+                fun b -> function | A (x1, x2) -> a (x1, x2) | B x1 -> b x1))
+            |~ (case1 "A" (pair int c_wit) (fun (x1, x2) -> A (x1, x2))))
+           |~ (case1 "B" c_wit (fun x1 -> B x1)))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type point_elsewhere4 =
   {
   lorem: string ;
   ipsum: ((c)[@generic c_wit]) ;
   dolor: int ;
   sit: ((d)[@generic generic_for_d]) }[@@deriving irmin]
-let point_elsewhere4_t =
-  let open Irmin.Type in
-    (((((record "point_elsewhere4"
-           (fun lorem ->
-              fun ipsum ->
-                fun dolor -> fun sit -> { lorem; ipsum; dolor; sit }))
-          |+ (field "lorem" string (fun t -> t.lorem)))
-         |+ (field "ipsum" c_wit (fun t -> t.ipsum)))
-        |+ (field "dolor" int (fun t -> t.dolor)))
-       |+ (field "sit" generic_for_d (fun t -> t.sit)))
-      |> sealr
+include
+  struct
+    let point_elsewhere4_t =
+      let open Irmin.Type in
+        (((((record "point_elsewhere4"
+               (fun lorem ->
+                  fun ipsum ->
+                    fun dolor -> fun sit -> { lorem; ipsum; dolor; sit }))
+              |+ (field "lorem" string (fun t -> t.lorem)))
+             |+ (field "ipsum" c_wit (fun t -> t.ipsum)))
+            |+ (field "dolor" int (fun t -> t.dolor)))
+           |+ (field "sit" generic_for_d (fun t -> t.sit)))
+          |> sealr
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/basic.expected
+++ b/test/ppx_irmin/deriver/passing/basic.expected
@@ -1,14 +1,22 @@
 type test_unit = unit[@@deriving irmin]
-let test_unit_t = Irmin.Type.unit
+include struct let test_unit_t = Irmin.Type.unit end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type test_bool = bool[@@deriving irmin]
-let test_bool_t = Irmin.Type.bool
+include struct let test_bool_t = Irmin.Type.bool end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type test_char = char[@@deriving irmin]
-let test_char_t = Irmin.Type.char
+include struct let test_char_t = Irmin.Type.char end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type test_int32 = int32[@@deriving irmin]
-let test_int32_t = Irmin.Type.int32
+include struct let test_int32_t = Irmin.Type.int32 end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type test_int64 = int64[@@deriving irmin]
-let test_int64_t = Irmin.Type.int64
+include struct let test_int64_t = Irmin.Type.int64 end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type test_float = float[@@deriving irmin]
-let test_float_t = Irmin.Type.float
+include struct let test_float_t = Irmin.Type.float end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
 type test_string = string[@@deriving irmin]
-let test_string_t = Irmin.Type.string
+include struct let test_string_t = Irmin.Type.string end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]

--- a/test/ppx_irmin/deriver/passing/composite.expected
+++ b/test/ppx_irmin/deriver/passing/composite.expected
@@ -1,14 +1,26 @@
 type test_list1 = string list[@@deriving irmin]
-let test_list1_t = let open Irmin.Type in list string
+include struct let test_list1_t = let open Irmin.Type in list string end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_list2 = int32 list list list[@@deriving irmin]
-let test_list2_t = let open Irmin.Type in list (list (list int32))
+include
+  struct
+    let test_list2_t = let open Irmin.Type in list (list (list int32))
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_array = bool array[@@deriving irmin]
-let test_array_t = let open Irmin.Type in array bool
+include struct let test_array_t = let open Irmin.Type in array bool end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_option = unit option[@@deriving irmin]
-let test_option_t = let open Irmin.Type in option unit
+include struct let test_option_t = let open Irmin.Type in option unit end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_pair = (string * int32)[@@deriving irmin]
-let test_pair_t = let open Irmin.Type in pair string int32
+include struct let test_pair_t = let open Irmin.Type in pair string int32 end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_triple = (string * int32 * bool)[@@deriving irmin]
-let test_triple_t = let open Irmin.Type in triple string int32 bool
+include
+  struct
+    let test_triple_t = let open Irmin.Type in triple string int32 bool
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_result = (int32, string) result[@@deriving irmin]
-let test_result_t = let open Irmin.Type in result int32 string
+include
+  struct let test_result_t = let open Irmin.Type in result int32 string end
+[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/module.expected
+++ b/test/ppx_irmin/deriver/passing/module.expected
@@ -1,19 +1,27 @@
 module ModuleQualifiedTypes =
   struct
     module X =
-      struct type t = int[@@deriving irmin]
-             let t = Irmin.Type.int end
+      struct
+        type t = int[@@deriving irmin]
+        include struct let t = Irmin.Type.int end[@@ocaml.doc "@inline"]
+        [@@merlin.hide ]
+      end
     module Y =
       struct
         type foo = X.t list[@@deriving irmin]
-        let foo_t = let open Irmin.Type in list X.t
+        include struct let foo_t = let open Irmin.Type in list X.t end
+        [@@ocaml.doc "@inline"][@@merlin.hide ]
       end
     type t = X.t[@@deriving irmin]
-    let t = X.t
+    include struct let t = X.t end[@@ocaml.doc "@inline"][@@merlin.hide ]
     type t_result = (X.t, unit) result[@@deriving irmin]
-    let t_result_t = let open Irmin.Type in result X.t unit
+    include
+      struct let t_result_t = let open Irmin.Type in result X.t unit end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
     type foo = Y.foo[@@deriving irmin]
-    let foo_t = Y.foo_t
+    include struct let foo_t = Y.foo_t end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                   ]
     type foo_list = Y.foo list[@@deriving irmin]
-    let foo_list_t = let open Irmin.Type in list Y.foo_t
+    include struct let foo_list_t = let open Irmin.Type in list Y.foo_t end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
   end

--- a/test/ppx_irmin/deriver/passing/nonrec.expected
+++ b/test/ppx_irmin/deriver/passing/nonrec.expected
@@ -3,28 +3,40 @@ type t_alias = unit
 module S1 :
   sig
     type nonrec t = t list[@@deriving irmin]
-    val t : t Irmin.Type.t
+    include sig val t : t Irmin.Type.t end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                   ]
     type nonrec t_alias = t_alias list[@@deriving irmin]
-    val t_alias_t : t_alias Irmin.Type.t
+    include sig val t_alias_t : t_alias Irmin.Type.t end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
   end =
   struct
     type nonrec t = t list[@@deriving irmin]
-    let t = let open Irmin.Type in list t
+    include struct let t = let open Irmin.Type in list t end[@@ocaml.doc
+                                                              "@inline"]
+    [@@merlin.hide ]
     type nonrec t_alias = t_alias list[@@deriving irmin]
-    let t_alias_t = let open Irmin.Type in list t_alias_t
+    include struct let t_alias_t = let open Irmin.Type in list t_alias_t end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
   end 
 module S2 :
   sig
     type nonrec t = t list[@@deriving irmin { name = "t_generic" }]
-    val t_generic : t Irmin.Type.t
+    include sig val t_generic : t Irmin.Type.t end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
     type nonrec t_alias = t_alias list[@@deriving
                                         irmin { name = "t_generic" }]
-    val t_generic : t_alias Irmin.Type.t
+    include sig val t_generic : t_alias Irmin.Type.t end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
   end =
   struct
     type nonrec t = t list[@@deriving irmin { name = "t_generic" }]
-    let t_generic = let open Irmin.Type in list t
+    include struct let t_generic = let open Irmin.Type in list t end[@@ocaml.doc
+                                                                    "@inline"]
+    [@@merlin.hide ]
     type nonrec t_alias = t_alias list[@@deriving
                                         irmin { name = "t_generic" }]
-    let t_generic = let open Irmin.Type in list t_alias_t
+    include struct let t_generic = let open Irmin.Type in list t_alias_t end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
   end 

--- a/test/ppx_irmin/deriver/passing/polyvariant.expected
+++ b/test/ppx_irmin/deriver/passing/polyvariant.expected
@@ -1,64 +1,77 @@
 type test_polyvar1 = [ `On of int  | `Off ][@@deriving irmin]
-let test_polyvar1_t =
-  let open Irmin.Type in
-    (((variant "test_polyvar1"
-         (fun on -> fun off -> function | `On x1 -> on x1 | `Off -> off))
-        |~ (case1 "On" int (fun x1 -> `On x1)))
-       |~ (case0 "Off" `Off))
-      |> sealv
+include
+  struct
+    let test_polyvar1_t =
+      let open Irmin.Type in
+        (((variant "test_polyvar1"
+             (fun on -> fun off -> function | `On x1 -> on x1 | `Off -> off))
+            |~ (case1 "On" int (fun x1 -> `On x1)))
+           |~ (case0 "Off" `Off))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_polyvar2 =
   [ `Outer_a of [ `Inner_a  | `Inner_b ]  | `Outer_b of [ `Inner_a ] 
   | `Outer_c of [ `Inner_a of string  | `Inner_c of int ] ][@@deriving irmin]
-let test_polyvar2_t =
-  let open Irmin.Type in
-    ((((variant "test_polyvar2"
-          (fun outer_a ->
-             fun outer_b ->
-               fun outer_c ->
-                 function
-                 | `Outer_a x1 -> outer_a x1
-                 | `Outer_b x1 -> outer_b x1
-                 | `Outer_c x1 -> outer_c x1))
-         |~
-         (case1 "Outer_a"
-            ((((variant "test_polyvar2"
-                  (fun inner_a ->
-                     fun inner_b ->
-                       function | `Inner_a -> inner_a | `Inner_b -> inner_b))
-                 |~ (case0 "Inner_a" `Inner_a))
-                |~ (case0 "Inner_b" `Inner_b))
-               |> sealv) (fun x1 -> `Outer_a x1)))
-        |~
-        (case1 "Outer_b"
-           (((variant "test_polyvar2"
-                (fun inner_a -> function | `Inner_a -> inner_a))
-               |~ (case0 "Inner_a" `Inner_a))
-              |> sealv) (fun x1 -> `Outer_b x1)))
-       |~
-       (case1 "Outer_c"
-          ((((variant "test_polyvar2"
-                (fun inner_a ->
-                   fun inner_c ->
+include
+  struct
+    let test_polyvar2_t =
+      let open Irmin.Type in
+        ((((variant "test_polyvar2"
+              (fun outer_a ->
+                 fun outer_b ->
+                   fun outer_c ->
                      function
-                     | `Inner_a x1 -> inner_a x1
-                     | `Inner_c x1 -> inner_c x1))
-               |~ (case1 "Inner_a" string (fun x1 -> `Inner_a x1)))
-              |~ (case1 "Inner_c" int (fun x1 -> `Inner_c x1)))
-             |> sealv) (fun x1 -> `Outer_c x1)))
-      |> sealv
+                     | `Outer_a x1 -> outer_a x1
+                     | `Outer_b x1 -> outer_b x1
+                     | `Outer_c x1 -> outer_c x1))
+             |~
+             (case1 "Outer_a"
+                ((((variant "test_polyvar2"
+                      (fun inner_a ->
+                         fun inner_b ->
+                           function
+                           | `Inner_a -> inner_a
+                           | `Inner_b -> inner_b))
+                     |~ (case0 "Inner_a" `Inner_a))
+                    |~ (case0 "Inner_b" `Inner_b))
+                   |> sealv) (fun x1 -> `Outer_a x1)))
+            |~
+            (case1 "Outer_b"
+               (((variant "test_polyvar2"
+                    (fun inner_a -> function | `Inner_a -> inner_a))
+                   |~ (case0 "Inner_a" `Inner_a))
+                  |> sealv) (fun x1 -> `Outer_b x1)))
+           |~
+           (case1 "Outer_c"
+              ((((variant "test_polyvar2"
+                    (fun inner_a ->
+                       fun inner_c ->
+                         function
+                         | `Inner_a x1 -> inner_a x1
+                         | `Inner_c x1 -> inner_c x1))
+                   |~ (case1 "Inner_a" string (fun x1 -> `Inner_a x1)))
+                  |~ (case1 "Inner_c" int (fun x1 -> `Inner_c x1)))
+                 |> sealv) (fun x1 -> `Outer_c x1)))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_polyvar3 =
   [ `Branch of (test_polyvar3 * test_polyvar3)  | `Leaf of string ][@@deriving
                                                                     irmin]
-let test_polyvar3_t =
-  Irmin.Type.mu
-    (fun test_polyvar3_t ->
-       let open Irmin.Type in
-         (((variant "test_polyvar3"
-              (fun branch ->
-                 fun leaf ->
-                   function | `Branch x1 -> branch x1 | `Leaf x1 -> leaf x1))
-             |~
-             (case1 "Branch" (pair test_polyvar3_t test_polyvar3_t)
-                (fun x1 -> `Branch x1)))
-            |~ (case1 "Leaf" string (fun x1 -> `Leaf x1)))
-           |> sealv)
+include
+  struct
+    let test_polyvar3_t =
+      Irmin.Type.mu
+        (fun test_polyvar3_t ->
+           let open Irmin.Type in
+             (((variant "test_polyvar3"
+                  (fun branch ->
+                     fun leaf ->
+                       function
+                       | `Branch x1 -> branch x1
+                       | `Leaf x1 -> leaf x1))
+                 |~
+                 (case1 "Branch" (pair test_polyvar3_t test_polyvar3_t)
+                    (fun x1 -> `Branch x1)))
+                |~ (case1 "Leaf" string (fun x1 -> `Leaf x1)))
+               |> sealv)
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/record.expected
+++ b/test/ppx_irmin/deriver/passing/record.expected
@@ -2,28 +2,34 @@ type test_record1 = {
   alpha: string ;
   beta: int64 list ;
   gamma: unit }[@@deriving irmin]
-let test_record1_t =
-  let open Irmin.Type in
-    ((((record "test_record1"
-          (fun alpha -> fun beta -> fun gamma -> { alpha; beta; gamma }))
-         |+ (field "alpha" string (fun t -> t.alpha)))
-        |+ (field "beta" (list int64) (fun t -> t.beta)))
-       |+ (field "gamma" unit (fun t -> t.gamma)))
-      |> sealr
+include
+  struct
+    let test_record1_t =
+      let open Irmin.Type in
+        ((((record "test_record1"
+              (fun alpha -> fun beta -> fun gamma -> { alpha; beta; gamma }))
+             |+ (field "alpha" string (fun t -> t.alpha)))
+            |+ (field "beta" (list int64) (fun t -> t.beta)))
+           |+ (field "gamma" unit (fun t -> t.gamma)))
+          |> sealr
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_record2 =
   {
   the_FIRST_identifier: test_record1 option ;
   the_SECOND_identifier: (string, int32) result list }[@@deriving irmin]
-let test_record2_t =
-  let open Irmin.Type in
-    (((record "test_record2"
-         (fun the_FIRST_identifier ->
-            fun the_SECOND_identifier ->
-              { the_FIRST_identifier; the_SECOND_identifier }))
-        |+
-        (field "the_FIRST_identifier" (option test_record1_t)
-           (fun t -> t.the_FIRST_identifier)))
-       |+
-       (field "the_SECOND_identifier" (list (result string int32))
-          (fun t -> t.the_SECOND_identifier)))
-      |> sealr
+include
+  struct
+    let test_record2_t =
+      let open Irmin.Type in
+        (((record "test_record2"
+             (fun the_FIRST_identifier ->
+                fun the_SECOND_identifier ->
+                  { the_FIRST_identifier; the_SECOND_identifier }))
+            |+
+            (field "the_FIRST_identifier" (option test_record1_t)
+               (fun t -> t.the_FIRST_identifier)))
+           |+
+           (field "the_SECOND_identifier" (list (result string int32))
+              (fun t -> t.the_SECOND_identifier)))
+          |> sealr
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/signature.expected
+++ b/test/ppx_irmin/deriver/passing/signature.expected
@@ -1,40 +1,53 @@
 module SigTests :
   sig
     type t = string[@@deriving irmin]
-    val t : t Irmin.Type.t
+    include sig val t : t Irmin.Type.t end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                   ]
     type foo = unit[@@deriving irmin { name = "foo_generic" }]
-    val foo_generic : foo Irmin.Type.t
+    include sig val foo_generic : foo Irmin.Type.t end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
     type my_int = (int32 * t)[@@deriving irmin]
-    val my_int_t : my_int Irmin.Type.t
+    include sig val my_int_t : my_int Irmin.Type.t end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
     type my_variant =
       | A of (my_int, int) result 
       | B of unit 
       | C of string * int32 [@@deriving irmin]
-    val my_variant_t : my_variant Irmin.Type.t
+    include sig val my_variant_t : my_variant Irmin.Type.t end[@@ocaml.doc
+                                                                "@inline"]
+    [@@merlin.hide ]
   end =
   struct
     type t = string[@@deriving irmin]
-    let t = Irmin.Type.string
+    include struct let t = Irmin.Type.string end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
     type foo = unit[@@deriving irmin { name = "foo_generic" }]
-    let foo_generic = Irmin.Type.unit
+    include struct let foo_generic = Irmin.Type.unit end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
     type my_int = (int32 * t)[@@deriving irmin]
-    let my_int_t = let open Irmin.Type in pair int32 t
+    include struct let my_int_t = let open Irmin.Type in pair int32 t end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
     type my_variant =
       | A of (my_int, int) result 
       | B of unit 
       | C of string * int32 [@@deriving irmin]
-    let my_variant_t =
-      let open Irmin.Type in
-        ((((variant "my_variant"
-              (fun a ->
-                 fun b ->
-                   fun c ->
-                     function
-                     | A x1 -> a x1
-                     | B x1 -> b x1
-                     | C (x1, x2) -> c (x1, x2)))
-             |~ (case1 "A" (result my_int_t int) (fun x1 -> A x1)))
-            |~ (case1 "B" unit (fun x1 -> B x1)))
-           |~ (case1 "C" (pair string int32) (fun (x1, x2) -> C (x1, x2))))
-          |> sealv
+    include
+      struct
+        let my_variant_t =
+          let open Irmin.Type in
+            ((((variant "my_variant"
+                  (fun a ->
+                     fun b ->
+                       fun c ->
+                         function
+                         | A x1 -> a x1
+                         | B x1 -> b x1
+                         | C (x1, x2) -> c (x1, x2)))
+                 |~ (case1 "A" (result my_int_t int) (fun x1 -> A x1)))
+                |~ (case1 "B" unit (fun x1 -> B x1)))
+               |~
+               (case1 "C" (pair string int32) (fun (x1, x2) -> C (x1, x2))))
+              |> sealv
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end 

--- a/test/ppx_irmin/deriver/passing/tuple_deep.expected
+++ b/test/ppx_irmin/deriver/passing/tuple_deep.expected
@@ -1,7 +1,10 @@
 type deep_tuple =
   ((((int32 * int32) * int32 * int32) * int32 * int32) * int32 * int32)
 [@@deriving irmin]
-let deep_tuple_t =
-  let open Irmin.Type in
-    triple (triple (triple (pair int32 int32) int32 int32) int32 int32) int32
-      int32
+include
+  struct
+    let deep_tuple_t =
+      let open Irmin.Type in
+        triple (triple (triple (pair int32 int32) int32 int32) int32 int32)
+          int32 int32
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/variant.expected
+++ b/test/ppx_irmin/deriver/passing/variant.expected
@@ -1,74 +1,94 @@
 type test_variant1 =
   | A [@@deriving irmin]
-let test_variant1_t =
-  let open Irmin.Type in
-    ((variant "test_variant1" (fun a -> function | A -> a)) |~ (case0 "A" A))
-      |> sealv
+include
+  struct
+    let test_variant1_t =
+      let open Irmin.Type in
+        ((variant "test_variant1" (fun a -> function | A -> a)) |~
+           (case0 "A" A))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_variant2 =
   | A2 of int64 [@@deriving irmin]
-let test_variant2_t =
-  let open Irmin.Type in
-    ((variant "test_variant2" (fun a2 -> function | A2 x1 -> a2 x1)) |~
-       (case1 "A2" int64 (fun x1 -> A2 x1)))
-      |> sealv
+include
+  struct
+    let test_variant2_t =
+      let open Irmin.Type in
+        ((variant "test_variant2" (fun a2 -> function | A2 x1 -> a2 x1)) |~
+           (case1 "A2" int64 (fun x1 -> A2 x1)))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_variant3 =
   | A3 of string * test_variant2 [@@deriving irmin]
-let test_variant3_t =
-  let open Irmin.Type in
-    ((variant "test_variant3"
-        (fun a3 -> function | A3 (x1, x2) -> a3 (x1, x2)))
-       |~
-       (case1 "A3" (pair string test_variant2_t)
-          (fun (x1, x2) -> A3 (x1, x2))))
-      |> sealv
+include
+  struct
+    let test_variant3_t =
+      let open Irmin.Type in
+        ((variant "test_variant3"
+            (fun a3 -> function | A3 (x1, x2) -> a3 (x1, x2)))
+           |~
+           (case1 "A3" (pair string test_variant2_t)
+              (fun (x1, x2) -> A3 (x1, x2))))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_variant4 =
   | A4 
   | B4 
   | C4 [@@deriving irmin]
-let test_variant4_t =
-  let open Irmin.Type in
-    ((((variant "test_variant4"
-          (fun a4 ->
-             fun b4 -> fun c4 -> function | A4 -> a4 | B4 -> b4 | C4 -> c4))
-         |~ (case0 "A4" A4))
-        |~ (case0 "B4" B4))
-       |~ (case0 "C4" C4))
-      |> sealv
+include
+  struct
+    let test_variant4_t =
+      let open Irmin.Type in
+        ((((variant "test_variant4"
+              (fun a4 ->
+                 fun b4 ->
+                   fun c4 -> function | A4 -> a4 | B4 -> b4 | C4 -> c4))
+             |~ (case0 "A4" A4))
+            |~ (case0 "B4" B4))
+           |~ (case0 "C4" C4))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_variant5 =
   | A5 
   | B5 of string * test_variant4 
   | C5 of int32 * string * unit [@@deriving irmin]
-let test_variant5_t =
-  let open Irmin.Type in
-    ((((variant "test_variant5"
-          (fun a5 ->
-             fun b5 ->
-               fun c5 ->
-                 function
-                 | A5 -> a5
-                 | B5 (x1, x2) -> b5 (x1, x2)
-                 | C5 (x1, x2, x3) -> c5 (x1, x2, x3)))
-         |~ (case0 "A5" A5))
-        |~
-        (case1 "B5" (pair string test_variant4_t)
-           (fun (x1, x2) -> B5 (x1, x2))))
-       |~
-       (case1 "C5" (triple int32 string unit)
-          (fun (x1, x2, x3) -> C5 (x1, x2, x3))))
-      |> sealv
+include
+  struct
+    let test_variant5_t =
+      let open Irmin.Type in
+        ((((variant "test_variant5"
+              (fun a5 ->
+                 fun b5 ->
+                   fun c5 ->
+                     function
+                     | A5 -> a5
+                     | B5 (x1, x2) -> b5 (x1, x2)
+                     | C5 (x1, x2, x3) -> c5 (x1, x2, x3)))
+             |~ (case0 "A5" A5))
+            |~
+            (case1 "B5" (pair string test_variant4_t)
+               (fun (x1, x2) -> B5 (x1, x2))))
+           |~
+           (case1 "C5" (triple int32 string unit)
+              (fun (x1, x2, x3) -> C5 (x1, x2, x3))))
+          |> sealv
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type test_variant6 =
   | Nil 
   | Cons of string * test_variant6 [@@deriving irmin]
-let test_variant6_t =
-  Irmin.Type.mu
-    (fun test_variant6_t ->
-       let open Irmin.Type in
-         (((variant "test_variant6"
-              (fun nil ->
-                 fun cons ->
-                   function | Nil -> nil | Cons (x1, x2) -> cons (x1, x2)))
-             |~ (case0 "Nil" Nil))
-            |~
-            (case1 "Cons" (pair string test_variant6_t)
-               (fun (x1, x2) -> Cons (x1, x2))))
-           |> sealv)
+include
+  struct
+    let test_variant6_t =
+      Irmin.Type.mu
+        (fun test_variant6_t ->
+           let open Irmin.Type in
+             (((variant "test_variant6"
+                  (fun nil ->
+                     fun cons ->
+                       function | Nil -> nil | Cons (x1, x2) -> cons (x1, x2)))
+                 |~ (case0 "Nil" Nil))
+                |~
+                (case1 "Cons" (pair string test_variant6_t)
+                   (fun (x1, x2) -> Cons (x1, x2))))
+               |> sealv)
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]


### PR DESCRIPTION
This release of `ppxlib` supports up to OCaml 4.10 (previously we could use up to OCaml 4.08).