### PR TITLE
Add a changelog check

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,20 @@
+name: Changelog check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: git diff
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        ! git diff --exit-code origin/$BASE_REF -- CHANGES.md


### PR DESCRIPTION
This will enable a GitHub action failing iff CHANGES.md was not modified and no-changelog-needed tag is not present.

Taken from https://github.com/ocaml-ppx/ocamlformat/blob/6c2524ba7cb737dda647176f47f155b4d74aa90f/.github/workflows/main.yml.