### PR TITLE
ppx_irmin: add --lib command-line flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,11 @@
     parameters. Type `'a t` generateseara representation of type
     `'a Type.t -> 'a t Type.t` (#1085, @CraigFe)
 
+  - Added a `--lib` command-line option which has the same behaviour as the
+    `lib` run-time argument (i.e. `--lib Foo` will cause `ppx_irmin` to derive
+    type representations using combinators in the `Foo` module). (#1086,
+    @CraigFe)
+
 #### Changed
 
 - **irmin**

--- a/README_PPX.md
+++ b/README_PPX.md
@@ -66,6 +66,9 @@ type foo = unit [@@deriving irmin { lib = Some "Mylib.Types" }]
 val foo_t = Mylib.Types.unit
 ```
 
+This argument can also be passed as a command-line option (i.e. `--lib
+Mylib.Types`, with `--lib ''` interpreted as the current module).
+
 #### Naming scheme
 
 The generated type representation will be called `<type-name>_t`, unless the

--- a/src/ppx_irmin/lib/deriver.ml
+++ b/src/ppx_irmin/lib/deriver.ml
@@ -38,15 +38,17 @@ let irmin_types =
     ]
 
 module type S = sig
+  val parse_lib : expression -> string option
+
   val derive_str :
     ?name:string ->
-    ?lib:expression ->
+    ?lib:string ->
     rec_flag * type_declaration list ->
     structure_item list
 
   val derive_sig :
     ?name:string ->
-    ?lib:expression ->
+    ?lib:string ->
     rec_flag * type_declaration list ->
     signature_item list
 end
@@ -268,8 +270,6 @@ module Located (A : Ast_builder.S) : S = struct
           "Could not process `lib' argument: must be either `Some \"Lib\"' or \
            `None'"
 
-  let lib_default = "Irmin.Type"
-
   let derive_sig ?name ?lib input_ast =
     match input_ast with
     | _, [ typ ] ->
@@ -279,9 +279,6 @@ module Located (A : Ast_builder.S) : S = struct
             (match name with
             | Some n -> n
             | None -> repr_name_of_type_name type_name)
-        in
-        let lib =
-          match lib with Some l -> parse_lib l | None -> Some lib_default
         in
         let ty_lident =
           (match lib with
@@ -318,9 +315,6 @@ module Located (A : Ast_builder.S) : S = struct
             | None -> repr_name_of_type_name type_name
           in
           let rec_detected = ref false in
-          let lib =
-            match lib with Some l -> parse_lib l | None -> Some lib_default
-          in
           let var_repr v = if List.mem v tparams then Some (evar v) else None in
           { rec_flag; type_name; repr_name; rec_detected; lib; var_repr }
         in

--- a/src/ppx_irmin/lib/deriver.mli
+++ b/src/ppx_irmin/lib/deriver.mli
@@ -17,9 +17,14 @@
 open Ppxlib
 
 module type S = sig
+  val parse_lib : expression -> string option
+  (** [parse_lib e] is [Some "foo"] or [None] if [e] is a [string option], and
+      raises a located exception otherwise. Intended to be used for parsing the
+      [lib] argument to the derivers. *)
+
   val derive_str :
     ?name:string ->
-    ?lib:expression ->
+    ?lib:string ->
     rec_flag * type_declaration list ->
     structure_item list
   (** Deriver for Irmin type representations.
@@ -33,7 +38,7 @@ module type S = sig
 
   val derive_sig :
     ?name:string ->
-    ?lib:expression ->
+    ?lib:string ->
     rec_flag * type_declaration list ->
     signature_item list
   (** Deriver for Irmin type representation signatures.


### PR DESCRIPTION
Allow the `lib` argument to be set globally by passing a command-line flag.  This will be helpful when using `ppx_irmin` inside `irmin` itself.