### PR TITLE
Make `S.Tree.t` abstract

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@
     - Fields of records which have value `None` are still omitted;
     - Fields of records which have value `Some x` are still unboxed into `x`.
 
+  - The type `Irmin.S.tree` is now abstract. The previous form can be coerced
+    to/from the abstract representation with the new functions
+    `Irmin.S.Tree.{v,destruct}` respectively. (#990, @CraigFe)
+    
 #### Fixed
 
 - **irmin-graphql**

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1845,8 +1845,7 @@ module Make (S : S) = struct
       S.master repo >>= fun t ->
       let update ?retries key strategy r w =
         S.with_tree t ?retries ~info:(infof "with-tree") ~strategy key (fun _ ->
-            Lwt_mvar.take r >|= fun v ->
-            Some (`Contents (v, S.Metadata.default)))
+            Lwt_mvar.take r >|= fun v -> Some (S.Tree.of_contents v))
         >>= Lwt_mvar.put w
       in
       let check_ok = function
@@ -1905,7 +1904,7 @@ module Make (S : S) = struct
               Alcotest.(check string) "test-and-set x" "1" a;
               Lwt_mvar.put ry "2" >>= fun () ->
               Lwt_mvar.take wy >>= fun e ->
-              check_test (Some (`Contents ("1", S.Metadata.default))) e;
+              check_test (Some (S.Tree.of_contents "1")) e;
               S.get t [ "a" ] >>= fun a ->
               Alcotest.(check string) "test-and-set y" "1" a;
               Lwt_mvar.put rz "3" >>= fun () ->
@@ -2002,7 +2001,7 @@ module Make (S : S) = struct
             ("foo", `Contents (foo_k, S.Metadata.default)); ("bar", `Node bar_k);
           ]
       in
-      let tree_3 = `Node (S.of_private_node repo node_3) in
+      let tree_3 = S.Tree.of_node (S.of_private_node repo node_3) in
       let info () = info "shallow" in
       S.master repo >>= fun t ->
       S.set_tree_exn t [ "1" ] tree_1 ~info >>= fun () ->

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -804,7 +804,7 @@ module type TREE = sig
 
   type node
 
-  type tree = [ `Node of node | `Contents of contents * metadata ]
+  type tree
 
   (** [Tree] provides immutable, in-memory partial mirror of the store, with
       lazy reads and delayed writes.
@@ -827,6 +827,12 @@ module type TREE = sig
 
   val of_node : node -> tree
   (** [of_node n] is the subtree built from the node [n]. *)
+
+  val v : [< `Node of node | `Contents of contents * metadata ] -> tree
+  (** General-purpose constructor for trees. *)
+
+  val destruct : tree -> [> `Node of node | `Contents of contents * metadata ]
+  (** General-purpose destructor for trees. *)
 
   val kind : tree -> key -> [ `Contents | `Node ] option Lwt.t
   (** [kind t k] is the type of [s] in [t]. It could either be a tree node or

--- a/src/irmin/stdlib_ext.ml
+++ b/src/irmin/stdlib_ext.ml
@@ -1,0 +1,21 @@
+(*
+ * Copyright (c) 2020 The Irmin authors
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module Option = struct
+  type 'a t = 'a option = None | Some of 'a
+
+  let map f o = match o with None -> None | Some v -> Some (f v)
+end

--- a/src/irmin/stdlib_ext.mli
+++ b/src/irmin/stdlib_ext.mli
@@ -1,0 +1,24 @@
+(*
+ * Copyright (c) 2020 The Irmin authors
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Hand implementations of future [Stdlib] additions. *)
+
+(** @since 4.08 *)
+module Option : sig
+  type 'a t = 'a option = None | Some of 'a
+
+  val map : ('a -> 'b) -> 'a option -> 'b option
+end

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -16,6 +16,7 @@
 
 open Lwt.Infix
 open Merge.Infix
+open Stdlib_ext
 
 let src = Logs.Src.create "irmin" ~doc:"Irmin branch-consistent store"
 

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -53,7 +53,7 @@ module type S = sig
   type node
   (** The type for store nodes. *)
 
-  type tree = [ `Node of node | `Contents of contents * metadata ]
+  type tree
   (** The type for store trees. *)
 
   type hash

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -206,9 +206,9 @@ module Make (P : S.PRIVATE) = struct
       in
       { v; info }
 
-    let export ?clear:c repo t k =
+    let export ?clear:(c = true) repo t k =
       let hash = t.info.hash in
-      if c = Some true then clear t;
+      if c then clear t;
       match (t.v, hash) with
       | Hash (_, k), _ -> t.v <- Hash (repo, k)
       | Value _, None -> t.v <- Hash (repo, k)
@@ -415,9 +415,9 @@ module Make (P : S.PRIVATE) = struct
       clear ~max_depth 0 n
 
     (* export t to the given repo and clear the cache *)
-    let export ?clear:c repo t k =
+    let export ?clear:(c = true) repo t k =
       let hash = t.info.hash in
-      if c = Some true then clear t;
+      if c then clear t;
       match t.v with
       | Hash (_, k) -> t.v <- Hash (repo, k)
       | Value (_, v, None) when P.Node.Val.is_empty v -> ()
@@ -903,6 +903,13 @@ module Make (P : S.PRIVATE) = struct
   let of_node n = `Node n
 
   let of_contents ?(metadata = Metadata.default) c = `Contents (c, metadata)
+
+  let v = function `Contents c -> `Contents c | `Node n -> `Node n
+
+  let destruct : tree -> [> `Node of node | `Contents of contents * metadata ] =
+    function
+    | `Node n -> `Node n
+    | `Contents c -> `Contents c
 
   let clear ?depth = function
     | `Node n -> Node.clear ?depth n


### PR DESCRIPTION
`S.Tree.t` was previously a concrete type with redundant constructurs `of_node` and `of_contents`. In some places, we were using these constructors; in others, we were constructing the value directly. 

This change encourages delegation by requiring all instances of `S.Tree.t` to go via the constructors and destructors in `S.Tree`.

I made this change last week while experimenting with 'foreign' hashes support (which likely want to add a case to this type), but I think it stands as an improvement by itself.