### PR TITLE
ppx_irmin: add support for the @nobuiltin attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@
 - **irmin**:
   - Added `Irmin.Type.empty` to represent an uninhabited type. (#961, @CraigFe)
 
+- **ppx_irmin**
+  - Added support for the `@nobuiltin` attribute, which can be used when
+    shadowing primitive types such as `unit`. See `README_PPX` for details.
+    (#993, @CraigFe)
+
 #### Changed
 
 - **irmin**:

--- a/README_PPX.md
+++ b/README_PPX.md
@@ -68,8 +68,8 @@ type foo = string list * int32 [@@deriving irmin { name = "foo_generic" }]
 val foo_generic = Irmin.Type.(pair (list string) int32)
 ```
 
-If the type references another user-defined type, `ppx_irmin` will expect the
-generic for that type to use the standard naming scheme. This can be overridden
+If the type contains an abstract type, `ppx_irmin` will expect to find a
+corresponding generic using its own naming rules. This can be overridden
 using the `[@generic ...]` attribute, as in:
 
 ```ocaml
@@ -77,6 +77,20 @@ type bar = (foo [@generic foo_generic], string) result [@@deriving irmin]
 
 (* generates the value *)
 val bar_t = Irmin.Type.(result foo_generic string)
+```
+
+Built-in abstract types such as `unit` are assumed to be represented in
+`Irmin.Type`. This behaviour can be overridden with the []`[@nobuiltin]`
+attribute:
+
+
+```ocaml
+type unit = string [@@deriving irmin]
+
+type t = unit [@nobuiltin] [@@deriving irmin]
+
+(* generates the value *)
+let t = string_t (* not [Irmin.Type.t] *)
 ```
 
 #### Signature type definitions

--- a/src/ppx_irmin/deriver/ppx_irmin.ml
+++ b/src/ppx_irmin/deriver/ppx_irmin.ml
@@ -34,10 +34,10 @@ let str_type_decl_generator =
   let attributes = Attributes.all in
   Deriving.Generator.make ~attributes args expand_str
 
-let sig_typ_decl_generator =
+let sig_type_decl_generator =
   let args = Deriving.Args.(empty +> arg "name" (estring __)) in
   Deriving.Generator.make args expand_sig
 
 let irmin =
   Deriving.add ~str_type_decl:str_type_decl_generator
-    ~sig_type_decl:sig_typ_decl_generator ppx_name
+    ~sig_type_decl:sig_type_decl_generator ppx_name

--- a/src/ppx_irmin/lib/attributes.ml
+++ b/src/ppx_irmin/lib/attributes.ml
@@ -25,4 +25,15 @@ let generic =
     Ast_pattern.(single_expr_payload __)
     (fun e -> e)
 
-let all = Attribute.[ T generic ]
+let nobuiltin =
+  Attribute.declare
+    (String.concat "." [ namespace; "nobuiltin" ])
+    Attribute.Context.Core_type
+    Ast_pattern.(pstr __')
+    (fun s ->
+      match s with
+      | { txt = _ :: _; loc } ->
+          Location.raise_errorf ~loc "`nobuiltin` payload must be empty"
+      | { txt = []; _ } -> ())
+
+let all = Attribute.[ T generic; T nobuiltin ]

--- a/src/ppx_irmin/lib/attributes.mli
+++ b/src/ppx_irmin/lib/attributes.mli
@@ -18,6 +18,8 @@ open Ppxlib
 
 val generic : (core_type, expression) Attribute.t
 
+val nobuiltin : (core_type, unit) Attribute.t
+
 val all : Attribute.packed list
 
 (* Boxed list of all of the attributes required by [ppx_irmin]. *)

--- a/src/ppx_irmin/lib/deriver.ml
+++ b/src/ppx_irmin/lib/deriver.ml
@@ -104,9 +104,15 @@ module Located (A : Ast_builder.S) : S = struct
                       generic_name
                       (* If not a base type, assume a composite generic with the
                          same naming convention *) )
-                    else if not @@ SSet.mem const_name irmin_types then
-                      generic_name_of_type_name const_name
-                    else const_name
+                    else
+                      let nobuiltin =
+                        match Attribute.get Attributes.nobuiltin typ with
+                        | Some () -> true
+                        | None -> false
+                      in
+                      if nobuiltin || not (SSet.mem const_name irmin_types) then
+                        generic_name_of_type_name const_name
+                      else const_name
                   in
                   Located.lident name
               | Ldot (lident, name) ->
@@ -232,8 +238,15 @@ module Located (A : Ast_builder.S) : S = struct
                       | None -> (
                           match txt with
                           | Lident cons_name ->
-                              if SSet.mem cons_name irmin_types then
-                                evar ("Irmin.Type." ^ cons_name)
+                              let nobuiltin =
+                                match Attribute.get Attributes.nobuiltin c with
+                                | Some () -> true
+                                | None -> false
+                              in
+                              if
+                                (not nobuiltin)
+                                && SSet.mem cons_name irmin_types
+                              then evar ("Irmin.Type." ^ cons_name)
                               else
                                 (* If not a basic type, assume a composite
                                    generic /w same naming convention *)

--- a/test/ppx_irmin/deriver/errors/dune.inc
+++ b/test/ppx_irmin/deriver/errors/dune.inc
@@ -7,6 +7,24 @@
 
 
 (rule
+ (targets nobuiltin_nonempty.actual)
+ (deps
+  (:pp pp.exe)
+  (:input nobuiltin_nonempty.ml))
+ (action
+  (with-stderr-to
+   %{targets}
+   (bash "! ./%{pp} -no-color --impl %{input}"))))
+
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (diff nobuiltin_nonempty.expected nobuiltin_nonempty.actual)))
+
+
+
+(rule
  (targets unsupported_tuple_size.actual)
  (deps
   (:pp pp.exe)

--- a/test/ppx_irmin/deriver/errors/nobuiltin_nonempty.expected
+++ b/test/ppx_irmin/deriver/errors/nobuiltin_nonempty.expected
@@ -1,0 +1,2 @@
+File "nobuiltin_nonempty.ml", line 1, characters 26-28:
+Error: `nobuiltin` payload must be empty

--- a/test/ppx_irmin/deriver/errors/nobuiltin_nonempty.ml
+++ b/test/ppx_irmin/deriver/errors/nobuiltin_nonempty.ml
@@ -1,0 +1,1 @@
+type x = (unit[@nobuiltin ()]) [@@deriving irmin]

--- a/test/ppx_irmin/deriver/passing/dune.inc
+++ b/test/ppx_irmin/deriver/passing/dune.inc
@@ -95,6 +95,24 @@
   (diff module.expected module.actual)))
 
 (library
+ (name nobuiltin)
+ (modules nobuiltin))
+
+(rule
+ (targets nobuiltin.actual)
+ (deps
+  (:pp pp.exe)
+  (:input nobuiltin.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (diff nobuiltin.expected nobuiltin.actual)))
+
+(library
  (name nonrec)
  (modules nonrec))
 

--- a/test/ppx_irmin/deriver/passing/nobuiltin.expected
+++ b/test/ppx_irmin/deriver/passing/nobuiltin.expected
@@ -1,0 +1,12 @@
+type unit = string[@@deriving irmin]
+include struct let unit_t = Irmin.Type.string end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]
+let result _some _opt = assert false
+type t = ((unit)[@nobuiltin ])[@@deriving irmin]
+include struct let t = unit_t end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type u = (((unit, unit) result)[@nobuiltin ])[@@deriving irmin]
+include struct let u_t = let open Irmin.Type in result_t unit unit end
+[@@ocaml.doc "@inline"][@@merlin.hide ]
+type foo = ((unit)[@irmin.nobuiltin ])[@@deriving irmin]
+include struct let foo_t = Irmin.Type.unit end[@@ocaml.doc "@inline"]
+[@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/nobuiltin.ml
+++ b/test/ppx_irmin/deriver/passing/nobuiltin.ml
@@ -1,0 +1,20 @@
+(* When a type is annotated with the [nobuiltin] annotation, it should be
+   considered as an abstract type (i.e. don't pull representations from
+   [Irmin.Type]). *)
+
+type unit = string [@@deriving irmin]
+
+let result _some _opt = assert false
+
+type t = (unit[@nobuiltin]) [@@deriving irmin]
+
+type u = ((unit, unit) result[@nobuiltin]) [@@deriving irmin]
+
+(* Should work as "irmin.nobuiltin" too *)
+type foo = (unit[@irmin.nobuiltin]) [@@deriving irmin]
+
+(* TODO: uncomment once https://github.com/mirage/irmin/pull/970 is merged *)
+
+(* let (_ : unit_t Irmin.Type.t) = t
+ * 
+ * let (_ : unit_t Irmin.Type.t) = foo_t *)


### PR DESCRIPTION
`@nobuiltin` is a [standard](https://github.com/ocaml-ppx/ppx_deriving#plugin-conventions) attribute for deriving plugins that causes them to view the annotated type as abstract / not use any built-in derived form for that type. This is ocassionally useful when shadowing types in the library: I implemented it more for the sake of convention than anything else.