### PR TITLE
Make ppx_irmin compatible with ppxlib.0.18.0

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune" {>= "2.5.1"}
   "ocaml" {>= "4.07.0"}
-  "ppxlib" {>= "0.12.0"}
+  "ppxlib" {>= "0.18.0"}
   "irmin" {with-test & post & >= "2.0.0"}
 ]
 

--- a/src/ppx_irmin/lib/deriver.ml
+++ b/src/ppx_irmin/lib/deriver.ml
@@ -261,7 +261,7 @@ module Located (A : Ast_builder.S) : S = struct
      pexp_desc =
        Pexp_construct
          ( { txt = Lident "Some"; _ },
-           Some { pexp_desc = Pexp_constant (Pconst_string (lib, None)); _ } );
+           Some { pexp_desc = Pexp_constant (Pconst_string (lib, _, None)); _ } );
      _;
     } ->
         Some lib


### PR DESCRIPTION
ppxlib.0.18.0 upgraded its AST to 4.11 which lead to a change in string constant representation. This PR make ppx_irmin compatible with the newest ppxlib.

You probably will want to wait for the release to go through before merging this!