### PR TITLE
Use correct fmt version in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 1.8)
 (name irmin)
-(using fmt 1.2)
+(using fmt 1.1)


### PR DESCRIPTION
As of Dune 2.5.0, warnings are emitted if the `(using lang <foo>)` stanza is using a version higher than is supported. This gives us the following warning in CI:

```
File "dune-project", line 3, characters 11-14:
3 | (using fmt 1.2)
               ^^^
Warning: Version 1.2 of integration with automatic formatters is not
supported until version 1.11 of the dune language.
Supported versions of this extension in version 1.8 of the dune language:
- 1.0 to 1.1
```