### PR TITLE
Add a clear function to all backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
     let encode_bin = Type.(unstage (encode_bin ty))
     let _ = <begin loop> ... encode_bin foo ... <end loop>
     ```
+  - Added a `clear` function for stores (#1071, @icristescu, @CraigFe)
 
 - **irmin-pack**:
   - Added `index_throttle` option to `Irmin_pack.config`, which exposes the

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -24,6 +24,7 @@ depends: [
   "logs"
   "lwt"
   "metrics-unix"
+  "ocaml-syntax-shims"
 ]
 
 synopsis: "Irmin test suite"

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -217,6 +217,8 @@ struct
 
   let close _ = Lwt.return_unit
 
+  let clear t = CA.clear t.db
+
   let batch t f = CA.batch t.db (fun db -> f { t with db })
 
   let find_leaves t key =

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -141,6 +141,13 @@ struct
             Log.err (fun l -> l "Irmin_fs.list: %s" e);
             acc)
       [] files
+
+  let clear t =
+    Log.debug (fun f -> f "clear");
+    let remove_file key =
+      IO.remove_file ~lock:(lock_of_key t key) (file_of_key t key)
+    in
+    list t >>= Lwt_list.iter_p remove_file
 end
 
 module Append_only_ext
@@ -262,6 +269,13 @@ struct
       ~set:(raw_value set)
     >>= fun b ->
     (if b then W.notify t.w key set else Lwt.return_unit) >|= fun () -> b
+
+  let clear t =
+    Log.debug (fun f -> f "clear");
+    let remove_file key =
+      IO.remove_file ~lock:(RO.lock_of_key t.t key) (RO.file_of_key t.t key)
+    in
+    list t >>= Lwt_list.iter_p remove_file
 end
 
 module Make_ext

--- a/src/irmin-git/closeable.ml
+++ b/src/irmin-git/closeable.ml
@@ -38,4 +38,8 @@ module Content_addressable (S : Irmin.CONTENT_ADDRESSABLE_STORE) = struct
   let unsafe_add t k v =
     check_not_closed t;
     S.unsafe_add (snd t) k v
+
+  let clear t =
+    check_not_closed t;
+    S.clear (snd t)
 end

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -146,6 +146,11 @@ struct
         Fmt.failwith
           "[Git.unsafe_append] %a is not a valid key. Expecting %a instead.\n"
           pp_key k pp_key k'
+
+    let clear t =
+      G.reset t >>= function
+      | Error e -> Fmt.kstrf Lwt.fail_with "%a" G.pp_error e
+      | Ok () -> Lwt.return_unit
   end)
 
   module Raw = Git.Value.Raw (G.Hash) (G.Inflate) (G.Deflate)
@@ -723,6 +728,20 @@ functor
           >|= fun () -> b)
 
     let close _ = Lwt.return_unit
+
+    let clear t =
+      Log.debug (fun l -> l "clear");
+      Lwt_mutex.with_lock t.m (fun () ->
+          G.Ref.list t.t >>= fun refs ->
+          Lwt_list.iter_p
+            (fun (r, _) ->
+              G.Ref.remove t.t r >>= function
+              | Error e -> Fmt.kstrf Lwt.fail_with "%a" G.pp_error e
+              | Ok () -> (
+                  match branch_of_git r with
+                  | Some k -> W.notify t.w k None
+                  | None -> Lwt.return_unit))
+            refs)
   end
 
 module Irmin_sync_store
@@ -944,6 +963,10 @@ functor
       else (
         t.closed := true;
         S.close t.t)
+
+    let clear t =
+      check_not_closed t;
+      S.clear t.t
   end
 
 module Make_ext
@@ -1159,6 +1182,8 @@ module Content_addressable (G : Git.S) (V : Irmin.Type.S) = struct
   let find = with_state X.find
 
   let mem = with_state X.mem
+
+  let clear _ = Lwt.fail_with "not implemented"
 end
 
 module Atomic_write (G : Git.S) (K : Irmin.Branch.S) = struct

--- a/src/irmin-http/closeable.ml
+++ b/src/irmin-http/closeable.ml
@@ -55,6 +55,10 @@ module Append_only (S : S.APPEND_ONLY_STORE) = struct
   let batch t f =
     check_not_closed t;
     S.batch t.t (fun w -> f { t = w; closed = t.closed })
+
+  let clear t =
+    check_not_closed t;
+    S.clear t.t
 end
 
 module Atomic_write (S : S.ATOMIC_WRITE_STORE) = struct
@@ -114,4 +118,8 @@ module Atomic_write (S : S.ATOMIC_WRITE_STORE) = struct
     else (
       t.closed := true;
       S.close t.t)
+
+  let clear t =
+    check_not_closed t;
+    S.clear t.t
 end

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -245,6 +245,9 @@ module RO (Client : Cohttp_lwt.S.Client) (K : Irmin.Type.S) (V : Irmin.Type.S) :
     f (cast t)
 
   let v ?ctx uri item items = Lwt.return { uri; item; items; ctx }
+
+  let clear t =
+    HTTP.call `POST t.uri t.ctx [ "clear"; t.items ] Irmin.Type.(of_string unit)
 end
 
 module AO (Client : Cohttp_lwt.S.Client) (K : Irmin.Hash.S) (V : Irmin.Type.S) =
