### PR TITLE
Use `ppx_irmin` internally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,22 @@ script: bash -ex .travis-docker.sh
 env:
   global:
   - ALCOTEST_SHOW_ERRORS=1
-  - PINS="irmin.dev:. irmin-mem.dev:. irmin-pack.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. ppx_irmin.dev:."
+  - PINS="irmin.dev:. irmin-mem.dev:. irmin-pack.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. irmin-containers.dev:. ppx_irmin.dev:."
   - DISTRO=debian-stable
   matrix:
   - OCAML_VERSION=4.08 PACKAGE="irmin-unix" REVDEPS="irmin-indexeddb"
   - OCAML_VERSION=4.09 PACKAGE="irmin"
   - OCAML_VERSION=4.09 PACKAGE="ppx_irmin"
   - OCAML_VERSION=4.08 PACKAGE="irmin"
-  - OCAML_VERSION=4.07 PACKAGE="irmin"
+  - OCAML_VERSION=4.08 PACKAGE="irmin"
   - OCAML_VERSION=4.08 PACKAGE="irmin-fs"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-mem"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-git"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-http"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-chunk"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-mem"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-git"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-http"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-chunk"
   - OCAML_VERSION=4.08 PACKAGE="irmin-mirage"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-mirage-git"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-mirage-graphql"
-  - OCAML_VERSION=4.07 PACKAGE="irmin-graphql"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-mirage-git"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-mirage-graphql"
+  - OCAML_VERSION=4.08 PACKAGE="irmin-graphql"
   - OCAML_VERSION=4.08 PACKAGE="irmin-pack"
   - OCAML_VERSION=4.08 PACKAGE="irmin-containers"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: bash -ex .travis-docker.sh
 env:
   global:
   - ALCOTEST_SHOW_ERRORS=1
-  - PINS="irmin.dev:. irmin-mem.dev:. irmin-pack.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:."
+  - PINS="irmin.dev:. irmin-mem.dev:. irmin-pack.dev:. irmin-fs.dev:. irmin-http.dev:. irmin-git.dev:. irmin-graphql.dev:. irmin-mirage.dev:. irmin-mirage-git.dev:. irmin-mirage-graphql.dev:. irmin-unix.dev:. irmin-test.dev:. irmin-chunk.dev:. ppx_irmin.dev:."
   - DISTRO=debian-stable
   matrix:
   - OCAML_VERSION=4.08 PACKAGE="irmin-unix" REVDEPS="irmin-indexeddb"

--- a/examples/custom_graphql.ml
+++ b/examples/custom_graphql.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
 
 module Car = struct
-  type color = Black | White | Other of string
+  type color = Black | White | Other of string [@@deriving irmin]
 
   type t = {
     license : string;
@@ -10,26 +10,7 @@ module Car = struct
     color : color;
     owner : string;
   }
-
-  let color =
-    let open Irmin.Type in
-    variant "color" (fun black white other -> function
-      | Black -> black | White -> white | Other color -> other color)
-    |~ case0 "Black" Black
-    |~ case0 "White" White
-    |~ case1 "Other" string (fun s -> Other s)
-    |> sealv
-
-  let t =
-    let open Irmin.Type in
-    record "car" (fun license year make_and_model color owner ->
-        { license; year; make_and_model; color; owner })
-    |+ field "license" string (fun t -> t.license)
-    |+ field "year" int32 (fun t -> t.year)
-    |+ field "make_and_model" (pair string string) (fun t -> t.make_and_model)
-    |+ field "color" color (fun t -> t.color)
-    |+ field "owner" string (fun t -> t.owner)
-    |> sealr
+  [@@deriving irmin]
 
   let merge = Irmin.Merge.(option (idempotent t))
 end

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -24,7 +24,7 @@ module Entry : sig
 
   val timestamp : t -> int64
 end = struct
-  type t = { timestamp : int64; message : string }
+  type t = { timestamp : int64; message : string } [@@deriving irmin]
 
   let compare x y = Int64.compare x.timestamp y.timestamp
 
