### PR TITLE
irmin: expose unit implementation of Sync.None.endpoint

### DIFF
--- a/src/irmin-http/irmin_http.mli
+++ b/src/irmin-http/irmin_http.mli
@@ -35,6 +35,7 @@ module Client (C : HTTP_CLIENT) (S : Irmin.S) :
      and type step = S.step
      and type metadata = S.metadata
      and type Key.step = S.Key.step
+     and type Private.Sync.endpoint = unit
 
 (** HTTP server *)
 

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -55,6 +55,7 @@ module Make_ext
        and type step = Path.step
        and type metadata = Metadata.t
        and type Key.step = Path.step
+       and type Private.Sync.endpoint = unit
 
   val integrity_check :
     ?ppf:Format.formatter ->
@@ -84,6 +85,7 @@ module Make
        and type contents = C.t
        and type branch = B.t
        and type hash = H.t
+       and type Private.Sync.endpoint = unit
 
   val integrity_check :
     ?ppf:Format.formatter ->

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -342,11 +342,7 @@ module Private = struct
     module type S = S.SLICE
   end
 
-  module Sync = struct
-    include Sync
-
-    module type S = S.SYNC
-  end
+  module Sync = Sync
 
   module type S = S.PRIVATE
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -405,17 +405,7 @@ module Private : sig
          and type commit = H.key * H.value
   end
 
-  module Sync : sig
-    module type S = S.SYNC
-
-    (** [None] is an implementation of {{!Private.Sync.S} S} which does nothing. *)
-    module None (H : Type.S) (B : Type.S) : sig
-      include S with type commit = H.t and type branch = B.t
-
-      val v : 'a -> t Lwt.t
-      (** Create a remote store handle. *)
-    end
-  end
+  module Sync = Sync
 
   (** The complete collection of private implementations. *)
   module type S = sig

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -885,6 +885,7 @@ module Make_ext
      and type step = Path.step
      and type metadata = Metadata.t
      and type Key.step = Path.step
+     and type Private.Sync.endpoint = unit
 
 (** Advanced store creator. *)
 module Of_private (P : Private.S) :

--- a/src/irmin/sync.ml
+++ b/src/irmin/sync.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module type S = S.SYNC
+
 module None (H : Type.S) (R : Type.S) = struct
   type t = unit
 

--- a/src/irmin/sync.mli
+++ b/src/irmin/sync.mli
@@ -16,8 +16,14 @@
 
 (** Store Synchronisation signatures. *)
 
+module type S = S.SYNC
+
+(** Provides stub implementations of the {!S} that always returns [Error] when
+    push/pull operations are attempted. *)
 module None (H : Type.S) (R : Type.S) : sig
-  include S.SYNC with type commit = H.t and type branch = R.t
+  include
+    S with type commit = H.t and type branch = R.t and type endpoint = unit
 
   val v : 'a -> t Lwt.t
+  (** Create a remote store handle. *)
 end


### PR DESCRIPTION
This allows 'endpoints' for backends that do not support `SYNC` (such as `Irmin_pack`) to be serialised.