@@ -420,6 +423,8 @@ functor
       Lwt.return_unit
 
     let close _ = Lwt.return_unit
+
+    let clear t = RO.clear t.t
   end
 
 module type HTTP_CLIENT = sig

--- a/src/irmin-http/s.ml
+++ b/src/irmin-http/s.ml
@@ -94,6 +94,8 @@ module type READ_ONLY_STORE = sig
   val batch : 'a t -> ([ `Read | `Write ] t -> 'b) -> 'b
 
   val v : ?ctx:ctx -> Uri.t -> string -> string -> 'a t Lwt.t
+
+  val clear : 'a t -> unit Lwt.t
 end
 
 module type APPEND_ONLY_STORE = sig
@@ -118,6 +120,8 @@ module type APPEND_ONLY_STORE = sig
   val close : 'a t -> unit Lwt.t
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
+
+  val clear : 'a t -> unit Lwt.t
 end
 
 module type APPEND_ONLY_STORE_MAKER = functor

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -37,9 +37,13 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
 
   let v _config = Lwt.return map
 
-  let close t =
-    Log.debug (fun f -> f "close");
+  let clear t =
+    Log.debug (fun f -> f "clear");
     t.t <- KMap.empty;
+    Lwt.return_unit
+
+  let close _ =
+    Log.debug (fun f -> f "close");
     Lwt.return_unit
 
   let cast t = (t :> [ `Read | `Write ] t)
@@ -130,6 +134,8 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
     >>= fun updated ->
     (if updated then W.notify t.w key set else Lwt.return_unit) >>= fun () ->
     Lwt.return updated
+
+  let clear t = W.clear t.w >>= fun () -> RO.clear t.t
 end
 
 let config () = Irmin.Private.Conf.empty

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -147,4 +147,8 @@ module Atomic_write (AW : S.ATOMIC_WRITE_STORE) = struct
     else (
       t.closed := true;
       AW.close t.t)
+
+  let clear t =
+    check_not_closed t;
+    AW.clear t.t
 end

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -824,5 +824,7 @@ struct
 
   let sync = Inode.sync
 
+  let clear = Inode.clear
+
   let clear_caches = Inode.clear_caches
 end

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -265,6 +265,12 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Tbl.clear t.cache;
     Tbl.clear t.index
 
+  let clear t =
+    Log.debug (fun l -> l "[branches] clear");
+    Lwt_mutex.with_lock t.lock (fun () ->
+        unsafe_clear t;
+        Lwt.return_unit)
+
   let create = Lwt_mutex.create ()
 
   let watches = W.v ()

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -2,6 +2,7 @@
  (name irmin_test)
  (public_name irmin-test)
  (modules Irmin_test Store Common)
+ (preprocess future_syntax)
  (libraries alcotest astring fmt irmin jsonm logs.fmt lwt lwt.unix mtime
    mtime.clock.os))
 

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -72,6 +72,8 @@ struct
 
   let find (_, t) = S.find t
 
+  let clear (_, t) = S.clear t
+
   let merge_node (t, _) = Merge.f (N.merge t)
 
   let pp_key = Type.pp S.Key.t

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -288,6 +288,8 @@ struct
 
   let mem = S.mem
 
+  let clear = S.clear
+
   let read_opt t = function None -> Lwt.return_none | Some k -> find t k
 
   let add_opt t = function

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -100,6 +100,10 @@ functor
       else (
         t.closed := true;
         S.close t.t)
+
+    let clear t =
+      check_not_closed t;
+      S.clear t.t
   end
 
 module AW_check_closed (AW : S.ATOMIC_WRITE_STORE_MAKER) :
@@ -164,6 +168,10 @@ functor
       else (
         t.closed := true;
         S.close t.t)
