### PR TITLE
Flaky tests: discard stale events

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -667,16 +667,15 @@ functor
     let set t r k =
       Log.debug (fun f -> f "set %a" pp_branch r);
       let gr = git_of_branch r in
-      Lwt_mutex.with_lock t.m (fun () ->
-          G.Ref.write t.t gr (G.Reference.Hash k))
-      >>= function
+      Lwt_mutex.with_lock t.m @@ fun () ->
+      G.Ref.write t.t gr (G.Reference.Hash k) >>= function
       | Error e -> Fmt.kstrf Lwt.fail_with "%a" G.pp_error e
       | Ok () -> W.notify t.w r (Some k) >>= fun () -> write_index t gr k
 
     let remove t r =
       Log.debug (fun f -> f "remove %a" pp_branch r);
-      Lwt_mutex.with_lock t.m (fun () -> G.Ref.remove t.t (git_of_branch r))
-      >>= function
+      Lwt_mutex.with_lock t.m @@ fun () ->
+      G.Ref.remove t.t (git_of_branch r) >>= function
       | Error e -> Fmt.kstrf Lwt.fail_with "%a" G.pp_error e
       | Ok () -> W.notify t.w r None
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -687,7 +687,9 @@ functor
       | _ -> false
 
     let test_and_set t r ~test ~set =
-      Log.debug (fun f -> f "test_and_set %a" pp_branch r);
+      Log.debug (fun f ->
+          let pp = Fmt.option ~none:(Fmt.any "<none>") (Irmin.Type.pp Val.t) in
+          f "test_and_set %a: %a => %a" pp_branch r pp test pp set);
       let gr = git_of_branch r in
       let c = function None -> None | Some h -> Some (G.Reference.Hash h) in
       let ok = function

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -58,6 +58,18 @@ let invalid_arg fmt = Fmt.kstrf Lwt.fail_invalid_arg fmt
 
 exception Escape of ((int * int) * (int * int)) * Jsonm.error
 
