### PR TITLE
Allow ppx_irmin to use ppxlib >= 0.12.0

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -9,11 +9,11 @@ dev-repo: "git+https://github.com/mirage/irmin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.8.0"}
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
   "ppxlib" {>= "0.12.0"}

--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -16,7 +16,7 @@ depends: [
   "dune"
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
-  "ppxlib" {= "0.12.0"}
+  "ppxlib" {>= "0.12.0"}
   "irmin" {with-test & >= "2.0.0"}
 ]
 


### PR DESCRIPTION
Currently ppx_irmin is flagged as requiring exactly ppxlib 0.12.0. I'm not totally sure why this constraint is so strict, but I just tested it with ppxlib 0.13.0 and it compiles fine.

Incidently, this PR allows ppx_irmin to be installable with OCaml 4.11 as ppxlib is only compatible with OCaml 4.11 as of 0.13.0.

If this PR is accepted I'll go ahead and return the fix in opam-repository in `ppx_irmin.2.2.0`.