### PR TITLE
Remove inaccurate benchmark target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test fuzz bench-type bench-mem bench-pack bench doc examples
+.PHONY: all clean test fuzz bench-mem bench-pack bench doc examples
 
 all:
 	dune build
@@ -6,16 +6,13 @@ all:
 test:
 	dune runtest
 
-bench-type:
-	dune exec ./bench/irmin/main.exe -- --output-dir _build/default/data
-
 bench-mem:
 	dune exec ./test/irmin-mem/bench.exe
 
 bench-pack:
 	dune exec ./test/irmin-pack/bench.exe
 
-bench: bench-type bench-mem bench-pack
+bench: bench-mem bench-pack
 
 fuzz:
 	dune build @fuzz --no-buffer


### PR DESCRIPTION
A quick fix to Makefile targets.

Follow-up to #1100; removing target entirely in anticipation of #1106.

(skipping changelog to match #1100)