### PR TITLE
irmin-bench: use latest Bechamel

### DIFF
--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -22,7 +22,7 @@ depends: [
 ]
 
 pin-depends: [
-  "bechamel.dev" "git+https://github.com/dinosaure/bechamel#60688198cf9bffe5467406181e231e13c57a1e7a"
+  "bechamel.dev" "git+https://github.com/dinosaure/bechamel#f1b3db0115af3854422697134a1555e3c07a19f5"
 ]
 
 synopsis: "Benchmarks for Irmin"


### PR DESCRIPTION
This updates our version of Bechamel to include https://github.com/dinosaure/bechamel/pull/8, which fixes our CI.