### PR TITLE
RO syncs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### Unreleased
+
+#### Changed
+- **irmin-pack**:
+  - `sync` has to be called by the read-only instance to synchronise with the
+    files on disk. (#1008, @icristescu)
+  - Renamed `sync` to `flush` for the operation that flushes to disk all buffers
+    of a read-write instance. (#1008, @icristescu)
+
 ### 2.2.0 (2020-06-26)
 
 #### Added

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -22,4 +22,8 @@ depends: [
   "alcotest-lwt" {with-test}
 ]
 
+pin-depends: [
+  "index.dev" "git+https://github.com/mirage/index#9717194feb57c27cac9ad993aaf24a64dc5b64a3"
+]
+
 synopsis: "Irmin backend which stores values in a pack file"

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -39,7 +39,7 @@ module type S = sig
 
   val version : t -> string
 
-  val sync : t -> unit
+  val flush : t -> unit
 
   val close : t -> unit
 end

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -69,11 +69,17 @@ module Pack (S : Pack.S) = struct
     check_not_closed t;
     S.sync t.t
 
+  let ro_sync t =
+    check_not_closed t;
+    S.ro_sync t.t
+
   type integrity_error = S.integrity_error
 
   let integrity_check ~offset ~length k t =
     check_not_closed t;
     S.integrity_check ~offset ~length k t.t
+
+  exception Invalid_read = S.Invalid_read
 end
 
 module Atomic_write (AW : S.ATOMIC_WRITE_STORE) = struct

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -65,13 +65,13 @@ module Pack (S : Pack.S) = struct
     check_not_closed t;
     S.unsafe_find t.t k
 
+  let flush t =
+    check_not_closed t;
+    S.flush t.t
+
   let sync t =
     check_not_closed t;
     S.sync t.t
-
-  let ro_sync t =
-    check_not_closed t;
-    S.ro_sync t.t
 
   type integrity_error = S.integrity_error
 

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -65,9 +65,9 @@ module Pack (S : Pack.S) = struct
     check_not_closed t;
     S.unsafe_find t.t k
 
-  let flush t =
+  let flush ?index t =
     check_not_closed t;
-    S.flush t.t
+    S.flush ?index t.t
 
   let sync t =
     check_not_closed t;
@@ -78,8 +78,6 @@ module Pack (S : Pack.S) = struct
   let integrity_check ~offset ~length k t =
     check_not_closed t;
     S.integrity_check ~offset ~length k t.t
-
-  exception Invalid_read = S.Invalid_read
 end
 
 module Atomic_write (AW : S.ATOMIC_WRITE_STORE) = struct

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -82,7 +82,7 @@ module Make (IO : IO.S) : S = struct
 
   let sync t =
     if IO.readonly t.io then sync_offset t
-    else invalid_arg "only an RO instance should call this function"
+    else invalid_arg "only a readonly instance should call this function"
 
   let flush t = IO.flush t.io
 

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -32,6 +32,8 @@ module type S = sig
 
   val sync : t -> unit
 
+  val ro_sync : t -> unit
+
   val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 
   val clear : t -> unit
@@ -78,11 +80,14 @@ module Make (IO : IO.S) : S = struct
     let log_offset = IO.force_offset t.io in
     if log_offset > former_log_offset then refill ~from:former_log_offset t
 
+  let ro_sync t =
+    if IO.readonly t.io then sync_offset t
+    else invalid_arg "only an RO instance should call this function"
+
   let sync t = IO.sync t.io
 
   let index t v =
     Log.debug (fun l -> l "[dict] index %S" v);
-    if IO.readonly t.io then sync_offset t;
     try Some (Hashtbl.find t.cache v)
     with Not_found ->
       let id = Hashtbl.length t.cache in
@@ -95,7 +100,6 @@ module Make (IO : IO.S) : S = struct
         Some id )
 
   let find t id =
-    if IO.readonly t.io then sync_offset t;
     Log.debug (fun l -> l "[dict] find %d" id);
     let v = try Some (Hashtbl.find t.index id) with Not_found -> None in
     v

--- a/src/irmin-pack/dict.mli
+++ b/src/irmin-pack/dict.mli
@@ -23,6 +23,8 @@ module type S = sig
 
   val sync : t -> unit
 
+  val ro_sync : t -> unit
+
   val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 
   val clear : t -> unit

--- a/src/irmin-pack/dict.mli
+++ b/src/irmin-pack/dict.mli
@@ -21,9 +21,9 @@ module type S = sig
 
   val index : t -> string -> int option
 
-  val sync : t -> unit
+  val flush : t -> unit
 
-  val ro_sync : t -> unit
+  val sync : t -> unit
 
   val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -47,7 +47,7 @@ module type S = sig
 
   val close : 'a t -> unit Lwt.t
 
-  val ro_sync : 'a t -> unit
+  val sync : 'a t -> unit
 end
 
 module type CONFIG = sig
@@ -803,5 +803,5 @@ struct
 
   let close = Inode.close
 
-  let ro_sync = Inode.ro_sync
+  let sync = Inode.sync
 end

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -46,6 +46,8 @@ module type S = sig
     offset:int64 -> length:int -> key -> 'a t -> (unit, integrity_error) result
 
   val close : 'a t -> unit Lwt.t
+
+  val ro_sync : 'a t -> unit
 end
 
 module type CONFIG = sig
@@ -800,4 +802,6 @@ struct
   let integrity_check = Inode.integrity_check
 
   let close = Inode.close
+
+  let ro_sync = Inode.ro_sync
 end

--- a/src/irmin-pack/inode.mli
+++ b/src/irmin-pack/inode.mli
@@ -46,7 +46,7 @@ module type S = sig
 
   val close : 'a t -> unit Lwt.t
 
-  val ro_sync : 'a t -> unit
+  val sync : 'a t -> unit
 end
 
 module Make

--- a/src/irmin-pack/inode.mli
+++ b/src/irmin-pack/inode.mli
@@ -45,6 +45,8 @@ module type S = sig
     offset:int64 -> length:int -> key -> 'a t -> (unit, integrity_error) result
 
   val close : 'a t -> unit Lwt.t
+
+  val ro_sync : 'a t -> unit
 end
 
 module Make

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -287,7 +287,7 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     if t.open_instances = 0 then (
       Tbl.reset t.index;
       Tbl.reset t.cache;
-      if not (IO.readonly t.block) then IO.sync t.block;
+      if not (IO.readonly t.block) then IO.flush t.block;
       IO.close t.block;
       W.clear t.w )
     else Lwt.return_unit
@@ -308,7 +308,7 @@ module type Stores_extra = sig
       [> `Cannot_fix of string | `Corrupted of int ] )
     result
 