@@ -42,13 +42,6 @@ end = struct
     | Some (x, message) -> (
         try Ok { timestamp = Int64.of_string x; message }
         with Failure e -> Error (`Msg e))
-
-  let t =
-    let open Irmin.Type in
-    record "entry" (fun timestamp message -> { timestamp; message })
-    |+ field "timestamp" int64 (fun t -> t.timestamp)
-    |+ field "message" string (fun t -> t.message)
-    |> sealr
 
   let t = Irmin.Type.like ~cli:(pp, of_string) ~compare t
 end

--- a/examples/dune
+++ b/examples/dune
@@ -1,7 +1,10 @@
 (executables
  (names readme trees sync process deploy irmin_git_store custom_merge push
    custom_graphql)
- (libraries astring cohttp fmt git irmin irmin-git irmin-unix lwt lwt.unix))
+ (libraries astring cohttp fmt git irmin irmin-git irmin-unix ppx_irmin lwt
+   lwt.unix)
+ (preprocess
+  (pps ppx_irmin)))
 
 (alias
  (name examples)

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -19,7 +19,7 @@ depends: [
   "irmin"
   "bechamel"
   "yojson"
-  "ppx_irmin"
+  "ppx_irmin" {= version}
   "ppx_deriving_yojson"
 ]
 

--- a/irmin-containers.opam
+++ b/irmin-containers.opam
@@ -20,6 +20,7 @@ depends: [
   "irmin-mem"  {>= "2.1.0"}
   "irmin-unix" {>= "2.1.0"}
   "irmin-git"  {>= "2.1.0"}
+  "ppx_irmin"
   "lwt"
   "mtime"
   "alcotest" {with-test}

--- a/irmin-containers.opam
+++ b/irmin-containers.opam
@@ -20,7 +20,7 @@ depends: [
   "irmin-mem"  {>= "2.1.0"}
   "irmin-unix" {>= "2.1.0"}
   "irmin-git"  {>= "2.1.0"}
-  "ppx_irmin"
+  "ppx_irmin"  {= version}
   "lwt"
   "mtime"
   "alcotest" {with-test}

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "2.5.1"}
   "irmin"      {>= "2.0.0"}
+  "ppx_irmin"
   "git"        {>= "2.1.1"}
   "digestif"   {>= "0.9.0"}
   "astring"

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "2.5.1"}
   "irmin"      {>= "2.0.0"}
-  "ppx_irmin"
+  "ppx_irmin"  {= version}
   "git"        {>= "2.1.1"}
   "digestif"   {>= "0.9.0"}
   "astring"

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -19,6 +19,7 @@ depends: [
   "crunch"     {>= "2.2.0"}
   "webmachine" {>= "0.6.0"}
   "irmin"      {>= "2.2.0"}
+  "ppx_irmin"
   "cohttp-lwt" {>= "1.0.0"}
   "irmin-git"  {with-test & >= "2.0.0"}
   "irmin-mem"  {with-test & >= "2.0.0"}

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -19,7 +19,7 @@ depends: [
   "crunch"     {>= "2.2.0"}
   "webmachine" {>= "0.6.0"}
   "irmin"      {>= "2.2.0"}
-  "ppx_irmin"
+  "ppx_irmin"  {= version}
   "cohttp-lwt" {>= "1.0.0"}
   "irmin-git"  {with-test & >= "2.0.0"}
   "irmin-mem"  {with-test & >= "2.0.0"}

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.5.1"}
   "irmin"      {>= "2.2.0"}
+  "ppx_irmin"
   "index"      {>= "1.2.1"}
   "fmt"
   "logs"

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.5.1"}
   "irmin"      {>= "2.2.0"}
-  "ppx_irmin"
+  "ppx_irmin"  {= version}
   "index"      {>= "1.2.1"}
   "fmt"
   "logs"

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml"    {>= "4.02.3"}
   "dune"     {>= "2.5.1"}
   "irmin"    {>= "2.2.0"}
+  "ppx_irmin"
   "alcotest" {>= "1.0.1"}
   "mtime"    {>= "1.0.0"}
   "astring"

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"    {>= "4.02.3"}
   "dune"     {>= "2.5.1"}
   "irmin"    {>= "2.2.0"}
-  "ppx_irmin"
+  "ppx_irmin" {= version}
   "alcotest" {>= "1.0.1"}
   "mtime"    {>= "1.0.0"}
   "astring"

--- a/irmin.opam
+++ b/irmin.opam
@@ -27,10 +27,10 @@ depends: [
   "logs"    {>= "0.5.0"}
   "bheap" {>= "2.0.0"}
   "astring"
+  "ppx_irmin"
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
-  "ppx_irmin" {with-test}
   "irmin-mem" {with-test & post}
 ]
 synopsis: """

--- a/irmin.opam
+++ b/irmin.opam
@@ -27,7 +27,7 @@ depends: [
   "logs"    {>= "0.5.0"}
   "bheap" {>= "2.0.0"}
   "astring"
-  "ppx_irmin"
+  "ppx_irmin" {= version}
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}

--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "dune" {>= "2.5.1"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "ppxlib" {>= "0.12.0"}
   "irmin" {with-test & post & >= "2.0.0"}
 ]

--- a/src/irmin-containers/blob_log.ml
+++ b/src/irmin-containers/blob_log.ml
@@ -23,9 +23,7 @@ let empty_info = Irmin.Info.none
 
 module Blob_log (T : Time.S) (V : Irmin.Type.S) :
   Irmin.Contents.S with type t = (V.t * T.t) list = struct
-  type t = (V.t * T.t) list
-
-  let t = Irmin.Type.(list (pair V.t T.t))
+  type t = (V.t * T.t) list [@@deriving irmin]
 
   let compare =
     let compare_times = Irmin.Type.compare T.t in

--- a/src/irmin-containers/dune
+++ b/src/irmin-containers/dune
@@ -1,4 +1,6 @@
 (library
  (name irmin_containers)
  (public_name irmin-containers)
- (libraries irmin irmin-mem irmin-unix irmin-git mtime))
+ (libraries irmin irmin-mem irmin-unix irmin-git mtime)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-containers/linked_log.ml
+++ b/src/irmin-containers/linked_log.ml
@@ -22,29 +22,13 @@ let return = Lwt.return
 let empty_info = Irmin.Info.none
 
 module Log_item (T : Time.S) (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
-  type t = { time : T.t; msg : V.t; prev : K.t option }
-
-  let t =
-    let open Irmin.Type in
-    record "t" (fun time msg prev -> { time; msg; prev })
-    |+ field "time" T.t (fun r -> r.time)
-    |+ field "msg" V.t (fun r -> r.msg)
-    |+ field "prev" (option K.t) (fun r -> r.prev)
-    |> sealr
+  type t = { time : T.t; msg : V.t; prev : K.t option } [@@deriving irmin]
 end
 
 module Store_item (T : Time.S) (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
   module L = Log_item (T) (K) (V)
 
-  type t = Value of L.t | Merge of L.t list
-
-  let t =
-    let open Irmin.Type in
-    variant "t" (fun value merge -> function
-      | Value v -> value v | Merge l -> merge l)
-    |~ case1 "Value" L.t (fun v -> Value v)
-    |~ case1 "Merge" (list L.t) (fun l -> Merge l)
-    |> sealv
+  type t = Value of L.t | Merge of L.t list [@@deriving irmin]
 end
 
 module Linked_log
@@ -53,9 +37,7 @@ module Linked_log
     (K : Irmin.Hash.S)
     (V : Irmin.Type.S) =
 struct
-  type t = K.t
-
-  let t = K.t
+  type t = K.t [@@deriving irmin]
 
   module L = Log_item (T) (K) (V)
   module S = Store_item (T) (K) (V)

--- a/src/irmin-containers/lww_register.ml
+++ b/src/irmin-containers/lww_register.ml
@@ -21,9 +21,7 @@ let empty_info = Irmin.Info.none
 
 module LWW (T : Time.S) (V : Irmin.Type.S) :
   Irmin.Contents.S with type t = V.t * T.t = struct
-  type t = V.t * T.t
-
-  let t = Irmin.Type.(pair V.t T.t)
+  type t = V.t * T.t [@@deriving irmin]
 
   let compare_t = Irmin.Type.compare T.t
 

--- a/src/irmin-git/dune
+++ b/src/irmin-git/dune
@@ -1,4 +1,6 @@
 (library
  (name irmin_git)
  (public_name irmin-git)
- (libraries astring cstruct fmt fpath git irmin logs lwt uri))
+ (libraries astring cstruct fmt fpath git irmin logs lwt uri)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -224,29 +224,16 @@ struct
 
       type t = G.Value.Tree.t
 
-      type metadata = Metadata.t
+      type metadata = Metadata.t [@@deriving irmin]
 
-      type hash = Key.t
+      type hash = Key.t [@@deriving irmin]
 
-      type step = Path.step
+      type step = Path.step [@@deriving irmin]
 
       type value = [ `Node of hash | `Contents of hash * metadata ]
-
-      let metadata_t = Metadata.t
-
-      let hash_t = Key.t
-
-      let step_t = Path.step_t
+      [@@deriving irmin]
 
       let default = Metadata.default
-
-      let value_t =
-        let open Irmin.Type in
-        variant "Tree.value" (fun node contents -> function
-          | `Node n -> node n | `Contents c -> contents c)
-        |~ case1 "node" hash_t (fun n -> `Node n)
-        |~ case1 "contents" (pair hash_t metadata_t) (fun c -> `Contents c)
-        |> sealv
 
       let of_step = Irmin.Type.to_string P.step_t
 
@@ -392,9 +379,7 @@ struct
     module Val = struct
       type t = G.Value.Commit.t
 
-      type hash = H.t
-
-      let hash_t = H.t
+      type hash = H.t [@@deriving irmin]
 
       let info_of_git author message =
         let id = author.Git.User.name in
@@ -834,6 +819,7 @@ module Reference : BRANCH with type t = reference = struct
 
   type t =
     [ `Branch of string | `Remote of string | `Tag of string | `Other of string ]
+  [@@deriving irmin]
 
   let pp_ref ppf = function
     | `Branch b -> Fmt.pf ppf "refs/heads/%s" b
@@ -850,19 +836,6 @@ module Reference : BRANCH with type t = reference = struct
     | "refs" :: "tags" :: t -> Ok (`Tag (path t))
     | "refs" :: o -> Ok (`Other (path o))
     | _ -> Error (`Msg (Fmt.strf "%s is not a valid reference" str))
-
-  let t =
-    let open Irmin.Type in
-    variant "reference" (fun branch remote tag other -> function
-      | `Branch x -> branch x
-      | `Remote x -> remote x
-      | `Tag x -> tag x
-      | `Other x -> other x)
-    |~ case1 "branch" string (fun t -> `Branch t)
-    |~ case1 "remote" string (fun t -> `Remote t)
-    |~ case1 "tag" string (fun t -> `Tag t)
-    |~ case1 "other" string (fun t -> `Other t)
-    |> sealv
 
   let t = Irmin.Type.like t ~cli:(pp_ref, of_ref)
 

--- a/src/irmin-http/dune
+++ b/src/irmin-http/dune
@@ -1,4 +1,6 @@
 (library
  (name irmin_http)
  (public_name irmin-http)
- (libraries astring cohttp cohttp-lwt fmt irmin jsonm logs lwt uri webmachine))
+ (libraries astring cohttp cohttp-lwt fmt irmin jsonm logs lwt uri webmachine)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-http/irmin_http_common.ml
+++ b/src/irmin-http/irmin_http_common.ml
@@ -21,14 +21,7 @@ let status_t =
   record "status" (fun x -> x) |+ field "status" string (fun x -> x) |> sealr
 
 type 'a set = { test : 'a option; set : 'a option; v : 'a option }
-
-let set_t a =
-  let open Irmin.Type in
-  record "set" (fun test set v -> { test; set; v })
-  |+ field "test" (option a) (fun x -> x.test)
-  |+ field "set" (option a) (fun x -> x.set)
-  |+ field "v" (option a) (fun x -> x.v)
-  |> sealr
+[@@deriving irmin]
 
 let event_t k x =
   let open Irmin.Type in
@@ -44,12 +37,4 @@ let init_t k x =
   |+ field "commit" x snd
   |> sealr
 
-type 'a merge = { old : 'a; left : 'a; right : 'a }
-
-let merge_t h =
-  let open Irmin.Type in
-  record "merge" (fun old left right -> { old; left; right })
-  |+ field "old" h (fun t -> t.old)
-  |+ field "left" h (fun t -> t.left)
-  |+ field "right" h (fun t -> t.right)
-  |> sealr
+type 'a merge = { old : 'a; left : 'a; right : 'a } [@@deriving irmin]

--- a/src/irmin-pack/dune
+++ b/src/irmin-pack/dune
@@ -1,4 +1,6 @@
 (library
  (public_name irmin-pack)
  (name irmin_pack)
- (libraries fmt index index.unix irmin logs lwt lwt.unix mtime))
+ (libraries fmt index index.unix irmin logs lwt lwt.unix mtime)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-pack/dune
+++ b/src/irmin-pack/dune
@@ -1,6 +1,6 @@
 (library
  (public_name irmin-pack)
  (name irmin_pack)
- (libraries fmt index index.unix irmin logs lwt lwt.unix mtime)
+ (libraries fmt index index.unix irmin logs lwt lwt.unix mtime ppx_irmin)
  (preprocess
   (pps ppx_irmin)))

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -64,15 +64,7 @@ struct
   module X = struct
     module Hash = H
 
-    type 'a value = { magic : char; hash : H.t; v : 'a }
-
-    let value a =
-      let open Irmin.Type in
-      record "value" (fun hash magic v -> { magic; hash; v })
-      |+ field "hash" H.t (fun v -> v.hash)
-      |+ field "magic" char (fun v -> v.magic)
-      |+ field "v" a (fun v -> v.v)
-      |> sealr
+    type 'a value = { magic : char; hash : H.t; v : 'a } [@@deriving irmin]
 
     module Contents = struct
       module CA = struct
@@ -87,7 +79,7 @@ struct
 
           let magic = 'B'
 
-          let value = value Val.t
+          let value = value_t Val.t
 
           let encode_value = Irmin.Type.(unstage (encode_bin value))
 
@@ -125,7 +117,7 @@ struct
 
           let hash = H.hash
 
-          let value = value Val.t
+          let value = value_t Val.t
 
           let magic = 'C'
 

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -2,7 +2,8 @@
  (name irmin_test)
  (public_name irmin-test)
  (modules Irmin_test Store Common)
- (preprocess future_syntax)
+ (preprocess
+  (pps ppx_irmin))
  (libraries alcotest astring fmt irmin jsonm logs.fmt lwt lwt.unix mtime
    mtime.clock.os))
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -219,7 +219,7 @@ module Make (S : S) = struct
       let g = g repo and n = n repo in
       let k = normal (P.Contents.Key.hash "foo") in
       let check_key = check P.Node.Key.t in
-      let check_val = check (T.option Graph.value_t) in
+      let check_val = check [%typ: Graph.value option] in
       let check_node msg v =
         let h' = H_node.hash v in
         with_node repo (fun n -> P.Node.add n v) >|= fun h ->
@@ -870,8 +870,8 @@ module Make (S : S) = struct
     (* simple merges *)
     let check_merge () =
       let ok = Irmin.Merge.ok in
-      let dt = T.(option int64) in
-      let dx = T.(list (pair string int64)) in
+      let dt = [%typ: int64 option] in
+      let dx = [%typ: (string * int64) list] in
       let merge_skip ~old:_ _ _ = ok None in
       let merge_left ~old:_ x _ = ok x in
       let merge_right ~old:_ _ y = ok y in
@@ -932,7 +932,7 @@ module Make (S : S) = struct
       merge_exn "k4" k4 >>= fun k4 ->
       let k4 = match k4 with Some k -> k | None -> failwith "k4" in
       let _ = k4 in
-      let succ_t = T.(pair string Graph.value_t) in
+      let succ_t = [%typ: string * Graph.value] in
       Graph.list g k4 >>= fun succ ->
       checks succ_t "k4" [ ("b", `Node k1); ("c", `Node k1) ] succ;
       let info date =
@@ -1211,7 +1211,7 @@ module Make (S : S) = struct
 
   let test_private_nodes x () =
     let test repo =
-      let check_val = check T.(option S.contents_t) in
+      let check_val = check [%typ: S.contents option] in
       let vx = "VX" in
       let vy = "VY" in
       S.master repo >>= fun t ->
@@ -1238,8 +1238,8 @@ module Make (S : S) = struct
 
   let test_stores x () =
     let test repo =
-      let check_val = check T.(option S.contents_t) in
-      let check_list = checks T.(pair S.Key.step_t S.kind_t) in
+      let check_val = check [%typ: S.contents option] in
+      let check_list = checks [%typ: S.Key.step * S.kind] in
       S.master repo >>= fun t ->
       S.set_exn t ~info:(infof "init") [ "a"; "b" ] v1 >>= fun () ->
       S.mem t [ "a"; "b" ] >>= fun b0 ->

--- a/src/irmin/diff.ml
+++ b/src/irmin/diff.ml
@@ -15,12 +15,4 @@
  *)
 
 type 'a t = [ `Updated of 'a * 'a | `Removed of 'a | `Added of 'a ]
-
-let t a =
-  let open Type in
-  variant "diff" (fun updated removed added -> function
-    | `Updated x -> updated x | `Removed x -> removed x | `Added x -> added x)
-  |~ case1 "updated" (pair a a) (fun x -> `Updated x)
-  |~ case1 "removed" a (fun x -> `Removed x)
-  |~ case1 "added" a (fun x -> `Added x)
-  |> sealv
+[@@deriving irmin]

--- a/src/irmin/diff.mli
+++ b/src/irmin/diff.mli
@@ -15,9 +15,5 @@
  *)
 
 type 'a t = [ `Updated of 'a * 'a | `Removed of 'a | `Added of 'a ]
+[@@deriving irmin]
 (** The type for representing differences betwen values. *)
-
-(** {1 Value Types} *)
-
-val t : 'a Type.t -> 'a t Type.t
-(** [t typ] is the value type for differences between values of type [typ]. *)

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -2,4 +2,6 @@
  (name irmin)
  (public_name irmin)
  (libraries astring base64 bheap digestif fmt irmin_type jsonm logs lwt
-   ocamlgraph uri uutf))
+   ocamlgraph uri uutf)
+ (preprocess
+  (pps ppx_irmin -- --lib "Irmin_type.Type")))

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -2,6 +2,6 @@
  (name irmin)
  (public_name irmin)
  (libraries astring base64 bheap digestif fmt irmin_type jsonm logs lwt
-   ocamlgraph uri uutf)
+   ocamlgraph uri uutf ppx_irmin)
  (preprocess
   (pps ppx_irmin -- --lib "Irmin_type.Type")))

--- a/src/irmin/info.ml
+++ b/src/irmin/info.ml
@@ -14,15 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type t = { date : int64; author : string; message : string }
-
-let t =
-  let open Type in
-  record "info" (fun date author message -> { date; author; message })
-  |+ field "date" int64 (fun t -> t.date)
-  |+ field "author" string (fun t -> t.author)
-  |+ field "message" string (fun t -> t.message)
-  |> sealr
+type t = { date : int64; author : string; message : string } [@@deriving irmin]
 
 type f = unit -> t
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -622,7 +622,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
         val timestamp : t -> int64
       end = struct
-        type t = { timestamp : int64; message : string }
+        type t = { timestamp : int64; message : string } [@@deriving irmin]
 
         let compare x y = Int64.compare x.timestamp y.timestamp
 
@@ -641,13 +641,6 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
           | Some (x, message) -> (
               try Ok { timestamp = Int64.of_string x; message }
               with Failure e -> Error (`Msg e))
