### PR TITLE
irmin-pack: update the file format to v2

### DIFF
--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -39,6 +39,10 @@ module type S = sig
 
   val force_offset : t -> int64
 
+  val generation : t -> int64
+
+  val force_generation : t -> int64
+
   val readonly : t -> bool
 
   val version : t -> string
@@ -52,6 +56,14 @@ let ( ++ ) = Int64.add
 
 let ( -- ) = Int64.sub
 
+type version = string
+
+let pp_version = Fmt.Dump.string
+
+let v1 = "00000001"
+
+let v2 = "00000002"
+
 module Unix : S = struct
   exception RO_Not_Allowed
 
@@ -60,16 +72,21 @@ module Unix : S = struct
   type t = {
     file : string;
     mutable raw : Raw.t;
+    mutable generation : int64;
     mutable offset : int64;
     mutable flushed : int64;
     readonly : bool;
-    version : string;
+    mutable version : string;
     buf : Buffer.t;
   }
 
   let name t = t.file
 
-  let header = 16L (* offset + version *)
+  let header_v1 = 16L (* offset + version *)
+
+  let header_v2 = 24L (* offset + version + generation *)
+
+  let header t = if t.version = v1 then header_v1 else header_v2
 
   let flush t =
     if t.readonly then raise RO_Not_Allowed;
@@ -80,15 +97,17 @@ module Unix : S = struct
     if buf = "" then ()
     else (
       Raw.unsafe_write t.raw ~off:t.flushed buf;
-      Raw.Offset.set t.raw offset;
+      (* version and generation can change after a clear *)
+      Raw.Header.set t.raw
+        { Raw.Header.version = t.version; offset; generation = t.generation };
 
       (* concurrent append might happen so here t.offset might differ
          from offset *)
-      if not (t.flushed ++ Int64.of_int (String.length buf) = header ++ offset)
-      then
+      let h = header t in
+      if not (t.flushed ++ Int64.of_int (String.length buf) = h ++ offset) then
         Fmt.failwith "sync error: %s flushed=%Ld offset+header=%Ld\n%!" t.file
-          t.flushed (offset ++ header);
-      t.flushed <- offset ++ header)
+          t.flushed (offset ++ h);
+      t.flushed <- offset ++ h)
 
   let auto_flush_limit = 1_000_000L
 
@@ -101,20 +120,23 @@ module Unix : S = struct
   let set t ~off buf =
     if t.readonly then raise RO_Not_Allowed;
     flush t;
-    Raw.unsafe_write t.raw ~off:(header ++ off) buf;
-    let len = Int64.of_int (String.length buf) in
-    let off = header ++ off ++ len in
-    assert (off <= t.flushed)
+    Raw.unsafe_write t.raw ~off:(header t ++ off) buf
 
   let read t ~off buf =
-    if not t.readonly then assert (header ++ off <= t.flushed);
-    Raw.unsafe_read t.raw ~off:(header ++ off) ~len:(Bytes.length buf) buf
+    if not t.readonly then assert (header t ++ off <= t.flushed);
+    Raw.unsafe_read t.raw ~off:(header t ++ off) ~len:(Bytes.length buf) buf
 
   let offset t = t.offset
 
   let force_offset t =
     t.offset <- Raw.Offset.get t.raw;
     t.offset
+
+  let generation t = t.generation
+
+  let force_generation t =
+    t.generation <- Raw.Generation.get t.raw;
+    t.generation
 
   let version t = t.version
 
@@ -143,10 +165,27 @@ module Unix : S = struct
     in
     aux dirname (fun () -> ())
 
+  let raw ~mode ~version file =
+    let x = Unix.openfile file Unix.[ O_CREAT; mode; O_CLOEXEC ] 0o644 in
+    let raw = Raw.v x in
+    let header = { Raw.Header.version; offset = 0L; generation = 0L } in
+    Raw.Header.set raw header;
+    raw
+
   let clear t =
+    if t.readonly then invalid_arg "Read-only IO cannot be cleared";
     t.offset <- 0L;
-    t.flushed <- header;
-    Buffer.clear t.buf
+    t.flushed <- header t;
+    if t.version = v1 then t.version <- v2;
+    t.generation <- Int64.succ t.generation;
+    Buffer.clear t.buf;
+    (* update the file contents for concurrent read-only instance to
+       notice that the file has been clear when they next sync. *)
+    flush t;
+    (* and delete the file. *)
+    Raw.close t.raw;
+    Unix.unlink t.file;
+    t.raw <- raw ~version:t.version ~mode:Unix.O_RDWR t.file
 
   let buffers = Hashtbl.create 256
 
