### PR TITLE
ppx_irmin: require OCaml 4.07.0

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -14,8 +14,7 @@ build: [
 
 depends: [
   "dune" {>= "2.5.1"}
-  "ocaml" {>= "4.06.0"}
-  "ocaml-syntax-shims"
+  "ocaml" {>= "4.07.0"}
   "ppxlib" {>= "0.12.0"}
   "irmin" {with-test & post & >= "2.0.0"}
 ]

--- a/src/ppx_irmin/lib/dune
+++ b/src/ppx_irmin/lib/dune
@@ -1,5 +1,4 @@
 (library
  (name ppx_irmin_lib)
  (public_name ppx_irmin._lib)
- (preprocess future_syntax)
  (libraries ppxlib))


### PR DESCRIPTION
... and drop dependency on `ocaml-syntax-shims`. Irmin itself requires 4.07.0 now, and this enables using `ppxlib.metaquot` in the implementation of `ppx_irmin`, which is a nice plus.