### PR TITLE
ppx_irmin: simplify implementation with Metaquot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,7 +42,7 @@
 
   - Added `Pack.clear` and `Dict.clear` (#1047, @icristescu, @CraigFe, @samoht)
 
-  - Added a `migrate` function for upgrading stores with old formats (#TODO,
+  - Added a `migrate` function for upgrading stores with old formats (#1070,
     @icristescu, @CraigFe)
 
 #### Changed
@@ -66,7 +66,8 @@
 
 - **ppx_irmin**:
 
-  - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (TODO)
+  - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (#1082,
+    @CraigFe)
 
 ### 2.2.0 (2020-06-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,10 @@
     number. Version 1 of irmin-pack was used for the previous format, version 2
     is used with the new format. (#1047, @icristescu, @CraigFe, @samoht)
 
+- **ppx_irmin**:
+
+  - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (TODO)
+
 ### 2.2.0 (2020-06-26)
 
 #### Added

--- a/README_PPX.md
+++ b/README_PPX.md
@@ -1,10 +1,10 @@
 ## ppx_irmin
 
-PPX extension for automatically generating Irmin generics.
+PPX extension for automatically generating Irmin type representations.
 
 ### Overview
 
-`ppx_irmin` automatically generates Irmin generics (values of type
+`ppx_irmin` automatically generates Irmin type representations (values of type
 `_ Irmin.Type.t`) corresponding to type declarations in your code. For example:
 
 ```ocaml
@@ -45,14 +45,14 @@ following field to your `library`, `executable` or `test` stanza:
 ```
 
 You can now use `[@@deriving irmin]` after a type declaration in your code to
-automatically derive an Irmin generic with the same name.
+automatically derive an Irmin type representation with the same name.
 
 ### Specifics
 
 `ppx_irmin` supports all of the type combinators exposed in the
 [Irmin.Type](https://docs.mirage.io/irmin/Irmin/Type/index.html) module (basic
 types, records, variants (plain and closed polymorphic), recursive types etc.).
-Irmin does not currently support higher-kinded generics: all Irmin types must
+Irmin does not currently support higher-kinded type representations: all Irmin types must
 fully grounded (no polymorphic type variables).
 
 To supply base representations from a module other than `Irmin.Type` (such as
@@ -68,26 +68,26 @@ val foo_t = Mylib.Types.unit
 
 #### Naming scheme
 
-The generated generics will be called `<type-name>_t`, unless the type-name is
-`t`, in which case the generic is simply `t`. This behaviour can be overridden
+The generated type representation will be called `<type-name>_t`, unless the type-name is
+`t`, in which case the representation is simply `t`. This behaviour can be overridden
 using the `name` argument, as in:
 
 ```ocaml
-type foo = string list * int32 [@@deriving irmin { name = "foo_generic" }]
+type foo = string list * int32 [@@deriving irmin { name = "foo_repr" }]
 
 (* generates the value *)
-val foo_generic = Irmin.Type.(pair (list string) int32)
+val foo_repr = Irmin.Type.(pair (list string) int32)
 ```
 
 If the type contains an abstract type, `ppx_irmin` will expect to find a
-corresponding generic using its own naming rules. This can be overridden
-using the `[@generic ...]` attribute, as in:
+corresponding type representation using its own naming rules. This can be
+overridden using the `[@repr ...]` attribute, as in:
 
 ```ocaml
-type bar = (foo [@generic foo_generic], string) result [@@deriving irmin]
+type bar = (foo [@repr foo_repr], string) result [@@deriving irmin]
 
 (* generates the value *)
-val bar_t = Irmin.Type.(result foo_generic string)
+val bar_t = Irmin.Type.(result foo_repr string)
 ```
 
 Built-in abstract types such as `unit` are assumed to be represented in
@@ -111,13 +111,13 @@ auto-generated value:
 module Contents : sig
   type t = int32 [@@deriving irmin]
 
-  (* exposes generic in signature *)
+  (* exposes repr in signature *)
   val t : t Irmin.Type.t
 
 end = struct
   type t = int32 [@@deriving irmin]
 
-  (* generates generic value *)
+  (* generates repr value *)
   val t = Irmin.Type.int32
 end
 ```

--- a/README_PPX.md
+++ b/README_PPX.md
@@ -52,12 +52,12 @@ automatically derive an Irmin type representation with the same name.
 `ppx_irmin` supports all of the type combinators exposed in the
 [Irmin.Type](https://docs.mirage.io/irmin/Irmin/Type/index.html) module (basic
 types, records, variants (plain and closed polymorphic), recursive types etc.).
-Irmin does not currently support higher-kinded type representations: all Irmin types must
-fully grounded (no polymorphic type variables).
+Irmin does not currently support higher-kinded type representations: all Irmin
+types must fully grounded (no polymorphic type variables).
 
 To supply base representations from a module other than `Irmin.Type` (such as
-when `Irmin.Type` is aliased to a different module path), the `lib` argument can
-be passed to `@@deriving irmin`:
+when `Irmin.Type` is aliased to a different module path), the `lib` argument
+can be passed to `@@deriving irmin`:
 
 ```ocaml
 type foo = unit [@@deriving irmin { lib = Some "Mylib.Types" }]
@@ -68,9 +68,9 @@ val foo_t = Mylib.Types.unit
 
 #### Naming scheme
 
-The generated type representation will be called `<type-name>_t`, unless the type-name is
-`t`, in which case the representation is simply `t`. This behaviour can be overridden
-using the `name` argument, as in:
+The generated type representation will be called `<type-name>_t`, unless the
+type-name is `t`, in which case the representation is simply `t`. This
+behaviour can be overridden using the `name` argument, as in:
 
 ```ocaml
 type foo = string list * int32 [@@deriving irmin { name = "foo_repr" }]
@@ -93,7 +93,6 @@ val bar_t = Irmin.Type.(result foo_repr string)
 Built-in abstract types such as `unit` are assumed to be represented in
 `Irmin.Type`. This behaviour can be overridden with the `[@nobuiltin]`
 attribute:
-
 
 ```ocaml
 type t = unit [@nobuiltin] [@@deriving irmin]

--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -19,4 +19,4 @@ depends: [
   "irmin" {with-test & post & >= "2.0.0"}
 ]
 
-synopsis: "PPX deriver for Irmin generics"
+synopsis: "PPX deriver for Irmin type representations"

--- a/src/ppx_irmin/deriver/ppx_irmin.ml
+++ b/src/ppx_irmin/deriver/ppx_irmin.ml
@@ -38,6 +38,7 @@ let sig_type_decl_generator =
   let args = Deriving.Args.(empty +> arg "name" (estring __) +> arg "lib" __) in
   Deriving.Generator.make args expand_sig
 
-let irmin =
+let () =
   Deriving.add ~str_type_decl:str_type_decl_generator
     ~sig_type_decl:sig_type_decl_generator ppx_name
+  |> Deriving.ignore

--- a/src/ppx_irmin/deriver/ppx_irmin.mli
+++ b/src/ppx_irmin/deriver/ppx_irmin.mli
@@ -1,18 +1,1 @@
-(*
- * Copyright (c) 2019-2020 Craig Ferguson <me@craigfe.io>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *)
-
-val irmin : Ppxlib.Deriving.t
-(** [Ppx_deriving] plugin for Irmin generics. *)
+(* Intentionally empty *)

--- a/src/ppx_irmin/lib/algebraic.ml
+++ b/src/ppx_irmin/lib/algebraic.ml
@@ -19,7 +19,7 @@ open Ppxlib
 module type S = sig
   type nonrec record_field_repr = {
     field_name : string;
-    field_generic : expression;
+    field_repr : expression;
   }
 
   and variant_case_repr = {
@@ -61,7 +61,7 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
 
   type nonrec record_field_repr = {
     field_name : string;
-    field_generic : expression;
+    field_repr : expression;
   }
 
   and variant_case_repr = {
@@ -126,14 +126,14 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
         variant_case1 ~polymorphic ~cons_name:case_name ~component_type ~idents
 
   (** [|+ field "field_name" (field_type) (fun t -> t.field_name)] *)
-  let record_field { field_name; field_generic } e =
+  let record_field { field_name; field_repr } e =
     pexp_apply (evar "|+")
       ([
          e;
          pexp_apply (evar "field")
            ([
               pexp_constant @@ Pconst_string (field_name, None);
-              field_generic;
+              field_repr;
               lambda "t" (pexp_field (evar "t") (Located.lident field_name));
             ]
            >|= unlabelled);

--- a/src/ppx_irmin/lib/algebraic.mli
+++ b/src/ppx_irmin/lib/algebraic.mli
@@ -16,44 +16,5 @@
 
 (** Helper functions for deriving encodings of algebraic data types. *)
 
-open Ppxlib
-
-module type S = sig
-  type nonrec record_field_repr = {
-    field_name : string;
-    field_repr : expression;
-  }
-
-  and variant_case_repr = {
-    case_name : string;
-    case_cons : (expression * int) option;
-  }
-
-  (** The algebraic datatypes supported by this module, parameterised by:
-
-      - ['a]: the subcomponent type of the algebraic type
-      - ['b]: a generic representation of the subcomponent type necessary to
-        derive the {i composite} type representation *)
-  type (_, _) typ =
-    | Record : (label_declaration, record_field_repr) typ
-    | Variant : (constructor_declaration, variant_case_repr) typ
-    | Polyvariant : (row_field, variant_case_repr) typ
-
-  module M : Monad.S
-
-  val encode :
-    ('a, 'b) typ ->
-    subderive:('a -> 'b M.t) ->
-    type_name:string ->
-    'a list ->
-    expression M.t
-  (** Build the functional encoding of a composite type. Combine the various
-      elements necessary for a functional encoding of a composite type
-      [('a, 'b) {!typ}], in terms its components of type ['a list] and the name
-      of the composite type [type_name].
-
-      This requires a function [subderive] for deriving the type representation
-      of the subcomponents, which may run in a monadic context [M.t]. *)
-end
-
-module Located (S : Ast_builder.S) (M : Monad.S) : S with module M = M
+include Algebraic_intf.Algebraic
+(** @inline *)

--- a/src/ppx_irmin/lib/algebraic.mli
+++ b/src/ppx_irmin/lib/algebraic.mli
@@ -14,14 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** Helper functions for deriving generic encodings of algebraic data types. *)
+(** Helper functions for deriving encodings of algebraic data types. *)
 
 open Ppxlib
 
 module type S = sig
   type nonrec record_field_repr = {
     field_name : string;
-    field_generic : expression;
+    field_repr : expression;
   }
 
   and variant_case_repr = {
@@ -33,7 +33,7 @@ module type S = sig
 
       - ['a]: the subcomponent type of the algebraic type
       - ['b]: a generic representation of the subcomponent type necessary to
-        derive the {i composite} generic *)
+        derive the {i composite} type representation *)
   type (_, _) typ =
     | Record : (label_declaration, record_field_repr) typ
     | Variant : (constructor_declaration, variant_case_repr) typ
@@ -52,9 +52,8 @@ module type S = sig
       [('a, 'b) {!typ}], in terms its components of type ['a list] and the name
       of the composite type [type_name].
 
-      This requires a function [subderive] for deriving the generic
-      representation of the subcomponents, which may run in a monadic context
-      [M.t]. *)
+      This requires a function [subderive] for deriving the type representation
+      of the subcomponents, which may run in a monadic context [M.t]. *)
 end
 
 module Located (S : Ast_builder.S) (M : Monad.S) : S with module M = M

--- a/src/ppx_irmin/lib/algebraic_intf.ml
+++ b/src/ppx_irmin/lib/algebraic_intf.ml
@@ -1,0 +1,65 @@
+(*
+ * Copyright (c) 2019-2020 Craig Ferguson <me@craigfe.io>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Ppxlib
+
+module Typ = struct
+  type nonrec record_field_repr = {
+    field_name : string;
+    field_repr : expression;
+  }
+
+  and variant_case_repr = {
+    case_name : string;
+    case_cons : (expression * int) option;
+  }
+
+  (** The algebraic datatypes supported by this module, parameterised by:
+
+      - ['a]: the subcomponent type of the algebraic type
+      - ['b]: a generic representation of the subcomponent type necessary to
+        derive the {i composite} type representation *)
+  type (_, _) t =
+    | Record : (label_declaration, record_field_repr) t
+    | Variant : (constructor_declaration, variant_case_repr) t
+    | Polyvariant : (row_field, variant_case_repr) t
+end
+
+module type S = sig
+  module M : Monad.S
+
+  val encode :
+    ('a, 'b) Typ.t ->
+    subderive:('a -> 'b M.t) ->
+    type_name:string ->
+    'a list ->
+    expression M.t
+  (** Build the functional encoding of a composite type. Combine the various
+      elements necessary for a functional encoding of a composite type
+      [('a, 'b) {!typ}], in terms its components of type ['a list] and the name
+      of the composite type [type_name].
+
+      This requires a function [subderive] for deriving the type representation
+      of the subcomponents, which may run in a monadic context [M.t]. *)
+end
+
+module type Algebraic = sig
+  module Typ = Typ
+
+  module type S = S
+
+  module Located (S : Ast_builder.S) (M : Monad.S) : S with module M = M
+end

--- a/src/ppx_irmin/lib/attributes.ml
+++ b/src/ppx_irmin/lib/attributes.ml
@@ -18,9 +18,9 @@ open Ppxlib
 
 let namespace = "irmin"
 
-let generic =
+let repr =
   Attribute.declare
-    (String.concat "." [ namespace; "generic" ])
+    (String.concat "." [ namespace; "repr" ])
     Attribute.Context.Core_type
     Ast_pattern.(single_expr_payload __)
     (fun e -> e)
@@ -36,4 +36,4 @@ let nobuiltin =
           Location.raise_errorf ~loc "`nobuiltin` payload must be empty"
       | { txt = []; _ } -> ())
 
-let all = Attribute.[ T generic; T nobuiltin ]
+let all = Attribute.[ T repr; T nobuiltin ]

--- a/src/ppx_irmin/lib/attributes.mli
+++ b/src/ppx_irmin/lib/attributes.mli
@@ -16,7 +16,7 @@
 
 open Ppxlib
 
-val generic : (core_type, expression) Attribute.t
+val repr : (core_type, expression) Attribute.t
 
 val nobuiltin : (core_type, unit) Attribute.t
 

--- a/src/ppx_irmin/lib/deriver.ml
+++ b/src/ppx_irmin/lib/deriver.ml
@@ -57,21 +57,20 @@ module Located (A : Ast_builder.S) : S = struct
       rec_flag : rec_flag;
       type_name : string;
       lib : string option;
-      generic_name : string;
+      repr_name : string;
       rec_detected : bool ref;
     }
   end
 
   module Reader = Monad.Reader (State)
-
-  let ( >>= ) x f = Reader.bind f x
-
   module Algebraic = Algebraic.Located (A) (Reader)
   open A
   open Reader.Syntax
   open Reader
 
   let unlabelled x = (Nolabel, x)
+
+  let ( >>= ) x f = Reader.bind f x
 
   let ( >|= ) x f = List.map f x
 
@@ -97,13 +96,13 @@ module Located (A : Ast_builder.S) : S = struct
       (evar (String.concat "." [ lib; "mu" ]))
       ([ lambda fparam e ] >|= unlabelled)
 
-  let generic_name_of_type_name = function "t" -> "t" | x -> x ^ "_t"
+  let repr_name_of_type_name = function "t" -> "t" | x -> x ^ "_t"
 
   let rec derive_core typ =
-    let* { rec_flag; type_name; generic_name; rec_detected; _ } = ask in
+    let* { rec_flag; type_name; repr_name; rec_detected; _ } = ask in
     match typ.ptyp_desc with
     | Ptyp_constr ({ txt = const_name; _ }, args) -> (
-        match Attribute.get Attributes.generic typ with
+        match Attribute.get Attributes.repr typ with
         | Some e -> return e
         | None ->
             let lident =
@@ -111,15 +110,15 @@ module Located (A : Ast_builder.S) : S = struct
               | Lident const_name ->
                   let name =
                     (* If this type is the one we are deriving and the 'nonrec'
-                       keyword hasn't been used, replace with the generic
+                       keyword hasn't been used, replace with the repr
                        name *)
                     if
                       rec_flag <> Nonrecursive
                       && String.equal const_name type_name
                     then (
                       rec_detected := true;
-                      generic_name
-                      (* If not a base type, assume a composite generic with the
+                      repr_name
+                      (* If not a base type, assume a composite repr with the
                          same naming convention *))
                     else
                       let nobuiltin =
@@ -128,12 +127,12 @@ module Located (A : Ast_builder.S) : S = struct
                         | None -> false
                       in
                       if nobuiltin || not (SSet.mem const_name irmin_types) then
-                        generic_name_of_type_name const_name
+                        repr_name_of_type_name const_name
                       else const_name
                   in
                   Located.lident name
               | Ldot (lident, name) ->
-                  let name = generic_name_of_type_name name in
+                  let name = repr_name_of_type_name name in
                   Located.mk @@ Ldot (lident, name)
               | Lapply _ -> invalid_arg "Lident.Lapply not supported"
             in
@@ -175,8 +174,8 @@ module Located (A : Ast_builder.S) : S = struct
     let* State.{ type_name; _ } = ask in
     let subderive label_decl =
       let field_name = label_decl.pld_name.txt in
-      let+ field_generic = derive_core label_decl.pld_type in
-      Algebraic.{ field_name; field_generic }
+      let+ field_repr = derive_core label_decl.pld_type in
+      Algebraic.{ field_name; field_repr }
     in
     Algebraic.(encode Record) ~subderive ~type_name ls
 
@@ -211,12 +210,11 @@ module Located (A : Ast_builder.S) : S = struct
     Algebraic.(encode Polyvariant) ~subderive ~type_name:name rowfields
 
   let derive_lident :
-      ?generic:expression -> ?nobuiltin:unit -> longident -> expression Reader.t
-      =
-   fun ?generic ?nobuiltin txt ->
+      ?repr:expression -> ?nobuiltin:unit -> longident -> expression Reader.t =
+   fun ?repr ?nobuiltin txt ->
     let+ { lib; _ } = ask in
     let nobuiltin = match nobuiltin with Some () -> true | None -> false in
-    match generic with
+    match repr with
     | Some e -> e
     | None -> (
         match txt with
@@ -227,11 +225,11 @@ module Located (A : Ast_builder.S) : S = struct
               | None -> evar cons_name
             else
               (* If not a basic type, assume a composite
-                 generic /w same naming convention *)
-              evar (generic_name_of_type_name cons_name)
+                 repr /w same naming convention *)
+              evar (repr_name_of_type_name cons_name)
         | Ldot (lident, cons_name) ->
             pexp_ident
-              (Located.mk @@ Ldot (lident, generic_name_of_type_name cons_name))
+              (Located.mk @@ Ldot (lident, repr_name_of_type_name cons_name))
         | Lapply _ -> invalid_arg "Lident.Lapply not supported")
 
   let derive_type_decl : type_declaration -> expression Reader.t =
@@ -244,9 +242,9 @@ module Located (A : Ast_builder.S) : S = struct
             match c.ptyp_desc with
             (* No need to open library module *)
             | Ptyp_constr ({ txt; loc = _ }, []) ->
-                let generic = Attribute.get Attributes.generic c
+                let repr = Attribute.get Attributes.repr c
                 and nobuiltin = Attribute.get Attributes.nobuiltin c in
-                derive_lident ?generic ?nobuiltin txt
+                derive_lident ?repr ?nobuiltin txt
             (* Type constructor: list, tuple, etc. *)
             | _ -> derive_core c >>= open_lib))
     | Ptype_variant cs -> derive_variant cs >>= open_lib
@@ -280,7 +278,7 @@ module Located (A : Ast_builder.S) : S = struct
           Located.mk
             (match name with
             | Some n -> n
-            | None -> generic_name_of_type_name type_name)
+            | None -> repr_name_of_type_name type_name)
         in
         let lib =
           match lib with Some l -> parse_lib l | None -> Some lib_default
@@ -305,16 +303,16 @@ module Located (A : Ast_builder.S) : S = struct
     | rec_flag, [ typ ] ->
         let env =
           let type_name = typ.ptype_name.txt in
-          let generic_name =
+          let repr_name =
             match name with
             | Some s -> s
-            | None -> generic_name_of_type_name type_name
+            | None -> repr_name_of_type_name type_name
           in
           let rec_detected = ref false in
           let lib =
             match lib with Some l -> parse_lib l | None -> Some lib_default
           in
-          State.{ rec_flag; type_name; generic_name; rec_detected; lib }
+          State.{ rec_flag; type_name; repr_name; rec_detected; lib }
         in
         let expr = run (derive_type_decl typ) env in
         (* If the type is syntactically self-referential and the user has not
@@ -322,10 +320,10 @@ module Located (A : Ast_builder.S) : S = struct
            combinator *)
         let expr =
           if !(env.rec_detected) && rec_flag == Recursive then
-            recursive ~lib:env.lib env.generic_name expr
+            recursive ~lib:env.lib env.repr_name expr
           else expr
         in
-        let pat = pvar env.generic_name in
+        let pat = pvar env.repr_name in
         [ pstr_value Nonrecursive [ value_binding ~pat ~expr ] ]
     | _ -> invalid_arg "Multiple type declarations not supported"
 end

--- a/src/ppx_irmin/lib/deriver.mli
+++ b/src/ppx_irmin/lib/deriver.mli
@@ -22,12 +22,13 @@ module type S = sig
     ?lib:expression ->
     rec_flag * type_declaration list ->
     structure_item list
-  (** Deriver for Irmin generics.
+  (** Deriver for Irmin type representations.
 
-      - [?name]: overrides the default name of the generated generic;
+      - [?name]: overrides the default name of the generated type
+        representation;
 
-      - [?lib]: overrides the default location for the primitive Irmin generics.
-        [~lib:None] will assume that the generics are available in the same
+      - [?lib]: overrides the default location for the primitive Irmin typereps.
+        [~lib:None] will assume that the typereps are available in the same
         namespace. *)
 
   val derive_sig :
@@ -35,7 +36,7 @@ module type S = sig
     ?lib:expression ->
     rec_flag * type_declaration list ->
     signature_item list
-  (** Deriver for Irmin generic type signatures.
+  (** Deriver for Irmin type representation signatures.
 
       Optional arguments have the same meaning as in {!derive_str}. *)
 end

--- a/src/ppx_irmin/lib/dune
+++ b/src/ppx_irmin/lib/dune
@@ -1,4 +1,6 @@
 (library
  (name ppx_irmin_lib)
  (public_name ppx_irmin._lib)
- (libraries ppxlib))
+ (libraries ppxlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/src/ppx_irmin/lib/monad.ml
+++ b/src/ppx_irmin/lib/monad.ml
@@ -14,27 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type FUNCTOR = sig
-  type 'a t
-
-  val return : 'a -> 'a t
-
-  val map : ('a -> 'b) -> 'a t -> 'b t
-end
-
-module type S = sig
-  include FUNCTOR
-
-  val bind : ('a -> 'b t) -> 'a t -> 'b t
-
-  val sequence : 'a t list -> 'a list t
-
-  module Syntax : sig
-    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
-
-    val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
-  end
-end
+include Monad_intf
 
 module Reader (E : sig
   type t

--- a/src/ppx_irmin/lib/monad.mli
+++ b/src/ppx_irmin/lib/monad.mli
@@ -14,45 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type FUNCTOR = sig
-  type 'a t
-
-  val return : 'a -> 'a t
-
-  val map : ('a -> 'b) -> 'a t -> 'b t
-end
-
-module type S = sig
-  include FUNCTOR
-
-  val bind : ('a -> 'b t) -> 'a t -> 'b t
-
-  val sequence : 'a t list -> 'a list t
-
-  module Syntax : sig
-    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
-
-    val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
-  end
-end
-
-module Reader (E : sig
-  type t
-end) : sig
-  (** Computations that read values from a shared environment. *)
-
-  include S
-
-  val run : 'a t -> E.t -> 'a
-  (** Runs a {!'a t} and extracts the final value ['a] from it. *)
-
-  val ask : E.t t
-  (** Retrieves the monad environment. *)
-
-  val asks : (E.t -> 'a) -> 'a t
-  (** Retrieves a projection of the current monad environment. *)
-
-  val local : (E.t -> E.t) -> 'a t -> 'a t
-  (** [local f m] executes a computation in [m] in an environment modified by
-      [f]. *)
-end
+include Monad_intf.Monad
+(** @inline *)

--- a/src/ppx_irmin/lib/monad_intf.ml
+++ b/src/ppx_irmin/lib/monad_intf.ml
@@ -1,0 +1,65 @@
+(*
+ * Copyright (c) 2019-2020 Craig Ferguson <me@craigfe.io>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module type FUNCTOR = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+end
+
+module type S = sig
+  include FUNCTOR
+
+  val bind : ('a -> 'b t) -> 'a t -> 'b t
+
+  val sequence : 'a t list -> 'a list t
+
+  module Syntax : sig
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+
+    val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+  end
+end
+
+module type Monad = sig
+  module type FUNCTOR = FUNCTOR
+
+  module type S = S
+
+  module Reader (E : sig
+    type t
+  end) : sig
+    (** Computations that read values from a shared environment. *)
+
+    include S
+    (** @inline *)
+
+    val run : 'a t -> E.t -> 'a
+    (** Runs a {!'a t} and extracts the final value ['a] from it. *)
+
+    val ask : E.t t
+    (** Retrieves the monad environment. *)
+
+    val asks : (E.t -> 'a) -> 'a t
+    (** Retrieves a projection of the current monad environment. *)
+
+    val local : (E.t -> E.t) -> 'a t -> 'a t
+    (** [local f m] executes a computation in [m] in an environment modified by
+        [f]. *)
+  end
+end

--- a/test/ppx_irmin/deriver/passing/arguments.expected
+++ b/test/ppx_irmin/deriver/passing/arguments.expected
@@ -2,20 +2,20 @@ type c = string[@@deriving irmin { name = "c_wit" }]
 include struct let c_wit = Irmin.Type.string end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
 let (_ : c Irmin.Type.t) = c_wit
-type d = int[@@deriving irmin { name = "generic_for_d" }]
-include struct let generic_for_d = Irmin.Type.int end[@@ocaml.doc "@inline"]
+type d = int[@@deriving irmin { name = "repr_for_d" }]
+include struct let repr_for_d = Irmin.Type.int end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
-let (_ : d Irmin.Type.t) = generic_for_d
-type point_elsewhere1 = ((c)[@generic c_wit])[@@deriving irmin]
+let (_ : d Irmin.Type.t) = repr_for_d
+type point_elsewhere1 = ((c)[@repr c_wit])[@@deriving irmin]
 include struct let point_elsewhere1_t = c_wit end[@@ocaml.doc "@inline"]
 [@@merlin.hide ]
-type point_elsewhere2 = (int * ((c)[@generic c_wit]))[@@deriving irmin]
+type point_elsewhere2 = (int * ((c)[@repr c_wit]))[@@deriving irmin]
 include
   struct let point_elsewhere2_t = let open Irmin.Type in pair int c_wit end
 [@@ocaml.doc "@inline"][@@merlin.hide ]
 type point_elsewhere3 =
-  | A of int * ((c)[@generic c_wit]) 
-  | B of ((c)[@generic c_wit]) [@@deriving irmin]
+  | A of int * ((c)[@repr c_wit]) 
+  | B of ((c)[@repr c_wit]) [@@deriving irmin]
 include
   struct
     let point_elsewhere3_t =
@@ -30,9 +30,9 @@ include
 type point_elsewhere4 =
   {
   lorem: string ;
-  ipsum: ((c)[@generic c_wit]) ;
+  ipsum: ((c)[@repr c_wit]) ;
   dolor: int ;
-  sit: ((d)[@generic generic_for_d]) }[@@deriving irmin]
+  sit: ((d)[@repr repr_for_d]) }[@@deriving irmin]
 include
   struct
     let point_elsewhere4_t =
@@ -44,7 +44,7 @@ include
               |+ (field "lorem" string (fun t -> t.lorem)))
              |+ (field "ipsum" c_wit (fun t -> t.ipsum)))
             |+ (field "dolor" int (fun t -> t.dolor)))
-           |+ (field "sit" generic_for_d (fun t -> t.sit)))
+           |+ (field "sit" repr_for_d (fun t -> t.sit)))
           |> sealr
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 let (_ : point_elsewhere1 Irmin.Type.t) = point_elsewhere1_t

--- a/test/ppx_irmin/deriver/passing/arguments.ml
+++ b/test/ppx_irmin/deriver/passing/arguments.ml
@@ -3,24 +3,22 @@ type c = string [@@deriving irmin { name = "c_wit" }]
 
 let (_ : c Irmin.Type.t) = c_wit
 
-type d = int [@@deriving irmin { name = "generic_for_d" }]
+type d = int [@@deriving irmin { name = "repr_for_d" }]
 
-let (_ : d Irmin.Type.t) = generic_for_d
+let (_ : d Irmin.Type.t) = repr_for_d
 
-type point_elsewhere1 = (c[@generic c_wit]) [@@deriving irmin]
+type point_elsewhere1 = (c[@repr c_wit]) [@@deriving irmin]
 
-type point_elsewhere2 = int * (c[@generic c_wit]) [@@deriving irmin]
+type point_elsewhere2 = int * (c[@repr c_wit]) [@@deriving irmin]
 
-type point_elsewhere3 =
-  | A of int * (c[@generic c_wit])
-  | B of (c[@generic c_wit])
+type point_elsewhere3 = A of int * (c[@repr c_wit]) | B of (c[@repr c_wit])
 [@@deriving irmin]
 
 type point_elsewhere4 = {
   lorem : string;
-  ipsum : (c[@generic c_wit]);
+  ipsum : (c[@repr c_wit]);
   dolor : int;
-  sit : (d[@generic generic_for_d]);
+  sit : (d[@repr repr_for_d]);
 }
 [@@deriving irmin]
 

--- a/test/ppx_irmin/deriver/passing/nonrec.expected
+++ b/test/ppx_irmin/deriver/passing/nonrec.expected
@@ -25,22 +25,19 @@ module S1 :
   end 
 module S2 :
   sig
-    type nonrec t = t list[@@deriving irmin { name = "t_generic" }]
-    include sig val t_generic : t Irmin.Type.t end[@@ocaml.doc "@inline"]
+    type nonrec t = t list[@@deriving irmin { name = "t_repr" }]
+    include sig val t_repr : t Irmin.Type.t end[@@ocaml.doc "@inline"]
     [@@merlin.hide ]
-    type nonrec t_alias = t_alias list[@@deriving
-                                        irmin { name = "t_generic" }]
-    include sig val t_generic : t_alias Irmin.Type.t end[@@ocaml.doc
-                                                          "@inline"][@@merlin.hide
-                                                                    ]
+    type nonrec t_alias = t_alias list[@@deriving irmin { name = "t_repr" }]
+    include sig val t_repr : t_alias Irmin.Type.t end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
   end =
   struct
-    type nonrec t = t list[@@deriving irmin { name = "t_generic" }]
-    include struct let t_generic = let open Irmin.Type in list t end[@@ocaml.doc
-                                                                    "@inline"]
+    type nonrec t = t list[@@deriving irmin { name = "t_repr" }]
+    include struct let t_repr = let open Irmin.Type in list t end[@@ocaml.doc
+                                                                   "@inline"]
     [@@merlin.hide ]
-    type nonrec t_alias = t_alias list[@@deriving
-                                        irmin { name = "t_generic" }]
-    include struct let t_generic = let open Irmin.Type in list t_alias_t end
+    type nonrec t_alias = t_alias list[@@deriving irmin { name = "t_repr" }]
+    include struct let t_repr = let open Irmin.Type in list t_alias_t end
     [@@ocaml.doc "@inline"][@@merlin.hide ]
   end 

--- a/test/ppx_irmin/deriver/passing/nonrec.ml
+++ b/test/ppx_irmin/deriver/passing/nonrec.ml
@@ -15,11 +15,11 @@ end
 
 (* Now test the interaction of 'nonrec' with custom naming *)
 module S2 : sig
-  type nonrec t = t list [@@deriving irmin { name = "t_generic" }]
+  type nonrec t = t list [@@deriving irmin { name = "t_repr" }]
 
-  type nonrec t_alias = t_alias list [@@deriving irmin { name = "t_generic" }]
+  type nonrec t_alias = t_alias list [@@deriving irmin { name = "t_repr" }]
 end = struct
-  type nonrec t = t list [@@deriving irmin { name = "t_generic" }]
+  type nonrec t = t list [@@deriving irmin { name = "t_repr" }]
 
-  type nonrec t_alias = t_alias list [@@deriving irmin { name = "t_generic" }]
+  type nonrec t_alias = t_alias list [@@deriving irmin { name = "t_repr" }]
 end

--- a/test/ppx_irmin/deriver/passing/signature.expected
+++ b/test/ppx_irmin/deriver/passing/signature.expected
@@ -3,8 +3,8 @@ module SigTests :
     type t = string[@@deriving irmin]
     include sig val t : t Irmin.Type.t end[@@ocaml.doc "@inline"][@@merlin.hide
                                                                    ]
-    type foo = unit[@@deriving irmin { name = "foo_generic" }]
-    include sig val foo_generic : foo Irmin.Type.t end[@@ocaml.doc "@inline"]
+    type foo = unit[@@deriving irmin { name = "foo_repr" }]
+    include sig val foo_repr : foo Irmin.Type.t end[@@ocaml.doc "@inline"]
     [@@merlin.hide ]
     type my_int = (int32 * t)[@@deriving irmin]
     include sig val my_int_t : my_int Irmin.Type.t end[@@ocaml.doc "@inline"]
@@ -21,10 +21,9 @@ module SigTests :
     type t = string[@@deriving irmin]
     include struct let t = Irmin.Type.string end[@@ocaml.doc "@inline"]
     [@@merlin.hide ]
-    type foo = unit[@@deriving irmin { name = "foo_generic" }]
-    include struct let foo_generic = Irmin.Type.unit end[@@ocaml.doc
-                                                          "@inline"][@@merlin.hide
-                                                                    ]
+    type foo = unit[@@deriving irmin { name = "foo_repr" }]
+    include struct let foo_repr = Irmin.Type.unit end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
     type my_int = (int32 * t)[@@deriving irmin]
     include struct let my_int_t = let open Irmin.Type in pair int32 t end
     [@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_irmin/deriver/passing/signature.ml
+++ b/test/ppx_irmin/deriver/passing/signature.ml
@@ -2,7 +2,7 @@
 module SigTests : sig
   type t = string [@@deriving irmin]
 
-  type foo = unit [@@deriving irmin { name = "foo_generic" }]
+  type foo = unit [@@deriving irmin { name = "foo_repr" }]
 
   type my_int = int32 * t [@@deriving irmin]
 
@@ -14,7 +14,7 @@ module SigTests : sig
 end = struct
   type t = string [@@deriving irmin]
 
-  type foo = unit [@@deriving irmin { name = "foo_generic" }]
+  type foo = unit [@@deriving irmin { name = "foo_repr" }]
 
   type my_int = int32 * t [@@deriving irmin]
 


### PR DESCRIPTION
... and fix uses of the word 'generic' in the code and documentation.  In the
literature, the term 'generic' describes an operation that is parameterised
over run-time type representations. The type representations themselves are not
'generic's.