### PR TITLE
Remove @runbench targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test bench doc examples
+.PHONY: all clean test bench-type bench-mem bench-pack bench doc examples
 
 all:
 	dune build
@@ -6,8 +6,16 @@ all:
 test:
 	dune runtest
 
-bench:
-	dune build @runbench --no-buffer -j 1 --force
+bench-type:
+	dune exec ./bench/irmin/main.exe -- --output-dir _build/default/data
+
+bench-mem:
+	dune exec ./test/irmin-mem/bench.exe
+
+bench-pack:
+	dune exec ./test/irmin-pack/bench.exe
+
+bench: bench-type bench-mem bench-pack
 
 examples:
 	dune build @examples

--- a/bench/irmin/dune
+++ b/bench/irmin/dune
@@ -17,11 +17,3 @@
  (package irmin-bench)
  (deps main.exe)
  (action progn))
-
-(rule
- (alias runbench)
- (package irmin-bench)
- (deps (universe))
- (targets ./data)
- (action
-  (run %{exe:main.exe} --output-dir ./data)))

--- a/test/irmin-mem/dune
+++ b/test/irmin-mem/dune
@@ -18,8 +18,3 @@
  (name bench)
  (modules bench)
  (libraries irmin-mem irmin-test.bench))
-
-(rule
- (alias runbench)
- (action
-  (run ./bench.exe)))

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -20,11 +20,6 @@
  (modules bench)
  (libraries irmin_pack irmin-test.bench))
 
-(rule
- (alias runbench)
- (action
-  (run ./bench.exe)))
-
 (library
  (name common)
  (modules common)


### PR DESCRIPTION
We don't want to run these benchmarks as part of `dune build`, so can't have `run` aliases for them as we do for the tests.