-
-        let t =
-          let open Irmin.Type in
-          record "entry" (fun timestamp message -> { timestamp; message })
-          |+ field "timestamp" int64 (fun t -> t.timestamp)
-          |+ field "message" string (fun t -> t.message)
-          |> sealr
 
         let t = Irmin.Type.like ~cli:(pp, of_string) ~compare t
       end

--- a/src/irmin/merge.ml
+++ b/src/irmin/merge.ml
@@ -432,10 +432,4 @@ let with_conflict rewrite (d, f) =
 let conflict_t =
   Type.(map string) (fun x -> `Conflict x) (function `Conflict x -> x)
 
-let result_t ok =
-  let open Type in
-  variant "result" (fun ok error -> function
-    | Ok x -> ok x | Error x -> error x)
-  |~ case1 "ok" ok (fun x -> Ok x)
-  |~ case1 "error" conflict_t (fun x -> Error x)
-  |> sealv
+type nonrec 'a result = ('a, conflict) result [@@deriving irmin]

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -21,9 +21,7 @@ module No_metadata : S.METADATA with type t = unit
 
 module Make
     (K : Type.S) (P : sig
-      type step
-
-      val step_t : step Type.t
+      type step [@@deriving irmin]
     end)
     (M : S.METADATA) :
   S.NODE with type hash = K.t and type step = P.step and type metadata = M.t

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -96,19 +96,7 @@ struct
       | `Node of Node.t
       | `Commit of Commit.t
       | `Branch of Branch.t ]
-
-    let t =
-      let open Type in
-      variant "vertex" (fun contents node commit branch -> function
-        | `Contents x -> contents x
-        | `Node x -> node x
-        | `Commit x -> commit x
-        | `Branch x -> branch x)
-      |~ case1 "contents" (pair Contents.t Metadata.t) (fun x -> `Contents x)
-      |~ case1 "node" Node.t (fun x -> `Node x)
-      |~ case1 "commit" Commit.t (fun x -> `Commit x)
-      |~ case1 "branch" Branch.t (fun x -> `Branch x)
-      |> sealv
+    [@@deriving irmin]
 
     let equal = Type.equal t
 
@@ -136,9 +124,7 @@ struct
   (* XXX: for the binary format, we can use offsets in the vertex list
      to save space. *)
   module Dump = struct
-    type t = X.t list * (X.t * X.t) list
-
-    let t = Type.(pair (list X.t) (list (pair X.t X.t)))
+    type t = X.t list * (X.t * X.t) list [@@deriving irmin]
   end
 
   let vertex g = G.fold_vertex (fun k set -> k :: set) g []

--- a/src/irmin/path.ml
+++ b/src/irmin/path.ml
@@ -17,9 +17,7 @@
 open Astring
 
 module String_list = struct
-  type step = string
-
-  let step_t = Type.string
+  type step = string [@@deriving irmin]
 
   type t = step list
 

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -106,11 +106,8 @@ end
 module type CONTENTS = sig
   (** {1 Signature for store contents} *)
 
-  type t
+  type t [@@deriving irmin]
   (** The type for user-defined contents. *)
-
-  val t : t Type.t
-  (** [t] is the value type for {!t}. *)
 
   val merge : t option Merge.t
   (** Merge function. Evaluates to [`Conflict msg] if the values cannot be
