### PR TITLE
irmin-type: allow `pp` and `of_string` to be overridden separately

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,9 +84,13 @@
 
 - **irmin**
   - Renamed the `Tree.tree` type to `Tree.t`. (#1022, @CraigFe)
+
   - Changed the JSON encoding of special floats. `Float.nan`, `Float.infinity`
     and `Float.neg_infinity` are now encoded as `"nan"`, `"inf"` and `"-inf"`
     respectively. (#979, @liautaud)
+
+  - The functions `Type.{v,like,map}` no longer take a `~cli` argument, and now
+    take separate `~pp` and `~of_string` arguments instead. (#1103, @CraigFe)
 
 - **irmin-pack**:
   - `sync` has to be called by the read-only instance to synchronise with the

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -43,7 +43,7 @@ end = struct
         try Ok { timestamp = Int64.of_string x; message }
         with Failure e -> Error (`Msg e))
 
-  let t = Irmin.Type.like ~cli:(pp, of_string) ~compare t
+  let t = Irmin.Type.like ~pp ~of_string ~compare t
 end
 
 (* A log file *)
@@ -54,7 +54,7 @@ module Log : sig
 
   val empty : t
 end = struct
-  type t = Entry.t list
+  type t = Entry.t list [@@deriving irmin]
 
   let empty = []
 
@@ -74,9 +74,7 @@ end = struct
       |> fun l -> Ok l
     with Failure e -> Error (`Msg e)
 
-  let cli = (lines, of_string)
-
-  let t = Irmin.Type.(like ~cli (list Entry.t))
+  let t = Irmin.Type.like ~pp:lines ~of_string t
 
   let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -837,7 +837,7 @@ module Reference : BRANCH with type t = reference = struct
     | "refs" :: o -> Ok (`Other (path o))
     | _ -> Error (`Msg (Fmt.strf "%s is not a valid reference" str))
 
-  let t = Irmin.Type.like t ~cli:(pp_ref, of_ref)
+  let t = Irmin.Type.like t ~pp:pp_ref ~of_string:of_ref
 
   let master = `Branch Irmin.Branch.String.master
 

--- a/src/irmin-type/type.mli
+++ b/src/irmin-type/type.mli
@@ -312,7 +312,7 @@ val pp : 'a t -> 'a pp
 (** [pp t] is the pretty-printer for values of type [t]. *)
 
 val pp_dump : 'a t -> 'a pp
-(** [pp t] is the dump pretty-printer for values of type [t].
+(** [pp_dump t] is the dump pretty-printer for values of type [t].
 
     This pretty-printer outputs an encoding which is as close as possible to
     native OCaml syntax, so that the result can easily be copy-pasted into an
@@ -497,10 +497,11 @@ module Unboxed : sig
   (** Same as {!size_of} for unboxed values. *)
 end
 
-(** {1 Customs converters} *)
+(** {1 Custom converters} *)
 
 val v :
-  cli:'a pp * 'a of_string ->
+  pp:'a pp ->
+  of_string:'a of_string ->
   json:'a encode_json * 'a decode_json ->
   bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
@@ -512,7 +513,8 @@ val v :
   'a t
 
 val like :
-  ?cli:'a pp * 'a of_string ->
+  ?pp:'a pp ->
+  ?of_string:'a of_string ->
   ?json:'a encode_json * 'a decode_json ->
   ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
@@ -524,7 +526,8 @@ val like :
   'a t
 
 val map :
-  ?cli:'a pp * 'a of_string ->
+  ?pp:'a pp ->
+  ?of_string:'a of_string ->
   ?json:'a encode_json * 'a decode_json ->
   ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -107,7 +107,7 @@ module Json_value = struct
         with Invalid_argument _ -> false)
     | _, _ -> false
 
-  let t = Type.like ~equal ~cli:(pp, of_string) t
+  let t = Type.like ~equal ~pp ~of_string t
 
   let rec merge_object ~old x y =
     let open Merge.Infix in
@@ -182,7 +182,7 @@ module Json = struct
 
   let equal a b = Json_value.equal (`O a) (`O b)
 
-  let t = Type.like ~equal ~cli:(pp, of_string) t
+  let t = Type.like ~equal ~pp ~of_string t
 
   let merge =
     Merge.(option (alist Type.string Json_value.t (fun _ -> Json_value.merge)))

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -31,7 +31,7 @@ module Make (H : Digestif.S) = struct
   let pp_hex ppf x = Fmt.string ppf (H.to_hex x)
 
   let t =
-    Type.map ~cli:(pp_hex, of_hex)
+    Type.map ~pp:pp_hex ~of_string:of_hex
       Type.(string_of (`Fixed hash_size))
       H.of_raw_string H.to_raw_string
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -642,7 +642,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
               try Ok { timestamp = Int64.of_string x; message }
               with Failure e -> Error (`Msg e))
 
-        let t = Irmin.Type.like ~cli:(pp, of_string) ~compare t
+        let t = Irmin.Type.like ~pp ~of_string ~compare t
       end
     ]}
 
@@ -659,7 +659,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
         val empty : t
       end = struct
-        type t = Entry.t list
+        type t = Entry.t list [@@deriving irmin]
 
         let empty = []
 
@@ -679,9 +679,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
             |> fun l -> Ok l
           with Failure e -> Error (`Msg e)
 
-        let cli = (lines, of_string)
-
-        let t = Irmin.Type.(like ~cli (list Entry.t))
+        let t = Irmin.Type.like ~pp:lines ~of_string t
 
         let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 

--- a/src/irmin/path.ml
+++ b/src/irmin/path.ml
@@ -50,5 +50,5 @@ module String_list = struct
 
   let of_string s = Ok (List.filter (( <> ) "") (String.cuts s ~sep:"/"))
 
-  let t = Type.like ~cli:(pp, of_string) Type.(list step_t)
+  let t = Type.like ~pp ~of_string Type.(list step_t)
 end

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -1122,7 +1122,7 @@ module Make (P : S.PRIVATE) = struct
 
   let write_error_t =
     let of_string _ = assert false in
-    Type.like ~cli:(pp_write_error, of_string) write_error_t
+    Type.like ~pp:pp_write_error ~of_string write_error_t
 end
 
 type S.remote += Store : (module Store_intf.S with type t = 'a) * 'a -> S.remote

--- a/test/irmin-type/test.ml
+++ b/test/irmin-type/test.ml
@@ -79,7 +79,7 @@ let pp_hex ppf s =
 
 let of_hex_string x = Ok (Hex.to_string (`Hex x))
 
-let hex = T.map T.string ~cli:(pp_hex, of_hex_string) id id
+let hex = T.map T.string ~pp:pp_hex ~of_string:of_hex_string id id
 
 let hex2 =
   let encode_json e x =
@@ -212,7 +212,9 @@ let test_json_float () =
   Alcotest.(check (float Float.epsilon)) "-inf from JSON" Float.neg_infinity x
 
 let l =
-  let hex = T.map (T.string_of (`Fixed 3)) ~cli:(pp_hex, of_hex_string) id id in
+  let hex =
+    T.map (T.string_of (`Fixed 3)) ~pp:pp_hex ~of_string:of_hex_string id id
+  in
   T.list ~len:(`Fixed 2) hex
 
 let tl = Alcotest.testable (T.pp l) (T.equal l)
@@ -529,7 +531,7 @@ let test_pp_ty () =
       let a2 _ _ = assert false in
       let s2 = T.stage @@ fun _ _ -> assert false in
       let hdr f = T.stage f in
-      T.v ~cli:(a2, a1) ~json:(a2, a1)
+      T.v ~pp:a2 ~of_string:a1 ~json:(a2, a1)
         ~bin:(hdr a2, hdr a2, hdr a1)
         ~equal:a2 ~compare:a2
         ~short_hash:(fun ?seed:_ -> a1)


### PR DESCRIPTION
This splits the existing `~cli` argument to the `Type.{v,like,map}` constructors into two separate arguments `~pp` and `~of_string`. The original naming seems to be legacy from the original use of these operations for the `irmin-unix` CLI. 

When using typereps for pretty-printing only (e.g. for debugging / testing), it's helpful to be able to quickly override `~pp` (even if this means that `pp` and `of_string` are no longer inverses).