### PR TITLE
ppx_irmin: add support for higher-kinded types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,12 @@
   - Added a `migrate` function for upgrading stores with old formats (#1070,
     @icristescu, @CraigFe)
 
+- **ppx_irmin**:
+
+  - Added support for deriving type representations for types with type
+    parameters. Type `'a t` generateseara representation of type
+    `'a Type.t -> 'a t Type.t` (#1085, @CraigFe)
+
 #### Changed
 
 - **irmin**

--- a/src/ppx_irmin/lib/algebraic.ml
+++ b/src/ppx_irmin/lib/algebraic.ml
@@ -18,22 +18,16 @@ include Algebraic_intf
 open Typ
 open Ppxlib
 
-let ( >> ) f g x = g (f x)
-
 module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
   module M = M
+  open Utils
+
+  open Utils.Make (A)
+
   open A
-
-  let ( >|= ) x f = List.map f x
-
-  let compose_all : type a. (a -> a) list -> a -> a =
-   fun l x -> List.fold_left ( |> ) x (List.rev l)
 
   let generate_identifiers n =
     List.init n (fun i -> Printf.sprintf "x%d" (i + 1))
-
-  (** [lambda \[ "x_1"; ...; "x_n" \] e] is [fun x1 ... xN -> e] *)
-  let lambda params = params >|= (pvar >> pexp_fun Nolabel None) |> compose_all
 
   let dsl ~lib =
     (function

--- a/src/ppx_irmin/lib/raise.ml
+++ b/src/ppx_irmin/lib/raise.ml
@@ -28,12 +28,6 @@ module Unsupported = struct
       "%s: function type encountered: %a. Functions are not Irmin-serialisable."
       name Pprintast.core_type ctyp
 
-  let type_var ~loc typvar =
-    Location.raise_errorf ~loc
-      "%s: uninstantiated type variable '%s found. Irmin types must be \
-       grounded."
-      name typvar
-
   let type_open ~loc =
     Location.raise_errorf ~loc
       "%s: extensible variant types are not Irmin-serialisable." name

--- a/src/ppx_irmin/lib/raise.mli
+++ b/src/ppx_irmin/lib/raise.mli
@@ -21,8 +21,6 @@ module Unsupported : sig
 
   val type_arrow : loc:location -> core_type -> 'a
 
-  val type_var : loc:location -> label -> 'a
-
   val type_open : loc:location -> 'a
 
   val type_poly : loc:location -> core_type -> 'a

--- a/src/ppx_irmin/lib/utils.ml
+++ b/src/ppx_irmin/lib/utils.ml
@@ -1,0 +1,24 @@
+open Ppxlib
+
+let ( >> ) f g x = g (f x)
+
+let ( >|= ) x f = List.map f x
+
+module Make (A : Ast_builder.S) : sig
+  val compose_all : ('a -> 'a) list -> 'a -> 'a
+  (** Left-to-right composition of a list of functions. *)
+
+  val lambda : string list -> expression -> expression
+  (** [lambda \[ "x_1"; ...; "x_n" \] e] is [fun x1 ... x_n -> e] *)
+
+  val arrow : core_type list -> core_type -> core_type
+  (** [arrow \[ "t_1"; ...; "t_n" \] u] is [t_1 -> ... -> t_n -> u] *)
+end = struct
+  open A
+
+  let compose_all l x = List.fold_left ( |> ) x (List.rev l)
+
+  let lambda = List.map (pvar >> pexp_fun Nolabel None) >> compose_all
+
+  let arrow = List.map (ptyp_arrow Nolabel) >> compose_all
+end

--- a/test/ppx_irmin/deriver/errors/dune.inc
+++ b/test/ppx_irmin/deriver/errors/dune.inc
@@ -212,27 +212,4 @@
  (action
   (diff unsupported_type_poly.expected unsupported_type_poly.actual)))
 
-; -------- Test: `unsupported_type_variable.ml` --------
-
-
-
-; Run the PPX on the `.ml` file
-(rule
- (targets unsupported_type_variable.actual)
- (deps
-  (:pp pp.exe)
-  (:input unsupported_type_variable.ml))
- (action
-  ; expect the process to fail, capturing stderr
-  (with-stderr-to
-   %{targets}
-   (bash "! ./%{pp} -no-color --impl %{input}"))))
-
-; Compare the post-processed output to the .expected file
-(rule
- (alias runtest)
- (package ppx_irmin)
- (action
-  (diff unsupported_type_variable.expected unsupported_type_variable.actual)))
-
 

--- a/test/ppx_irmin/deriver/errors/unsupported_type_variable.expected
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_variable.expected
@@ -1,2 +1,0 @@
-File "unsupported_type_variable.ml", line 1, characters 17-24:
-Error: ppx_irmin: uninstantiated type variable 'typvar found. Irmin types must be grounded.

--- a/test/ppx_irmin/deriver/errors/unsupported_type_variable.ml
+++ b/test/ppx_irmin/deriver/errors/unsupported_type_variable.ml
@@ -1,1 +1,0 @@
-type 'typvar t = 'typvar [@@deriving irmin]

--- a/test/ppx_irmin/deriver/passing/dune.inc
+++ b/test/ppx_irmin/deriver/passing/dune.inc
@@ -414,6 +414,38 @@
  (action
   (run ./tuple_deep.exe)))
 
