### PR TITLE
Sync merge example and doc example

### DIFF
--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -24,10 +24,7 @@ module Entry : sig
 
   val timestamp : t -> int64
 end = struct
-  type t =
-    { timestamp : int64
-    ; message : string
-    }
+  type t = { timestamp : int64; message : string }
 
   let compare x y = Int64.compare x.timestamp y.timestamp
 
@@ -41,10 +38,10 @@ end = struct
 
   let of_string str =
     match String.cut ~sep:": " str with
-    | None              -> Error (`Msg ("invalid entry: " ^ str))
-    | Some (x, message) ->
-    try Ok { timestamp = Int64.of_string x; message }
-    with Failure e -> Error (`Msg e)
+    | None -> Error (`Msg ("invalid entry: " ^ str))
+    | Some (x, message) -> (
+        try Ok { timestamp = Int64.of_string x; message }
+        with Failure e -> Error (`Msg e))
 
   let t =
     let open Irmin.Type in
@@ -78,7 +75,7 @@ end = struct
       List.fold_left
         (fun acc l ->
           match Irmin.Type.of_string Entry.t l with
-          | Ok x           -> x :: acc
+          | Ok x -> x :: acc
           | Error (`Msg e) -> failwith e)
         [] lines
       |> fun l -> Ok l
@@ -88,9 +85,7 @@ end = struct
 
   let t = Irmin.Type.(like ~cli (list Entry.t))
 
-  let timestamp = function
-    | []     -> 0L
-    | e :: _ -> Entry.timestamp e
+  let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 
   let newer_than timestamp file =
     let rec aux acc = function
@@ -103,11 +98,7 @@ end = struct
   let merge ~old t1 t2 =
     let open Irmin.Merge.Infix in
     old () >>=* fun old ->
-    let old =
-      match old with
-      | None   -> []
-      | Some o -> o
-    in
+    let old = match old with None -> [] | Some o -> o in
     let ts = timestamp old in
     let t1 = newer_than ts t1 in
     let t2 = newer_than ts t2 in
@@ -131,9 +122,7 @@ let info = Irmin_unix.info
 let log_file = [ "local"; "debug" ]
 
 let all_logs t =
-  Store.find t log_file >|= function
-  | None   -> Log.empty
-  | Some l -> l
+  Store.find t log_file >|= function None -> Log.empty | Some l -> l
 
 (* Persist a new entry in the log. Pretty inefficient as it
    reads/writes the whole file every time. *)
@@ -169,7 +158,7 @@ let main () =
   log t "Yes. On t!" >>= fun () ->
   print_logs "branch 2" t >>= fun () ->
   Store.merge_into ~info:(info "Merging x into t") x ~into:t >>= function
-  | Ok ()   -> print_logs "merge" t
+  | Ok () -> print_logs "merge" t
   | Error _ -> failwith "conflict!"
 
 let () = Lwt_main.run (main ())

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -124,8 +124,8 @@ let log_file = [ "local"; "debug" ]
 let all_logs t =
   Store.find t log_file >|= function None -> Log.empty | Some l -> l
 
-(* Persist a new entry in the log. Pretty inefficient as it
-   reads/writes the whole file every time. *)
+(** Persist a new entry in the log. Pretty inefficient as it reads/writes the
+    whole file every time. *)
 let log t fmt =
   Printf.ksprintf
     (fun message ->

--- a/examples/dune
+++ b/examples/dune
@@ -6,7 +6,7 @@
 (alias
  (name examples)
  (deps readme.exe trees.exe sync.exe process.exe deploy.exe push.exe
-   irmin_git_store.exe custom_merge.exe custom_graphql))
+   irmin_git_store.exe custom_merge.exe custom_graphql.exe))
 
 (alias
  (name runtest)

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -599,46 +599,55 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
     {3 Mergeable logs}
 
+    The complete code for the following can be found in
+    [examples/custom_merge.ml].
+
     We will demonstrate the use of custom merge operators by defining mergeable
     debug log files. We first define a log entry as a pair of a timestamp and a
     message, using the combinator exposed by {!Irmin.Type}:
 
     {[
+      open Lwt.Infix
+      open Astring
+
+      let time = ref 0L
+
+      let failure fmt = Fmt.kstrf failwith fmt
+
+      (* A log entry *)
       module Entry : sig
         include Irmin.Type.S
 
         val v : string -> t
 
-        val timestamp : t -> int
+        val timestamp : t -> int64
       end = struct
-        type t = { timestamp : int; message : string }
+        type t =
+          { timestamp : int64
+          ; message : string
+          }
 
-        let compare x y = compare x.timestamp y.timestamp
-
-        let time = ref 0
+        let compare x y = Int64.compare x.timestamp y.timestamp
 
         let v message =
-          incr time;
+          time := Int64.add 1L !time;
           { timestamp = !time; message }
 
         let timestamp t = t.timestamp
 
-        let pp ppf { timestamp; message } =
-          Fmt.pf ppf "%04d: %s" timestamp message
+        let pp ppf { timestamp; message } = Fmt.pf ppf "%04Ld: %s" timestamp message
 
         let of_string str =
-          match String.split_on_char '\t' str with
-          | [] -> Error (`Msg ("invalid entry: " ^ str))
-          | ts :: msg_sects -> (
-              let message = String.concat "\t" msg_sects in
-              try Ok { timestamp = int_of_string ts; message }
-              with Failure e -> Error (`Msg e))
+          match String.cut ~sep:": " str with
+          | None              -> Error (`Msg ("invalid entry: " ^ str))
+          | Some (x, message) ->
+            try Ok { timestamp = Int64.of_string x; message }
+            with Failure e -> Error (`Msg e)
 
         let t =
           let open Irmin.Type in
-          record "entry" (fun t32 message ->
-              { timestamp = Int32.to_int t32; message })
-          |+ field "timestamp" int32 (fun t -> Int32.of_int t.timestamp)
+          record "entry" (fun timestamp message -> { timestamp; message })
+          |+ field "timestamp" int64 (fun t -> t.timestamp)
           |+ field "message" string (fun t -> t.message)
           |> sealr
 
@@ -663,25 +672,29 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
         let empty = []
 
-        let pp ppf l = List.iter (Fmt.pf ppf "%a\n" Entry.pp) (List.rev l)
+        let pp_entry = Irmin.Type.pp Entry.t
+
+        let lines ppf l = List.iter (Fmt.pf ppf "%a\n" pp_entry) (List.rev l)
 
         let of_string str =
           let lines = String.cuts ~empty:false ~sep:"\n" str in
           try
             List.fold_left
               (fun acc l ->
-                match Entry.of_string l with
-                | Ok x -> x :: acc
-                | Error (`Msg e) -> failwith e)
+                 match Irmin.Type.of_string Entry.t l with
+                 | Ok x           -> x :: acc
+                 | Error (`Msg e) -> failwith e)
               [] lines
             |> fun l -> Ok l
           with Failure e -> Error (`Msg e)
 
-        let t = Irmin.Type.(list Entry.t)
+        let cli = (lines, of_string)
 
-        let t = Irmin.Type.like' ~cli:(pp, of_string) t
+        let t = Irmin.Type.(like ~cli (list Entry.t))
 
-        let timestamp = function [] -> 0 | e :: _ -> Entry.timestamp e
+        let timestamp = function
+          | []     -> 0L
+          | e :: _ -> Entry.timestamp e
 
         let newer_than timestamp file =
           let rec aux acc = function
@@ -694,11 +707,15 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
         let merge ~old t1 t2 =
           let open Irmin.Merge.Infix in
           old () >>=* fun old ->
-          let old = match old with None -> [] | Some o -> o in
+          let old =
+            match old with
+            | None   -> []
+            | Some o -> o
+          in
           let ts = timestamp old in
           let t1 = newer_than ts t1 in
           let t2 = newer_than ts t2 in
-          let t3 = List.sort Entry.compare (List.rev_append t1 t2) in
+          let t3 = List.sort (Irmin.Type.compare Entry.t) (List.rev_append t1 t2) in
           Irmin.Merge.ok (List.rev_append t3 old)
 
         let merge = Irmin.Merge.(option (v t merge))
@@ -716,13 +733,14 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
     {[
       (* Build an Irmin store containing log files. *)
-      module S = Irmin_unix.Git.FS.KV (Log)
+      module Store = Irmin_unix.Git.FS.KV (Log)
 
       (* Set-up the local configuration of the Git repository. *)
-      let config = Irmin_git.config ~bare:true "/tmp/irmin/test"
+      let config = Irmin_git.config ~bare:true Config.root
 
-      (* Set-up the commit info function *)
-      let info fmt = Irmin_unix.info ~author:"logger" fmt
+      (* Convenient alias for the info function for commit messages *)
+      let info = Irmin_unix.info
+
     ]}
 
     We can now define a toy example to use our mergeable log files.
@@ -730,34 +748,49 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
     {[
       open Lwt.Infix
 
-      (* Name of the log file. *)
-      let file = [ "local"; "debug" ]
+      let log_file = [ "local"; "debug" ]
 
-      (* Read the entire log file. *)
-      let read_file t = S.find t file >|= function None -> [] | Some l -> l
+      let all_logs t =
+        Store.find t log_file >|= function None -> Log.empty | Some l -> l
 
-      (* Persist a new entry in the log. *)
+      (* Persist a new entry in the log. Pretty inefficient as it
+         reads/writes the whole file every time. *)
       let log t fmt =
-        Fmt.kstrf
+        Printf.ksprintf
           (fun message ->
-            read_file t >>= fun logs ->
-            let logs = Log.add logs (Entry.v message) in
-            S.set t (info "Adding a new entry") file logs)
+             all_logs t >>= fun logs ->
+             let logs = Log.add logs (Entry.v message) in
+             Store.set_exn t ~info:(info "Adding a new entry") log_file logs)
           fmt
 
-      let () =
-        Lwt_main.run
-          ( S.Repo.v config >>= S.master >>= fun t ->
-            log t "Adding a new log entry" >>= fun () ->
-            Irmin.clone_force ~src:t ~dst:"x" >>= fun x ->
-            log x "Adding new stuff to x" >>= fun () ->
-            log x "Adding more stuff to x" >>= fun () ->
-            log x "More. Stuff. To x." >>= fun () ->
-            log t "I can add stuff on t also" >>= fun () ->
-            log t "Yes. On t!" >>= fun () ->
-            S.merge (info "Merging x into t") x ~into:t >|= function
-            | Ok () -> ()
-            | Error _ -> failwith "merge conflict!" )
+      let print_logs name t =
+        all_logs t >|= fun logs ->
+        Fmt.pr "-----------\n%s:\n-----------\n%a%!" name (Irmin.Type.pp Log.t) logs
+
+      let main () =
+        Config.init ();
+        Store.Repo.v config >>= fun repo ->
+        Store.master repo >>= fun t ->
+        (* populate the log with some random messages *)
+        Lwt_list.iter_s
+          (fun msg -> log t "This is my %s " msg)
+          [ "first"; "second"; "third" ]
+        >>= fun () ->
+        Printf.printf "%s\n\n" what;
+        print_logs "lca" t >>= fun () ->
+        Store.clone ~src:t ~dst:"test" >>= fun x ->
+        log x "Adding new stuff to x" >>= fun () ->
+        log x "Adding more stuff to x" >>= fun () ->
+        log x "More. Stuff. To x." >>= fun () ->
+        print_logs "branch 1" x >>= fun () ->
+        log t "I can add stuff on t also" >>= fun () ->
+        log t "Yes. On t!" >>= fun () ->
+        print_logs "branch 2" t >>= fun () ->
+        Store.merge_into ~info:(info "Merging x into t") x ~into:t >>= function
+        | Ok () -> print_logs "merge" t
+        | Error _ -> failwith "conflict!"
+
+      let () = Lwt_main.run (main ())
     ]} *)
 
 (** {1 Helpers} *)

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -632,7 +632,8 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
         let timestamp t = t.timestamp
 
