### PR TITLE
Use workaround for broken locks in Dune pre-2.5.1

### DIFF
--- a/test/irmin-unix/dune
+++ b/test/irmin-unix/dune
@@ -13,6 +13,9 @@
 (rule
  (alias runtest)
  (package irmin-unix)
+ ; Locks mechanism is broken in Dune lang 2.0+
+ (deps
+  (alias ../irmin-http/runtest))
  (locks ../http)
  (action
   (chdir


### PR DESCRIPTION
This should fix at least some of the spurious failures in the CI at present.

Cherry-picked from https://github.com/mirage/irmin/pull/991, since it may be some time before that can be merged.