### PR TITLE
Do not run the HTTP test and the unix tests concurrently

### DIFF
--- a/test/irmin-unix/dune
+++ b/test/irmin-unix/dune
@@ -13,6 +13,7 @@
 (rule
  (alias runtest)
  (package irmin-unix)
+ (locks ../http)
  (action
   (chdir
    %{workspace_root}


### PR DESCRIPTION
The unix tests alos contains HTTP tests, so they might try to use
the same ressources and then explode.