### PR TITLE
Upgrade to ocamlformat 0.15.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.14.2
+version = 0.15.0
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters = no

--- a/examples/custom_graphql.ml
+++ b/examples/custom_graphql.ml
@@ -13,8 +13,8 @@ module Car = struct
 
   let color =
     let open Irmin.Type in
-    variant "color" (fun black white other ->
-      function Black -> black | White -> white | Other color -> other color)
+    variant "color" (fun black white other -> function
+      | Black -> black | White -> white | Other color -> other color)
     |~ case0 "Black" Black
     |~ case0 "White" White
     |~ case1 "Other" string (fun s -> Other s)

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -76,8 +76,8 @@ module Chunk (K : Irmin.Hash.S) = struct
 
   let v =
     let open Irmin.Type in
-    variant "chunk" (fun d i ->
-      function Data data -> d data | Index index -> i index)
+    variant "chunk" (fun d i -> function
+      | Data data -> d data | Index index -> i index)
     |~ case1 "Data" string (fun d -> Data d)
     |~ case1 "Index" (list ~len:`Int16 K.t) (fun i -> Index i)
     |> sealv

--- a/src/irmin-containers/linked_log.ml
+++ b/src/irmin-containers/linked_log.ml
@@ -40,8 +40,8 @@ module Store_item (T : Time.S) (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
 
   let t =
     let open Irmin.Type in
-    variant "t" (fun value merge ->
-      function Value v -> value v | Merge l -> merge l)
+    variant "t" (fun value merge -> function
+      | Value v -> value v | Merge l -> merge l)
     |~ case1 "Value" L.t (fun v -> Value v)
     |~ case1 "Merge" (list L.t) (fun l -> Merge l)
     |> sealv

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -231,8 +231,8 @@ struct
 
       let value_t =
         let open Irmin.Type in
-        variant "Tree.value" (fun node contents ->
-          function `Node n -> node n | `Contents c -> contents c)
+        variant "Tree.value" (fun node contents -> function
+          | `Node n -> node n | `Contents c -> contents c)
         |~ case1 "node" hash_t (fun n -> `Node n)
         |~ case1 "contents" (pair hash_t metadata_t) (fun c -> `Contents c)
         |> sealv
@@ -714,7 +714,7 @@ functor
               is not critical for Irmin consistency (it's only a
               convenience for the user). *)
            b
-         then
+          then
            match set with
            | None -> Lwt.return_unit
            | Some v -> write_index t gr v
@@ -830,8 +830,7 @@ module Reference : BRANCH with type t = reference = struct
 
   let t =
     let open Irmin.Type in
-    variant "reference" (fun branch remote tag other ->
-      function
+    variant "reference" (fun branch remote tag other -> function
       | `Branch x -> branch x
       | `Remote x -> remote x
       | `Tag x -> tag x

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -136,8 +136,8 @@ struct
 
       let v_t : v Irmin.Type.t =
         let open Irmin.Type in
-        variant "Bin.v" (fun values inodes ->
-          function Values l -> values l | Inodes i -> inodes i)
+        variant "Bin.v" (fun values inodes -> function
+          | Values l -> values l | Inodes i -> inodes i)
         |~ case1 "Values" (list (pair step_t value_t)) (fun t -> Values t)
         |~ case1 "Inodes" inodes (fun t -> Inodes t)
         |> sealv
@@ -182,8 +182,8 @@ struct
 
       let address : address Irmin.Type.t =
         let open Irmin.Type in
-        variant "Compress.address" (fun i d ->
-          function Indirect x -> i x | Direct x -> d x)
+        variant "Compress.address" (fun i d -> function
+          | Indirect x -> i x | Direct x -> d x)
         |~ case1 "Indirect" int64 (fun x -> Indirect x)
         |~ case1 "Direct" H.t (fun x -> Direct x)
         |> sealv
@@ -217,20 +217,20 @@ struct
       let value : value Irmin.Type.t =
         let open Irmin.Type in
         variant "Compress.value"
-          (fun contents_ii
-               contents_x_ii
-               node_ii
-               contents_id
-               contents_x_id
-               node_id
-               contents_di
-               contents_x_di
-               node_di
-               contents_dd
-               contents_x_dd
-               node_dd
-               ->
-          function
+          (fun
+            contents_ii
+            contents_x_ii
+            node_ii
+            contents_id
+            contents_x_id
+            node_id
+            contents_di
+            contents_x_di
+            node_di
+            contents_dd
+            contents_x_dd
+            node_dd
+          -> function
           | Contents (Indirect n, Indirect h, m) ->
               if is_default m then contents_ii (n, h)
               else contents_x_ii (n, h, m)
@@ -277,8 +277,8 @@ struct
 
       let v_t : v Irmin.Type.t =
         let open Irmin.Type in
-        variant "Compress.v" (fun values inodes ->
-          function Values x -> values x | Inodes x -> inodes x)
+        variant "Compress.v" (fun values inodes -> function
+          | Values x -> values x | Inodes x -> inodes x)
         |~ case1 "Values" (list value) (fun x -> Values x)
         |~ case1 "Inodes" inodes (fun x -> Inodes x)
         |> sealv
@@ -335,8 +335,8 @@ struct
 
       let entry_t inode : entry Irmin.Type.t =
         let open Irmin.Type in
-        variant "Node.entry" (fun empty inode ->
-          function Empty -> empty | Inode i -> inode i)
+        variant "Node.entry" (fun empty inode -> function
+          | Empty -> empty | Inode i -> inode i)
         |~ case0 "Empty" Empty
         |~ case1 "Inode" inode (fun i -> Inode i)
         |> sealv
@@ -448,8 +448,8 @@ struct
         let open Irmin.Type in
         let pre_hash = stage (fun x -> pre_hash_bin (to_bin_v x)) in
         let entry = entry_t (inode_t t) in
-        variant "Inode.t" (fun values inodes ->
-          function Values v -> values v | Inodes i -> inodes i)
+        variant "Inode.t" (fun values inodes -> function
+          | Values v -> values v | Inodes i -> inodes i)
         |~ case1 "Values" (StepMap.t value_t) (fun t -> Values t)
         |~ case1 "Inodes" (inodes entry) (fun t -> Inodes t)
         |> sealv

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -91,8 +91,7 @@ module Json_value = struct
   let t =
     let open Type in
     mu (fun ty ->
-        variant "json" (fun null bool string float obj arr ->
-          function
+        variant "json" (fun null bool string float obj arr -> function
           | `Null -> null
           | `Bool b -> bool b
           | `String s -> string s

--- a/src/irmin/diff.ml
+++ b/src/irmin/diff.ml
@@ -18,8 +18,7 @@ type 'a t = [ `Updated of 'a * 'a | `Removed of 'a | `Added of 'a ]
 
 let t a =
   let open Type in
-  variant "diff" (fun updated removed added ->
-    function
+  variant "diff" (fun updated removed added -> function
     | `Updated x -> updated x | `Removed x -> removed x | `Added x -> added x)
   |~ case1 "updated" (pair a a) (fun x -> `Updated x)
   |~ case1 "removed" a (fun x -> `Removed x)

--- a/src/irmin/merge.ml
+++ b/src/irmin/merge.ml
@@ -434,8 +434,8 @@ let conflict_t =
 
 let result_t ok =
   let open Type in
-  variant "result" (fun ok error ->
-    function Ok x -> ok x | Error x -> error x)
+  variant "result" (fun ok error -> function
+    | Ok x -> ok x | Error x -> error x)
   |~ case1 "ok" ok (fun x -> Ok x)
   |~ case1 "error" conflict_t (fun x -> Error x)
   |> sealv

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -51,8 +51,7 @@ struct
 
   let kind_t =
     let open Type in
-    variant "Tree.kind" (fun node contents contents_m ->
-      function
+    variant "Tree.kind" (fun node contents contents_m -> function
       | `Node -> node
       | `Contents m ->
           if Type.equal M.t m M.default then contents else contents_m m)
@@ -126,8 +125,7 @@ struct
 
   let value_t =
     let open Type in
-    variant "value" (fun n c x ->
-      function
+    variant "value" (fun n c x -> function
       | `Node h -> n h
       | `Contents (h, m) -> if Type.equal M.t m M.default then c h else x (h, m))
     |~ case1 "node" K.t (fun k -> `Node k)

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -99,8 +99,7 @@ struct
 
     let t =
       let open Type in
-      variant "vertex" (fun contents node commit branch ->
-        function
+      variant "vertex" (fun contents node commit branch -> function
         | `Contents x -> contents x
         | `Node x -> node x
         | `Commit x -> commit x

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -224,9 +224,9 @@ module type CONTENTS_STORE = sig
   val merge : [ `Read | `Write ] t -> key option Merge.t
   (** [merge t] lifts the merge functions defined on contents values to contents
       key. The merge function will: {e (i)} read the values associated with the
-      given keys, {e (ii)} use the merge function defined on values and {e
-      (iii)} write the resulting values into the store to get the resulting key.
-      See {!Contents.S.merge}.
+      given keys, {e (ii)} use the merge function defined on values and
+      {e (iii)} write the resulting values into the store to get the resulting
+      key. See {!Contents.S.merge}.
 
       If any of these operations fail, return [`Conflict]. *)
 

--- a/src/irmin/slice.ml
+++ b/src/irmin/slice.ml
@@ -74,8 +74,7 @@ struct
 
   let value_t =
     let open Type in
-    variant "slice" (fun contents node commit ->
-      function
+    variant "slice" (fun contents node commit -> function
       | `Contents x -> contents x | `Node x -> node x | `Commit x -> commit x)
     |~ case1 "contents" contents_t (fun x -> `Contents x)
     |~ case1 "node" node_t (fun x -> `Node x)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -1062,8 +1062,7 @@ module Make (P : S.PRIVATE) = struct
 
     let t r =
       let open Type in
-      variant "status" (fun empty branch commit ->
-        function
+      variant "status" (fun empty branch commit -> function
         | `Empty -> empty | `Branch b -> branch b | `Commit c -> commit c)
       |~ case0 "empty" `Empty
       |~ case1 "branch" Branch.t (fun b -> `Branch b)
@@ -1114,8 +1113,7 @@ module Make (P : S.PRIVATE) = struct
 
   let write_error_t =
     let open Type in
-    variant "write-error" (fun c m e ->
-      function
+    variant "write-error" (fun c m e -> function
       | `Conflict x -> c x | `Too_many_retries x -> m x | `Test_was x -> e x)
     |~ case1 "conflict" string (fun x -> `Conflict x)
     |~ case1 "too-many-retries" int (fun x -> `Too_many_retries x)

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -89,8 +89,8 @@ module Make (S : Store.S) = struct
 
   let status_t t =
     let open Type in
-    variant "status" (fun empty head ->
-      function `Empty -> empty | `Head c -> head c)
+    variant "status" (fun empty head -> function
+      | `Empty -> empty | `Head c -> head c)
     |~ case0 "empty" `Empty
     |~ case1 "head" S.(commit_t @@ repo t) (fun c -> `Head c)
     |> sealv

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -68,17 +68,18 @@ module Make (P : S.PRIVATE) = struct
   let counters_t =
     let open Type in
     record "counters"
-      (fun contents_hash
-           contents_find
-           contents_add
-           node_hash
-           node_mem
-           node_add
-           node_find
-           node_val_v
-           node_val_find
-           node_val_list
-           ->
+      (fun
+        contents_hash
+        contents_find
+        contents_add
+        node_hash
+        node_mem
+        node_add
+        node_find
+        node_val_v
+        node_val_find
+        node_val_list
+      ->
         {
           contents_hash;
           contents_find;
@@ -190,8 +191,8 @@ module Make (P : S.PRIVATE) = struct
 
     let v =
       let open Type in
-      variant "Node.Contents.v" (fun hash value ->
-        function Hash (_, x) -> hash x | Value v -> value v)
+      variant "Node.Contents.v" (fun hash value -> function
+        | Hash (_, x) -> hash x | Value v -> value v)
       |~ case1 "hash" P.Hash.t (fun _ -> assert false)
       |~ case1 "value" P.Contents.Val.t (fun v -> Value v)
       |> sealv
@@ -333,8 +334,7 @@ module Make (P : S.PRIVATE) = struct
 
     let elt_t t : elt Type.t =
       let open Type in
-      variant "Node.value" (fun node contents contents_m ->
-        function
+      variant "Node.value" (fun node contents contents_m -> function
         | `Node x -> node x
         | `Contents (c, m) ->
             if Type.equal Metadata.t m Metadata.default then contents c
@@ -354,8 +354,7 @@ module Make (P : S.PRIVATE) = struct
 
     let v_t (m : map Type.t) : v Type.t =
       let open Type in
-      variant "Node.node" (fun map hash value ->
-        function
+      variant "Node.node" (fun map hash value -> function
         | Map m -> map m
         | Hash (_, y) -> hash y
         | Value (_, v, m) -> value (v, m))
@@ -885,8 +884,8 @@ module Make (P : S.PRIVATE) = struct
 
   let tree_t =
     let open Type in
-    variant "tree" (fun node contents ->
-      function `Node n -> node n | `Contents c -> contents c)
+    variant "tree" (fun node contents -> function
+      | `Node n -> node n | `Contents c -> contents c)
     |~ case1 "node" Node.t (fun n -> `Node n)
     |~ case1 "contents" (pair P.Contents.Val.t Metadata.t) (fun c ->
            `Contents c)
@@ -1406,8 +1405,8 @@ module Make (P : S.PRIVATE) = struct
   let concrete_t : concrete Type.t =
     let open Type in
     mu (fun concrete_t ->
-        variant "concrete" (fun tree contents ->
-          function `Tree t -> tree t | `Contents c -> contents c)
+        variant "concrete" (fun tree contents -> function
+          | `Tree t -> tree t | `Contents c -> contents c)
         |~ case1 "tree" (list (pair Path.step_t concrete_t)) (fun t -> `Tree t)
         |~ case1 "contents" (pair P.Contents.Val.t Metadata.t) (fun c ->
                `Contents c)

--- a/src/irmin/type/type.ml
+++ b/src/irmin/type/type.ml
@@ -255,8 +255,8 @@ let enum vname l =
   Variant { vwit; vname; vcases; vget = (fun x -> List.assq x mk) }
 
 let result a b =
-  variant "result" (fun ok error ->
-    function Ok x -> ok x | Error x -> error x)
+  variant "result" (fun ok error -> function
+    | Ok x -> ok x | Error x -> error x)
   |~ case1 "ok" a (fun a -> Ok a)
   |~ case1 "error" b (fun b -> Error b)
   |> sealv

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -507,8 +507,8 @@ let test_pp_ty () =
     let tree_t, node_t =
       let open T in
       mu2 (fun tree node ->
-          ( variant "tree" (fun empty node ->
-              function Empty -> empty | Node n -> node n)
+          ( variant "tree" (fun empty node -> function
+              | Empty -> empty | Node n -> node n)
             |~ case0 "empty" Empty
             |~ case1 "node" node (fun n -> Node n)
             |> sealv,


### PR DESCRIPTION
Hi, this is what the project would look like after being reformated with the current version (candidate) of ocamlformat 0.15.0.
**Please do not merge until ocamlformat.0.15.0 is available with opam.**

The main changes are due to the improved inconsistency of option `indicate-multiline-delimiters`, a lot of spaces where missing before closing parentheses in the previous versions.
Please let me know if you see any regressions that I may have missed.