-  val ro_sync : repo -> unit
+  val sync : repo -> unit
 end
 
 module Make_ext
@@ -464,7 +464,7 @@ struct
         Commit.CA.close (snd (commit_t t)) >>= fun () -> Branch.close t.branch
 
       (** stores share instances in memory, one sync is enough *)
-      let ro_sync t = Contents.CA.ro_sync (contents_t t)
+      let sync t = Contents.CA.sync (contents_t t)
     end
   end
 
@@ -535,7 +535,7 @@ struct
 
   include Irmin.Of_private (X)
 
-  let ro_sync = X.Repo.ro_sync
+  let sync = X.Repo.sync
 end
 
 module Hash = Irmin.Hash.BLAKE2B

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -49,8 +49,9 @@ module type Stores_extra = sig
       reporting. [`Fixed] and [`Corrupted] report the number of fixed/corrupted
       entries. *)
 
-  val ro_sync : repo -> unit
-  (** [ro_sync t] syncs an RO instance with the files on disk. *)
+  val sync : repo -> unit
+  (** [sync t] syncs a readonly pack with the files on disk. Raises
+      [invalid_argument] if called by a read-write pack.*)
 end
 
 module Make_ext

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -34,6 +34,25 @@ module type CONFIG = sig
   val stable_hash : int
 end
 
+module type Stores_extra = sig
+  type repo
+
+  val integrity_check :
+    ?ppf:Format.formatter ->
+    auto_repair:bool ->
+    repo ->
+    ( [> `Fixed of int | `No_error ],
+      [> `Cannot_fix of string | `Corrupted of int ] )
+    result
+  (** Checks the integrity of the repository. if [auto_repair] is [true], will
+      also try to fix the issues. [ppf] is a formatter for progressive
+      reporting. [`Fixed] and [`Corrupted] report the number of fixed/corrupted
+      entries. *)
+
+  val ro_sync : repo -> unit
+  (** [ro_sync t] syncs an RO instance with the files on disk. *)
+end
+
 module Make_ext
     (Config : CONFIG)
     (Metadata : Irmin.Metadata.S)
