### PR TITLE
recursive flag for cp on macOS

### DIFF
--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -28,7 +28,7 @@ depends: [
 ]
 
 pin-depends: [
-  "index.dev" "git+https://github.com/mirage/index#95cd162ad3bcf8e136469a384c4d01a03cae1482"
+  "index.dev" "git+https://github.com/mirage/index#b3b21b6ff21cd23974f8451b0c959f5b183f9d56"
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"

--- a/test/irmin-pack/migration.ml
+++ b/test/irmin-pack/migration.ml
@@ -45,8 +45,7 @@ let setup_test_env () =
   goto_project_root ();
   rm_dir root_v1;
   let cmd =
-    Filename.quote_command "cp"
-      [ "--recursive"; "-p"; root_v1_archive; root_v1 ]
+    Filename.quote_command "cp" [ "-R"; "-p"; root_v1_archive; root_v1 ]
   in
   Log.info (fun l -> l "exec: %s\n%!" cmd);
   match Sys.command cmd with


### PR DESCRIPTION
The `--recursive` flag does not work on macOS
```
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
```
and also updated the pin on index. 