@@ -159,7 +198,8 @@ module Unix : S = struct
 
   let v ~fresh ~version:current_version ~readonly file =
     assert (String.length current_version = 8);
-    let v ~offset ~version raw =
+    let v ~offset ~version ~generation raw =
+      let header = if current_version = v1 then header_v1 else header_v2 in
       {
         version;
         file;
@@ -168,29 +208,30 @@ module Unix : S = struct
         readonly;
         buf = buffer file;
         flushed = header ++ offset;
+        generation;
       }
     in
     let mode = Unix.(if readonly then O_RDONLY else O_RDWR) in
     mkdir (Filename.dirname file);
     match Sys.file_exists file with
     | false ->
-        let x = Unix.openfile file Unix.[ O_CREAT; mode; O_CLOEXEC ] 0o644 in
-        let raw = Raw.v x in
-        Raw.Offset.set raw 0L;
-        Raw.Version.set raw current_version;
-        v ~offset:0L ~version:current_version raw
+        let raw = raw ~mode ~version:current_version file in
+        v ~offset:0L ~version:current_version ~generation:0L raw
     | true ->
         let x = Unix.openfile file Unix.[ O_EXCL; mode; O_CLOEXEC ] 0o644 in
         let raw = Raw.v x in
         if fresh then (
           Raw.Offset.set raw 0L;
           Raw.Version.set raw current_version;
-          v ~offset:0L ~version:current_version raw)
+          Raw.Generation.set raw 0L;
+          v ~offset:0L ~version:current_version ~generation:0L raw)
         else
           let offset = Raw.Offset.get raw in
           let version = Raw.Version.get raw in
-          assert (version = current_version);
-          v ~offset ~version raw
+          let generation =
+            if version = v1 then 0L else Raw.Generation.get raw
+          in
+          v ~offset ~version ~generation raw
 
   let close t = Raw.close t.raw
 end

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -14,12 +14,20 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type version
+
+val v1 : version
+
+val v2 : version
+
+val pp_version : version Fmt.t
+
 module type S = sig
   type t
 
   exception RO_Not_Allowed
 
-  val v : fresh:bool -> version:string -> readonly:bool -> string -> t
+  val v : fresh:bool -> version:version -> readonly:bool -> string -> t
 
   val name : t -> string
 
@@ -35,9 +43,13 @@ module type S = sig
 
   val force_offset : t -> int64
 
+  val generation : t -> int64
+
+  val force_generation : t -> int64
+
   val readonly : t -> bool
 
-  val version : t -> string
+  val version : t -> version
 
   val flush : t -> unit
 

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -14,11 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type version
-
-val v1 : version
-
-val v2 : version
+type version = [ `V1 | `V2 ]
 
 val pp_version : version Fmt.t
 
@@ -27,7 +23,7 @@ module type S = sig
 
   exception RO_Not_Allowed
 
-  val v : fresh:bool -> version:version -> readonly:bool -> string -> t
+  val v : version:version -> fresh:bool -> readonly:bool -> string -> t
 
   val name : t -> string
 
@@ -59,8 +55,9 @@ end
 module Unix : S
 
 val with_cache :
