### PR TITLE
ppx_irmin: add irmin-type as a runtime dependency

### DIFF
--- a/src/ppx_irmin/bin/dune
+++ b/src/ppx_irmin/bin/dune
@@ -1,4 +1,5 @@
 (library
  (public_name ppx_irmin)
  (kind ppx_deriver)
+ (ppx_runtime_libraries irmin-type)
  (libraries ppx_irmin_lib ppxlib))


### PR DESCRIPTION
This will cause Dune to automatically add `irmin-type` as a dependency wherever the PPX is used.