@@ -57,17 +76,7 @@ module Make_ext
        and type Key.step = Path.step
        and type Private.Sync.endpoint = unit
 
-  val integrity_check :
-    ?ppf:Format.formatter ->
-    auto_repair:bool ->
-    repo ->
-    ( [> `Fixed of int | `No_error ],
-      [> `Cannot_fix of string | `Corrupted of int ] )
-    result
-  (** Checks the integrity of the repository. if [auto_repair] is [true], will
-      also try to fix the issues. [ppf] is a formatter for progressive
-      reporting. [`Fixed] and [`Corrupted] report the number of fixed/corrupted
-      entries. *)
+  include Stores_extra with type repo := repo
 end
 
 module Make
@@ -87,17 +96,7 @@ module Make
        and type hash = H.t
        and type Private.Sync.endpoint = unit
 
-  val integrity_check :
-    ?ppf:Format.formatter ->
-    auto_repair:bool ->
-    repo ->
-    ( [> `Fixed of int | `No_error ],
-      [> `Cannot_fix of string | `Corrupted of int ] )
-    result
-  (** Checks the integrity of the repository. if [auto_repair] is [true], will
-      also try to fix the issues. [ppf] is a formatter for progressive
-      reporting. [`Fixed] and [`Corrupted] report the number of fixed/corrupted
-      entries. *)
+  include Stores_extra with type repo := repo
 end
 
 module KV (Config : CONFIG) : Irmin.KV_MAKER

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -66,12 +66,16 @@ module type S = sig
 
   val sync : 'a t -> unit
 
+  val ro_sync : 'a t -> unit
+
   type integrity_error = [ `Wrong_hash | `Absent_value ]
 
   val integrity_check :
     offset:int64 -> length:int -> key -> 'a t -> (unit, integrity_error) result
 
   val close : 'a t -> unit Lwt.t
+
+  exception Invalid_read
 end
 
 module type MAKER = sig
@@ -352,5 +356,9 @@ struct
       Lwt_mutex.with_lock t.pack.lock (fun () ->
           unsafe_close t;
           Lwt.return_unit)
+
+    let ro_sync t =
+      Dict.ro_sync t.pack.dict;
+      Index.ro_sync t.pack.index
   end
 end

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -58,12 +58,16 @@ module type S = sig
 
   val sync : 'a t -> unit
 
+  val ro_sync : 'a t -> unit
+
   type integrity_error = [ `Wrong_hash | `Absent_value ]
 
   val integrity_check :
     offset:int64 -> length:int -> key -> 'a t -> (unit, integrity_error) result
 
   val close : 'a t -> unit Lwt.t
+
+  exception Invalid_read
 end
 
 module type MAKER = sig

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -56,9 +56,9 @@ module type S = sig
 
   val unsafe_find : 'a t -> key -> value option
 
-  val sync : 'a t -> unit
+  val flush : 'a t -> unit
 
-  val ro_sync : 'a t -> unit
+  val sync : 'a t -> unit
 
   type integrity_error = [ `Wrong_hash | `Absent_value ]
 

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -56,7 +56,7 @@ module type S = sig
 
   val unsafe_find : 'a t -> key -> value option
 
-  val flush : 'a t -> unit
+  val flush : ?index:bool -> 'a t -> unit
 
   val sync : 'a t -> unit
 
@@ -66,8 +66,6 @@ module type S = sig
     offset:int64 -> length:int -> key -> 'a t -> (unit, integrity_error) result
 
   val close : 'a t -> unit Lwt.t
-
-  exception Invalid_read
 end
 
 module type MAKER = sig

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -68,8 +68,12 @@ struct
 
   let get_pack () =
     let name = fresh_name "dict" in
-    let index = Index.v ~log_size ~fresh:true name in
+    let f = ref (fun () -> ()) in
+    let index =
+      Index.v ~auto_flush_callback:(fun () -> !f ()) ~log_size ~fresh:true name
+    in
     Pack.v ~fresh:true ~lru_size:0 ~index name >|= fun pack ->
+    (f := fun () -> Pack.flush ~index:false pack);
     let clone_pack ~readonly = Pack.v ~fresh:false ~readonly ~index name in
     let clone_index_pack ~readonly =
       let index = Index.v ~log_size ~fresh:false ~readonly name in

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -45,8 +45,57 @@ let open_ro_after_rw_closed () =
       Alcotest.(check (option string)) "RO find" (Some "x") x;
       S.Repo.close ro
 
