### PR TITLE
Fixed "illegal literal" error when JSON-decoding NaN.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
   - Remove the `headers` option in `Type.{encode_bin,decode_bin,size_of}`. Use
     `Type.Unboxed.<fn>` instead (#1030, @samoht)
   - `Type.v` now takes an extra mandatory `unit` argument (#1030, @samoht)
+  - Added `Type.pp_dump`, which provides a way to pretty-print values with a
+    syntax almost identical to native OCaml syntax, so that they can easily be
+    copy-pasted into an OCaml REPL for inspection. (#1046, @liautaud)
   - Generic functions in `Irmin.Type` are now more efficient when a partial
     closure is constructed to the type representation (#1030, @samoht).
     To make this even more explicit, these functions are now staged and
@@ -29,6 +32,9 @@
 
 - **irmin**
   - Renamed the `Tree.tree` type to `Tree.t`. (#1022, @CraigFe)
+  - Changed the JSON encoding of special floats. `Float.nan`, `Float.infinity`
+    and `Float.neg_infinity` are now encoded as `"nan"`, `"inf"` and `"-inf"`
+    respectively. (#979, @liautaud)
 
 - **irmin-pack**:
   - `sync` has to be called by the read-only instance to synchronise with the

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -40,9 +40,10 @@ module Encode = struct
     let s = String.make 1 c in
     string e s
 
-  let float e f = match classify_float f with
-  | FP_nan -> lexeme e `Null
-  | _ -> lexeme e (`Float f)
+  let float e f =
+    match classify_float f with
+    | FP_nan | FP_infinite -> lexeme e (`String (string_of_float f))
+    | _ -> lexeme e (`Float f)
 
   let int e i = float e (float_of_int i)
 
@@ -227,7 +228,9 @@ module Decode = struct
   let float e =
     lexeme e >>= function
     | `Float f -> Ok f
-    | `Null -> Ok Float.nan
+    | `String "nan" -> Ok Float.nan
+    | `String "inf" -> Ok Float.infinity
+    | `String "-inf" -> Ok Float.neg_infinity
     | l -> error e l "`Float"
 
   let char e =

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -40,7 +40,9 @@ module Encode = struct
     let s = String.make 1 c in
     string e s
 
-  let float e f = lexeme e (`Float f)
+  let float e f = match classify_float f with
+  | FP_nan -> lexeme e `Null
+  | _ -> lexeme e (`Float f)
 
   let int e i = float e (float_of_int i)
 
@@ -223,7 +225,10 @@ module Decode = struct
     | l -> error e l "`String"
 
   let float e =
-    lexeme e >>= function `Float f -> Ok f | l -> error e l "`Float"
+    lexeme e >>= function
+    | `Float f -> Ok f
+    | `Null -> Ok Float.nan
+    | l -> error e l "`Float"
 
   let char e =
     lexeme e >>= function

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -197,6 +197,20 @@ let test_json_option () =
     (Ok { c = None; d = Some None })
     x
 
+let test_json_float () =
+  let x = T.to_json_string T.float Float.nan in
+  Alcotest.(check string) "NaN to JSON" "\"nan\"" x;
+  let x = T.to_json_string T.float Float.infinity in
+  Alcotest.(check string) "+inf to JSON" "\"inf\"" x;
+  let x = T.to_json_string T.float Float.neg_infinity in
+  Alcotest.(check string) "-inf to JSON" "\"-inf\"" x;
+  let x = T.of_json_string T.float "\"nan\"" |> Result.get_ok in
+  Alcotest.(check (float Float.epsilon)) "NaN from JSON" Float.nan x;
+  let x = T.of_json_string T.float "\"inf\"" |> Result.get_ok in
+  Alcotest.(check (float Float.epsilon)) "+inf from JSON" Float.infinity x;
+  let x = T.of_json_string T.float "\"-inf\"" |> Result.get_ok in
+  Alcotest.(check (float Float.epsilon)) "-inf from JSON" Float.neg_infinity x
+
 let l =
   let hex = T.map (T.string_of (`Fixed 3)) ~cli:(pp_hex, of_hex_string) id id in
   T.list ~len:(`Fixed 2) hex
@@ -862,6 +876,7 @@ let suite =
     ("boxing", `Quick, test_boxing);
     ("json", `Quick, test_json);
     ("json_option", `Quick, test_json_option);
+    ("json_float", `Quick, test_json_float);
     ("bin", `Quick, test_bin);
     ("to_string", `Quick, test_to_string);
     ("pp_dump", `Quick, test_pp_dump);

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -310,7 +310,7 @@ let test_to_string () =
       Stdlib.infinity;
       Stdlib.nan;
     |]
-    "[-inf,-0,0,2.220446049250313e-16,inf,nan]";
+    "[\"-inf\",-0,0,2.220446049250313e-16,\"inf\",\"nan\"]";
   test "(unit * int)" T.(pair unit int) ((), 1) "[{},1]";
   test "unit option{some}" T.(option unit) (Some ()) "{\"some\":{}}";
   test "unit option{none}" T.(option unit) None "null";


### PR DESCRIPTION
While running the fuzzer, I discovered that we don't properly support the floating-point value `NaN`. 

When converting it into JSON, we pass it to Jsonm which produces the token `nan` (because Jsonm uses `string_of_float` and `string_of_float Float.nan = "nan"`). Yet, since `nan` is not a valid JSON token [according to the specification](https://www.json.org/json-en.html), Jsonm doesn't know how to print it and fails with an "illegal literal" error when decoding.

This pull request fixes the issue by encoding `NaN` floats to `null`.