### PR TITLE
irmin-graphql: fix path ordering with get_{contents,tree.list}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,12 @@
     - Fields of records which have value `None` are still omitted;
     - Fields of records which have value `Some x` are still unboxed into `x`.
 
+#### Fixed
+
+- **irmin-graphql**
+  - Fixed an issue with keys inside `get_{contents,tree}` fields having
+    incorrect ordering (#989, @CraigFe)
+
 ### 2.1.0 (2020-02-01)
 
 #### Added

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -22,6 +22,8 @@ depends: [
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"
   "graphql_parser" {>= "0.13.0"}
+  "alcotest-lwt" {>= "1.1.0" & with-test}
+  "yojson" {with-test}
 ]
 
 

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -184,10 +184,10 @@ struct
     | Some b -> Store.of_branch repo b
     | None -> Store.master repo
 
-  let rec concat_key key key' =
-    match Store.Key.decons key' with
-    | None -> key
-    | Some (step, key'') -> concat_key (Store.Key.cons step key) key''
+  let rec concat_key a b =
+    match Store.Key.decons a with
+    | None -> b
+    | Some (step, a_tl) -> Store.Key.cons step (concat_key a_tl b)
 
   module Input = struct
     let coerce_remote = function

--- a/test/irmin-graphql/common.ml
+++ b/test/irmin-graphql/common.ml
@@ -1,0 +1,68 @@
+open Lwt.Infix
+module Store = Irmin_unix.Git.Mem.KV (Irmin.Contents.String)
+
+module Remote = struct
+  let remote = Some Store.remote
+end
+
+module Server = Irmin_unix.Graphql.Server.Make (Store) (Remote)
+
+let host, port = ("0.0.0.0", 37634)
+
+(** Create a GraphQL server over the supplied Irmin repository, returning the
+    event loop thread. *)
+let server_of_repo : type a. Store.repo -> a Lwt.t =
+ fun repo ->
+  let server = Server.v repo in
+  Conduit_lwt_unix.init ~src:host () >>= fun ctx ->
+  let ctx = Cohttp_lwt_unix.Net.init ~ctx ()
+  and on_exn = raise
+  and mode = `TCP (`Port port) in
+  Cohttp_lwt_unix.Server.create ~ctx ~on_exn ~mode server >>= fun () ->
+  Lwt.fail_with "GraphQL server terminated unexpectedly"
+
+type server = {
+  event_loop : 'a. 'a Lwt.t;
+  set_tree : Store.Tree.concrete -> unit Lwt.t;
+}
+
+let spawn_graphql_server () =
+  let config =
+    let tmp = Filename.get_temp_dir_name ()
+    and test_repo_name =
+      Format.sprintf "test-irmin-graphql-%d" (Random.int 100_000)
+    in
+    Filename.concat tmp test_repo_name |> Irmin_git.config
+  in
+  Store.Repo.v config >>= fun repo ->
+  Store.master repo >|= fun master ->
+  let event_loop = server_of_repo repo
+  and set_tree tree =
+    Store.Tree.of_concrete tree
+    |> Store.set_tree_exn ~info:Irmin.Info.none master []
+  in
+  { event_loop; set_tree }
+
+(** Issue a query to the localhost server and return the body of the response
+    message *)
+let send_query : string -> (string, [ `Msg of string ]) result Lwt.t =
+ fun query ->
+  let headers = Cohttp.Header.init_with "Content-Type" "application/json"
+  and body =
+    Yojson.Safe.to_string (`Assoc [ ("query", `String query) ])
+    |> Cohttp_lwt.Body.of_string
+  in
+  Cohttp_lwt_unix.Client.post ~headers ~body
+    (Uri.make ~scheme:"http" ~host ~port ~path:"graphql" ())
+  >>= fun (response, body) ->
+  let status = Cohttp_lwt.Response.status response in
+  Cohttp_lwt.Body.to_string body >|= fun body ->
+  match Cohttp.Code.(status |> code_of_status |> is_success) with
+  | true -> Ok body
+  | false ->
+      let msg =
+        Format.sprintf "Response: %s\nBody:\n%s"
+          (Cohttp.Code.string_of_status status)
+          body
+      in
+      Error (`Msg msg)

--- a/test/irmin-graphql/common.mli
+++ b/test/irmin-graphql/common.mli
@@ -1,0 +1,19 @@
+(** Default Irmin GraphQL store *)
+module Store :
+  Irmin.S
+    with type contents = string
+     and type step = string
+     and type metadata = Irmin_git.Metadata.t
+
+type server = {
+  event_loop : 'a. 'a Lwt.t;
+      (** The server runtime. Cancelling this thread terminates the server. *)
+  set_tree : Store.Tree.concrete -> unit Lwt.t;
+      (** Set the state of the [master] branch in the underlying store. *)
+}
+
+val spawn_graphql_server : unit -> server Lwt.t
+(** Initialise a GraphQL server. At most one server may be running concurrently. *)
+
+val send_query : string -> (string, [ `Msg of string ]) result Lwt.t
+(** Send a GraphQL query string to the currently running test GraphQL instance. *)

--- a/test/irmin-graphql/dune
+++ b/test/irmin-graphql/dune
@@ -1,0 +1,11 @@
+(executable
+ (name test)
+ (modules test common)
+ (libraries alcotest alcotest-lwt yojson checkseum.c digestif.c irmin
+   irmin-graphql irmin-unix))
+
+(alias
+ (name runtest)
+ (package irmin-git)
+ (action
+  (run ./test.exe -q --color=always)))

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -1,0 +1,115 @@
+open Common
+open Lwt.Infix
+
+type concrete = Store.Tree.concrete
+
+let members keys json =
+  List.fold_left (fun key json -> Yojson.Safe.Util.member json key) json keys
+
+let assert_ok : type a. (a, [ `Msg of string ]) result -> a = function
+  | Ok x -> x
+  | Error (`Msg msg) -> Alcotest.fail msg
+
+module Alcotest = struct
+  include Alcotest
+
+  let yojson = testable Yojson.Safe.pp Yojson.Safe.equal
+end
+
+(** Helpers for constructing data *)
+
+(** Tree with a single child *)
+let stree only_key only_child = `Tree [ (only_key, only_child) ]
+
+(** Sequence of nested trees each with exactly one child *)
+let strees : string list -> concrete -> concrete = List.fold_right stree
+
+let contents ?(metadata = Irmin_git.Metadata.default) v = `Contents (v, metadata)
+
+type test_case = set_tree:(concrete -> unit Lwt.t) -> unit -> unit Lwt.t
+(** Test cases consume a setter for updating the server state *)
+
+let test_get_contents_list : test_case =
+ fun ~set_tree () ->
+  let data = strees [ "a"; "b"; "c" ] (contents "data")
+  and query =
+    {|{
+  master {
+    tree {
+      get_contents(key: "/a/b/c") {
+        key
+        __typename
+      }
+    }
+  }
+}|}
+  in
+  set_tree data >>= fun () ->
+  send_query query >|= assert_ok >|= Yojson.Safe.from_string >|= fun result ->
+  let result : (string * Yojson.Safe.t) list =
+    let open Yojson.Safe.Util in
+    result |> members [ "data"; "master"; "tree"; "get_contents" ] |> to_assoc
+  in
+  Alcotest.(check (list (pair string yojson)))
+    "Returned entry data is valid"
+    [ ("key", `String "/c/b/a"); ("__typename", `String "Contents") ]
+    result;
+  ()
+
+let test_get_tree_list : test_case =
+ fun ~set_tree () ->
+  let data =
+    strees [ "a"; "b"; "c" ]
+      (`Tree
+        [ ("leaf", contents "data1"); ("branch", stree "f" (contents "data2")) ])
+  and query =
+    {|{
+  master {
+    tree {
+      get_tree(key: "/a/b/c") {
+        list {
+          key
+          __typename
+        }
+      }
+    }
+  }
+}|}
+  in
+  set_tree data >>= fun () ->
+  send_query query >|= assert_ok >|= Yojson.Safe.from_string >|= fun result ->
+  let key_data : (string * Yojson.Safe.t) list list =
+    let open Yojson.Safe.Util in
+    result
+    |> members [ "data"; "master"; "tree"; "get_tree"; "list" ]
+    |> to_list
+    |> List.map to_assoc
+  in
+  Alcotest.(check (list (list (pair string yojson))))
+    "Returned entry data is valid"
+    [
+      [ ("key", `String "/c/b/a/branch"); ("__typename", `String "Tree") ];
+      [ ("key", `String "/c/b/a/leaf"); ("__typename", `String "Contents") ];
+    ]
+    key_data;
+  ()
+
+let suite ~set_tree =
+  let test_case : string -> test_case -> unit Alcotest_lwt.test_case =
+   fun name f -> Alcotest_lwt.test_case name `Quick (fun _ () -> f ~set_tree ())
+  in
+  [
+    ( "GRAPHQL",
+      [
+        test_case "get_contents-list" test_get_contents_list;
+        test_case "get_tree-list" test_get_tree_list;
+      ] );
+  ]
+
+let () =
+  Random.self_init ();
+  let main =
+    spawn_graphql_server () >>= fun { event_loop; set_tree } ->
+    Lwt.pick [ event_loop; Alcotest_lwt.run "irmin-graphql" (suite ~set_tree) ]
+  in
+  Lwt_main.run main

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -52,7 +52,7 @@ let test_get_contents_list : test_case =
   in
   Alcotest.(check (list (pair string yojson)))
     "Returned entry data is valid"
-    [ ("key", `String "/c/b/a"); ("__typename", `String "Contents") ]
+    [ ("key", `String "/a/b/c"); ("__typename", `String "Contents") ]
     result;
   ()
 
@@ -88,8 +88,8 @@ let test_get_tree_list : test_case =
   Alcotest.(check (list (list (pair string yojson))))
     "Returned entry data is valid"
     [
-      [ ("key", `String "/c/b/a/branch"); ("__typename", `String "Tree") ];
-      [ ("key", `String "/c/b/a/leaf"); ("__typename", `String "Contents") ];
+      [ ("key", `String "/a/b/c/branch"); ("__typename", `String "Tree") ];
+      [ ("key", `String "/a/b/c/leaf"); ("__typename", `String "Contents") ];
     ]
     key_data;
   ()

--- a/test/irmin-graphql/test.mli
+++ b/test/irmin-graphql/test.mli
@@ -1,0 +1,1 @@
+(* left empty on purpose *)


### PR DESCRIPTION
Resolves an issue [reported on `discuss.ocaml.org`](https://discuss.ocaml.org/t/irmin-graphql-keys-are-reversed/5509) in which key information returned by `get_tree.list` and `get_contents` is reversed. For example, the following query:

```graphql
{
  master {
    tree {
      get_tree(key: "/a/b/c") {
        list {
          key
        }
      }
    }
  }
}
```
would return keys of the form `/c/b/a/foo` rather than `/a/b/c/foo`.

This PR fixes the bug and adds an initial end-to-end test suite for `irmin-graphql` exposing the original bug. The test suite props up a GraphQL server, queries it, then checks the response using `yojson` (a new test dependency).