### PR TITLE
ppx_irmin: support primitive representations outside 'Irmin.Type'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
     shadowing primitive types such as `unit`. See `README_PPX` for details.
     (#993, @CraigFe)
 
+  - Added support for a `lib` argument, which can be used to supply primitive
+    type representations from modules other than `Irmin.Type`. (#994, @CraigFe)
+
 #### Changed
 
 - **irmin**:

--- a/README_PPX.md
+++ b/README_PPX.md
@@ -55,6 +55,17 @@ types, records, variants (plain and closed polymorphic), recursive types etc.).
 Irmin does not currently support higher-kinded generics: all Irmin types must
 fully grounded (no polymorphic type variables).
 
+To supply base representations from a module other than `Irmin.Type` (such as
+when `Irmin.Type` is aliased to a different module path), the `lib` argument can
+be passed to `@@deriving irmin`:
+
+```ocaml
+type foo = unit [@@deriving irmin { lib = Some "Mylib.Types" }]
+
+(* generates the value *)
+val foo_t = Mylib.Types.unit
+```
+
 #### Naming scheme
 
 The generated generics will be called `<type-name>_t`, unless the type-name is

--- a/README_PPX.md
+++ b/README_PPX.md
@@ -91,17 +91,15 @@ val bar_t = Irmin.Type.(result foo_generic string)
 ```
 
 Built-in abstract types such as `unit` are assumed to be represented in
-`Irmin.Type`. This behaviour can be overridden with the []`[@nobuiltin]`
+`Irmin.Type`. This behaviour can be overridden with the `[@nobuiltin]`
 attribute:
 
 
 ```ocaml
-type unit = string [@@deriving irmin]
-
 type t = unit [@nobuiltin] [@@deriving irmin]
 
 (* generates the value *)
-let t = string_t (* not [Irmin.Type.t] *)
+let t = unit_t (* not [Irmin.Type.unit] *)
 ```
 
 #### Signature type definitions

--- a/src/ppx_irmin/deriver/ppx_irmin.ml
+++ b/src/ppx_irmin/deriver/ppx_irmin.ml
@@ -19,23 +19,23 @@ open Ppx_irmin_lib
 
 let ppx_name = "irmin"
 
-let expand_str ~loc ~path:_ input_ast name =
+let expand_str ~loc ~path:_ input_ast name lib =
   let (module S) = Ast_builder.make loc in
   let (module L) = (module Deriver.Located (S) : Deriver.S) in
-  L.derive_str ?name input_ast
+  L.derive_str ?name ?lib input_ast
 
-let expand_sig ~loc ~path:_ input_ast name =
+let expand_sig ~loc ~path:_ input_ast name lib =
   let (module S) = Ast_builder.make loc in
   let (module L) = (module Deriver.Located (S) : Deriver.S) in
-  L.derive_sig ?name input_ast
+  L.derive_sig ?name ?lib input_ast
 
 let str_type_decl_generator =
-  let args = Deriving.Args.(empty +> arg "name" (estring __)) in
+  let args = Deriving.Args.(empty +> arg "name" (estring __) +> arg "lib" __) in
   let attributes = Attributes.all in
   Deriving.Generator.make ~attributes args expand_str
 
 let sig_type_decl_generator =
-  let args = Deriving.Args.(empty +> arg "name" (estring __)) in
+  let args = Deriving.Args.(empty +> arg "name" (estring __) +> arg "lib" __) in
   Deriving.Generator.make args expand_sig
 
 let irmin =

--- a/src/ppx_irmin/lib/deriver.mli
+++ b/src/ppx_irmin/lib/deriver.mli
@@ -18,12 +18,26 @@ open Ppxlib
 
 module type S = sig
   val derive_str :
-    ?name:string -> rec_flag * type_declaration list -> structure_item list
-  (** Deriver for Irmin generics. *)
+    ?name:string ->
+    ?lib:expression ->
+    rec_flag * type_declaration list ->
+    structure_item list
+  (** Deriver for Irmin generics.
+
+      - [?name]: overrides the default name of the generated generic;
+
+      - [?lib]: overrides the default location for the primitive Irmin generics.
+        [~lib:None] will assume that the generics are available in the same
+        namespace. *)
 
   val derive_sig :
-    ?name:string -> rec_flag * type_declaration list -> signature_item list
-  (** Deriver for Irmin generic type signatures. *)
+    ?name:string ->
+    ?lib:expression ->
+    rec_flag * type_declaration list ->
+    signature_item list
+  (** Deriver for Irmin generic type signatures.
+
+      Optional arguments have the same meaning as in {!derive_str}. *)
 end
 
 module Located (A : Ast_builder.S) : S

--- a/test/ppx_irmin/deriver/errors/dune.inc
+++ b/test/ppx_irmin/deriver/errors/dune.inc
@@ -7,6 +7,24 @@
 
 
 (rule
+ (targets lib_invalid.actual)
+ (deps
+  (:pp pp.exe)
+  (:input lib_invalid.ml))
+ (action
+  (with-stderr-to
+   %{targets}
+   (bash "! ./%{pp} -no-color --impl %{input}"))))
+
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (diff lib_invalid.expected lib_invalid.actual)))
+
+
+
+(rule
  (targets nobuiltin_nonempty.actual)
  (deps
   (:pp pp.exe)

--- a/test/ppx_irmin/deriver/errors/lib_invalid.expected
+++ b/test/ppx_irmin/deriver/errors/lib_invalid.expected
@@ -1,0 +1,2 @@
+File "lib_invalid.ml", line 1, characters 40-45:
+Error: Could not process `lib' argument: must be either `Some "Lib"' or `None'

--- a/test/ppx_irmin/deriver/errors/lib_invalid.ml
+++ b/test/ppx_irmin/deriver/errors/lib_invalid.ml
@@ -1,0 +1,1 @@
+type t = unit [@@deriving irmin { lib = "foo" }] (* should be [Some "foo"] *)

--- a/test/ppx_irmin/deriver/passing/dune.inc
+++ b/test/ppx_irmin/deriver/passing/dune.inc
@@ -77,6 +77,24 @@
   (diff composite.expected composite.actual)))
 
 (library
+ (name lib_relocated)
+ (modules lib_relocated))
+
+(rule
+ (targets lib_relocated.actual)
+ (deps
+  (:pp pp.exe)
+  (:input lib_relocated.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+(alias
+ (name runtest)
+ (package ppx_irmin)
+ (action
+  (diff lib_relocated.expected lib_relocated.actual)))
+
+(library
  (name module)
  (modules module))
 

--- a/test/ppx_irmin/deriver/passing/lib_relocated.expected
+++ b/test/ppx_irmin/deriver/passing/lib_relocated.expected
@@ -1,0 +1,21 @@
+module Elsewhere :
+  sig
+    type t[@@deriving irmin { lib = (Some "Foo") }]
+    include sig val t : t Foo.t end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end =
+  struct
+    type t = (unit * unit)[@@deriving irmin { lib = (Some "Foo") }]
+    include struct let t = let open Foo in pair unit unit end[@@ocaml.doc
+                                                               "@inline"]
+    [@@merlin.hide ]
+  end 
+module Locally_avaliable :
+  sig
+    type t[@@deriving irmin { lib = None }]
+    include sig val t : t ty end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end =
+  struct
+    type t = (unit * unit)[@@deriving irmin { lib = None }]
+    include struct let t = pair unit unit end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                    ]
+  end 

--- a/test/ppx_irmin/deriver/passing/lib_relocated.ml
+++ b/test/ppx_irmin/deriver/passing/lib_relocated.ml
@@ -1,0 +1,19 @@
+module Elsewhere : sig
+  type t [@@deriving irmin { lib = Some "Foo" }]
+end = struct
+  (* module Foo = Irmin.Type
+   * 
+   * module Irmin = struct end *)
+
+  type t = unit * unit [@@deriving irmin { lib = Some "Foo" }]
+end
+
+module Locally_avaliable : sig
+  type t [@@deriving irmin { lib = None }]
+end = struct
+  (* open Irmin.Type
+   * 
+   * module Irmin = struct end *)
+
+  type t = unit * unit [@@deriving irmin { lib = None }]
+end


### PR DESCRIPTION
This adds support for a `lib` argument to `[@@deriving irmin]` that can be used to pull type representations from a location other than `Irmin.Type` (such as when `Irmin.Type` is aliased to another name).