### PR TITLE
irmin-pack: drop tailcall annotation causing build failure on flambda

### DIFF
--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -199,7 +199,7 @@ module Unix : S = struct
         protect (Unix.mkdir dir) 0o755;
         k () )
     in
-    (aux [@tailcall]) dirname (fun () -> ())
+    aux dirname (fun () -> ())
 
   let clear t =
     t.offset <- 0L;


### PR DESCRIPTION
Fixes https://github.com/mirage/irmin/issues/998.

This function is inlined by flambda, causing the outer call to no longer be in tail position and the `[@tailcall]` annotation to be rejected.