### PR TITLE
ppx_irmin: implicitly depend on Base

### DIFF
--- a/src/ppx_irmin/deriver/dune
+++ b/src/ppx_irmin/deriver/dune
@@ -1,4 +1,4 @@
 (library
  (public_name ppx_irmin)
  (kind ppx_deriver)
- (libraries ppx_irmin_lib ppxlib base))
+ (libraries ppx_irmin_lib ppxlib))


### PR DESCRIPTION
Temporarily solution to Travis CI errors caused by the latest release of Ppxlib. A better solution would be to just require the latest version, but other packages in the repository are not compatible with it (see https://github.com/mirage/irmin/pull/1063).