-        let pp ppf { timestamp; message } = Fmt.pf ppf "%04Ld: %s" timestamp message
+        let pp ppf { timestamp; message } =
+          Fmt.pf ppf "%04Ld: %s" timestamp message
 
         let of_string str =
           match String.cut ~sep:": " str with
@@ -678,9 +679,9 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
           try
             List.fold_left
               (fun acc l ->
-                 match Irmin.Type.of_string Entry.t l with
-                 | Ok x -> x :: acc
-                 | Error (`Msg e) -> failwith e)
+                match Irmin.Type.of_string Entry.t l with
+                | Ok x -> x :: acc
+                | Error (`Msg e) -> failwith e)
               [] lines
             |> fun l -> Ok l
           with Failure e -> Error (`Msg e)
@@ -706,7 +707,9 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
           let ts = timestamp old in
           let t1 = newer_than ts t1 in
           let t2 = newer_than ts t2 in
-          let t3 = List.sort (Irmin.Type.compare Entry.t) (List.rev_append t1 t2) in
+          let t3 =
+            List.sort (Irmin.Type.compare Entry.t) (List.rev_append t1 t2)
+          in
           Irmin.Merge.ok (List.rev_append t3 old)
 
         let merge = Irmin.Merge.(option (v t merge))
@@ -741,19 +744,20 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
       let all_logs t =
         Store.find t log_file >|= function None -> Log.empty | Some l -> l
 
-      (* Persist a new entry in the log. Pretty inefficient as it
-         reads/writes the whole file every time. *)
+      (** Persist a new entry in the log. Pretty inefficient as it reads/writes
+          the whole file every time. *)
       let log t fmt =
         Printf.ksprintf
           (fun message ->
-             all_logs t >>= fun logs ->
-             let logs = Log.add logs (Entry.v message) in
-             Store.set_exn t ~info:(info "Adding a new entry") log_file logs)
+            all_logs t >>= fun logs ->
+            let logs = Log.add logs (Entry.v message) in
+            Store.set_exn t ~info:(info "Adding a new entry") log_file logs)
           fmt
 
       let print_logs name t =
         all_logs t >|= fun logs ->
-        Fmt.pr "-----------\n%s:\n-----------\n%a%!" name (Irmin.Type.pp Log.t) logs
+        Fmt.pr "-----------\n%s:\n-----------\n%a%!" name (Irmin.Type.pp Log.t)
+          logs
 
       let main () =
         Config.init ();


### PR DESCRIPTION
Hi! I was trying out Irmin for the first time, and following the example on in the `irmin.mli` docs, but found that some of the code didn't compile.

The principle point of this PR is to sync the docs with the current code in `examples/custom_merge.ml` (12fac5f). Along the way I also

- fixed one misnamed target (i think) that blocked (abe3758)
- made some tiny tweaks to the example code, for readability and documentation (cf794de)
  - this commit also applies auto formatting my editor imposed due to the `.ocamlformat` config in the repo. Let me know if you'd like me to revert that stuff.