-  v:('a -> fresh:bool -> readonly:bool -> string -> 'b) ->
+  v:('a -> version:version -> fresh:bool -> readonly:bool -> string -> 'b) ->
   clear:('b -> unit) ->
   valid:('b -> bool) ->
   string ->
-  [ `Staged of 'a -> ?fresh:bool -> ?readonly:bool -> string -> 'b ]
+  [ `Staged of
+    'a -> ?version:version -> ?fresh:bool -> ?readonly:bool -> string -> 'b ]

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -73,6 +73,10 @@ module Pack (S : Pack.S) = struct
     check_not_closed t;
     S.sync t.t
 
+  let clear t =
+    check_not_closed t;
+    S.clear t.t
+
   type integrity_error = S.integrity_error
 
   let integrity_check ~offset ~length k t =

--- a/src/irmin-pack/closeable.mli
+++ b/src/irmin-pack/closeable.mli
@@ -12,8 +12,11 @@
 
 (** Augments primitive store modules with close semantics *)
 
-module Pack (S : Pack.S) :
-  Pack.S with type key = S.key and type value = S.value and type index = S.index
+module Content_addressable (CA : S.CONTENT_ADDRESSABLE_STORE) :
+  S.CONTENT_ADDRESSABLE_STORE
+    with type key = CA.key
+     and type value = CA.value
+     and type index = CA.index
 
 module Atomic_write (AW : S.ATOMIC_WRITE_STORE) :
   S.ATOMIC_WRITE_STORE

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -19,31 +19,9 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let current_version = IO.v2
-
 let ( -- ) = Int64.sub
 
-module type S = sig
-  type t
-
-  val find : t -> int -> string option
-
-  val index : t -> string -> int option
-
-  val flush : t -> unit
-
-  val sync : t -> unit
-
-  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
-
-  val clear : t -> unit
-
-  val close : t -> unit
-
-  val valid : t -> bool
-end
-
-module Make (IO : IO.S) : S = struct
+module Make (IO : IO.S) : S.DICT = struct
   type t = {
     capacity : int;
     cache : (string, int) Hashtbl.t;
@@ -51,6 +29,10 @@ module Make (IO : IO.S) : S = struct
     io : IO.t;
     mutable open_instances : int;
   }
+
+  let version t = IO.version t.io
+
+  let generation t = IO.generation t.io
 
   let append_string t v =
     let len = Int32.of_int (String.length v) in
@@ -117,8 +99,9 @@ module Make (IO : IO.S) : S = struct
     Hashtbl.clear t.cache;
     Hashtbl.clear t.index
 
-  let v ?(fresh = true) ?(readonly = false) ?(capacity = 100_000) file =
-    let io = IO.v ~fresh ~version:current_version ~readonly file in
+  let v ?(version = `V2) ?(fresh = true) ?(readonly = false)
+      ?(capacity = 100_000) file =
+    let io = IO.v ~fresh ~version ~readonly file in
     let cache = Hashtbl.create 997 in
     let index = Hashtbl.create 997 in
     let t = { capacity; index; cache; io; open_instances = 1 } in

--- a/src/irmin-pack/dict.mli
+++ b/src/irmin-pack/dict.mli
@@ -14,24 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type S = sig
-  type t
-
-  val find : t -> int -> string option
-
-  val index : t -> string -> int option
-
-  val flush : t -> unit
-
-  val sync : t -> unit
-
-  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
-
-  val clear : t -> unit
-
-  val close : t -> unit
-
-  val valid : t -> bool
-end
-
-module Make (IO : IO.S) : S
+module Make (IO : IO.S) : S.DICT

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -27,6 +27,7 @@ module type S = sig
   type index
 
   val v :
+    ?version:[ `V1 | `V2 ] ->
     ?fresh:bool ->
     ?readonly:bool ->
     ?lru_size:int ->

--- a/src/irmin-pack/inode.mli
+++ b/src/irmin-pack/inode.mli
@@ -26,6 +26,7 @@ module type S = sig
   type index
 
   val v :
+    ?version:[ `V1 | `V2 ] ->
     ?fresh:bool ->
     ?readonly:bool ->
     ?lru_size:int ->

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -18,7 +18,7 @@ let src = Logs.Src.create "irmin.pack" ~doc:"irmin-pack backend"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let current_version = "00000001"
+let current_version = IO.v2
 
 module Default = struct
   let fresh = false
@@ -163,9 +163,13 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     aux from
 
   let sync_offset t =
-    let former_log_offset = IO.offset t.block in
-    let log_offset = IO.force_offset t.block in
-    if log_offset > former_log_offset then refill t ~from:former_log_offset
+    let former_generation = IO.generation t.block in
+    let generation = IO.force_generation t.block in
+    if former_generation <> generation then refill t ~from:0L
+    else
+      let former_log_offset = IO.offset t.block in
+      let log_offset = IO.force_offset t.block in
+      if log_offset > former_log_offset then refill t ~from:former_log_offset
 
   let unsafe_find t k =
     Log.debug (fun l -> l "[branches] find %a" pp_branch k);

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -105,7 +105,14 @@ module KV (Config : CONFIG) : Irmin.KV_MAKER
 module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) : sig
   include Irmin.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
-  val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t
+  val v :
+    ?version:[ `V1 | `V2 ] -> ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t
+
+  val version : t -> [ `V1 | `V2 ]
 end
 
 module Stats = Stats
+
+type version = [ `V1 | `V2 ]
+
+val pp_version : version Fmt.t

--- a/src/irmin-pack/lru.ml
+++ b/src/irmin-pack/lru.ml
@@ -55,6 +55,10 @@ module Make (H : Hashtbl.HashedType) = struct
     let node x = { value = x; prev = None; next = None }
 
     let create () = { first = None; last = None }
+
+    let clear t =
+      t.first <- None;
+      t.last <- None
   end
 
   type key = HT.key
@@ -116,5 +120,7 @@ module Make (H : Hashtbl.HashedType) = struct
         promote t k;
         true
 
-  let clear t = create t.cap
+  let clear t =
+    HT.clear t.ht;
+    Q.clear t.q
 end

--- a/src/irmin-pack/lru.ml
+++ b/src/irmin-pack/lru.ml
@@ -87,7 +87,7 @@ module Make (H : Hashtbl.HashedType) = struct
     with Not_found -> ()
 
   let add t k v =
-    if t.w = 0 then ()
+    if t.cap = 0 then ()
     else (
       remove t k;
       let n = Q.node (k, v) in

--- a/src/irmin-pack/lru.mli
+++ b/src/irmin-pack/lru.mli
@@ -24,5 +24,5 @@ module Make (H : Hashtbl.HashedType) : sig
 
   val mem : 'a t -> H.t -> bool
 
-  val clear : 'a t -> 'a t
+  val clear : 'a t -> unit
 end

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -176,7 +176,8 @@ struct
 
     let clear t =
       clear t.pack;
-      Tbl.clear t.staging
+      Tbl.clear t.staging;
+      Lru.clear t.lru
 
     (* we need another cache here, as we want to share the LRU and
        staging caches too. *)
@@ -349,7 +350,7 @@ struct
       if t.open_instances = 0 then (
         Log.debug (fun l -> l "[pack] close %s" (IO.name t.pack.block));
         Tbl.clear t.staging;
-        ignore (Lru.clear t.lru);
+        Lru.clear t.lru;
         close t.pack)
 
     let close t =

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -68,6 +68,8 @@ module type S = sig
 
   val sync : 'a t -> unit
 
+  val clear : 'a t -> unit
+
   type integrity_error = [ `Wrong_hash | `Absent_value ]
 
   val integrity_check :

--- a/src/irmin-pack/pack.mli
+++ b/src/irmin-pack/pack.mli
@@ -60,6 +60,8 @@ module type S = sig
 
   val sync : 'a t -> unit
 
+  val clear : 'a t -> unit
+
   type integrity_error = [ `Wrong_hash | `Absent_value ]
 
   val integrity_check :

--- a/src/irmin-pack/pack_dict.ml
+++ b/src/irmin-pack/pack_dict.ml
@@ -14,10 +14,10 @@ include Dict.Make (IO.Unix)
 
 (* Add IO caching around Dict.v *)
 let (`Staged v) =
-  let v_no_cache ~fresh ~readonly = v ~fresh ~readonly in
+  let v_no_cache ~version ~fresh ~readonly = v ~version ~fresh ~readonly in
   IO.with_cache ~clear ~valid
     ~v:(fun capacity -> v_no_cache ~capacity)
     "store.dict"
 
-let v ?fresh ?readonly ?(capacity = 100_000) root =
-  v capacity ?fresh ?readonly root
+let v ?version ?fresh ?readonly ?(capacity = 100_000) root =
+  v capacity ?version ?fresh ?readonly root

--- a/src/irmin-pack/pack_dict.mli
+++ b/src/irmin-pack/pack_dict.mli
@@ -10,6 +10,12 @@
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
-include Dict.S
+include S.DICT
 
-val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
+val v :
+  ?version:[ `V1 | `V2 ] ->
+  ?fresh:bool ->
+  ?readonly:bool ->
+  ?capacity:int ->
+  string ->
+  t

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2013-2019 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,8 +14,83 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module type DICT = sig
+  type t
+
+  val find : t -> int -> string option
+
+  val index : t -> string -> int option
+
+  val flush : t -> unit
+
+  val sync : t -> unit
+
+  val v :
+    ?version:[ `V1 | `V2 ] ->
+    ?fresh:bool ->
+    ?readonly:bool ->
+    ?capacity:int ->
+    string ->
+    t
+
+  val clear : t -> unit
+
+  val close : t -> unit
+
+  val valid : t -> bool
+
+  val version : t -> [ `V1 | `V2 ]
+
+  val generation : t -> int64
+end
+
 module type ATOMIC_WRITE_STORE = sig
   include Irmin.ATOMIC_WRITE_STORE
 
-  val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t
+  val v :
+    ?version:[ `V1 | `V2 ] -> ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t
+
+  val version : t -> [ `V1 | `V2 ]
+
+  val generation : t -> int64
+end
+
+module type CONTENT_ADDRESSABLE_STORE = sig
+  include Irmin.CONTENT_ADDRESSABLE_STORE
+
+  type index
+
+  val v :
+    ?version:[ `V1 | `V2 ] ->
+    ?fresh:bool ->
+    ?readonly:bool ->
+    ?lru_size:int ->
+    index:index ->
+    string ->
+    [ `Read ] t Lwt.t
+
+  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
+
+  val unsafe_append : 'a t -> key -> value -> unit
+
+  val unsafe_mem : 'a t -> key -> bool
+
+  val unsafe_find : 'a t -> key -> value option
+
+  val flush : ?index:bool -> 'a t -> unit
+
+  val sync : 'a t -> unit
+
+  val clear : 'a t -> unit
+
+  type integrity_error = [ `Wrong_hash | `Absent_value ]
+
+  val integrity_check :
+    offset:int64 -> length:int -> key -> 'a t -> (unit, integrity_error) result
+
+  val close : 'a t -> unit Lwt.t
+
+  val version : 'a t -> [ `V1 | `V2 ]
+
+  val generation : 'a t -> int64
 end

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -66,13 +66,13 @@ struct
 
   let log_size = 10_000_000
 
-  let get_pack () =
+  let get_pack ?(lru_size = 0) () =
     let name = fresh_name "dict" in
     let f = ref (fun () -> ()) in
     let index =
       Index.v ~auto_flush_callback:(fun () -> !f ()) ~log_size ~fresh:true name
     in
-    Pack.v ~fresh:true ~lru_size:0 ~index name >|= fun pack ->
+    Pack.v ~fresh:true ~lru_size ~index name >|= fun pack ->
     (f := fun () -> Pack.flush ~index:false pack);
     let clone_pack ~readonly = Pack.v ~fresh:false ~readonly ~index name in
     let clone_index_pack ~readonly =

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -29,7 +29,7 @@ end) : sig
     clone_index_pack : readonly:bool -> (Index.t * [ `Read ] Pack.t) Lwt.t;
   }
 
