### PR TITLE
Better pretty-printer output.

### DIFF
--- a/src/irmin/type/type.ml
+++ b/src/irmin/type/type.ml
@@ -351,7 +351,8 @@ end
 
 let equal, compare = Type_ordered.(equal, compare)
 
-let pp, pp_ty, to_string, of_string = Type_pp.(t, ty, to_string, of_string)
+let pp, pp_ty, to_string, to_ocaml_string, of_string =
+  Type_pp.(t, ty, to_string, to_ocaml_string, of_string)
 
 let ( to_json_string,
       of_json_string,

--- a/src/irmin/type/type.ml
+++ b/src/irmin/type/type.ml
@@ -351,8 +351,8 @@ end
 
 let equal, compare = Type_ordered.(equal, compare)
 
-let pp, pp_ty, to_string, to_ocaml_string, of_string =
-  Type_pp.(t, ty, to_string, to_ocaml_string, of_string)
+let pp, pp_dump, pp_ty, to_string, of_string =
+  Type_pp.(t, dump, ty, to_string, of_string)
 
 let ( to_json_string,
       of_json_string,

--- a/src/irmin/type/type.mli
+++ b/src/irmin/type/type.mli
@@ -306,17 +306,21 @@ type 'a pp = 'a Fmt.t
 type 'a of_string = string -> ('a, [ `Msg of string ]) result
 (** The type for parsers. *)
 
-val pp : ?ocaml_syntax:bool -> 'a t -> 'a pp
-(** [pp t] is the pretty-printer for values of type [t]. *)
+val pp : ?ocaml_syntax:unit -> 'a t -> 'a pp
+(** [pp ~ocaml_syntax t] is the pretty-printer for values of type [t].
+
+    When [~ocaml_syntax:()], the pretty-printer will use an output format which
+    is as close as possible to OCaml syntax, so that the result can easily be
+    copy-pasted into an OCaml REPL to inspect the value further. *)
 
 val pp_ty : 'a t pp
 (** The pretty printer for generics of type {!t}. *)
 
 val to_string : 'a t -> 'a -> string
-(** [to_string t] is [Fmt.to_to_string (pp ~ocaml_syntax:false t)]. *)
+(** [to_string t] is [Fmt.to_to_string (pp t)]. *)
 
 val to_ocaml_string : 'a t -> 'a -> string
-(** [to_ocaml_string t] is [Fmt.to_to_string (pp ~ocaml_syntax:true t)]. *)
+(** [to_ocaml_string t] is [Fmt.to_to_string (pp ~ocaml_syntax:() t)]. *)
 
 val of_string : 'a t -> 'a of_string
 (** [of_string t] parses values of type [t]. *)

--- a/src/irmin/type/type.mli
+++ b/src/irmin/type/type.mli
@@ -306,14 +306,17 @@ type 'a pp = 'a Fmt.t
 type 'a of_string = string -> ('a, [ `Msg of string ]) result
 (** The type for parsers. *)
 
-val pp : 'a t -> 'a pp
+val pp : ?ocaml_syntax:bool -> 'a t -> 'a pp
 (** [pp t] is the pretty-printer for values of type [t]. *)
 
 val pp_ty : 'a t pp
 (** The pretty printer for generics of type {!t}. *)
 
 val to_string : 'a t -> 'a -> string
-(** [to_string t] is [Fmt.to_to_string (pp t)]. *)
+(** [to_string t] is [Fmt.to_to_string (pp ~ocaml_syntax:false t)]. *)
+
+val to_ocaml_string : 'a t -> 'a -> string
+(** [to_ocaml_string t] is [Fmt.to_to_string (pp ~ocaml_syntax:true t)]. *)
 
 val of_string : 'a t -> 'a of_string
 (** [of_string t] parses values of type [t]. *)

--- a/src/irmin/type/type.mli
+++ b/src/irmin/type/type.mli
@@ -306,21 +306,21 @@ type 'a pp = 'a Fmt.t
 type 'a of_string = string -> ('a, [ `Msg of string ]) result
 (** The type for parsers. *)
 
-val pp : ?ocaml_syntax:unit -> 'a t -> 'a pp
-(** [pp ~ocaml_syntax t] is the pretty-printer for values of type [t].
+val pp : 'a t -> 'a pp
+(** [pp t] is the pretty-printer for values of type [t]. *)
 
-    When [~ocaml_syntax:()], the pretty-printer will use an output format which
-    is as close as possible to OCaml syntax, so that the result can easily be
-    copy-pasted into an OCaml REPL to inspect the value further. *)
+val pp_dump : 'a t -> 'a pp
+(** [pp t] is the dump pretty-printer for values of type [t].
+
+    This pretty-printer outputs an encoding which is as close as possible to
+    native OCaml syntax, so that the result can easily be copy-pasted into an
+    OCaml REPL to inspect the value further. *)
 
 val pp_ty : 'a t pp
 (** The pretty printer for generics of type {!t}. *)
 
 val to_string : 'a t -> 'a -> string
 (** [to_string t] is [Fmt.to_to_string (pp t)]. *)
-
-val to_ocaml_string : 'a t -> 'a -> string
-(** [to_ocaml_string t] is [Fmt.to_to_string (pp ~ocaml_syntax:() t)]. *)
 
 val of_string : 'a t -> 'a of_string
 (** [of_string t] parses values of type [t]. *)

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -33,26 +33,22 @@ let t t =
     | Variant v -> variant v ppf x
   and map : type a b. (a, b) map -> b pp = fun l ppf x -> aux l.x ppf (l.g x)
   and prim : type a. a prim -> a pp =
-   fun t ->
+   fun t ppf x ->
     match t with
-    | Unit -> Fmt.(using (fun _ -> "()") string)
-    | Bool -> Fmt.bool
-    | Char -> Fmt.char
-    | Int -> Fmt.int
-    | Int32 -> Fmt.int32
-    | Int64 -> Fmt.int64
+    | Unit -> Fmt.string ppf "()"
+    | Bool -> Fmt.bool ppf x
+    | Char -> Fmt.(pf ppf "'%c'" x)
+    | Int -> Fmt.int ppf x
+    | Int32 -> Fmt.int32 ppf x
+    | Int64 -> Fmt.int64 ppf x
     | Float ->
-        Fmt.(
-          using
-            (fun f ->
-              match classify_float f with
-              | FP_infinite when f < 0. -> "neg_infinity"
-              | FP_infinite -> "infinity"
-              | _ -> string_of_float f
-              (* Usually yields better precision than Fmt.float. *))
-            string)
-    | String _ -> Fmt.Dump.string
-    | Bytes _ -> Fmt.(using Bytes.unsafe_to_string Dump.string)
+        Fmt.string ppf
+          ( match classify_float x with
+          | FP_infinite when x < 0. -> "neg_infinity"
+          | FP_infinite -> "infinity"
+          | _ -> string_of_float x (* Usually more precise than Fmt.float. *) )
+    | String _ -> Fmt.Dump.string ppf x
+    | Bytes _ -> Fmt.Dump.string ppf (Bytes.unsafe_to_string x)
   and tuple : type a. a tuple -> a pp =
    fun t ->
     match t with

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -17,7 +17,7 @@
 open Type_core
 
 let t ?ocaml_syntax t =
-  let is_ocaml = Option.is_some ocaml_syntax in
+  let use_ocaml_syntax = ocaml_syntax = Some () in
   let rec aux : type a. a t -> a pp =
    fun t ppf x ->
     match t with
@@ -25,7 +25,7 @@ let t ?ocaml_syntax t =
     | Custom c -> c.pp ppf x
     | Map m -> map m ppf x
     | Prim p -> prim p ppf x
-    | _ when not is_ocaml -> Type_json.pp t ppf x
+    | _ when not use_ocaml_syntax -> Type_json.pp t ppf x
     | Var v -> raise (Unbound_type_variable v)
     | List l -> Fmt.Dump.list (aux l.v) ppf x
     | Array a -> Fmt.Dump.array (aux a.v) ppf x
@@ -36,7 +36,7 @@ let t ?ocaml_syntax t =
   and map : type a b. (a, b) map -> b pp = fun l ppf x -> aux l.x ppf (l.g x)
   and prim : type a. a prim -> a pp =
    fun t ppf x ->
-    match (t, is_ocaml) with
+    match (t, use_ocaml_syntax) with
     | Unit, false -> ()
     | Unit, true -> Fmt.string ppf "()"
     | Bool, _ -> Fmt.bool ppf x

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -37,23 +37,23 @@ let t ?(ocaml_syntax = false) t =
    fun t ppf x ->
     match (t, ocaml_syntax) with
     | Unit, false -> ()
-    | Char, false -> Fmt.char ppf x
-    | Float, false when Float.is_nan x -> Fmt.string ppf "\"nan\""
-    | Float, false when x = infinity -> Fmt.string ppf "\"inf\""
-    | Float, false when x = neg_infinity -> Fmt.string ppf "\"-inf\""
-    | String _, false -> Fmt.string ppf x
     | Unit, true -> Fmt.string ppf "()"
-    | Char, true -> Fmt.(pf ppf "'%c'" x)
-    | Float, true when Float.is_nan x -> Fmt.string ppf "nan"
-    | Float, true when x = infinity -> Fmt.string ppf "infinity"
-    | Float, true when x = neg_infinity -> Fmt.string ppf "neg_infinity"
-    | String _, true -> Fmt.Dump.string ppf x
     | Bool, _ -> Fmt.bool ppf x
+    | Char, false -> Fmt.char ppf x
+    | Char, true -> Fmt.(pf ppf "'%c'" x)
+    | String _, false -> Fmt.string ppf x
+    | String _, true -> Fmt.Dump.string ppf x
+    | Bytes _, _ -> Fmt.string ppf (Bytes.unsafe_to_string x)
     | Int, _ -> Fmt.int ppf x
     | Int32, _ -> Fmt.int32 ppf x
     | Int64, _ -> Fmt.int64 ppf x
+    | Float, false when Float.is_nan x -> Fmt.string ppf "\"nan\""
+    | Float, false when x = infinity -> Fmt.string ppf "\"inf\""
+    | Float, false when x = neg_infinity -> Fmt.string ppf "\"-inf\""
+    | Float, true when Float.is_nan x -> Fmt.string ppf "nan"
+    | Float, true when x = infinity -> Fmt.string ppf "infinity"
+    | Float, true when x = neg_infinity -> Fmt.string ppf "neg_infinity"
     | Float, _ -> Fmt.string ppf (string_of_float x)
-    | Bytes _, _ -> Fmt.string ppf (Bytes.unsafe_to_string x)
   and tuple : type a. a tuple -> a pp =
    fun t ->
     match t with

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -27,7 +27,7 @@ let t t =
     | Var v -> raise (Unbound_type_variable v)
     | List l -> Fmt.Dump.list (aux l.v) ppf x
     | Array a -> Fmt.Dump.array (aux a.v) ppf x
-    | Option o -> Fmt.Dump.option (aux o) ppf x
+    | Option o -> option o ppf x
     | Tuple t -> tuple t ppf x
     | Record r -> record r ppf x
     | Variant v -> variant v ppf x
@@ -68,6 +68,13 @@ let t t =
     |> List.map (fun (Field f) ->
            Fmt.Dump.field ~label:Fmt.string f.fname f.fget (aux f.ftype))
     |> Fmt.Dump.record
+  and option : type a. a t -> a option pp =
+   fun t ppf -> function
+    | None -> Fmt.string ppf "None"
+    | Some x ->
+        Fmt.(
+          string ppf "Some ";
+          parens (aux t) ppf x)
   and variant : type a. a variant -> a pp =
    fun t ppf x ->
     match t.vget x with

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -16,6 +16,9 @@
 
 open Type_core
 
+(* Polyfill for [Float.is_nan] which is only >=4.08. *)
+let is_nan x = Float.classify_float x = FP_nan
+
 let t ?ocaml_syntax t =
   let use_ocaml_syntax = ocaml_syntax = Some () in
   let rec aux : type a. a t -> a pp =
@@ -48,10 +51,10 @@ let t ?ocaml_syntax t =
     | Int, _ -> Fmt.int ppf x
     | Int32, _ -> Fmt.int32 ppf x
     | Int64, _ -> Fmt.int64 ppf x
-    | Float, false when Float.is_nan x -> Fmt.string ppf "\"nan\""
+    | Float, false when is_nan x -> Fmt.string ppf "\"nan\""
     | Float, false when x = infinity -> Fmt.string ppf "\"inf\""
     | Float, false when x = neg_infinity -> Fmt.string ppf "\"-inf\""
-    | Float, true when Float.is_nan x -> Fmt.string ppf "nan"
+    | Float, true when is_nan x -> Fmt.string ppf "nan"
     | Float, true when x = infinity -> Fmt.string ppf "infinity"
     | Float, true when x = neg_infinity -> Fmt.string ppf "neg_infinity"
     | Float, _ -> Fmt.string ppf (string_of_float x)

--- a/src/irmin/type/type_pp.ml
+++ b/src/irmin/type/type_pp.ml
@@ -65,7 +65,8 @@ let t t =
   and record : type a. a record -> a pp =
    fun t ->
     fields t
-    |> List.map (fun (Field f) -> Fmt.Dump.field f.fname f.fget (aux f.ftype))
+    |> List.map (fun (Field f) ->
+           Fmt.Dump.field ~label:Fmt.string f.fname f.fget (aux f.ftype))
     |> Fmt.Dump.record
   and variant : type a. a variant -> a pp =
    fun t ppf x ->

--- a/src/irmin/type/type_pp.mli
+++ b/src/irmin/type/type_pp.mli
@@ -16,12 +16,12 @@
 
 open Type_core
 
-val t : ?ocaml_syntax:unit -> 'a t -> 'a Fmt.t
+val t : 'a t -> 'a Fmt.t
+
+val dump : 'a t -> 'a Fmt.t
 
 val ty : 'a t Fmt.t
 
 val to_string : 'a t -> 'a to_string
-
-val to_ocaml_string : 'a t -> 'a to_string
 
 val of_string : 'a t -> 'a of_string

--- a/src/irmin/type/type_pp.mli
+++ b/src/irmin/type/type_pp.mli
@@ -16,10 +16,12 @@
 
 open Type_core
 
-val t : 'a t -> 'a Fmt.t
+val t : ?ocaml_syntax:bool -> 'a t -> 'a Fmt.t
 
 val ty : 'a t Fmt.t
 
 val to_string : 'a t -> 'a to_string
+
+val to_ocaml_string : 'a t -> 'a to_string
 
 val of_string : 'a t -> 'a of_string

--- a/src/irmin/type/type_pp.mli
+++ b/src/irmin/type/type_pp.mli
@@ -16,7 +16,7 @@
 
 open Type_core
 
-val t : ?ocaml_syntax:bool -> 'a t -> 'a Fmt.t
+val t : ?ocaml_syntax:unit -> 'a t -> 'a Fmt.t
 
 val ty : 'a t Fmt.t
 

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -211,7 +211,7 @@ let sha1 x = Irmin.Hash.BLAKE2B.hash (fun l -> l x)
 let test_bin () =
   let s = T.to_string l [ "foo"; "foo" ] in
   Alcotest.(check string) "hex list" "[\"666f6f\",\"666f6f\"]" s;
-  let s = T.to_bin_string l [ "foo"; "bar" ] in
+  let s = to_bin_string l [ "foo"; "bar" ] in
   Alcotest.(check string) "encode list" "foobar" s;
   Alcotest.(check (option int))
     "size of list" (Some 6)
@@ -335,13 +335,14 @@ let test_to_string () =
 
 (** Test the behaviour of {!Irmin.Type.to_ocaml_string}. *)
 let test_to_ocaml_string () =
+  let to_string_dump ty = Fmt.to_to_string (T.pp_dump ty) in
   let test : type a. string -> a T.t -> a -> string -> unit =
    fun case_name typ input expected_output ->
     let assertion =
       Fmt.strf "Expected output of `to_ocaml_string` for representation of `%s`"
         case_name
     in
-    T.to_ocaml_string typ input
+    to_string_dump typ input
     |> Alcotest.(check string) assertion expected_output
   in
 

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -333,17 +333,16 @@ let test_to_string () =
 
   ()
 
-(** Test the behaviour of {!Irmin.Type.to_ocaml_string}. *)
-let test_to_ocaml_string () =
-  let to_string_dump ty = Fmt.to_to_string (T.pp_dump ty) in
+(** Test the behaviour of {!Irmin.Type.pp_dump}. *)
+let test_pp_dump () =
+  let to_string ty = Fmt.to_to_string (T.pp_dump ty) in
   let test : type a. string -> a T.t -> a -> string -> unit =
    fun case_name typ input expected_output ->
     let assertion =
-      Fmt.strf "Expected output of `to_ocaml_string` for representation of `%s`"
+      Fmt.strf "Expected output of `pp_dump` for representation of `%s`"
         case_name
     in
-    to_string_dump typ input
-    |> Alcotest.(check string) assertion expected_output
+    to_string typ input |> Alcotest.(check string) assertion expected_output
   in
 
   (* Test cases for basic types *)
@@ -865,7 +864,7 @@ let suite =
     ("json_option", `Quick, test_json_option);
     ("bin", `Quick, test_bin);
     ("to_string", `Quick, test_to_string);
-    ("to_ocaml_string", `Quick, test_to_ocaml_string);
+    ("pp_dump", `Quick, test_pp_dump);
     ("pp_ty", `Quick, test_pp_ty);
     ("compare", `Quick, test_compare);
     ("equal", `Quick, test_equal);

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -296,8 +296,14 @@ let test_to_string () =
     |]
     "[|neg_infinity; -0.; 0.; 2.22044604925e-16; infinity; nan|]";
   test "(unit * int)" T.(pair unit int) ((), 1) "((), 1)";
-  test "unit option{some}" T.(option unit) (Some ()) "Some ()";
-  test "int option{none}" T.(option unit) None "None";
+  test "unit option{some}" T.(option unit) (Some ()) "Some (())";
+  test "unit option{none}" T.(option unit) None "None";
+  test "unit option option{some some}"
+    T.(option (option unit))
+    (Some (Some ())) "Some (Some (()))";
+  test "unit option option{some none}"
+    T.(option (option unit))
+    (Some None) "Some (None)";
   test "(int * string * bool)"
     T.(triple int string bool)
     (1, "foo", true) "(1, \"foo\", true)";
@@ -324,8 +330,8 @@ let test_to_string () =
   test "recursive record" my_recursive_record_t
     { head = 1; tail = Some { head = 2; tail = None } }
     {|{ head = 1;
-  tail = Some { head = 2;
-                tail = None } }|};
+  tail = Some ({ head = 2;
+                 tail = None }) }|};
 
   ()
 

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -272,7 +272,7 @@ let test_to_string () =
   test "unit" T.unit () "()";
   test "bool{true}" T.bool true "true";
   test "bool{false}" T.bool false "false";
-  test "char" T.char 'a' "a";
+  test "char" T.char 'a' "'a'";
   test "int" T.int (-100) "-100";
   test "int32" T.int32 Int32.max_int "2147483647";
   test "int64" T.int64 Int64.max_int "9223372036854775807";

--- a/test/irmin/test_type.ml
+++ b/test/irmin/test_type.ml
@@ -317,15 +317,15 @@ let test_to_string () =
     "Branch ([Branch ([Leaf (1)]); Leaf (2)])";
   test "record" my_record_t
     { foo = 2; flag = false; letter = Delta }
-    {|{ "foo" = 2;
-  "flag" = false;
-  "letter" = Delta }|};
+    {|{ foo = 2;
+  flag = false;
+  letter = Delta }|};
 
   test "recursive record" my_recursive_record_t
     { head = 1; tail = Some { head = 2; tail = None } }
-    {|{ "head" = 1;
-  "tail" = Some { "head" = 2;
-                  "tail" = None } }|};
+    {|{ head = 1;
+  tail = Some { head = 2;
+                tail = None } }|};
 
   ()
 


### PR DESCRIPTION
This pull request solves two issues regarding the `Irmin.Type` pretty-printer:
1. Right now, the pretty printer falls back to the JSON encoder in some cases (see `src/irmin/type/type_pp.ml:27`). This can lead to consistency issues when the behavior of the JSON encoder changes, which would be the case if #979 gets merged for instance.
2. Right now, the output of the pretty-printer is a mixture of OCaml-like syntax and JSON. Ideally (cc. @CraigFe), the pretty-printer should "give us something that can be copy-pasted" into an OCaml REPL, which could be helpful when debugging Alcotest diffs.

The first commit rewrites `Type_pp.t` to remove the dependency on the JSON encoder, and to use a new output format which "can be copy-pasted". The second commit updates the unit tests to reflected the new (breaking) output of the pretty-printer.