@@ -211,11 +208,8 @@ module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
 end
 
 module type METADATA = sig
-  type t
+  type t [@@deriving irmin]
   (** The type for metadata. *)
-
-  val t : t Type.t
-  (** [t] is the value type for {!t}. *)
 
   val merge : t Merge.t
   (** [merge] is the merge function for metadata. *)
@@ -625,11 +619,8 @@ end
 module type BRANCH = sig
   (** {1 Signature for Branches} *)
 
-  type t
+  type t [@@deriving irmin]
   (** The type for branches. *)
-
-  val t : t Type.t
-  (** [t] is the value type for {!t}. *)
 
   val master : t
   (** The name of the master branch. *)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -61,13 +61,13 @@ module Make (P : S.PRIVATE) = struct
 
   type hash = Hash.t
 
-  type lca_error = [ `Max_depth_reached | `Too_many_lcas ]
+  type lca_error = [ `Max_depth_reached | `Too_many_lcas ] [@@deriving irmin]
 
   type ff_error = [ `No_change | `Rejected | lca_error ]
 
   module Key = P.Node.Path
 
-  type key = Key.t
+  type key = Key.t [@@deriving irmin]
 
   module Metadata = P.Node.Metadata
   module H = Commit.History (P.Commit)
@@ -100,11 +100,11 @@ module Make (P : S.PRIVATE) = struct
     | `Contents (c, _) -> save_contents x c
     | `Node n -> Tree.export ~clear r x y n
 
