### PR TITLE
ppx_irmin: improve locations in Unsupported error messages

### DIFF
--- a/src/ppx_irmin/lib/algebraic.ml
+++ b/src/ppx_irmin/lib/algebraic.ml
@@ -220,13 +220,13 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
     { combinator; composite; augment; sealer }
 
   let encode :
-      type a b.
+      type a b e.
       (a, b) Typ.t ->
-      subderive:(a -> b M.t) ->
+      subderive:(a -> (b, e) M.t) ->
       lib:string option ->
       type_name:string ->
       a list ->
-      expression M.t =
+      (expression, e) M.t =
    fun typ ~subderive ~lib ~type_name ts ->
     let open M.Syntax in
     let dsl = terms_of_typ ~lib typ in

--- a/src/ppx_irmin/lib/algebraic_intf.ml
+++ b/src/ppx_irmin/lib/algebraic_intf.ml
@@ -43,11 +43,11 @@ module type S = sig
 
   val encode :
     ('a, 'b) Typ.t ->
-    subderive:('a -> 'b M.t) ->
+    subderive:('a -> ('b, 'e) M.t) ->
     lib:string option ->
     type_name:string ->
     'a list ->
-    expression M.t
+    (expression, 'e) M.t
   (** Build the functional encoding of a composite type. Combine the various
       elements necessary for a functional encoding of a composite type
       [('a, 'b) {!typ}], in terms its components of type ['a list] and the name

--- a/src/ppx_irmin/lib/deriver.ml
+++ b/src/ppx_irmin/lib/deriver.ml
@@ -87,6 +87,7 @@ module Located (A : Ast_builder.S) : S = struct
 
   let rec derive_core typ =
     let* { rec_flag; type_name; repr_name; rec_detected; lib } = ask in
+    let loc = typ.ptyp_loc in
     match typ.ptyp_desc with
     | Ptyp_constr ({ txt = const_name; _ }, args) -> (
         match Attribute.get Attributes.repr typ with

--- a/src/ppx_irmin/lib/monad.ml
+++ b/src/ppx_irmin/lib/monad.ml
@@ -16,11 +16,8 @@
 
 include Monad_intf
 
-module Reader (E : sig
-  type t
-end) =
-struct
-  type 'a t = Reader of (E.t -> 'a)
+module Reader = struct
+  type ('a, 'e) t = Reader of ('e -> 'a)
 
   let run (Reader r) = r
 
@@ -30,15 +27,15 @@ struct
 
   let return x = Reader (fun _ -> x)
 
-  let sequence ms =
+  let sequence (type a e) ms =
     List.fold_right
-      (fun (aM : 'a t) (bM : 'a list t) ->
+      (fun (aM : (a, e) t) (bM : (a list, e) t) ->
         bind (fun a -> map (fun b -> a :: b) bM) aM)
       ms (return [])
 
   let asks f = Reader (fun env -> f env)
 
-  let ask = asks (fun x -> x)
+  let ask = Reader (fun env -> env)
 
   let local f m = Reader (fun env -> run m (f env))
 

--- a/test/ppx_irmin/deriver/errors/unsupported_type_arrow.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_arrow.expected
@@ -1,2 +1,2 @@
-File "unsupported_type_arrow.ml", line 1, characters 0-39:
+File "unsupported_type_arrow.ml", line 1, characters 9-20:
 Error: ppx_irmin: function type encountered: unit -> int. Functions are not Irmin-serialisable.

--- a/test/ppx_irmin/deriver/errors/unsupported_type_extension.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_extension.expected
@@ -1,2 +1,2 @@
-File "unsupported_type_extension.ml", line 1, characters 0-34:
+File "unsupported_type_extension.ml", line 1, characters 9-15:
 Error: ppx_irmin: unprocessed extension [%typ ] encountered.

--- a/test/ppx_irmin/deriver/errors/unsupported_type_open_polyvariant.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_open_polyvariant.expected
@@ -1,2 +1,2 @@
-File "unsupported_type_open_polyvariant.ml", line 1, characters 0-43:
+File "unsupported_type_open_polyvariant.ml", line 1, characters 9-24:
 Error: ppx_irmin: open polymorphic variant [> `On  | `Off ] encountered. Polymorphic variants must be closed.

--- a/test/ppx_irmin/deriver/errors/unsupported_type_package.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_package.expected
@@ -1,2 +1,2 @@
-File "unsupported_type_package.ml", line 5, characters 0-38:
+File "unsupported_type_package.ml", line 5, characters 9-19:
 Error: ppx_irmin: package type (module S) encountered. Package types are not Irmin-serialisable.

--- a/test/ppx_irmin/deriver/errors/unsupported_type_poly.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_poly.expected
@@ -1,2 +1,2 @@
-File "unsupported_type_poly.ml", line 1, characters 0-42:
+File "unsupported_type_poly.ml", line 1, characters 15-21:
 Error: ppx_irmin: universally-quantified type 'a . 'a encountered. Irmin types must be grounded.

--- a/test/ppx_irmin/deriver/errors/unsupported_type_variable.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_variable.expected
@@ -1,2 +1,2 @@
-File "unsupported_type_variable.ml", line 1, characters 0-43:
+File "unsupported_type_variable.ml", line 1, characters 17-24:
 Error: ppx_irmin: uninstantiated type variable 'typvar found. Irmin types must be grounded.


### PR DESCRIPTION
Also contains a small refactoring to scrap an unnecessary functor in the implementation.

Depends on https://github.com/mirage/irmin/pull/1083.