### PR TITLE
Add missing `post` flag in the `ppx_irmin` → `irmin` dependency

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocaml-syntax-shims"
   "ppxlib" {>= "0.12.0"}
-  "irmin" {with-test & >= "2.0.0"}
+  "irmin" {with-test & post & >= "2.0.0"}
 ]
 
 synopsis: "PPX deriver for Irmin generics"


### PR DESCRIPTION
This fixes a cyclic actions error when attempting to install all packages in the Irmin repository along with their test dependencies:

```
The actions to process have cyclic dependencies:
  - install irmin.dev -> install ppx_irmin.dev -> install irmin.dev

No solution found, exiting
```

As discussed offline, neither of our CIs caught this error, but the fix is witnessed by the following `Dockerfile`:

```dockerfile
FROM ocurrent/opam:alpine-3.12-ocaml-4.09
WORKDIR /src
RUN sudo chown opam /src
RUN opam update -u
RUN git clone --single-branch --branch add-missing-post https://github.com/CraigFe/irmin /src
RUN opam pin add -yn ppx_irmin.dev "./" && \
  opam pin add -yn irmin.dev "./" && \
  opam pin add -yn irmin-unix.dev "./" && \
  opam pin add -yn irmin-test.dev "./" && \
  opam pin add -yn irmin-pack.dev "./" && \
  opam pin add -yn irmin-mirage.dev "./" && \
  opam pin add -yn irmin-mirage-graphql.dev "./" && \
  opam pin add -yn irmin-mirage-git.dev "./" && \
  opam pin add -yn irmin-mem.dev "./" && \
  opam pin add -yn irmin-http.dev "./" && \
  opam pin add -yn irmin-graphql.dev "./" && \
  opam pin add -yn irmin-git.dev "./" && \
  opam pin add -yn irmin-fuzz.dev "./" && \
  opam pin add -yn irmin-fs.dev "./" && \
  opam pin add -yn irmin-containers.dev "./" && \
  opam pin add -yn irmin-chunk.dev "./" && \
  opam pin add -yn irmin-bench.dev "./"
RUN opam install --deps-only --with-test /src
```