### PR TITLE
Update irmin to the last version of ocaml-git

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Fixed
 
+- **irmin-git**
+  - Update `irmin` to the last version of `ocaml-git` (#1065)
+    It fixes an issue on serialization/deserialization of big tree object
+    (see #1001) 
+
 - **irmin-pack***
   - Fix a major bug in the LRU which was never used (#1035, @samoht)
 

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
 let config =
-  let head = Store.Git.Reference.of_string "refs/heads/upstream" in
+  let head = Git.Reference.v "refs/heads/upstream" in
   Irmin_git.config ~head ~bare:false Config.root
 
 let info ~user msg () =

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -87,7 +87,8 @@ let images = [| (*ubuntu; *) wordpress; mysql |]
 
 module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
-let head = Store.Git.Reference.of_string ("refs/heads/" ^ branch images.(0))
+let head = Git.Reference.v ("refs/heads/" ^ branch images.(0))
+
 let config = Irmin_git.config ~bare:true ~head Config.root
 
 let info image msg () =

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -88,7 +88,6 @@ let images = [| (*ubuntu; *) wordpress; mysql |]
 module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
 let head = Git.Reference.v ("refs/heads/" ^ branch images.(0))
-
 let config = Irmin_git.config ~bare:true ~head Config.root
 
 let info image msg () =

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"
+  "git"        {>= "3.0.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"
@@ -40,17 +40,3 @@ description: """
 `Irmin_git` expose a bi-directional bridge between Git repositories and
 Irmin stores.
 """
-
-pin-depends: [
-  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "awa.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
-  [ "awa-mirage.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
-]

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "2.1.1"}
+  "git"
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"
@@ -27,9 +27,10 @@ depends: [
   "logs"
   "lwt"
   "uri"
+  "git-cohttp-unix" {with-test}
   "irmin-test" {with-test & = version}
   "irmin-mem"  {with-test & = version}
-  "git-unix"   {with-test & >= "2.1.1"}
+  "git-unix"   {with-test}
   "mtime"      {with-test & >= "1.0.0"}
   "alcotest"   {with-test}
 ]
@@ -39,3 +40,17 @@ description: """
 `Irmin_git` expose a bi-directional bridge between Git repositories and
 Irmin stores.
 """
+
+pin-depends: [
+  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "awa.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
+  [ "awa-mirage.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
+]

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -28,11 +28,32 @@ depends: [
   "logs"
   "lwt"
   "uri"
+  "conduit"    {>= "2.1.0" & with-test}
   "irmin-git"  {with-test & = version}
   "irmin-mem"  {with-test & = version}
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test}
   "digestif"   {with-test & >= "0.9.0"}
+  "alcotest"   {>= "1.2.3" & with-test}
+  "cohttp-lwt-unix" {>= "2.5.4" & with-test}
+  "conduit-lwt-unix" {>= "2.2.2" & with-test}
+  "fpath"      {>= "0.7.3" & with-test}
+  "git"        {>= "2.1.3" & with-test}
+  "git-cohttp-unix" {>= "~dev" & with-test}
+]
+
+pin-depends: [
+  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "awa.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
+  [ "awa-mirage.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -31,22 +31,8 @@ depends: [
   "irmin-git"  {with-test & = version}
   "irmin-mem"  {with-test & = version}
   "irmin-test" {with-test & = version}
-  "git-unix"   {with-test}
+  "git-unix"   {with-test & >= "3.0.0"}
   "digestif"   {with-test & >= "0.9.0"}
-]
-
-pin-depends: [
-  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "awa.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
-  [ "awa-mirage.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -28,18 +28,11 @@ depends: [
   "logs"
   "lwt"
   "uri"
-  "conduit"    {>= "2.1.0" & with-test}
   "irmin-git"  {with-test & = version}
   "irmin-mem"  {with-test & = version}
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test}
   "digestif"   {with-test & >= "0.9.0"}
-  "alcotest"   {>= "1.2.3" & with-test}
-  "cohttp-lwt-unix" {>= "2.5.4" & with-test}
-  "conduit-lwt-unix" {>= "2.2.2" & with-test}
-  "fpath"      {>= "0.7.3" & with-test}
-  "git"        {>= "2.1.3" & with-test}
-  "git-cohttp-unix" {>= "~dev" & with-test}
 ]
 
 pin-depends: [

--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -16,11 +16,11 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "git-mirage"   {>= "2.1.2"}
   "mirage-kv"    {>= "3.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
+  "git-cohttp-mirage"
   "fmt"
   "git"
   "lwt"
@@ -29,3 +29,13 @@ depends: [
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"
+
+pin-depends: [
+  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp-mirage.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+]

--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -20,22 +20,12 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-cohttp-mirage"
+  "git-cohttp-mirage" {>= "3.0.0"}
   "fmt"
-  "git"
+  "git"               {>= "3.0.0"}
   "lwt"
   "mirage-clock"
   "uri"
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"
-
-pin-depends: [
-  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp-mirage.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-]

--- a/irmin-mirage-graphql.opam
+++ b/irmin-mirage-graphql.opam
@@ -16,11 +16,15 @@ depends: [
   "dune"          {>= "2.7.0"}
   "irmin-mirage"  {= version}
   "irmin-graphql" {= version}
-  "git-mirage"    {>= "2.1.1"}
   "mirage-clock"
   "cohttp-lwt"
   "lwt"
   "uri"
+  "git-nss"
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"
+
+pin-depends: [
+  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+]

--- a/irmin-mirage-graphql.opam
+++ b/irmin-mirage-graphql.opam
@@ -20,11 +20,7 @@ depends: [
   "cohttp-lwt"
   "lwt"
   "uri"
-  "git-nss"
+  "git"           {>= "3.0.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"
-
-pin-depends: [
-  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-]

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -24,7 +24,7 @@ depends: [
   "irmin-pack"    {= version}
   "irmin-graphql" {= version}
   "irmin-layers"  {= version}
-  "git-unix"      {>= "1.11.4"}
+  "git-unix"
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "0.1.0"}
@@ -32,6 +32,7 @@ depends: [
   "astring"
   "cohttp"
   "cohttp-lwt"
+  "cohttp-lwt-unix"
   "conduit"
   "conduit-lwt"
   "conduit-lwt-unix"
@@ -41,9 +42,25 @@ depends: [
   "cohttp-lwt-unix"
   "fmt"
   "git"
+  "git-cohttp-unix"
   "lwt"
-  "irmin-test" {with-test & = version}
-  "alcotest"   {with-test}
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+  "fpath"         {>= "0.7.3" & with-test}
+]
+
+pin-depends: [
+  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-cohttp-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "git-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
+  [ "awa.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
+  [ "awa-mirage.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
 ]
 
 synopsis: "Unix backends for Irmin"

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -41,30 +41,9 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"
-  "git-cohttp-unix"
+  "git"             {>= "3.0.0"}
+  "git-cohttp-unix" {>= "3.0.0"}
   "lwt"
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
 ]
-
-pin-depends: [
-  [ "git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-nss.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-cohttp-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "git-unix.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-git.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "carton-lwt.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#b8a1d07147cbc8d5f8a563055b84fd166da9d0a0" ]
-  [ "awa.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
-  [ "awa-mirage.dev" "git+https://github.com/mirage/awa-ssh.git#c337fbac71e3699ba4bcefe9382c9842354b3bee" ]
-]
-
-synopsis: "Unix backends for Irmin"
-description: """
-`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
-as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
-stores.
-"""

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -47,3 +47,10 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
 ]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -46,7 +46,6 @@ depends: [
   "lwt"
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
-  "fpath"         {>= "0.7.3" & with-test}
 ]
 
 pin-depends: [

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -183,7 +183,6 @@ struct
       include C
 
       let to_bin t = Raw.to_raw (GitContents.to_git t)
-
       let encode_bin = Irmin.Type.stage (fun (t : t) k -> k (to_bin t))
 
       let decode_bin =
@@ -319,7 +318,6 @@ struct
 
       let to_n t = N.v (alist t)
       let of_n n = v (N.list n)
-
       let to_bin t = Raw.to_raw (G.Value.tree t)
 
       let encode_bin =
@@ -529,7 +527,6 @@ functor
       match B.of_ref str with Ok r -> Some r | Error (`Msg _) -> None
 
     let git_of_branch r = Git.Reference.v (Fmt.to_to_string B.pp_ref r)
-
     let pp_key = Irmin.Type.pp Key.t
 
     let mem { t; _ } r =
@@ -701,17 +698,14 @@ struct
   let src = Logs.Src.create "irmin.git-output" ~doc:"Git output"
 
   module Gitlog = (val Logs.src_log src : Logs.LOG)
-
   module H = Irmin.Hash.Make (G.Hash)
 
   type t = G.t
   type commit = H.t
   type branch = B.t
-
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   let git_of_branch_str str = Git.Reference.v ("refs/heads/" ^ str)
-
   let git_of_branch r = git_of_branch_str (Irmin.Type.to_string B.t r)
 
   (* let o_head_of_git = function None -> Ok None | Some k -> Ok (Some k) *)
@@ -720,7 +714,6 @@ struct
     x >>= function Ok x -> f x | Error err -> Lwt.return (Error err)
 
   let msgf fmt = Fmt.kstrf (fun err -> `Msg err) fmt
-
   let reword_error f = function Ok _ as v -> v | Error err -> Error (f err)
 
   let fetch t ?depth (ctx, e) br =
@@ -1018,7 +1011,6 @@ module Make
 
 module No_sync (G : Git.S) = struct
   type hash = G.hash
-
   type store = G.t
 
   type error =

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -1021,9 +1021,6 @@ module No_sync (G : Git.S) = struct
 
   type store = G.t
 
-  (* XXX(samoht): so much boilerplate... *)
-  (* XXX(dinosaure): not anymore. *)
-
   type error =
     [ `Not_found | `Msg of string | `Exn of exn | `Cycle | `Invalid_flow ]
 

--- a/src/irmin-mirage/git/dune
+++ b/src/irmin-mirage/git/dune
@@ -1,5 +1,5 @@
 (library
  (name irmin_mirage_git)
  (public_name irmin-mirage-git)
- (libraries fmt cohttp conduit-lwt conduit-mirage git git-mirage irmin
-   irmin-mirage irmin-git lwt mirage-clock mirage-kv uri))
+ (libraries fmt cohttp conduit-lwt conduit-mirage git irmin irmin-mirage
+   irmin-git git-cohttp-mirage lwt mirage-clock mirage-kv uri))

--- a/src/irmin-mirage/git/irmin_mirage_git.mli
+++ b/src/irmin-mirage/git/irmin_mirage_git.mli
@@ -1,12 +1,10 @@
 module type S = sig
-  include Irmin_git.S with type Private.Sync.endpoint = Git_mirage.endpoint
+  include
+    Irmin_git.S
+      with type Private.Sync.endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   val remote :
-    ?conduit:Conduit_mirage.conduit ->
-    ?resolver:Resolver_lwt.t ->
-    ?headers:Cohttp.Header.t ->
-    string ->
-    Irmin.remote
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
 end
 
 module type S_MAKER = functor
@@ -52,8 +50,7 @@ module type KV_RO = sig
     ?depth:int ->
     ?branch:string ->
     ?root:key ->
-    ?conduit:Conduit_mirage.t ->
-    ?resolver:Resolver_lwt.t ->
+    ?ctx:Mimic.ctx ->
     ?headers:Cohttp.Header.t ->
     git ->
     string ->
@@ -77,8 +74,7 @@ module type KV_RW = sig
     ?depth:int ->
     ?branch:string ->
     ?root:key ->
-    ?conduit:Conduit_mirage.t ->
-    ?resolver:Resolver_lwt.t ->
+    ?ctx:Mimic.ctx ->
     ?headers:Cohttp.Header.t ->
     ?author:(unit -> string) ->
     ?msg:([ `Set of key | `Remove of key | `Batch ] -> string) ->

--- a/src/irmin-mirage/graphql/dune
+++ b/src/irmin-mirage/graphql/dune
@@ -1,5 +1,5 @@
 (library
  (name irmin_mirage_graphql)
  (public_name irmin-mirage-graphql)
- (libraries cohttp-lwt git-mirage irmin irmin-mirage irmin-graphql lwt
+ (libraries git.nss.git cohttp-lwt irmin irmin-mirage irmin-graphql lwt
    mirage-clock uri))

--- a/src/irmin-mirage/graphql/irmin_mirage_graphql.mli
+++ b/src/irmin-mirage/graphql/irmin_mirage_graphql.mli
@@ -2,14 +2,16 @@ module Server : sig
   module type S = sig
     module Pclock : Mirage_clock.PCLOCK
     module Http : Cohttp_lwt.S.Server
-    module Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
+
+    module Store :
+      Irmin.S with type Private.Sync.endpoint = Smart_git.Endpoint.t
 
     val start : http:(Http.t -> unit Lwt.t) -> Store.repo -> unit Lwt.t
   end
 
   module Make
       (Http : Cohttp_lwt.S.Server)
-      (Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint)
+      (Store : Irmin.S with type Private.Sync.endpoint = Smart_git.Endpoint.t)
       (Pclock : Mirage_clock.PCLOCK) :
     S
       with module Pclock = Pclock

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -311,7 +311,7 @@ let remove =
 
 let apply e f =
   match (e, f) with
-  | R (h, e), Some f -> f ?headers:h e
+  | R (h, e), Some f -> f ?ctx:None ?headers:h e
   | R _, None -> Fmt.failwith "invalid remote for that kind of store"
   | r, _ -> r
 

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -2,6 +2,6 @@
  (name irmin_unix)
  (public_name irmin-unix)
  (libraries astring cmdliner cohttp cohttp-lwt cohttp-lwt-unix conduit
-   conduit-lwt-unix fmt.cli fmt.tty git git-unix irmin irmin-fs irmin-git
-   irmin-graphql irmin-http irmin-mem irmin-pack irmin-watcher logs.cli
-   logs.fmt lwt lwt.unix uri yaml))
+   conduit-lwt-unix git-cohttp-unix fmt.cli fmt.tty git git-unix irmin
+   irmin-fs irmin-git irmin-graphql irmin-http irmin-mem irmin-pack
+   irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml))

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -19,7 +19,11 @@ module Server = struct
       (Cohttp_lwt_unix.Server)
       (struct
         let info = Info.v
-        let remote = Remote.remote
+
+        let remote =
+          match Remote.remote with
+          | Some fn -> Some (fun ?headers v -> fn ?headers v)
+          | None -> None
       end)
       (S)
       (T)
@@ -32,7 +36,11 @@ module Server = struct
       (Cohttp_lwt_unix.Server)
       (struct
         let info = Info.v
-        let remote = Remote.remote
+
+        let remote =
+          match Remote.remote with
+          | Some fn -> Some (fun ?headers v -> fn ?headers v)
+          | None -> None
       end)
       (S)
 end

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -71,9 +71,12 @@ module Git : sig
   (** {1 Git Store} *)
 
   module type S = sig
-    include Irmin_git.S with type Private.Sync.endpoint = Git_unix.endpoint
+    include
+      Irmin_git.S
+        with type Private.Sync.endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
-    val remote : ?headers:Cohttp.Header.t -> string -> Irmin.remote
+    val remote :
+      ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
   end
 
   module Make

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -244,7 +244,9 @@ type hash = Hash.t
 (* Store *)
 
 module Store = struct
-  type remote_fn = ?headers:Cohttp.Header.t -> string -> Irmin.remote
+  type remote_fn =
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
+
   type t = T : (module Irmin.S) * remote_fn option -> t
 
   type store_functor =
@@ -419,7 +421,7 @@ let from_config_file_with_defaults path (store, hash, contents) config branch :
       | None -> Irmin.Private.Conf.default Irmin_git.bare
       | Some b -> b
     in
-    let head = assoc "head" (fun x -> Git.Reference.of_string x) in
+    let head = assoc "head" (fun x -> Git.Reference.v x) in
     let uri = assoc "uri" Uri.of_string in
     let add k v config = Irmin.Private.Conf.add config k v in
     Irmin.Private.Conf.empty

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -54,7 +54,8 @@ module Store : sig
     | Fixed_hash of (contents -> t)
     | Variable_hash of (hash -> contents -> t)
 
-  type remote_fn = ?headers:Cohttp.Header.t -> string -> Irmin.remote
+  type remote_fn =
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
 
   val v : ?remote:remote_fn -> (module Irmin.S) -> t
   val mem : hash -> contents -> t

--- a/src/irmin-unix/xgit.mli
+++ b/src/irmin-unix/xgit.mli
@@ -15,9 +15,12 @@
  *)
 
 module type S = sig
-  include Irmin_git.S with type Private.Sync.endpoint = Git_unix.endpoint
+  include
+    Irmin_git.S
+      with type Private.Sync.endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
-  val remote : ?headers:Cohttp.Header.t -> string -> Irmin.remote
+  val remote :
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
 end
 
 module type S_MAKER = functor

--- a/test/irmin-git/dune
+++ b/test/irmin-git/dune
@@ -2,7 +2,7 @@
  (name test_git)
  (modules test_git)
  (libraries alcotest fmt fpath irmin irmin-test irmin-mem irmin-git git
-   git-unix lwt lwt.unix)
+   git-unix git-cohttp-unix lwt lwt.unix)
  (preprocess
   (pps ppx_irmin)))
 

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -19,10 +19,8 @@ open Lwt.Infix
 let test_db = Filename.concat "_build" "test-db-git"
 
 let config =
-  let head = Git.Reference.of_string "refs/heads/test" in
+  let head = Git.Reference.v "refs/heads/test" in
   Irmin_git.config ~head ~bare:true test_db
-
-module Net = Git_unix.Net
 
 module type S = sig
   include Irmin_test.S
@@ -50,7 +48,7 @@ module type X =
 
 module Mem (C : Irmin.Contents.S) = struct
   module G = Irmin_git.Mem
-  module S = Irmin_git.KV (G) (Git_unix.Sync (G)) (C)
+  module S = Irmin_git.KV (G) (Git_unix.Sync (G) (Git_cohttp_unix)) (C)
   include S
 
   let init () =
@@ -146,7 +144,10 @@ let test_sort_order (module S : S) =
   Lwt.return_unit
 
 module Ref (S : Irmin_git.G) =
-  Irmin_git.Ref (S) (Git_unix.Sync (S)) (Irmin.Contents.String)
+  Irmin_git.Ref
+    (S)
+    (Git_unix.Sync (S) (Git_cohttp_unix))
+    (Irmin.Contents.String)
 
 let pp_reference ppf = function
   | `Branch s -> Fmt.pf ppf "branch: %s" s

--- a/test/irmin-unix/test_unix.ml
+++ b/test/irmin-unix/test_unix.ml
@@ -83,7 +83,7 @@ module Git = struct
     Lwt.return_unit
 
   let config =
-    let head = Git.Reference.of_string "refs/heads/test" in
+    let head = Git.Reference.v "refs/heads/test" in
     Irmin_git.config ~head ~bare:true test_db
 
   let suite =


### PR DESCRIPTION
This is a draft about an update to the new version of git presented on mirage/ocaml-git#395 and the new version of conduit presented on mirage/ocaml-conduit#311 (including patches into mirage/ocaml-cohttp#692). I think the patch is small enough. The CI will fail but locally (with a `pin` of `conduit` and `cohttp` and a simple `dune runtest`) it's work (believe me).

This is a draft but people can start to comment it if some details are obscures. Currently, the biggest change is about the synchronization where I updated the interface which seems to be much more simpler.