+let () =
+  Printexc.register_printer (function
+    | Escape ((start, end_), err) ->
+        Fmt.kstr
+          (fun s -> Some s)
+          "Escape ({ start = %a; end = %a; error = %a })"
+          Fmt.(Dump.pair int int)
+          start
+          Fmt.(Dump.pair int int)
+          end_ Jsonm.pp_error err
+    | _ -> None)
+
 let json_stream (stream : string Lwt_stream.t) : Jsonm.lexeme list Lwt_stream.t
     =
   let d = Jsonm.decoder `Manual in

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -791,7 +791,10 @@ module Make (S : S) = struct
             let tag = Fmt.strf "t%d" n in
             S.Branch.remove repo tag)
       in
-      S.Branch.watch_all repo (fun _ -> State.process state) >>= fun u ->
+      S.Branch.get repo "master" >>= fun master ->
+      S.Branch.watch_all ~init:[ ("master", master) ] repo (fun _ ->
+          State.process state)
+      >>= fun u ->
       add true (0, 0, 0) 10 ~first:true >>= fun () ->
       remove true (10, 0, 0) 5 >>= fun () ->
       S.unwatch u >>= fun () ->

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -649,11 +649,17 @@ module Make (S : S) = struct
 
       let empty () = { adds = 0; updates = 0; removes = 0 }
 
-      let add t = t.adds <- t.adds + 1
+      let add t =
+        Log.debug (fun l -> l "add %a" pp t);
+        t.adds <- t.adds + 1
 
-      let update t = t.updates <- t.updates + 1
+      let update t =
+        Log.debug (fun l -> l "update %a" pp t);
+        t.updates <- t.updates + 1
 
-      let remove t = t.removes <- t.removes + 1
+      let remove t =
+        Log.debug (fun l -> l "remove %a" pp t);
+        t.removes <- t.removes + 1
 
       let pretty ppf t = Fmt.pf ppf "%d/%d/%d" t.adds t.updates t.removes
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -681,19 +681,18 @@ module Make (S : S) = struct
             if a = b then line msg
             else Alcotest.failf "%s: %a / %a" msg pp a pp b)
 
-      let process ?sleep_t t = function
-        | head ->
-            (match sleep_t with
-            | None -> Lwt.return_unit
-            | Some s -> Lwt_unix.sleep s)
-            >>= fun () ->
-            let () =
-              match head with
-              | `Added _ -> add t
-              | `Updated _ -> update t
-              | `Removed _ -> remove t
-            in
-            Lwt.return_unit
+      let process ?sleep_t t head =
+        (match sleep_t with
+        | None -> Lwt.return_unit
+        | Some s -> Lwt_unix.sleep s)
+        >>= fun () ->
+        let () =
+          match head with
+          | `Added _ -> add t
+          | `Updated _ -> update t
+          | `Removed _ -> remove t
+        in
+        Lwt.return_unit
 
       let apply msg state kind fn ?(first = false) on s n =
         let msg mode n w s =

--- a/src/irmin/watch.ml
+++ b/src/irmin/watch.ml
@@ -241,11 +241,12 @@ struct
       IMap.fold
         (fun id ((init, f) as arg) acc ->
           let fire old_value =
-            Log.debug (fun f ->
-                f "notify-all[%d.%d:%a]: firing! (%a -> %a)" t.id id pp_key key
-                  (pp_option pp_value) old_value (pp_option pp_value) value);
             todo :=
               protect (fun () ->
+                  Log.debug (fun f ->
+                      f "notify-all[%d.%d:%a]: %d firing! (%a -> %a)" t.id id
+                        pp_key key t.notifications (pp_option pp_value)
+                        old_value (pp_option pp_value) value);
                   t.notifications <- t.notifications + 1;
                   f key (mk old_value value))
               :: !todo;
@@ -284,10 +285,12 @@ struct
                   key);
             IMap.add id arg acc)
           else (
-            Log.debug (fun f ->
-                f "notify-key[%d:%d:%a] firing!" t.id id pp_key key);
             todo :=
               protect (fun () ->
+                  Log.debug (fun f ->
+                      f "notify-key[%d:%d:%a] %d firing! (%a -> %a)" t.id id
+                        pp_key key t.notifications (pp_option pp_value)
+                        old_value (pp_option pp_value) value);
                   t.notifications <- t.notifications + 1;
                   f (mk old_value value))
               :: !todo;

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -58,19 +58,23 @@ let http_store id (module S : Irmin_test.S) =
 
 let remove file = try Unix.unlink file with _ -> ()
 
-let rec wait_for_the_server_to_start id =
-  let pid_file = pid_file id in
-  if Sys.file_exists pid_file then (
-    let ic = open_in pid_file in
-    let line = input_line ic in
-    close_in ic;
-    let pid = int_of_string line in
-    Logs.debug (fun l -> l "read PID %d from %s" pid pid_file);
-    Unix.unlink pid_file;
-    Lwt.return pid)
-  else (
-    Logs.debug (fun l -> l "waiting for the server to start...");
-    Lwt_unix.sleep 0.1 >>= fun () -> wait_for_the_server_to_start id)
+let wait_for_the_server_to_start id =
+  let rec aux n =
+    let pid_file = pid_file id in
+    let socket = socket id in
+    if Sys.file_exists pid_file && Sys.file_exists socket then (
+      let ic = open_in pid_file in
+      let line = input_line ic in
+      close_in ic;
+      let pid = int_of_string line in
+      Logs.debug (fun l -> l "read PID %d from %s" pid pid_file);
+      Unix.unlink pid_file;
+      Lwt.return pid)
+    else (
+      Logs.debug (fun l -> l "waiting for the server to start...");
+      Lwt_unix.sleep (float n *. 0.1) >>= fun () -> aux (n + 1))
+  in
+  aux 1
 
 let servers = [ (`Quick, Test_mem.suite); (`Quick, Test_git.suite) ]
 


### PR DESCRIPTION
Discard stale events

There are two different ways to produce events (which are then consumed by watchers):
- every update to the reference store will call notify, which will notify watcher connected to the same repository in that process
- there is a background thread, using irmin-watcher (with either polling mode, inotify or fsevents), which check for filesystem changes, and call notify whenever a reference change.

It is necessary that the events are delivered in (commit) order, as the API is exposing diffs and it would be confusing if the events go back in time.

There is a small race right now between these two mechanism: the background thread could read a new reference value, be interrupted, and then call notify. During that interruption, the store can change and events be delivered. If that's the case, we want to discard the current event and try again.