### PR TITLE
Iter on node and commit graphs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@
   - Added a `clear` function for stores (#1071, @icristescu, @CraigFe)
   - Requires digestif>=0.9 to use digestif's default variants
     (#873, @pascutto, @samoht)
+  - Added `iter_commits` and `iter_nodes` functions to traverse the commits and
+    nodes graphs (#1077, @icristescu)
 
 - **irmin-pack**:
   - Added `index_throttle` option to `Irmin_pack.config`, which exposes the

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -558,6 +558,19 @@ module type COMMIT_HISTORY = sig
   (** Same as {{!Private.Node.GRAPH.closure} GRAPH.closure} but for the history
       graph. *)
 
+  val iter :
+    [> `Read ] t ->
+    min:node list ->
+    max:node list ->
+    ?commit:(commit -> unit Lwt.t) ->
+    ?edge:(node -> node -> unit Lwt.t) ->
+    ?skip:(node -> bool Lwt.t) ->
+    ?rev:bool ->
+    unit ->
+    unit Lwt.t
+  (** [iter min max commit edge skip rev ()] iterates over the closure of [t] as
+      specified by {{!Irmin__.S.NODE_GRAPH.iter} GRAPH.iter}. *)
+
   (** {1 Value Types} *)
 
   val commit_t : commit Type.t

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -372,9 +372,9 @@ module type NODE_GRAPH = sig
     ?rev:bool ->
     unit ->
     unit Lwt.t
-  (** [iter min max node edge skip rev ()] iterates in topological order over
-      the closure of [t] as specified by {{!Private.Node.GRAPH.closure}
-      GRAPH.closure}.
+  (** [iter t min max node edge skip rev ()] iterates in topological order over
+      the closure of [t] as specified by {{!Irmin__Object_graph.S.closure}
+      Object_graph.closure}.
 
       It applies three functions while traversing the graph: [node] on the
       nodes; [edge n predecessor_of_n] on the directed edges and [skip n] to not
@@ -555,7 +555,7 @@ module type COMMIT_HISTORY = sig
 
   val closure :
     [> `Read ] t -> min:commit list -> max:commit list -> commit list Lwt.t
-  (** Same as {{!Private.Node.GRAPH.closure} GRAPH.closure} but for the history
+  (** Same as {{!NODE_GRAPH.closure} NODE_GRAPH.closure} but for the history
       graph. *)
 
   val iter :
@@ -568,8 +568,8 @@ module type COMMIT_HISTORY = sig
     ?rev:bool ->
     unit ->
     unit Lwt.t
-  (** [iter min max commit edge skip rev ()] iterates over the closure of [t] as
-      specified by {{!Irmin__.S.NODE_GRAPH.iter} GRAPH.iter}. *)
+  (** Same as {{!NODE_GRAPH.iter} NODE_GRAPH.iter} but for traversing the
+      history graph. *)
 
   (** {1 Value Types} *)
 

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -331,6 +331,10 @@ module Make (P : S.PRIVATE) = struct
         (function
           | Import_error e -> Lwt.return (Error (`Msg e))
           | e -> Fmt.kstrf Lwt.fail_invalid_arg "impot error: %a" Fmt.exn e)
+
+    let iter_nodes t = Graph.iter (graph_t t)
+
+    let iter_commits t = H.iter (history_t t)
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -122,6 +122,33 @@ module type S = sig
     val import : t -> slice -> (unit, [ `Msg of string ]) result Lwt.t
     (** [import t s] imports the contents of the slice [s] in [t]. Does not
         modify branches. *)
+
+    val iter_nodes :
+      t ->
+      min:hash list ->
+      max:hash list ->
+      ?node:(hash -> unit Lwt.t) ->
+      ?contents:(hash * metadata -> unit Lwt.t) ->
+      ?edge:(hash -> hash -> unit Lwt.t) ->
+      ?skip:(hash -> bool Lwt.t) ->
+      ?rev:bool ->
+      unit ->
+      unit Lwt.t
+    (** [iter t] iterates in reverse topological order over the closure graph of
+        [t] as specified by {{!Irmin__.S.NODE_GRAPH.iter} NODE_GRAPH.iter}. *)
+
+    val iter_commits :
+      t ->
+      min:hash list ->
+      max:hash list ->
+      ?commit:(hash -> unit Lwt.t) ->
+      ?edge:(hash -> hash -> unit Lwt.t) ->
+      ?skip:(hash -> bool Lwt.t) ->
+      ?rev:bool ->
+      unit ->
+      unit Lwt.t
+    (** [iter t] iterates over the closure graph of [t] as specified by
+        {{!Irmin__.S.COMMIT_HISTORY.iter} COMMIT_HISTORY.iter}. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
The two `iter` functions are used in the [layered store](https://github.com/mirage/irmin/pull/882), to iterate over the [commi graph](https://github.com/mirage/irmin/pull/882/files#diff-52ce06d08638434eac31d8f0240b3b5eR583) and the [node graph](https://github.com/mirage/irmin/pull/882/files#diff-52ce06d08638434eac31d8f0240b3b5eR546). Having two separate functions allows us to choose in which order we iterate over the commit graph, whereas for the node graph the order is fixed: we have to iterate in reverse order to keep the compression of inodes.