+let ro_sync_after_add () =
+  let check ro c k v =
+    S.Commit.of_hash ro (S.Commit.hash c) >>= function
+    | None -> Alcotest.failf "commit not found"
+    | Some commit ->
+        let tree = S.Commit.tree commit in
+        S.Tree.find tree [ k ] >|= fun x ->
+        Alcotest.(check (option string)) "RO find" (Some v) x
+  in
+  rm_dir root;
+  S.Repo.v (config ~readonly:false ~fresh:true root) >>= fun rw ->
+  S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
+  S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
+  S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c1 ->
+  S.ro_sync ro;
+  check ro c1 "a" "x" >>= fun () ->
+  S.Tree.add S.Tree.empty [ "a" ] "y" >>= fun tree ->
+  S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c2 ->
+  check ro c1 "a" "x" >>= fun () ->
+  (S.Commit.of_hash ro (S.Commit.hash c2) >|= function
+   | None -> ()
+   | Some _ -> Alcotest.failf "should not find branch by")
+  >>= fun () ->
+  S.ro_sync ro;
+  check ro c2 "a" "y" >>= fun () ->
+  S.Repo.close ro >>= fun () -> S.Repo.close rw
+
+let ro_sync_after_close () =
+  let check ro c k v =
+    S.Commit.of_hash ro (S.Commit.hash c) >>= function
+    | None -> Alcotest.failf "commit not found"
+    | Some commit ->
+        let tree = S.Commit.tree commit in
+        S.Tree.find tree [ k ] >|= fun x ->
+        Alcotest.(check (option string)) "RO find" (Some v) x
+  in
+  rm_dir root;
+  S.Repo.v (config ~readonly:false ~fresh:true root) >>= fun rw ->
+  S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
+  S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
+  S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c1 ->
+  S.Repo.close rw >>= fun () ->
+  S.ro_sync ro;
+  check ro c1 "a" "x" >>= fun () -> S.Repo.close ro
+
 let tests =
   [
     Alcotest.test_case "Test open ro after rw closed" `Quick (fun () ->
         Lwt_main.run (open_ro_after_rw_closed ()));
+    Alcotest.test_case "Test ro sync after add" `Quick (fun () ->
+        Lwt_main.run (ro_sync_after_add ()));
+    Alcotest.test_case "Test ro sync after close" `Quick (fun () ->
+        Lwt_main.run (ro_sync_after_close ()));
   ]

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -59,7 +59,7 @@ let ro_sync_after_add () =
   S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
   S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
   S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c1 ->
-  S.ro_sync ro;
+  S.sync ro;
   check ro c1 "a" "x" >>= fun () ->
   S.Tree.add S.Tree.empty [ "a" ] "y" >>= fun tree ->
   S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c2 ->
@@ -68,7 +68,7 @@ let ro_sync_after_add () =
    | None -> ()
    | Some _ -> Alcotest.failf "should not find branch by")
   >>= fun () ->
-  S.ro_sync ro;
+  S.sync ro;
   check ro c2 "a" "y" >>= fun () ->
   S.Repo.close ro >>= fun () -> S.Repo.close rw
 
@@ -87,7 +87,7 @@ let ro_sync_after_close () =
   S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
   S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c1 ->
   S.Repo.close rw >>= fun () ->
-  S.ro_sync ro;
+  S.sync ro;
   check ro c1 "a" "x" >>= fun () -> S.Repo.close ro
 
 let tests =

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -111,6 +111,7 @@ module Dict = struct
     ignore_int (Dict.index dict "titiabc");
     ignore_int (Dict.index dict "foo");
     Dict.sync dict;
+    Dict.ro_sync r;
     check_index "titiabc" 3;
     check_index "bar" 1;
     check_index "toto" 2;
@@ -120,6 +121,7 @@ module Dict = struct
     check_raise "hello";
     check_none "hello" 4;
     Dict.sync dict;
+    Dict.ro_sync r;
     check_find "hello" 4;
     Dict.close dict;
     Dict.close r
@@ -176,6 +178,7 @@ module Pack = struct
       Pack.find r h2 >>= fun y2 ->
       Alcotest.(check (option string)) "before sync" None y2;
       Pack.sync w;
+      Pack.ro_sync r;
       Pack.find r h2 >>= fun y2 ->
       Alcotest.(check (option string)) "after sync" (Some x2) y2;
       let x3 = "otoo" in
@@ -184,6 +187,7 @@ module Pack = struct
       let h4 = sha1 x4 in
       adds [ (h3, x3); (h4, x4) ];
       Pack.sync w;
+      Pack.ro_sync r;
       Pack.find r h2 >>= fun y2 ->
       Alcotest.(check (option string)) "y2" (Some x2) y2;
       Pack.find r h3 >>= fun y3 ->
@@ -280,6 +284,73 @@ module Pack = struct
         Alcotest.fail "Add after closing the index should not be allowed")
       (function I.Closed -> Lwt.return_unit | exn -> Lwt.fail exn)
 
+  (** Index can be flushed to disk independently of pack, we simulate this in
+      the tests using [Index.filter] and [Index.flush]. *)
+  let readonly_sync_index_flush () =
+    Context.get_pack () >>= fun t ->
+    t.clone_index_pack ~readonly:true >>= fun (i, r) ->
+    let test w =
+      let x1 = "foo" in
+      let h1 = sha1 x1 in
+      Pack.unsafe_append w h1 x1;
+      Pack.ro_sync r;
+      Pack.find r h1 >>= fun y1 ->
+      Alcotest.(check (option string)) "sync before filter" None y1;
+      Index.filter t.index (fun _ -> true);
+      Pack.ro_sync r;
+      Lwt.catch
+        (fun () ->
+          Pack.find r h1 >|= fun _ ->
+          Alcotest.fail "index is flushed but not pack, should raise exception")
+        (function Pack.Invalid_read -> Lwt.return_unit | exn -> Lwt.fail exn)
+      >>= fun () ->
+      let x2 = "toto" in
+      let h2 = sha1 x2 in
+      Pack.unsafe_append w h2 x2;
+      Index.flush t.index;
+      Pack.ro_sync r;
+      Lwt.catch
+        (fun () ->
+          Pack.find r h2 >|= fun _ ->
+          Alcotest.fail "index is flushed but not pack, should raise exception")
+        (function Pack.Invalid_read -> Lwt.return_unit | exn -> Lwt.fail exn)
+    in
+    test t.pack >>= fun () ->
+    Context.close t.index t.pack >>= fun () -> Context.close i r
+
+  let readonly_find_index_flush () =
+    Context.get_pack () >>= fun t ->
+    t.clone_index_pack ~readonly:true >>= fun (i, r) ->
+    let check h x msg =
+      Pack.find r h >|= fun y -> Alcotest.(check (option string)) msg (Some x) y
+    in
+    let test w =
+      let x1 = "foo" in
+      let h1 = sha1 x1 in
+      Pack.unsafe_append w h1 x1;
+      Pack.sync t.pack;
+      Pack.ro_sync r;
+      check h1 x1 "find before filter" >>= fun () ->
+      Index.filter t.index (fun _ -> true);
+      check h1 x1 "find after filter" >>= fun () ->
+      let x2 = "bar" in
+      let h2 = sha1 x2 in
+      Pack.unsafe_append w h2 x2;
+      Pack.sync t.pack;
+      Pack.ro_sync r;
+      check h2 x2 "find before flush" >>= fun () ->
+      let x3 = "toto" in
+      let h3 = sha1 x3 in
+      Pack.unsafe_append w h3 x3;
+      Index.flush t.index;
+      check h2 x2 "find after flush" >>= fun () ->
+      Pack.sync t.pack;
+      Pack.ro_sync r;
+      check h3 x3 "find after flush new values"
+    in
+    test t.pack >>= fun () ->
+    Context.close t.index t.pack >>= fun () -> Context.close i r
+
   let tests =
     [
       Alcotest.test_case "pack" `Quick (fun () -> Lwt_main.run (test_pack ()));
@@ -291,6 +362,10 @@ module Pack = struct
           Lwt_main.run (test_close_pack ()));
       Alcotest.test_case "close readonly" `Quick (fun () ->
           Lwt_main.run (test_close_pack_more ()));
+      Alcotest.test_case "readonly sync, index flush" `Quick (fun () ->
+          Lwt_main.run (readonly_sync_index_flush ()));
+      Alcotest.test_case "readonly find, index flush" `Quick (fun () ->
+          Lwt_main.run (readonly_find_index_flush ()));
     ]
 end
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -110,8 +110,8 @@ module Dict = struct
     ignore_int (Dict.index dict "toto");
     ignore_int (Dict.index dict "titiabc");
     ignore_int (Dict.index dict "foo");
-    Dict.sync dict;
-    Dict.ro_sync r;
+    Dict.flush dict;
+    Dict.sync r;
     check_index "titiabc" 3;
     check_index "bar" 1;
     check_index "toto" 2;
@@ -120,8 +120,8 @@ module Dict = struct
     ignore_int (Dict.index dict "hello");
     check_raise "hello";
     check_none "hello" 4;
-    Dict.sync dict;
-    Dict.ro_sync r;
+    Dict.flush dict;
+    Dict.sync r;
     check_find "hello" 4;
     Dict.close dict;
     Dict.close r
@@ -177,8 +177,8 @@ module Pack = struct
       adds [ (h1, x1); (h2, x2) ];
       Pack.find r h2 >>= fun y2 ->
       Alcotest.(check (option string)) "before sync" None y2;
-      Pack.sync w;
-      Pack.ro_sync r;
+      Pack.flush w;
+      Pack.sync r;
       Pack.find r h2 >>= fun y2 ->
       Alcotest.(check (option string)) "after sync" (Some x2) y2;
       let x3 = "otoo" in
@@ -186,8 +186,8 @@ module Pack = struct
       let h3 = sha1 x3 in
       let h4 = sha1 x4 in
       adds [ (h3, x3); (h4, x4) ];
-      Pack.sync w;
-      Pack.ro_sync r;
+      Pack.flush w;
+      Pack.sync r;
       Pack.find r h2 >>= fun y2 ->
       Alcotest.(check (option string)) "y2" (Some x2) y2;
       Pack.find r h3 >>= fun y3 ->
@@ -216,7 +216,7 @@ module Pack = struct
     let x1 = "foo" in
     let h1 = sha1 x1 in
     Pack.unsafe_append w h1 x1;
-    Pack.sync w;
+    Pack.flush w;
     Index.close t.index;
     Pack.close w >>= fun () ->
     (*open and close in ro*)
@@ -293,11 +293,11 @@ module Pack = struct
       let x1 = "foo" in
       let h1 = sha1 x1 in
       Pack.unsafe_append w h1 x1;
-      Pack.ro_sync r;
+      Pack.sync r;
       Pack.find r h1 >>= fun y1 ->
       Alcotest.(check (option string)) "sync before filter" None y1;
       Index.filter t.index (fun _ -> true);
-      Pack.ro_sync r;
+      Pack.sync r;
       Lwt.catch
         (fun () ->
           Pack.find r h1 >|= fun _ ->
@@ -308,7 +308,7 @@ module Pack = struct
       let h2 = sha1 x2 in
       Pack.unsafe_append w h2 x2;
       Index.flush t.index;
-      Pack.ro_sync r;
+      Pack.sync r;
       Lwt.catch
         (fun () ->
           Pack.find r h2 >|= fun _ ->
@@ -328,24 +328,24 @@ module Pack = struct
       let x1 = "foo" in
       let h1 = sha1 x1 in
       Pack.unsafe_append w h1 x1;
-      Pack.sync t.pack;
-      Pack.ro_sync r;
+      Pack.flush t.pack;
+      Pack.sync r;
       check h1 x1 "find before filter" >>= fun () ->
       Index.filter t.index (fun _ -> true);
       check h1 x1 "find after filter" >>= fun () ->
       let x2 = "bar" in
       let h2 = sha1 x2 in
       Pack.unsafe_append w h2 x2;
-      Pack.sync t.pack;
-      Pack.ro_sync r;
+      Pack.flush t.pack;
+      Pack.sync r;
       check h2 x2 "find before flush" >>= fun () ->
       let x3 = "toto" in
       let h3 = sha1 x3 in
       Pack.unsafe_append w h3 x3;
       Index.flush t.index;
       check h2 x2 "find after flush" >>= fun () ->
-      Pack.sync t.pack;
-      Pack.ro_sync r;
+      Pack.flush t.pack;
+      Pack.sync r;
       check h3 x3 "find after flush new values"
     in
     test t.pack >>= fun () ->


### PR DESCRIPTION
A straightforward implementation for RO sync. I'll add more tests (concurrent ones too) so for now its a draft. 

The way I think `ro_sync` should be used is to catch exceptions for RO operations, and retry `ro_sync` in case of failure.  

Depends on https://github.com/mirage/index/pull/175