### PR TITLE
Build a self contained upper, and some other fixes

### DIFF
--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -146,6 +146,8 @@ struct
 
   let upper_in_use _repo = failwith "not implemented"
 
+  let self_contained ?min:_ ~max:_ _repo = failwith "not implemented"
+
   module PrivateLayer = struct
     module Hook = struct
       type 'a t = unit

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -17,6 +17,12 @@
 open Lwt.Infix
 include Irmin_layers_intf
 
+let pp_layer_id =
+  Fmt.of_to_string (function
+    | `Upper0 -> "upper0"
+    | `Upper1 -> "upper1"
+    | `Lower -> "lower")
+
 module Make_ext
     (CA : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER)
     (AW : Irmin.ATOMIC_WRITE_STORE_MAKER)

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -44,6 +44,11 @@ module type S = sig
       helpful when a single freeze is called, to check whether it completed or
       not. *)
 
+  val self_contained : ?min:commit list -> max:commit list -> repo -> unit Lwt.t
+  (** [self_contained min max t] copies the commits in the range of [min, max]
+      from lower into upper, in order to make the upper self contained. If [min]
+      is missing then only the [max] commits are copied. *)
+
   (** These modules should not be used. They are exposed purely for testing
       purposes. *)
   module PrivateLayer : sig

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -95,6 +95,8 @@ module type S_MAKER = functor
 module type Irmin_layers = sig
   type nonrec layer_id = layer_id
 
+  val pp_layer_id : layer_id Fmt.t
+
   module type S = S
 
   module type S_MAKER = S_MAKER

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -23,6 +23,7 @@ type t = {
   mutable copied_branches : int list;
   mutable waiting_freeze : float list;
   mutable completed_freeze : float list;
+  mutable skips : int;
 }
 
 type i = {
@@ -42,6 +43,7 @@ let fresh_stats_t () =
     copied_branches = [];
     waiting_freeze = [];
     completed_freeze = [];
+    skips = 0;
   }
 
 let fresh_stats_i () =
@@ -64,6 +66,7 @@ let reset_stats () =
   stats_t.copied_nodes <- [];
   stats_t.copied_commits <- [];
   stats_t.copied_branches <- [];
+  stats_t.skips <- 0;
   reset_stats_i ()
 
 let get () =
@@ -75,6 +78,7 @@ let get () =
     copied_branches = stats_i.branches :: stats_t.copied_branches;
     waiting_freeze = stats_t.waiting_freeze;
     completed_freeze = stats_t.completed_freeze;
+    skips = stats_t.skips;
   }
 
 (** Ensure lists are not growing indefinitely by dropping elements. *)
@@ -97,6 +101,7 @@ let drop_last_elements n =
 
 let freeze () =
   stats_t.nb_freeze <- succ stats_t.nb_freeze;
+  stats_t.skips <- 0;
   if stats_t.nb_freeze <> 1 then (
     stats_t.copied_contents <- stats_i.contents :: stats_t.copied_contents;
     stats_t.copied_nodes <- stats_i.nodes :: stats_t.copied_nodes;
@@ -113,6 +118,8 @@ let copy_nodes () = stats_i.nodes <- succ stats_i.nodes
 let copy_commits () = stats_i.commits <- succ stats_i.commits
 
 let copy_branches () = stats_i.branches <- succ stats_i.branches
+
+let skip () = stats_t.skips <- succ stats_t.skips
 
 let add () = stats_i.adds <- succ stats_i.adds
 

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -57,8 +57,7 @@ let reset_stats_i () =
   stats_i.contents <- 0;
   stats_i.nodes <- 0;
   stats_i.commits <- 0;
-  stats_i.branches <- 0;
-  stats_i.adds <- 0
+  stats_i.branches <- 0
 
 let reset_stats () =
   stats_t.nb_freeze <- 0;

--- a/src/irmin-layers/stats.mli
+++ b/src/irmin-layers/stats.mli
@@ -22,6 +22,7 @@ type t = {
   mutable copied_branches : int list;
   mutable waiting_freeze : float list;
   mutable completed_freeze : float list;
+  mutable skips : int;
 }
 (** The type for stats for a store S.
 
@@ -29,7 +30,13 @@ type t = {
     - [copied_contents] is the number of contents copied per freeze;
     - [copied_nodes] is the number of nodes copied per freeze;
     - [copied_commits] is the number of commits copied per freeze;
-    - [copied_branches] is the number of branches copied per freeze.
+    - [copied_branches] is the number of branches copied per freeze;
+    - [waiting_freeze] are the times the freeze threads waited to start, for the
+      last 10 freezes at most;
+    - [completed_freeze] are the times the freeze threads took to complete, for
+      the last 10 freezes at most;
+    - [skips] the number of skips during the graph traversals called by the
+      freeze, where the same object can be skipped several times;
 
     Note that stats assume that there always is an ongoing freeze. If its not
     the case, you should discard the last 0.*)
@@ -67,3 +74,6 @@ val reset_adds : unit -> unit
 val with_timer : [ `Freeze | `Waiting ] -> (unit -> unit Lwt.t) -> unit Lwt.t
 (** Either the duration of a freeze thread waiting on the freeze lock to start;
     or the duration of a freeze thread to complete a freeze. *)
+
+val skip : unit -> unit
+(** Increment the number of skips during a graph traversal. *)

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -144,7 +144,6 @@ struct
 
   let copy ~add ~mem t k =
     Log.debug (fun l -> l "copy Node %a" (Irmin.Type.pp Key.t) k);
-    Irmin_layers.Stats.copy_nodes ();
     Inode.U.find (Inode.current_upper t) k >>= function
     | None -> pause ()
     | Some v ->
@@ -155,6 +154,7 @@ struct
            they are copied in the dst layer. *)
         List.iter ignore (Val.list v');
         let add k v =
+          Irmin_layers.Stats.copy_nodes ();
           add k v;
           pause ()
         in

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -30,6 +30,8 @@ module type S = sig
 
   val next_upper : 'a t -> [ `Read ] U.t
 