-  type node = Tree.node
+  type node = Tree.node [@@deriving irmin]
 
-  type contents = Contents.t
+  type contents = Contents.t [@@deriving irmin]
 
-  type metadata = Metadata.t
+  type metadata = Metadata.t [@@deriving irmin]
 
   type tree = Tree.t
 
@@ -180,7 +180,7 @@ module Make (P : S.PRIVATE) = struct
       (P.Commit.Key)
       (Branch_store.Key)
 
-  type slice = P.Slice.t
+  type slice = P.Slice.t [@@deriving irmin]
 
   type watch = unit -> unit Lwt.t
 
@@ -345,7 +345,7 @@ module Make (P : S.PRIVATE) = struct
     lock : Lwt_mutex.t;
   }
 
-  type step = Key.step
+  type step = Key.step [@@deriving irmin]
 
   let repo t = t.repo
 
@@ -1094,32 +1094,13 @@ module Make (P : S.PRIVATE) = struct
       | `Commit c -> Type.pp Hash.t ppf (Commit.hash c)
   end
 
-  let slice_t = P.Slice.t
-
   let tree_t = Tree.tree_t
-
-  let contents_t = Contents.t
-
-  let metadata_t = Metadata.t
-
-  let key_t = Key.t
-
-  let step_t = Key.step_t
-
-  let node_t = Tree.node_t
 
   let commit_t = Commit.t
 
   let branch_t = Branch.t
 
-  let kind_t = Type.enum "kind" [ ("contents", `Contents); ("node", `Node) ]
-
-  let lca_error_t =
-    Type.enum "lca-error"
-      [
-        ("max-depth-reached", `Max_depth_reached);
-        ("too-many-lcas", `Too_many_lcas);
-      ]
+  type kind = [ `Contents | `Node ] [@@deriving irmin]
 
   let ff_error_t =
     Type.enum "ff-error"

--- a/test/irmin-git/dune
+++ b/test/irmin-git/dune
@@ -2,7 +2,9 @@
  (name test_git)
  (modules test_git)
  (libraries alcotest fmt fpath irmin irmin-test irmin-mem irmin-git git
-   git-unix lwt lwt.unix))
+   git-unix lwt lwt.unix)
+ (preprocess
+  (pps ppx_irmin)))
 
 (executable
  (name test)

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -37,16 +37,9 @@ module type G = sig
 end
 
 module X = struct
-  type t = X of (int * int) | Y of string list
+  type t = X of (int * int) | Y of string list [@@deriving irmin]
 
-  let t : t Irmin.Type.t =
-    let open Irmin.Type in
-    variant "test" (fun x y -> function X i -> x i | Y i -> y i)
-    |~ case1 "x" (pair int int) (fun x -> X x)
-    |~ case1 "y" (list string) (fun y -> Y y)
-    |> sealv
-
-  let merge = Irmin.Merge.idempotent Irmin.Type.(option t)
+  let merge = Irmin.Merge.idempotent [%typ: t option]
 end
 
 module type X =
@@ -198,9 +191,9 @@ let test_blobs (module S : S) =
   let module X = Mem (X) in
   let str = pre_hash X.Contents.t (Y [ "foo"; "bar" ]) in
   Alcotest.(check bin_string)
-    "blob foo" "blob 19\000{\"y\":[\"foo\",\"bar\"]}" str;
+    "blob foo" "blob 19\000{\"Y\":[\"foo\",\"bar\"]}" str;
   let str = pre_hash X.Contents.t (X (1, 2)) in
-  Alcotest.(check bin_string) "blob ''" "blob 11\000{\"x\":[1,2]}" str;
+  Alcotest.(check bin_string) "blob ''" "blob 11\000{\"X\":[1,2]}" str;
   let t = X.Tree.empty in
   X.Tree.add t [ "foo" ] (X (1, 2)) >>= fun t ->
   let k1 = X.Tree.hash t in


### PR DESCRIPTION
Last in the batch of PPX updates for now :) This one uses the new features in `ppx_irmin` inside the `irmin` repository itself.

Will need to watch Travis closely to see if `opam` is able to handle the new constraints.

Depends on https://github.com/mirage/irmin/pull/1087.