+; -------- Test: `type_params.ml` --------
+
+; The PPX-dependent executable under test
+(executable
+ (name type_params)
+ (modules type_params)
+ (preprocess (pps ppx_irmin))
+ (libraries irmin))
+
+; Run the PPX on the `.ml` file
+(rule
+ (targets type_params.actual)
+ (deps
+  (:pp pp.exe)
+  (:input type_params.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+; Compare the post-processed output to the .expected file
+(rule
+ (alias runtest)
+ (package ppx_irmin)
+ (action
+  (diff type_params.expected type_params.actual)))
+
+; Ensure that the post-processed executable runs correctly
+(rule
+ (alias runtest)
+ (package ppx_irmin)
+ (action
+  (run ./type_params.exe)))
+
 ; -------- Test: `variant.ml` --------
 
 ; The PPX-dependent executable under test

--- a/test/ppx_irmin/deriver/passing/type_params.expected
+++ b/test/ppx_irmin/deriver/passing/type_params.expected
@@ -1,0 +1,61 @@
+type 'a typ = 'a Irmin.Type.t
+module Id :
+  sig
+    type 'a t[@@deriving irmin]
+    include sig val t : 'a Irmin.Type.t -> 'a t Irmin.Type.t end[@@ocaml.doc
+                                                                  "@inline"]
+    [@@merlin.hide ]
+  end =
+  struct
+    type 'a t = 'a[@@deriving irmin]
+    include struct let t a = a end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end 
+let __ : type a. a typ -> a Id.t typ = Id.t
+module Phantom :
+  sig
+    type _ t = int[@@deriving irmin]
+    include
+      sig val t : 'v_x__001_ Irmin.Type.t -> 'v_x__001_ t Irmin.Type.t end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
+  end =
+  struct
+    type _ t = int[@@deriving irmin]
+    include struct let t _ = Irmin.Type.int end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+  end 
+let __ : type a. a typ -> a Phantom.t typ = Phantom.t
+module Multiple :
+  sig
+    type ('a, 'b, 'c) t = {
+      foo: 'a ;
+      bar: 'b list ;
+      baz: ('b * 'c) }[@@deriving irmin]
+    include
+      sig
+        val t :
+          'a Irmin.Type.t ->
+            'b Irmin.Type.t -> 'c Irmin.Type.t -> ('a, 'b, 'c) t Irmin.Type.t
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end =
+  struct
+    type ('a, 'b, 'c) t = {
+      foo: 'a ;
+      bar: 'b list ;
+      baz: ('b * 'c) }[@@deriving irmin]
+    include
+      struct
+        let t a b c =
+          Irmin.Type.sealr
+            (Irmin.Type.(|+)
+               (Irmin.Type.(|+)
+                  (Irmin.Type.(|+)
+                     (Irmin.Type.record "t"
+                        (fun foo -> fun bar -> fun baz -> { foo; bar; baz }))
+                     (Irmin.Type.field "foo" a (fun t -> t.foo)))
+                  (Irmin.Type.field "bar" (Irmin.Type.list b)
+                     (fun t -> t.bar)))
+               (Irmin.Type.field "baz" (Irmin.Type.pair b c) (fun t -> t.baz)))
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end 
+let __ : type a b c. a typ -> b typ -> c typ -> (a, b, c) Multiple.t typ =
+  Multiple.t

--- a/test/ppx_irmin/deriver/passing/type_params.ml
+++ b/test/ppx_irmin/deriver/passing/type_params.ml
@@ -1,0 +1,28 @@
+type 'a typ = 'a Irmin.Type.t
+
+module Id : sig
+  type 'a t [@@deriving irmin]
+end = struct
+  type 'a t = 'a [@@deriving irmin]
+end
+
+let __ : type a. a typ -> a Id.t typ = Id.t
+
+module Phantom : sig
+  type _ t = int [@@deriving irmin]
+end = struct
+  type _ t = int [@@deriving irmin]
+end
+
+let __ : type a. a typ -> a Phantom.t typ = Phantom.t
+
+module Multiple : sig
+  type ('a, 'b, 'c) t = { foo : 'a; bar : 'b list; baz : 'b * 'c }
+  [@@deriving irmin]
+end = struct
+  type ('a, 'b, 'c) t = { foo : 'a; bar : 'b list; baz : 'b * 'c }
+  [@@deriving irmin]
+end
+
+let __ : type a b c. a typ -> b typ -> c typ -> (a, b, c) Multiple.t typ =
+  Multiple.t


### PR DESCRIPTION
e.g. the type `('a, 'b) t` is represented as `'a typ -> 'b typ -> ('a, 'b) t typ`.