### PR TITLE
irmin.type: improve pp_ty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@
     - Fields of records which have value `None` are still omitted;
     - Fields of records which have value `Some x` are still unboxed into `x`.
 
+  - Changed pretty-printing of Irmin types to more closely resemble OCaml types.
+    e.g. `pair int string` prints as `int * string`. (#997, @CraigFe)
+
   - The type `Irmin.S.tree` is now abstract. The previous form can be coerced
     to/from the abstract representation with the new functions
     `Irmin.S.Tree.{v,destruct}` respectively. (#990, @CraigFe)

--- a/src/irmin/type/type.ml
+++ b/src/irmin/type/type.ml
@@ -94,7 +94,7 @@ let v ~cli ~json ~bin ~equal ~compare ~short_hash ~pre_hash =
 
 let mu : type a. (a t -> a t) -> a t =
  fun f ->
-  let rec fake_x : a self = { self = f; self_fix = Self fake_x } in
+  let rec fake_x : a self = { self_unroll = f; self_fix = Self fake_x } in
   let real_x = f (Self fake_x) in
   fake_x.self_fix <- real_x;
   Self fake_x
@@ -102,18 +102,18 @@ let mu : type a. (a t -> a t) -> a t =
 let mu2 : type a b. (a t -> b t -> a t * b t) -> a t * b t =
  fun f ->
   let rec fake_x =
-    let self a =
+    let self_unroll a =
       let b = mu (fun b -> f a b |> snd) in
       f a b |> fst
     in
-    { self; self_fix = Self fake_x }
+    { self_unroll; self_fix = Self fake_x }
   in
   let rec fake_y =
-    let self b =
+    let self_unroll b =
       let a = mu (fun a -> f a b |> fst) in
       f a b |> snd
     in
-    { self; self_fix = Self fake_y }
+    { self_unroll; self_fix = Self fake_y }
   in
   let real_x, real_y = f (Self fake_x) (Self fake_y) in
   fake_x.self_fix <- real_x;

--- a/src/irmin/type/type_binary.ml
+++ b/src/irmin/type/type_binary.ml
@@ -144,7 +144,7 @@ module Encode = struct
   let rec t : type a. a t -> a encode_bin =
    fun ty ?headers e k ->
     match ty with
-    | Self s -> t ?headers s.self e k
+    | Self s -> t ?headers s.self_fix e k
     | Custom c -> c.encode_bin ?headers e k
     | Map b -> map ?headers b e k
     | Prim t -> prim ?headers t e k
@@ -283,7 +283,7 @@ module Decode = struct
   let rec t : type a. a t -> a decode_bin =
    fun ty ?headers buf ofs ->
     match ty with
-    | Self s -> t ?headers s.self buf ofs
+    | Self s -> t ?headers s.self_fix buf ofs
     | Custom c -> c.decode_bin ?headers buf ofs
     | Map b -> map ?headers b buf ofs
     | Prim t -> prim ?headers t buf ofs
@@ -355,7 +355,7 @@ let to_bin_string t x =
   let rec aux : type a. a t -> a -> string =
    fun t x ->
     match t with
-    | Self s -> aux s.self x
+    | Self s -> aux s.self_fix x
     | Map m -> aux m.x (m.g x)
     | Prim (String _) -> x
     | Prim (Bytes _) -> Bytes.to_string x
@@ -375,7 +375,7 @@ let of_bin_string t x =
   let rec aux : type a. a t -> string -> (a, [ `Msg of string ]) result =
    fun t x ->
     match t with
-    | Self s -> aux s.self x
+    | Self s -> aux s.self_fix x
     | Map l -> aux l.x x |> map_result l.f
     | Prim (String _) -> Ok x
     | Prim (Bytes _) -> Ok (Bytes.of_string x)

--- a/src/irmin/type/type_binary.ml
+++ b/src/irmin/type/type_binary.ml
@@ -154,6 +154,7 @@ module Encode = struct
     | Option x -> option (t x) e k
     | Record r -> record ?headers r e k
     | Variant v -> variant ?headers v e k
+    | Var v -> raise (Unbound_type_variable v)
 
   and tuple : type a. a tuple -> a encode_bin =
    fun ty ?headers:_ ->
@@ -293,6 +294,7 @@ module Decode = struct
     | Option x -> option ?headers (t x) buf ofs
     | Record r -> record ?headers r buf ofs
     | Variant v -> variant ?headers v buf ofs
+    | Var v -> raise (Unbound_type_variable v)
 
   and tuple : type a. a tuple -> a decode_bin =
    fun ty ?headers:_ ->

--- a/src/irmin/type/type_core.ml
+++ b/src/irmin/type/type_core.ml
@@ -69,7 +69,10 @@ type 'a equal = 'a -> 'a -> bool
 
 type 'a short_hash = ?seed:int -> 'a -> int
 
+exception Unbound_type_variable of string
+
 type 'a t =
+  | Var : string -> 'a t
   | Self : 'a self -> 'a t
   | Custom : 'a custom -> 'a t
   | Map : ('a, 'b) map -> 'b t

--- a/src/irmin/type/type_core.ml
+++ b/src/irmin/type/type_core.ml
@@ -103,7 +103,7 @@ and 'a custom = {
 
 and ('a, 'b) map = { x : 'a t; f : 'a -> 'b; g : 'b -> 'a; mwit : 'b Witness.t }
 
-and 'a self = { self : 'a t -> 'a t; mutable self_fix : 'a t }
+and 'a self = { self_unroll : 'a t -> 'a t; mutable self_fix : 'a t }
 
 and 'a prim =
   | Unit : unit prim

--- a/src/irmin/type/type_core.ml
+++ b/src/irmin/type/type_core.ml
@@ -100,7 +100,7 @@ and 'a custom = {
 
 and ('a, 'b) map = { x : 'a t; f : 'a -> 'b; g : 'b -> 'a; mwit : 'b Witness.t }
 
-and 'a self = { mutable self : 'a t }
+and 'a self = { self : 'a t -> 'a t; mutable self_fix : 'a t }
 
 and 'a prim =
   | Unit : unit prim

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -84,7 +84,7 @@ module Encode = struct
   let rec t : type a. a t -> a encode_json =
    fun ty e ->
     match ty with
-    | Self s -> t s.self e
+    | Self s -> t s.self_fix e
     | Custom c -> c.encode_json e
     | Map b -> map b e
     | Prim t -> prim t e
@@ -277,7 +277,7 @@ module Decode = struct
   let rec t : type a. a t -> a decode_json =
    fun ty d ->
     match ty with
-    | Self s -> t s.self d
+    | Self s -> t s.self_fix d
     | Custom c -> c.decode_json d
     | Map b -> map b d
     | Prim t -> prim t d

--- a/src/irmin/type/type_json.ml
+++ b/src/irmin/type/type_json.ml
@@ -94,6 +94,7 @@ module Encode = struct
     | Option x -> boxed_option (t x) e
     | Record r -> record r e
     | Variant v -> variant v e
+    | Var v -> raise (Unbound_type_variable v)
 
   and tuple : type a. a tuple -> a encode_json = function
     | Pair (x, y) -> pair (t x) (t y)
@@ -287,6 +288,7 @@ module Decode = struct
     | Option x -> boxed_option (t x) d
     | Record r -> record r d
     | Variant v -> variant v d
+    | Var v -> raise (Unbound_type_variable v)
 
   (* Some types need to be decoded differently when wrapped inside records,
      since e.g. `k: None` is omitted and `k: Some v` is unboxed into `k: v`. *)

--- a/src/irmin/type/type_ordered.ml
+++ b/src/irmin/type/type_ordered.ml
@@ -36,8 +36,8 @@ module Refl = struct
   let rec t : type a b. a ty -> b ty -> (a, b) eq option =
    fun a b ->
     match (a, b) with
-    | Self a, _ -> t a.self b
-    | _, Self b -> t a b.self
+    | Self a, _ -> t a.self_fix b
+    | _, Self b -> t a b.self_fix
     | Map a, Map b -> Witness.eq a.mwit b.mwit
     | Custom a, Custom b -> custom a b
     | Prim a, Prim b -> prim a b
@@ -123,7 +123,7 @@ module Equal = struct
   let rec t : type a. a t -> a equal =
    fun ty a b ->
     match ty with
-    | Self s -> t s.self a b
+    | Self s -> t s.self_fix a b
     | Custom c -> c.equal a b
     | Map m -> map m a b
     | Prim p -> prim p a b
@@ -258,7 +258,7 @@ module Compare = struct
   let rec t : type a. a t -> a compare =
    fun ty a b ->
     match ty with
-    | Self s -> t s.self a b
+    | Self s -> t s.self_fix a b
     | Custom c -> c.compare a b
     | Map m -> map m a b
     | Prim p -> (prim [@inlined]) p a b

--- a/src/irmin/type/type_ordered.ml
+++ b/src/irmin/type/type_ordered.ml
@@ -133,6 +133,7 @@ module Equal = struct
     | Option x -> option (t x) a b
     | Record r -> record r a b
     | Variant v -> variant v a b
+    | Var v -> raise (Unbound_type_variable v)
 
   and tuple : type a. a tuple -> a equal = function
     | Pair (a, b) -> pair (t a) (t b)
@@ -268,6 +269,7 @@ module Compare = struct
     | Option x -> option (t x) a b
     | Record r -> record r a b
     | Variant v -> variant v a b
+    | Var v -> raise (Unbound_type_variable v)
 
   and tuple : type a. a tuple -> a compare = function
     | Pair (x, y) -> pair (t x) (t y)

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -120,7 +120,7 @@ let ty : type a. a t Fmt.t =
     let last_i = Array.length cases - 1 in
     Format.pp_open_hvbox ppf 0;
     Format.pp_print_string ppf "[";
-    cases |> Array.iteri (fun i -> pp_case ~last:(Int.equal i last_i) ppf);
+    cases |> Array.iteri (fun i -> pp_case ~last:(i = last_i) ppf);
     Format.pp_close_box ppf ()
   and custom : type a. a custom Fmt.t =
    fun ppf c ->

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -61,8 +61,10 @@ let rec ty : type a. a t Fmt.t =
   | Option t -> Fmt.pf ppf "@[%a option@]" ty t
   | Record { rname; rfields = Fields (fields, _); _ } ->
       Fmt.pf ppf "(@[<hv>%a>@] as %s)" pp_fields fields rname
-  | Variant { vname; vcases; _ } ->
-      Fmt.pf ppf "(@[%a]@] as %s)" pp_cases vcases vname
+  | Variant { vname; vcases; _ } -> (
+      match Array.length vcases with
+      | 0 -> Fmt.pf ppf "({} as %s)" vname (* empty type *)
+      | _ -> Fmt.pf ppf "(@[%a]@] as %s)" pp_cases vcases vname )
   | Var v -> Fmt.string ppf v
 
 and pp_fields : type r b. (r, b) fields Fmt.t =

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -65,15 +65,15 @@ let ty : type a. a t Fmt.t =
 
   let rec ty : type a. a t Fmt.t =
    fun ppf -> function
-    | Self s -> (
-        match s.self (Var "") with
+    | Self { self_unroll; _ } -> (
+        match self_unroll (Var "") with
         (* If it's a recursive variant or record, don't print the [as 'a]
            constraint since the type is already named. *)
-        | Variant { vname; _ } -> ty ppf (s.self (Var vname))
-        | Record { rname; _ } -> ty ppf (s.self (Var rname))
+        | Variant { vname; _ } -> ty ppf (self_unroll (Var vname))
+        | Record { rname; _ } -> ty ppf (self_unroll (Var rname))
         | _ ->
             let var = Var (get_tvar ()) in
-            Fmt.pf ppf "@[(%a as %a)@]" ty (s.self var) ty var )
+            Fmt.pf ppf "@[(%a as %a)@]" ty (self_unroll var) ty var )
     | Custom c -> Fmt.pf ppf "@[Custom (%a)@]" custom c
     | Map m -> Fmt.pf ppf "@[Map (%a)@]" ty m.x
     | Prim p -> Fmt.pf ppf "@[%a@]" prim p

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -46,13 +46,12 @@ let rec ty : type a. a t Fmt.t =
   | Self s -> Fmt.pf ppf "@[Self (%a@)]" ty s.self
   | Custom c -> Fmt.pf ppf "@[Custom (%a)@]" custom c
   | Map m -> Fmt.pf ppf "@[Map (%a)@]" ty m.x
-  | Prim p -> Fmt.pf ppf "@[Prim %a@]" prim p
-  | List l -> Fmt.pf ppf "@[List%a (%a)@]" len l.len ty l.v
-  | Array a -> Fmt.pf ppf "@[Array%a (%a)@]" len a.len ty a.v
-  | Tuple (Pair (a, b)) -> Fmt.pf ppf "@[Pair (%a, %a)@]" ty a ty b
-  | Tuple (Triple (a, b, c)) ->
-      Fmt.pf ppf "@[Triple (%a, %a, %a)@]" ty a ty b ty c
-  | Option t -> Fmt.pf ppf "@[Option (%a)@]" ty t
+  | Prim p -> Fmt.pf ppf "@[%a@]" prim p
+  | List l -> Fmt.pf ppf "@[%a list%a@]" ty l.v len l.len
+  | Array a -> Fmt.pf ppf "@[%a array%a@]" ty a.v len a.len
+  | Tuple (Pair (a, b)) -> Fmt.pf ppf "@[(%a * %a)@]" ty a ty b
+  | Tuple (Triple (a, b, c)) -> Fmt.pf ppf "@[(%a * %a * %a)@]" ty a ty b ty c
+  | Option t -> Fmt.pf ppf "@[%a option@]" ty t
   | Record _ -> Fmt.pf ppf "@[Record@]"
   | Variant _ -> Fmt.pf ppf "@[Variant@]"
 
@@ -62,15 +61,15 @@ and custom : type a. a custom Fmt.t =
 
 and prim : type a. a prim Fmt.t =
  fun ppf -> function
-  | Unit -> Fmt.string ppf "Unit"
-  | Bool -> Fmt.string ppf "Bool"
-  | Char -> Fmt.string ppf "Char"
-  | Int -> Fmt.string ppf "Int"
-  | Int32 -> Fmt.string ppf "Int32"
-  | Int64 -> Fmt.string ppf "Int64"
-  | Float -> Fmt.string ppf "Float"
-  | String n -> Fmt.pf ppf "String%a" len n
-  | Bytes n -> Fmt.pf ppf "Bytes%a" len n
+  | Unit -> Fmt.string ppf "unit"
+  | Bool -> Fmt.string ppf "bool"
+  | Char -> Fmt.string ppf "char"
+  | Int -> Fmt.string ppf "int"
+  | Int32 -> Fmt.string ppf "int32"
+  | Int64 -> Fmt.string ppf "int64"
+  | Float -> Fmt.string ppf "float"
+  | String n -> Fmt.pf ppf "string%a" len n
+  | Bytes n -> Fmt.pf ppf "bytes%a" len n
 
 and len : len Fmt.t =
  fun ppf -> function

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -68,7 +68,7 @@ let ty : type a. a t Fmt.t =
     | Self { self_unroll; _ } -> (
         match self_unroll (Var "") with
         (* If it's a recursive variant or record, don't print the [as 'a]
-           constraint since the type is already named. *)
+           alias since the type is already named. *)
         | Variant { vname; _ } -> ty ppf (self_unroll (Var vname))
         | Record { rname; _ } -> ty ppf (self_unroll (Var rname))
         | _ ->

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -20,7 +20,7 @@ let t t =
   let rec aux : type a. a t -> a pp =
    fun t ppf x ->
     match t with
-    | Self s -> aux s.self ppf x
+    | Self s -> aux s.self_fix ppf x
     | Custom c -> c.pp ppf x
     | Map m -> map m ppf x
     | Prim p -> prim p ppf x
@@ -43,7 +43,7 @@ let t t =
 
 let rec ty : type a. a t Fmt.t =
  fun ppf -> function
-  | Self s -> Fmt.pf ppf "@[Self (%a@)]" ty s.self
+  | Self s -> Fmt.pf ppf "%a as 'a" ty s.self_fix
   | Custom c -> Fmt.pf ppf "@[Custom (%a)@]" custom c
   | Map m -> Fmt.pf ppf "@[Map (%a)@]" ty m.x
   | Prim p -> Fmt.pf ppf "@[%a@]" prim p
@@ -88,7 +88,7 @@ let of_string t =
   let rec aux : type a a. a t -> a of_string =
    fun t x ->
     match t with
-    | Self s -> aux s.self x
+    | Self s -> aux s.self_fix x
     | Custom c -> c.of_string x
     | Map m -> aux m.x x |> map_result m.f
     | Prim p -> prim p x

--- a/src/irmin/type/type_size.ml
+++ b/src/irmin/type/type_size.ml
@@ -96,6 +96,7 @@ let rec t : type a. a t -> a size_of =
   | Option x -> option (t x) e
   | Record r -> record ?headers r e
   | Variant v -> variant ?headers v e
+  | Var v -> raise (Unbound_type_variable v)
 
 and tuple : type a. a tuple -> a size_of =
  fun ty ?headers:_ ->

--- a/src/irmin/type/type_size.ml
+++ b/src/irmin/type/type_size.ml
@@ -86,7 +86,7 @@ let option o = function
 let rec t : type a. a t -> a size_of =
  fun ty ?headers e ->
   match ty with
-  | Self s -> t ?headers s.self e
+  | Self s -> t ?headers s.self_fix e
   | Custom c -> c.size_of ?headers e
   | Map b -> map ?headers b e
   | Prim t -> prim ?headers t e

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -327,6 +327,8 @@ let test_pp_ty () =
     "unit array:<3>";
 
   (* Test cases for algebraic combinators *)
+  test ~case_name:"empty" T.empty "({} as empty)";
+
   test ~case_name:"enum" Algebraic.my_enum_t
     "([ Alpha | Beta | Gamma | Delta ] as my_enum)";
 


### PR DESCRIPTION
Resolves https://github.com/mirage/irmin/issues/958.

This changes the pretty-printer for Irmin types to more closely match OCaml types (e.g. `(unit * int) option` rather than `Option (Pair (Prim Unit, Prim Int))`). It adds functionality for pretty-printing the components of algebraic types: record types are pretty-printed like OCaml object types and variants are pretty-printed similarly to OCaml polymorphic variants.

The tricky case here is recursive types, which were previously broken (would cause stack overflow when pretty-printed). Handling this properly requires preserving the `unroll` function passed to the `mu` combinator for later use. The type can then be pretty-printed by unrolling once with a type alias:

```ocaml
type my_recursive_record = { head : int; tail : my_recursive_record option } [@@deriving irmin]

(* gets pretty-printed as: *)
(< head : int; tail : my_recursive_record option > as my_recursive_record)
```

For recursive or mutually recursive types that are _not_ algebraic, there is no sensible name for the type alias, so we pick them in some deterministic order.

This change also fixes an existing 'bug' in which the `mu` and `mu2` fixpoints were unfolded once more than necessary (by returning the unfolded form). This was observable when pretty-printing the type.