+  val current_upper : 'a t -> [ `Read ] U.t
+
   val lower : 'a t -> [ `Read ] L.t
 
   val clear_previous_upper : 'a t -> unit Lwt.t
@@ -51,6 +53,10 @@ module type S = sig
     key ->
     'a t ->
     (unit, S.integrity_error) result
+
+  val flush : ?index:bool -> 'a t -> unit
+
+  val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
 end
 
 module type Inode_layers = sig

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -126,6 +126,7 @@ struct
 
   let unsafe_append' t k v =
     Log.debug (fun l -> l "unsafe_append in %s" (log_current_upper t));
+    Irmin_layers.Stats.add ();
     let upper = current_upper t in
     U.unsafe_append upper k v;
     if Lwt_mutex.is_locked t.freeze_lock then (

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -26,7 +26,7 @@ module type CA = sig
   module Key : Irmin.Hash.TYPED with type t = key and type value = value
 end
 
-let return = Lwt.pause
+let pause = Lwt.pause
 
 module Copy
     (Key : Irmin.Hash.S)
@@ -55,13 +55,13 @@ struct
     | None ->
         (* This can happen when we try to copy an object to lower, that is
            already in lower and no longer in upper, due to a previous freeze. *)
-        return ()
+        pause ()
     | Some v ->
-        aux v >>= return >>= fun () -> add_to_dst (DST.unsafe_add dst) (k, v)
+        aux v >>= pause >>= fun () -> add_to_dst (DST.unsafe_add dst) (k, v)
 
   let check_and_copy ~src ~dst ?aux str k =
     already_in_dst ~dst k >>= function
-    | true -> return ()
+    | true -> pause ()
     | false -> copy ~src ~dst ?aux str k
 end
 
@@ -147,7 +147,7 @@ struct
   let unsafe_append t k v =
     Lwt_mutex.with_lock t.add_lock (fun () ->
         unsafe_append' t k v;
-        return ())
+        pause ())
 
   (** Everything is in current upper, no need to look in next upper. *)
   let find t k =

--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -87,4 +87,6 @@ module Make (K : Irmin.Hash.S) = struct
   let add t k v = replace t k v
 
   let find t k = match find t k with exception Not_found -> None | h -> Some h
+
+  let close t = Index.close t
 end

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -129,6 +129,14 @@ module type LAYERED = sig
     key ->
     unit Lwt.t
 
+  val copy_from_lower :
+    [ `Read ] t ->
+    dst:'a U.t ->
+    ?aux:(value -> unit Lwt.t) ->
+    string ->
+    key ->
+    unit Lwt.t
+
   val mem_lower : 'a t -> key -> bool Lwt.t
 
   val mem_next : [> `Read ] t -> key -> bool Lwt.t

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -129,14 +129,6 @@ module type LAYERED = sig
     key ->
     unit Lwt.t
 
-  val check_and_copy :
-    'l layer_type * 'l ->
-    [ `Read ] t ->
-    ?aux:(value -> unit Lwt.t) ->
-    string ->
-    key ->
-    unit Lwt.t
-
   val mem_lower : 'a t -> key -> bool Lwt.t
 
   val mem_next : [> `Read ] t -> key -> bool Lwt.t

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,7 +1,7 @@
 (library
  (name irmin)
  (public_name irmin)
- (libraries astring base64 bheap digestif fmt irmin_type jsonm logs lwt
-   ocamlgraph uri uutf irmin-type ppx_irmin)
+ (libraries astring base64 bheap digestif fmt jsonm logs lwt ocamlgraph uri
+   uutf irmin-type ppx_irmin)
  (preprocess
   (pps ppx_irmin -- --lib "Irmin_type.Type")))

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -53,7 +53,7 @@ module type S = sig
     min:vertex list ->
     max:vertex list ->
     node:(vertex -> unit Lwt.t) ->
-    edge:(vertex -> vertex -> unit Lwt.t) ->
+    ?edge:(vertex -> vertex -> unit Lwt.t) ->
     skip:(vertex -> bool Lwt.t) ->
     rev:bool ->
     unit ->


### PR DESCRIPTION
Adds a `self_contained` function to make the upper layer self contained. When we have a simple store (i.e. not layered) as for instance in the benchmarks, we might want to make the upper layer self contained. Unfortunately, I cannot use it for the benchmarks, because I don't know the `min`, `max` commits (and I tried to guess them with no success), but it could be useful for the migration process.

Some other fixes as well, that are all independent of which type of upper layer we use, they will be useful for https://github.com/mirage/irmin/pull/1099 as well.