### PR TITLE
irmin-pack: use explicit instance sharing API for Index

### DIFF
--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -25,7 +25,7 @@ depends: [
 ]
 
 pin-depends: [
-  "index.dev" "git+https://github.com/mirage/index#bd2c09387053cb893fcbb41d9833a09460899cc6"
+  "index.dev" "git+https://github.com/mirage/index#9c88660feefe0efede39fc4dfb001c64f5bdad79"
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"

--- a/src/irmin-pack/pack_index.mli
+++ b/src/irmin-pack/pack_index.mli
@@ -13,6 +13,16 @@
 module type S = sig
   include Index.S with type value = int64 * int * char
 
+  val v :
+    ?auto_flush_callback:(unit -> unit) ->
+    ?fresh:bool ->
+    ?readonly:bool ->
+    ?throttle:[ `Block_writes | `Overcommit_memory ] ->
+    log_size:int ->
+    string ->
+    t
+  (** Constructor for indices, memoized by [(path, readonly)] pairs. *)
+
   val find : t -> key -> value option
 
   val add : t -> key -> value -> unit


### PR DESCRIPTION
This updates the Index pin to current master, adding the minimal necessary changes.

This supersedes https://github.com/mirage/irmin/pull/1042, which was a little _too_ minimal.