### PR TITLE
irmin-graphql: use irmin-mem in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,10 @@
     to/from the abstract representation with the new functions
     `Irmin.S.Tree.{v,destruct}` respectively. (#990, @CraigFe)
     
+- **irmin-mem**
+  - Stores created with `KV` now expose their unit metadata type. (#995,
+    @CraigFe)
+
 #### Fixed
 
 - **irmin-graphql**

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -24,6 +24,8 @@ depends: [
   "graphql_parser" {>= "0.13.0"}
   "alcotest-lwt" {>= "1.1.0" & with-test}
   "yojson" {with-test}
+  "irmin-mem" {with-test}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -139,3 +139,6 @@ module Make =
 module KV (C : Irmin.Contents.S) =
   Make (Irmin.Metadata.None) (C) (Irmin.Path.String_list) (Irmin.Branch.String)
     (Irmin.Hash.BLAKE2B)
+
+(* Enforce that {!KV} is a sub-type of {!Irmin.KV_MAKER}. *)
+module KV_is_a_KV_MAKER : Irmin.KV_MAKER = KV

--- a/src/irmin-mem/irmin_mem.mli
+++ b/src/irmin-mem/irmin_mem.mli
@@ -30,7 +30,8 @@ module Atomic_write : Irmin.ATOMIC_WRITE_STORE_MAKER
 (** An in-memory store with atomic-write guarantees. *)
 
 module Make : Irmin.S_MAKER
-(** An in-memory Irmin store. *)
+(** Constructor for in-memory Irmin store. *)
 
-module KV : Irmin.KV_MAKER
-(** An in-memory KV store. *)
+(** Constructor for in-memory KV stores. Subtype of {!Irmin.KV_MAKER}. *)
+module KV (C : Irmin.Contents.S) :
+  Irmin.KV with type contents = C.t and type metadata = unit

--- a/test/irmin-graphql/common.mli
+++ b/test/irmin-graphql/common.mli
@@ -3,7 +3,7 @@ module Store :
   Irmin.S
     with type contents = string
      and type step = string
-     and type metadata = Irmin_git.Metadata.t
+     and type metadata = unit
 
 type server = {
   event_loop : 'a. 'a Lwt.t;

--- a/test/irmin-graphql/dune
+++ b/test/irmin-graphql/dune
@@ -6,6 +6,6 @@
 
 (alias
  (name runtest)
- (package irmin-git)
+ (package irmin-graphql)
  (action
   (run ./test.exe -q --color=always)))

--- a/test/irmin-graphql/dune
+++ b/test/irmin-graphql/dune
@@ -2,7 +2,7 @@
  (name test)
  (modules test common)
  (libraries alcotest alcotest-lwt yojson checkseum.c digestif.c irmin
-   irmin-graphql irmin-unix))
+   irmin-graphql irmin-mem cohttp-lwt-unix))
 
 (alias
  (name runtest)

--- a/test/irmin-graphql/dune
+++ b/test/irmin-graphql/dune
@@ -1,8 +1,8 @@
 (executable
  (name test)
  (modules test common)
- (libraries alcotest alcotest-lwt yojson checkseum.c digestif.c irmin
-   irmin-graphql irmin-mem cohttp-lwt-unix))
+ (libraries alcotest alcotest-lwt yojson irmin irmin-graphql irmin-mem
+   cohttp-lwt-unix))
 
 (alias
  (name runtest)

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -24,7 +24,7 @@ let stree only_key only_child = `Tree [ (only_key, only_child) ]
 (** Sequence of nested trees each with exactly one child *)
 let strees : string list -> concrete -> concrete = List.fold_right stree
 
-let contents ?(metadata = Irmin_git.Metadata.default) v = `Contents (v, metadata)
+let contents v = `Contents (v, ())
 
 type test_case = set_tree:(concrete -> unit Lwt.t) -> unit -> unit Lwt.t
 (** Test cases consume a setter for updating the server state *)


### PR DESCRIPTION
The test-suite introduced by https://github.com/mirage/irmin/pull/989 was accidentally attached to the `irmin-git` package, causing CI for `irmin-git` to fail in Travis (but not in OCaml-CI, since these cross-package bugs are not caught there).

Only _one_ of the two failures on that PR were "unrelated"...