+
+    let clear t =
+      check_not_closed t;
+      S.clear t.t
   end
 
 module Make_ext

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -171,6 +171,8 @@ struct
 
   let find (_, t) = S.find t
 
+  let clear (_, t) = S.clear t
+
   let add (_, t) = S.add t
 
   let unsafe_add (_, t) = S.unsafe_add t

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -152,6 +152,9 @@ module type CONTENT_ADDRESSABLE_STORE = sig
   (** Same as {!add} but allows to specify the key directly. The backend might
       choose to discared that key and/or can be corrupt if the key scheme is not
       consistent. *)
+
+  val clear : 'a t -> unit Lwt.t
+  (** Clear the store. This operation is expected to be slow. *)
 end
 
 module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
@@ -192,6 +195,9 @@ module type APPEND_ONLY_STORE = sig
 
   val add : [> `Write ] t -> key -> value -> unit Lwt.t
   (** Write the contents of a value to the store. *)
+
+  val clear : 'a t -> unit Lwt.t
+  (** Clear the store. This operation is expected to be slow. *)
 end
 
 module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
@@ -686,6 +692,9 @@ module type ATOMIC_WRITE_STORE = sig
   val close : t -> unit Lwt.t
   (** [close t] frees up all the resources associated to [t]. Any operations run
       on a closed store will raise {!Closed}. *)
+
+  val clear : t -> unit Lwt.t
+  (** [clear t] clears the store. This operation is expected to be slow. *)
 end
 
 module type ATOMIC_WRITE_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -82,9 +82,18 @@ let config = Irmin_chunk.config ()
 
 let clean () =
   let (module S : Irmin_test.S) = store in
+  let module P = S.Private in
+  let clear repo =
+    Lwt.join
+      [
+        P.Commit.clear (P.Repo.commit_t repo);
+        P.Node.clear (P.Repo.node_t repo);
+        P.Contents.clear (P.Repo.contents_t repo);
+        P.Branch.clear (P.Repo.branch_t repo);
+      ]
+  in
   S.Repo.v config >>= fun repo ->
-  S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo) >>= fun () ->
-  S.Repo.close repo
+  clear repo >>= fun () -> S.Repo.close repo
 
 let suite =
   { Irmin_test.name = "CHUNK"; init; store; config; clean; stats = None }

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -23,9 +23,18 @@ let config = Irmin_mem.config ()
 
 let clean () =
   let (module S : Irmin_test.S) = store in
+  let module P = S.Private in
+  let clear repo =
+    Lwt.join
+      [
+        P.Commit.clear (P.Repo.commit_t repo);
+        P.Node.clear (P.Repo.node_t repo);
+        P.Contents.clear (P.Repo.contents_t repo);
+        P.Branch.clear (P.Repo.branch_t repo);
+      ]
+  in
   S.Repo.v config >>= fun repo ->
-  S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo) >>= fun () ->
-  S.Repo.close repo
+  clear repo >>= fun () -> S.Repo.close repo
 
 let init () = Lwt.return_unit
 

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -1,6 +1,8 @@
 open Lwt.Infix
 module Dict = Irmin_pack.Dict
 
+let ( let* ) x f = Lwt.bind x f
+
 let get = function Some x -> x | None -> Alcotest.fail "None"
 
 let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
@@ -11,6 +13,8 @@ let rm_dir root =
     Logs.info (fun l -> l "exec: %s\n%!" cmd);
     let _ = Sys.command cmd in
     ())
+
+let index_log_size = Some 1_000
 
 module Conf = struct
   let entries = 32

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -20,12 +20,6 @@ module Alcotest : sig
   val check_raises_lwt : string -> exn -> (unit -> _ Lwt.t) -> unit Lwt.t
 end
 
-module Conf : sig
-  val entries : int
-
-  val stable_hash : int
-end
-
 module Index : Irmin_pack.Index.S with type key = H.t
 
 module Pack :
@@ -60,8 +54,18 @@ end) : sig
   val close : Index.t -> [ `Read ] Pack.t -> unit Lwt.t
 end
 
