### PR TITLE
ppx_irmin: require ppxlib.0.15.0

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.5.1"}
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
-  "ppxlib" {>= "0.12.0"}
+  "ppxlib" {>= "0.15.0"}
   "irmin" {with-test & >= "2.0.0"}
 ]
 


### PR DESCRIPTION
Ppxlib.0.15.0 drops a dependency on Base, allowing us to not explicitly depend on it. This fixes a bug picked up by Travis (see [discussion](https://github.com/mirage/irmin/pull/1060#issuecomment-671918231)).