### PR TITLE
Add {= version} constraints on all internal dependencies

### DIFF
--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -14,12 +14,12 @@ build: [
 ]
 
 depends: [
+  "irmin"     {= version}
+  "ppx_irmin" {= version}
   "ocaml"   {>= "4.07.0"}
   "dune"    {>= "2.5.1"}
-  "irmin"
   "bechamel"
   "yojson"
-  "ppx_irmin" {= version}
   "ppx_deriving_yojson"
 ]
 

--- a/irmin-chunk.opam
+++ b/irmin-chunk.opam
@@ -15,12 +15,12 @@ build: [
 depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.0.0"}
+  "irmin"      {= version}
   "fmt"
   "logs"
   "lwt"
-  "irmin-mem"  {with-test & >= "2.0.0"}
-  "irmin-test" {with-test & >= "2.0.0"}
+  "irmin-mem"  {with-test & = version}
+  "irmin-test" {with-test & = version}
 ]
 
 synopsis: "Irmin backend which allow to store values into chunks"

--- a/irmin-containers.opam
+++ b/irmin-containers.opam
@@ -16,10 +16,10 @@ build: [
 depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.1.0"}
-  "irmin-mem"  {>= "2.1.0"}
-  "irmin-unix" {>= "2.1.0"}
-  "irmin-git"  {>= "2.1.0"}
+  "irmin"      {= version}
+  "irmin-mem"  {= version}
+  "irmin-unix" {= version}
+  "irmin-git"  {= version}
   "ppx_irmin"  {= version}
   "lwt"
   "mtime"

--- a/irmin-fs.opam
+++ b/irmin-fs.opam
@@ -16,10 +16,10 @@ build: [
 depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.0.0"}
+  "irmin"      {= version}
   "logs"
   "lwt"
-  "irmin-test" {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & = version}
 ]
 
 synopsis: "Generic file-system backend for Irmin"

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.02.3"}
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.0.0"}
+  "irmin"      {= version}
   "ppx_irmin"  {= version}
   "git"        {>= "2.1.1"}
   "digestif"   {>= "0.9.0"}
@@ -25,8 +25,8 @@ depends: [
   "logs"
   "lwt"
   "uri"
-  "irmin-test" {with-test & >= "2.0.0"}
-  "irmin-mem"  {with-test & >= "2.0.0"}
+  "irmin-test" {with-test & = version}
+  "irmin-mem"  {with-test & = version}
   "git-unix"   {with-test & >= "2.1.1"}
   "mtime"      {with-test & >= "1.0.0"}
 ]

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -16,15 +16,15 @@ build: [
 depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "2.5.1"}
-  "irmin"   {>= "2.2.0"}
+  "irmin"   {= version}
   "graphql" {>= "0.13.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"
   "graphql_parser" {>= "0.13.0"}
+  "irmin-mem" {with-test & = version}
   "alcotest-lwt" {>= "1.1.0" & with-test}
   "yojson" {with-test}
-  "irmin-mem" {with-test}
   "cohttp-lwt-unix" {with-test}
 ]
 

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -18,12 +18,12 @@ depends: [
   "dune"       {>= "2.5.1"}
   "crunch"     {>= "2.2.0"}
   "webmachine" {>= "0.6.0"}
-  "irmin"      {>= "2.2.0"}
+  "irmin"      {= version}
   "ppx_irmin"  {= version}
   "cohttp-lwt" {>= "1.0.0"}
-  "irmin-git"  {with-test & >= "2.0.0"}
-  "irmin-mem"  {with-test & >= "2.0.0"}
-  "irmin-test" {with-test & >= "2.0.0"}
+  "irmin-git"  {with-test & = version}
+  "irmin-mem"  {with-test & = version}
+  "irmin-test" {with-test & = version}
   "git-unix"   {with-test}
   "digestif"   {with-test & >= "0.9.0"}
 ]

--- a/irmin-layers.opam
+++ b/irmin-layers.opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "2.5.1"}
   "mtime"      {>= "1.0.0"}
-  "irmin"      {>= "2.0.0"}
-  "irmin-test" {with-test & post}
+  "irmin"      {= version}
+  "irmin-test" {with-test & post & = version}
 ]
 
 synopsis: "Combine different Irmin stores into a single, layered store"

--- a/irmin-mem.opam
+++ b/irmin-mem.opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.2.0"}
-  "irmin-layers"
-  "irmin-test" {with-test}
+  "irmin"      {= version}
+  "irmin-layers" {= version}
+  "irmin-test" {with-test & = version}
 ]
 
 