+val ( let* ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
+
 val get : 'a option -> 'a
 
 val sha1 : string -> H.t
 
 val rm_dir : string -> unit
+
+val index_log_size : int option
+
+module Conf : sig
+  val entries : int
+
+  val stable_hash : int
+end

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -1,6 +1,8 @@
 open Lwt.Infix
 open Common
 
+let ( let* ) x f = Lwt.bind x f
+
 let root = Filename.concat "_build" "test-instances"
 
 let src = Logs.Src.create "tests.instances" ~doc:"Tests"
@@ -29,21 +31,40 @@ let info () = Irmin.Info.empty
 
 let open_ro_after_rw_closed () =
   rm_dir root;
-  S.Repo.v (config ~readonly:false ~fresh:true root) >>= fun rw ->
-  S.master rw >>= fun t ->
-  S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
-  S.set_tree_exn ~parents:[] ~info t [] tree >>= fun () ->
-  S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
-  S.Repo.close rw >>= fun () ->
-  S.master ro >>= fun t ->
-  S.Head.get t >>= fun c ->
+  let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
+  let* t = S.master rw in
+  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* () = S.set_tree_exn ~parents:[] ~info t [] tree in
+  let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
+  let* () = S.Repo.close rw in
+  let* t = S.master ro in
+  let* c = S.Head.get t in
   S.Commit.of_hash ro (S.Commit.hash c) >>= function
   | None -> Alcotest.fail "no hash"
   | Some commit ->
       let tree = S.Commit.tree commit in
-      S.Tree.find tree [ "a" ] >>= fun x ->
+      let* x = S.Tree.find tree [ "a" ] in
       Alcotest.(check (option string)) "RO find" (Some "x") x;
       S.Repo.close ro
+
+let check_commit_absent repo commit =
+  S.Commit.of_hash repo (S.Commit.hash commit) >|= function
+  | None -> ()
+  | Some _ -> Alcotest.fail "should not find hash"
+
+let check_binding ?msg repo commit key value =
+  let msg =
+    match msg with
+    | Some m -> m
+    | None ->
+        Fmt.str "Expected binding [%a ↦ %s]" Fmt.(Dump.list string) key value
+  in
+  S.Commit.of_hash repo (S.Commit.hash commit) >>= function
+  | None -> Alcotest.failf "commit not found"
+  | Some commit ->
+      let tree = S.Commit.tree commit in
+      S.Tree.find tree key >|= fun x ->
+      Alcotest.(check (option string)) msg (Some value) x
 
 let ro_sync_after_add () =
   let check ro c k v =
@@ -55,47 +76,120 @@ let ro_sync_after_add () =
         Alcotest.(check (option string)) "RO find" (Some v) x
   in
   rm_dir root;
-  S.Repo.v (config ~readonly:false ~fresh:true root) >>= fun rw ->
-  S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
-  S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
-  S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c1 ->
+  let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
+  let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
+  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
-  check ro c1 "a" "x" >>= fun () ->
-  S.Tree.add S.Tree.empty [ "a" ] "y" >>= fun tree ->
-  S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c2 ->
-  check ro c1 "a" "x" >>= fun () ->
-  (S.Commit.of_hash ro (S.Commit.hash c2) >|= function
-   | None -> ()
-   | Some _ -> Alcotest.failf "should not find branch by")
-  >>= fun () ->
+  let* () = check ro c1 "a" "x" in
+  let* tree = S.Tree.add S.Tree.empty [ "a" ] "y" in
+  let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
+  let* () = check ro c1 "a" "x" in
+  let* () =
+    S.Commit.of_hash ro (S.Commit.hash c2) >|= function
+    | None -> ()
+    | Some _ -> Alcotest.failf "should not find branch by"
+  in
   S.sync ro;
-  check ro c2 "a" "y" >>= fun () ->
-  S.Repo.close ro >>= fun () -> S.Repo.close rw
+  let* () = check ro c2 "a" "y" in
+  let* () = S.Repo.close ro in
+  S.Repo.close rw
 
 let ro_sync_after_close () =
-  let check ro c k v =
-    S.Commit.of_hash ro (S.Commit.hash c) >>= function
-    | None -> Alcotest.failf "commit not found"
-    | Some commit ->
-        let tree = S.Commit.tree commit in
-        S.Tree.find tree [ k ] >|= fun x ->
-        Alcotest.(check (option string)) "RO find" (Some v) x
-  in
+  let binding f = f [ "a" ] "x" in
   rm_dir root;
-  S.Repo.v (config ~readonly:false ~fresh:true root) >>= fun rw ->
-  S.Repo.v (config ~readonly:true ~fresh:false root) >>= fun ro ->
-  S.Tree.add S.Tree.empty [ "a" ] "x" >>= fun tree ->
-  S.Commit.v rw ~parents:[] ~info:(info ()) tree >>= fun c1 ->
-  S.Repo.close rw >>= fun () ->
+  let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
+  let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
+  let* tree = binding (S.Tree.add S.Tree.empty ?metadata:None) in
+  let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
+  let* () = S.Repo.close rw in
   S.sync ro;
-  check ro c1 "a" "x" >>= fun () -> S.Repo.close ro
+  let* () = binding (check_binding ro c1) in
+  S.Repo.close ro
+
+module P = S.Private
+
+let clear_all repo =
+  Log.debug (fun l -> l "clear repo");
+  Lwt.join
+    [
+      P.Contents.clear (P.Repo.contents_t repo);
+      P.Branch.clear (P.Repo.branch_t repo);
+      P.Commit.clear (P.Repo.commit_t repo);
+      P.Node.clear (P.Repo.node_t repo);
+    ]
+
+(** Open RO after RW was cleared. *)
+let clear_rw_open_ro () =
+  rm_dir root;
+  let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
+  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
+  let* () = clear_all rw in
+  let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
+  let* () = check_commit_absent ro c in
+  let* () = S.Repo.close rw in
+  S.Repo.close ro
+
+(** RO looks for values before and after sync but after RW was cleared. *)
+let clear_rw_find_ro () =
+  rm_dir root;
+  let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
+  let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
+  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
+  S.sync ro;
+  let* () = check_binding ro c1 ~msg:"RO finds value" [ "a" ] "x" in
+  let* () = clear_all rw in
+  let* tree = S.Tree.add S.Tree.empty [ "b" ] "y" in
+  let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
+  let* () =
+    check_binding ro c1 ~msg:"RO finds value after clear but before sync"
+      [ "a" ] "x"
+  in
+  S.sync ro;
+  let* () =
+    check_binding ro c2 ~msg:"RO finds value added after clear" [ "b" ] "y"
+  in
+  let* () = check_commit_absent ro c1 in
+  let* () = S.Repo.close rw in
+  S.Repo.close ro
+
+let clear_rw_twice () =
+  rm_dir root;
+  let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
+  let* t = S.master rw in
+  let check_empty () =
+    S.Head.find t >|= function
+    | None -> ()
+    | Some _ -> Alcotest.fail "should be empty"
+  in
+  let add () =
+    let* () = check_empty () in
+    let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+    S.set_tree_exn ~parents:[] ~info t [] tree
+  in
+  let add_after_clear () =
+    let* () = add () in
+    let* c = S.Head.get t in
+    check_binding rw c ~msg:"RW finds value added after clear" [ "a" ] "x"
+  in
+  let* () = add () in
+  let* () = clear_all rw in
+  let* () = add_after_clear () in
+  let* () = clear_all rw in
+  let* () = check_empty () in
+  S.Repo.close rw
 
 let tests =
+  let tc name test =
+    Alcotest.test_case name `Quick (fun () -> Lwt_main.run (test ()))
+  in
   [
-    Alcotest.test_case "Test open ro after rw closed" `Quick (fun () ->
-        Lwt_main.run (open_ro_after_rw_closed ()));
-    Alcotest.test_case "Test ro sync after add" `Quick (fun () ->
-        Lwt_main.run (ro_sync_after_add ()));
-    Alcotest.test_case "Test ro sync after close" `Quick (fun () ->
-        Lwt_main.run (ro_sync_after_close ()));
+    tc "Test open ro after rw closed" open_ro_after_rw_closed;
+    tc "Open ro after rw cleared" clear_rw_open_ro;
+    tc "Clear rw twice" clear_rw_twice;
+    tc "Find in ro after rw cleared" clear_rw_find_ro;
+    tc "Test ro sync after add" ro_sync_after_add;
+    tc "Test ro sync after close" ro_sync_after_close;
   ]

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -43,10 +43,18 @@ let suite =
   let clean () =
     let (module S : Irmin_test.S) = store in
     let module P = S.Private in
+    let clear repo =
+      Lwt.join
+        [
+          P.Commit.clear (P.Repo.commit_t repo);
+          P.Node.clear (P.Repo.node_t repo);
+          P.Contents.clear (P.Repo.contents_t repo);
+          P.Branch.clear (P.Repo.branch_t repo);
+        ]
+    in
     let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_dir in
     S.Repo.v config >>= fun repo ->
-    S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo)
-    >>= fun () -> S.Repo.close repo
+    clear repo >>= fun () -> S.Repo.close repo
   in
   let stats = None in
   { Irmin_test.name = "PACK"; init; clean; config; store; stats }


### PR DESCRIPTION
This supersedes the other half of https://github.com/mirage/irmin/pull/1015, along with https://github.com/mirage/irmin/pull/1070. The implementation is mostly unchanged from the original.