### PR TITLE
Expose more unit endpoint types

### DIFF
--- a/src/irmin-mem/irmin_mem.mli
+++ b/src/irmin-mem/irmin_mem.mli
@@ -34,4 +34,7 @@ module Make : Irmin.S_MAKER
 
 (** Constructor for in-memory KV stores. Subtype of {!Irmin.KV_MAKER}. *)
 module KV (C : Irmin.Contents.S) :
-  Irmin.KV with type contents = C.t and type metadata = unit
+  Irmin.KV
+    with type contents = C.t
+     and type metadata = unit
+     and type Private.Sync.endpoint = unit

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -537,6 +537,7 @@ module type S_MAKER = functor
      and type contents = C.t
      and type branch = B.t
      and type hash = H.t
+     and type Private.Sync.endpoint = unit
 
 (** [KV] is similar to {!S} but chooses sensible implementations for path and
     branch. *)

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -844,6 +844,7 @@ module type MAKER = functor
      and type contents = C.t
      and type branch = B.t
      and type hash = H.t
+     and type Private.Sync.endpoint = unit
 
 module type Store = sig
   module type S = S


### PR DESCRIPTION
... in stores constructed via `S_MAKER`s such as `irmin-mem`.