-  val get_pack : unit -> t Lwt.t
+  val get_pack : ?lru_size:int -> unit -> t Lwt.t
   (** Fresh, empty index and pack. [clone_pack] opens a clone of the pack at the
       same location, [clone_index_pack] opens a clone of the index and the pack. *)
 

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -19,7 +19,7 @@ end) : sig
 
   type d = { dict : Dict.t; clone : readonly:bool -> Dict.t }
 
-  val get_dict : unit -> d
+  val get_dict : ?version:[ `V1 | `V2 ] -> unit -> d
   (** Fresh, empty dict. *)
 
   type t = {
@@ -29,7 +29,7 @@ end) : sig
     clone_index_pack : readonly:bool -> (Index.t * [ `Read ] Pack.t) Lwt.t;
   }
 
-  val get_pack : ?lru_size:int -> unit -> t Lwt.t
+  val get_pack : ?version:[ `V1 | `V2 ] -> ?lru_size:int -> unit -> t Lwt.t
   (** Fresh, empty index and pack. [clone_pack] opens a clone of the pack at the
       same location, [clone_index_pack] opens a clone of the index and the pack. *)
 
@@ -41,3 +41,5 @@ val get : 'a option -> 'a
 val sha1 : string -> H.t
 
 val rm_dir : string -> unit
+
+val version : [ `V1 | `V2 ] Alcotest.testable

--- a/test/irmin-pack/test.ml
+++ b/test/irmin-pack/test.ml
@@ -15,5 +15,5 @@
  *)
 
 let () =
-  Irmin_test.Store.run "irmin-pack" ~misc:[ Test_pack.misc ]
+  Irmin_test.Store.run "irmin-pack" ~misc:Test_pack.misc
     [ (`Quick, Test_pack.suite) ]

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -126,10 +126,24 @@ module Dict = struct
     Dict.close dict;
     Dict.close r
 
+  let test_clear () =
+    let Context.{ dict; _ } = Context.get_dict () in
+    let i =
+      match Dict.index dict "foo" with
+      | None -> Alcotest.fail "full dict!"
+      | Some i -> i
+    in
+    Dict.flush dict;
+    Alcotest.(check (option string)) "find foo" (Some "foo") (Dict.find dict i);
+    Dict.clear dict;
+    Alcotest.(check (option string))
+      "find foo after clear" None (Dict.find dict i)
+
   let tests =
     [
       Alcotest.test_case "dict" `Quick test_dict;
       Alcotest.test_case "RO dict" `Quick test_readonly_dict;
+      Alcotest.test_case "clear" `Quick test_clear;
     ]
 end
 

--- a/test/irmin-pack/test_pack.mli
+++ b/test/irmin-pack/test_pack.mli
@@ -1,3 +1,3 @@
 val suite : Irmin_test.t
 
-val misc : string * unit Alcotest.test_case list
+val misc : (string * unit Alcotest.test_case list) list


### PR DESCRIPTION
The change is backward compatible (v1 format is still readable) as
it just adds a 'generation' field, which is incremented after every
clear. The first time a V1 file is cleared, its version is upgraded
to V2. A V1 file always has generation=0.