--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -14,8 +14,8 @@ build: [
 
 depends: [
   "dune"       {>= "2.5.1"}
-  "irmin-mirage"
-  "irmin-git"  {>= "2.0.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"  {= version}
   "git-mirage" {>= "2.1.2"}
   "mirage-kv" {>= "3.0.0"}
 ]

--- a/irmin-mirage-graphql.opam
+++ b/irmin-mirage-graphql.opam
@@ -14,9 +14,9 @@ build: [
 
 depends: [
   "dune"    {>= "2.5.1"}
-  "irmin-mirage"
+  "irmin-mirage" {= version}
   "git-mirage" {>= "2.1.1"}
-  "irmin-graphql"
+  "irmin-graphql" {= version}
   "mirage-clock"
 ]
 

--- a/irmin-mirage.opam
+++ b/irmin-mirage.opam
@@ -14,8 +14,8 @@ build: [
 
 depends: [
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.0.0"}
-  "irmin-mem"  {>= "2.0.0"}
+  "irmin"      {= version}
+  "irmin-mem"  {= version}
   "fmt"
   "ptime"
   "mirage-clock" {>= "3.0.0"}

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -15,15 +15,15 @@ build: [
 depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.5.1"}
-  "irmin"      {>= "2.2.0"}
+  "irmin"      {= version}
+  "irmin-layers" {= version}
   "ppx_irmin"  {= version}
   "index"      {>= "1.2.1"}
   "fmt"
   "logs"
   "lwt"
   "mtime"
-  "irmin-layers"
-  "irmin-test" {with-test & >= "2.2.0"}
+  "irmin-test" {with-test & = version}
   "alcotest-lwt" {with-test}
   "astring" {with-test}
   "fpath" {with-test}

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -15,7 +15,8 @@ build: [
 depends: [
   "ocaml"    {>= "4.02.3"}
   "dune"     {>= "2.5.1"}
-  "irmin"    {>= "2.2.0"}
+  "irmin"    {= version}
+  "irmin-layers" {= version}
   "ppx_irmin" {= version}
   "alcotest" {>= "1.0.1"}
   "mtime"    {>= "1.0.0"}
@@ -26,7 +27,6 @@ depends: [
   "lwt"
   "metrics-unix"
   "ocaml-syntax-shims"
-  "irmin-layers"
 ]
 
 synopsis: "Irmin test suite"

--- a/irmin-type.opam
+++ b/irmin-type.opam
@@ -20,7 +20,7 @@ depends: [
   "uutf"
   "jsonm"   {>= "1.0.0"}
   "base64"  {>= "2.0.0"}
-  "irmin" {with-test & post}
+  "irmin" {with-test & post & = version}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
 ]

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -16,14 +16,14 @@ build: [
 depends: [
   "ocaml"         {>= "4.01.0"}
   "dune"          {>= "2.5.1"}
-  "irmin"         {>= "2.1.0"}
-  "irmin-mem"     {>= "2.0.0"}
-  "irmin-git"     {>= "2.0.0"}
-  "irmin-http"    {>= "2.0.0"}
-  "irmin-fs"      {>= "2.0.0"}
-  "irmin-pack"    {>= "2.0.0"}
-  "irmin-graphql"
-  "irmin-layers"
+  "irmin"         {= version}
+  "irmin-mem"     {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-layers"  {= version}
   "git-unix"      {>= "1.11.4"}
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
@@ -37,7 +37,7 @@ depends: [
   "conduit-lwt-unix"
   "logs"
   "uri"
-  "irmin-test"    {with-test & >= "2.0.0"}
+  "irmin-test"    {with-test & = version}
 ]
 
 synopsis: "Unix backends for Irmin"

--- a/irmin.opam
+++ b/irmin.opam
@@ -32,8 +32,7 @@ depends: [
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
-  "ppx_irmin" {with-test}
-  "irmin-mem" {with-test & post}
+  "irmin-mem" {with-test & post & = version}
 ]
 synopsis: """
 Irmin, a distributed database that follows the same design principles as Git

--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune" {>= "2.5.1"}
   "ocaml" {>= "4.08.0"}
-  "ppxlib" {>= "0.12.0"}
+  "ppxlib" {>= "0.12.0" & < "0.18.0"}
   "irmin-type" {with-test & post & = version}
 ]
 

--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.5.1"}
   "ocaml" {>= "4.08.0"}
   "ppxlib" {>= "0.12.0"}
-  "irmin-type" {with-test & post & >= "2.0.0"}
+  "irmin-type" {with-test & post & = version}
 ]
 
 synopsis: "PPX deriver for Irmin type representations"


### PR DESCRIPTION
As discussed offline, the plan is to conduct simultaneous releases of all Irmin packages in future. This PR adds `{= version}` constraints to avoid us needing to manually maintain individual version bounds for each internal dependency (since we have no tooling capable of enabling this).

Dpeends on https://github.com/mirage/irmin/pull/1100.