### PR TITLE
irmin-type: use JSON Booleans

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,9 @@
     and `Float.neg_infinity` are now encoded as `"nan"`, `"inf"` and `"-inf"`
     respectively. (#979, @liautaud)
 
+  - Changed the JSON encoding of Boolean values to use JSON Booleans, rather
+    than the numbers 0 and 1. (#1104, @CraigFe)
+
   - The functions `Type.{v,like,map}` no longer take a `~cli` argument, and now
     take separate `~pp` and `~of_string` arguments instead. (#1103, @CraigFe)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,9 +84,13 @@
 
 - **irmin**
   - Renamed the `Tree.tree` type to `Tree.t`. (#1022, @CraigFe)
+
   - Changed the JSON encoding of special floats. `Float.nan`, `Float.infinity`
     and `Float.neg_infinity` are now encoded as `"nan"`, `"inf"` and `"-inf"`
     respectively. (#979, @liautaud)
+
+  - The functions `Type.{v,like,map}` no longer take a `~cli` argument, and now
+    take separate `~pp` and `~of_string` arguments instead. (#1103, @CraigFe)
 
 - **irmin-pack**:
   - `sync` has to be called by the read-only instance to synchronise with the

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -43,7 +43,7 @@ end = struct
         try Ok { timestamp = Int64.of_string x; message }
         with Failure e -> Error (`Msg e))
 
-  let t = Irmin.Type.like ~cli:(pp, of_string) ~compare t
+  let t = Irmin.Type.like ~pp ~of_string ~compare t
 end
 
 (* A log file *)
@@ -54,7 +54,7 @@ module Log : sig
 
   val empty : t
 end = struct
-  type t = Entry.t list
+  type t = Entry.t list [@@deriving irmin]
 
   let empty = []
 
@@ -74,9 +74,7 @@ end = struct
       |> fun l -> Ok l
     with Failure e -> Error (`Msg e)
 
-  let cli = (lines, of_string)
-
-  let t = Irmin.Type.(like ~cli (list Entry.t))
+  let t = Irmin.Type.like ~pp:lines ~of_string t
 
   let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -837,7 +837,7 @@ module Reference : BRANCH with type t = reference = struct
     | "refs" :: o -> Ok (`Other (path o))
     | _ -> Error (`Msg (Fmt.strf "%s is not a valid reference" str))
 
-  let t = Irmin.Type.like t ~cli:(pp_ref, of_ref)
+  let t = Irmin.Type.like t ~pp:pp_ref ~of_string:of_ref
 
   let master = `Branch Irmin.Branch.String.master
 

--- a/src/irmin-type/type.mli
+++ b/src/irmin-type/type.mli
@@ -312,7 +312,7 @@ val pp : 'a t -> 'a pp
 (** [pp t] is the pretty-printer for values of type [t]. *)
 
 val pp_dump : 'a t -> 'a pp
-(** [pp t] is the dump pretty-printer for values of type [t].
+(** [pp_dump t] is the dump pretty-printer for values of type [t].
 
     This pretty-printer outputs an encoding which is as close as possible to
     native OCaml syntax, so that the result can easily be copy-pasted into an
@@ -497,10 +497,11 @@ module Unboxed : sig
   (** Same as {!size_of} for unboxed values. *)
 end
 
-(** {1 Customs converters} *)
+(** {1 Custom converters} *)
 
 val v :
-  cli:'a pp * 'a of_string ->
+  pp:'a pp ->
+  of_string:'a of_string ->
   json:'a encode_json * 'a decode_json ->
   bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
@@ -512,7 +513,8 @@ val v :
   'a t
 
 val like :
-  ?cli:'a pp * 'a of_string ->
+  ?pp:'a pp ->
+  ?of_string:'a of_string ->
   ?json:'a encode_json * 'a decode_json ->
   ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
@@ -524,7 +526,8 @@ val like :
   'a t
 
 val map :
-  ?cli:'a pp * 'a of_string ->
+  ?pp:'a pp ->
+  ?of_string:'a of_string ->
   ?json:'a encode_json * 'a decode_json ->
   ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
   ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->

--- a/src/irmin-type/type_json.ml
+++ b/src/irmin-type/type_json.ml
@@ -52,7 +52,7 @@ module Encode = struct
 
   let int64 e i = float e (Int64.to_float i)
 
-  let bool e = function false -> float e 0. | _ -> float e 1.
+  let bool e b = lexeme e (`Bool b)
 
   let list l e x =
     lexeme e `As;
@@ -247,7 +247,7 @@ module Decode = struct
 
   let int e = float e >|= int_of_float
 
-  let bool e = int e >|= function 0 -> false | _ -> true
+  let bool e = lexeme e >>= function `Bool b -> Ok b | l -> error e l "`Bool"
 
   let list l e =
     expect_lexeme e `As >>= fun () ->

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -107,7 +107,7 @@ module Json_value = struct
         with Invalid_argument _ -> false)
     | _, _ -> false
 
-  let t = Type.like ~equal ~cli:(pp, of_string) t
+  let t = Type.like ~equal ~pp ~of_string t
 
   let rec merge_object ~old x y =
     let open Merge.Infix in
@@ -182,7 +182,7 @@ module Json = struct
 
   let equal a b = Json_value.equal (`O a) (`O b)
 
-  let t = Type.like ~equal ~cli:(pp, of_string) t
+  let t = Type.like ~equal ~pp ~of_string t
 
   let merge =
     Merge.(option (alist Type.string Json_value.t (fun _ -> Json_value.merge)))

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -31,7 +31,7 @@ module Make (H : Digestif.S) = struct
   let pp_hex ppf x = Fmt.string ppf (H.to_hex x)
 
   let t =
-    Type.map ~cli:(pp_hex, of_hex)
+    Type.map ~pp:pp_hex ~of_string:of_hex
       Type.(string_of (`Fixed hash_size))
       H.of_raw_string H.to_raw_string
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -642,7 +642,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
               try Ok { timestamp = Int64.of_string x; message }
               with Failure e -> Error (`Msg e))
 
-        let t = Irmin.Type.like ~cli:(pp, of_string) ~compare t
+        let t = Irmin.Type.like ~pp ~of_string ~compare t
       end
     ]}
 
@@ -659,7 +659,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
 
         val empty : t
       end = struct
-        type t = Entry.t list
+        type t = Entry.t list [@@deriving irmin]
 
         let empty = []
 
@@ -679,9 +679,7 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
             |> fun l -> Ok l
           with Failure e -> Error (`Msg e)
 
-        let cli = (lines, of_string)
-
-        let t = Irmin.Type.(like ~cli (list Entry.t))
+        let t = Irmin.Type.like ~pp:lines ~of_string t
 
         let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 

--- a/src/irmin/path.ml
+++ b/src/irmin/path.ml
@@ -50,5 +50,5 @@ module String_list = struct
 
   let of_string s = Ok (List.filter (( <> ) "") (String.cuts s ~sep:"/"))
 
-  let t = Type.like ~cli:(pp, of_string) Type.(list step_t)
+  let t = Type.like ~pp ~of_string Type.(list step_t)
 end

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -1122,7 +1122,7 @@ module Make (P : S.PRIVATE) = struct
 
   let write_error_t =
     let of_string _ = assert false in
-    Type.like ~cli:(pp_write_error, of_string) write_error_t
+    Type.like ~pp:pp_write_error ~of_string write_error_t
 end
 
 type S.remote += Store : (module Store_intf.S with type t = 'a) * 'a -> S.remote

--- a/test/irmin-type/test.ml
+++ b/test/irmin-type/test.ml
@@ -324,13 +324,13 @@ let test_to_string () =
     (Some None) "{\"some\":null}";
   test "(int * string * bool)"
     T.(triple int string bool)
-    (1, "foo", true) "[1,\"foo\",1]";
+    (1, "foo", true) "[1,\"foo\",true]";
   test "(string, bool) result{ok}"
     T.(result string bool)
     (Ok "foo") "{\"ok\":\"foo\"}";
   test "(string, bool) result{error}"
     T.(result string bool)
-    (Error false) "{\"error\":0}";
+    (Error false) "{\"error\":false}";
 
   (* Test cases for algebraic combinators *)
   let open Algebraic in
@@ -341,7 +341,7 @@ let test_to_string () =
     "{\"Branch\":[{\"Branch\":[{\"Leaf\":1}]},{\"Leaf\":2}]}";
   test "record" my_record_t
     { foo = 2; flag = false; letter = Delta }
-    "{\"foo\":2,\"flag\":0,\"letter\":\"Delta\"}";
+    "{\"foo\":2,\"flag\":false,\"letter\":\"Delta\"}";
 
   test "recursive record" my_recursive_record_t
     { head = 1; tail = Some { head = 2; tail = None } }

--- a/test/irmin-type/test.ml
+++ b/test/irmin-type/test.ml
@@ -79,7 +79,7 @@ let pp_hex ppf s =
 
 let of_hex_string x = Ok (Hex.to_string (`Hex x))
 
-let hex = T.map T.string ~cli:(pp_hex, of_hex_string) id id
+let hex = T.map T.string ~pp:pp_hex ~of_string:of_hex_string id id
 
 let hex2 =
   let encode_json e x =
@@ -212,7 +212,9 @@ let test_json_float () =
   Alcotest.(check (float Float.epsilon)) "-inf from JSON" Float.neg_infinity x
 
 let l =
-  let hex = T.map (T.string_of (`Fixed 3)) ~cli:(pp_hex, of_hex_string) id id in
+  let hex =
+    T.map (T.string_of (`Fixed 3)) ~pp:pp_hex ~of_string:of_hex_string id id
+  in
   T.list ~len:(`Fixed 2) hex
 
 let tl = Alcotest.testable (T.pp l) (T.equal l)
@@ -529,7 +531,7 @@ let test_pp_ty () =
       let a2 _ _ = assert false in
       let s2 = T.stage @@ fun _ _ -> assert false in
       let hdr f = T.stage f in
-      T.v ~cli:(a2, a1) ~json:(a2, a1)
+      T.v ~pp:a2 ~of_string:a1 ~json:(a2, a1)
         ~bin:(hdr a2, hdr a2, hdr a1)
         ~equal:a2 ~compare:a2
         ~short_hash:(fun ?seed:_ -> a1)


### PR DESCRIPTION
Changes the default JSON encoding of Booleans to use JSON Booleans, rather than the numbers 0 and 1.

Depends on https://github.com/mirage/irmin/pull/1103.