### PR TITLE
Traverse newies

### DIFF
--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -118,9 +118,9 @@ struct
 
   let current_upper = Inode.current_upper
 
-  let copy_newies_to_next_upper = Inode.copy_newies_to_next_upper
+  let unsafe_get_newies = Inode.unsafe_get_newies
 
-  let copy_last_newies_to_next_upper = Inode.copy_last_newies_to_next_upper
+  let get_newies = Inode.get_newies
 
   let update_flip = Inode.update_flip
 

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -118,9 +118,9 @@ struct
 
   let current_upper = Inode.current_upper
 
-  let unsafe_get_newies = Inode.unsafe_get_newies
+  let unsafe_consume_newies = Inode.unsafe_consume_newies
 
-  let get_newies = Inode.get_newies
+  let consume_newies = Inode.consume_newies
 
   let update_flip = Inode.update_flip
 

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -55,6 +55,10 @@ module type S = sig
   val flush : ?index:bool -> 'a t -> unit
 
   val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
+
+  val unsafe_get_newies : unit -> key list
+
+  val get_newies : 'a t -> key list Lwt.t
 end
 
 module type Inode_layers = sig

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -56,9 +56,9 @@ module type S = sig
 
   val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
 
-  val unsafe_get_newies : unit -> key list
+  val unsafe_consume_newies : unit -> key list
 
-  val get_newies : 'a t -> key list Lwt.t
+  val consume_newies : 'a t -> key list Lwt.t
 end
 
 module type Inode_layers = sig

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -108,6 +108,7 @@ val config_layers :
   ?upper_root0:string ->
   ?copy_in_upper:bool ->
   ?with_lower:bool ->
+  ?blocking_copy_size:int ->
   unit ->
   Irmin.config
 

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -86,8 +86,8 @@ let with_lower conf = Conf.get conf with_lower_key
 let blocking_copy_size_key =
   Conf.key
     ~doc:
-      "Specify the size (in bytes) that can be copied in the blocking portion \
-       of the freeze."
+      "Specify the maximum size (in bytes) that can be copied in the blocking \
+       portion of the freeze."
     "blocking-copy" Conf.int Default.blocking_copy_size
 
 let blocking_copy_size conf = Conf.get conf blocking_copy_size_key

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -745,18 +745,18 @@ struct
         Log.debug (fun l -> l "copy newies");
         let newies_commits =
           if with_lock then
-            X.Commit.CA.unsafe_get_newies () |> List.rev |> Lwt.return
-          else X.Commit.CA.get_newies t.X.Repo.commit >|= List.rev
+            X.Commit.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
+          else X.Commit.CA.consume_newies t.X.Repo.commit >|= List.rev
         in
         let newies_nodes =
           if with_lock then
-            X.Node.CA.unsafe_get_newies () |> List.rev |> Lwt.return
-          else X.Node.CA.get_newies t.X.Repo.node >|= List.rev
+            X.Node.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
+          else X.Node.CA.consume_newies t.X.Repo.node >|= List.rev
         in
         let newies_contents =
           if with_lock then
-            X.Contents.CA.unsafe_get_newies () |> List.rev |> Lwt.return
-          else X.Contents.CA.get_newies t.X.Repo.contents >|= List.rev
+            X.Contents.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
+          else X.Contents.CA.consume_newies t.X.Repo.contents >|= List.rev
         in
         let copy_contents contents t k =
           X.Contents.CA.copy contents t.X.Repo.contents "Contents" k

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -611,19 +611,19 @@ struct
   module Copy = struct
     let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
 
-    let mem_commit_upper t = X.Commit.CA.mem_next t.X.Repo.commit
+    let mem_commit_next t = X.Commit.CA.mem_next t.X.Repo.commit
 
     let mem_node_lower t = X.Node.CA.mem_lower t.X.Repo.node
 
-    let mem_node_upper t = X.Node.CA.mem_next t.X.Repo.node
+    let mem_node_next t = X.Node.CA.mem_next t.X.Repo.node
 
     let mem_contents_lower t = X.Contents.CA.mem_lower t.X.Repo.contents
 
-    let mem_contents_upper t = X.Contents.CA.mem_next t.X.Repo.contents
+    let mem_contents_next t = X.Contents.CA.mem_next t.X.Repo.contents
 
     let copy_branches t =
       X.Branch.copy ~mem_commit_lower:(mem_commit_lower t)
-        ~mem_commit_upper:(mem_commit_upper t) t.X.Repo.branch
+        ~mem_commit_upper:(mem_commit_next t) t.X.Repo.branch
 
     let skip_with_stats ~skip h =
       pause () >>= fun () ->
@@ -699,15 +699,14 @@ struct
         f contents nodes commits
 
       let copy_commit contents nodes commits t =
-        copy_commit ~skip:(mem_node_upper t)
-          ~skip_contents:(mem_contents_upper t)
+        copy_commit ~skip:(mem_node_next t) ~skip_contents:(mem_contents_next t)
           (X.Contents.CA.Upper, contents)
           (X.Node.CA.Upper, nodes)
           (X.Commit.CA.Upper, commits)
           t
 
       let copy ~min ~max t =
-        let skip h = skip_with_stats ~skip:(mem_commit_upper t) h in
+        let skip h = skip_with_stats ~skip:(mem_commit_next t) h in
         on_next_upper t (fun contents nodes commits ->
             let commit = copy_commit contents nodes commits t in
             Repo.iter_commits t ~min ~max ~commit ~skip ())

--- a/src/irmin-pack/irmin_pack_layers.mli
+++ b/src/irmin-pack/irmin_pack_layers.mli
@@ -21,6 +21,7 @@ val config_layers :
   ?upper_root0:string ->
   ?copy_in_upper:bool ->
   ?with_lower:bool ->
+  ?blocking_copy_size:int ->
   unit ->
   Irmin.config
 (** Configuration options for layered stores.
@@ -34,7 +35,9 @@ val config_layers :
     @param copy_in_upper if true then at the end of a freee the max commits are
     copied back in upper. This option can be overriden when calling a freeze
     with the [copy_in_upper] argument set. By default it is set to false.
-    @param with_lower if true (the default) use a lower layer during freezes. *)
+    @param with_lower if true (the default) use a lower layer during freezes.
+    @param blocking_copy_size specifies the size (in bytes) that can be copied
+    in the blocking portion of the freeze. *)
 
 module Make_ext
     (Config : Config.S)

--- a/src/irmin-pack/irmin_pack_layers.mli
+++ b/src/irmin-pack/irmin_pack_layers.mli
@@ -36,8 +36,8 @@ val config_layers :
     copied back in upper. This option can be overriden when calling a freeze
     with the [copy_in_upper] argument set. By default it is set to false.
     @param with_lower if true (the default) use a lower layer during freezes.
-    @param blocking_copy_size specifies the size (in bytes) that can be copied
-    in the blocking portion of the freeze. *)
+    @param blocking_copy_size specifies the maximum size (in bytes) that can be
+    copied in the blocking portion of the freeze. *)
 
 module Make_ext
     (Config : Config.S)

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -100,14 +100,14 @@ struct
   (** Objects added during a freeze *)
   let newies : key list ref = ref []
 
-  let unsafe_get_newies () =
+  let unsafe_consume_newies () =
     let tmp = !newies in
     newies := [];
     tmp
 
-  let get_newies t =
+  let consume_newies t =
     Lwt_mutex.with_lock t.add_lock (fun () ->
-        let tmp = unsafe_get_newies () in
+        let tmp = unsafe_consume_newies () in
         Lwt.return tmp)
 
   let add' t v =

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -98,7 +98,17 @@ struct
   let mem_next t k = U.mem (next_upper t) k
 
   (** Objects added during a freeze *)
-  let newies : (key * value) list ref = ref []
+  let newies : key list ref = ref []
+
+  let unsafe_get_newies () =
+    let tmp = !newies in
+    newies := [];
+    tmp
+
+  let get_newies t =
+    Lwt_mutex.with_lock t.add_lock (fun () ->
+        let tmp = unsafe_get_newies () in
+        Lwt.return tmp)
 
   let add' t v =
     Log.debug (fun l -> l "add in %s" (log_current_upper t));
@@ -107,7 +117,7 @@ struct
     U.add upper v >|= fun k ->
     if Lwt_mutex.is_locked t.freeze_lock then (
       Log.debug (fun l -> l "adds during freeze");
-      newies := (k, v) :: !newies);
+      newies := k :: !newies);
     k
 
   let add t v = Lwt_mutex.with_lock t.add_lock (fun () -> add' t v)
@@ -119,7 +129,7 @@ struct
     U.unsafe_add upper k v >|= fun () ->
     if Lwt_mutex.is_locked t.freeze_lock then (
       Log.debug (fun l -> l "adds during freeze");
-      newies := (k, v) :: !newies)
+      newies := k :: !newies)
 
   let unsafe_add t k v =
     Lwt_mutex.with_lock t.add_lock (fun () -> unsafe_add' t k v)
@@ -131,7 +141,7 @@ struct
     U.unsafe_append upper k v;
     if Lwt_mutex.is_locked t.freeze_lock then (
       Log.debug (fun l -> l "adds during freeze");
-      newies := (k, v) :: !newies)
+      newies := k :: !newies)
 
   let unsafe_append t k v =
     Lwt_mutex.with_lock t.add_lock (fun () ->
@@ -325,35 +335,6 @@ struct
             stats str;
             U.unsafe_add dst k v
         | None -> Fmt.failwith "%s %a not found" str (Irmin.Type.pp H.t) k)
-
-  let yield = Lwt_unix.auto_yield 0.1
-
-  (** Copy newies (objects added during the freeze) to the next upper. No lock
-      is used during this copy, so additional newies can be added during this
-      operation. *)
-  let copy_newies_to_next_upper t =
-    Log.debug (fun l ->
-        l "copy %d newies in %s " (List.length !newies) (log_next_upper t));
-    let next = next_upper t in
-    let tmp_newies : (key * value) list ref = ref [] in
-    Lwt_mutex.with_lock t.add_lock (fun () ->
-        tmp_newies := !newies;
-        newies := [];
-        Lwt.return_unit)
-    >>= fun () ->
-    Lwt_list.iter_s
-      (fun (k, v) -> yield () >|= fun () -> U.unsafe_append next k v)
-      (List.rev !tmp_newies)
-
-  (** As copy_newies_to_next_upper but inside a lock, which ensure that no
-      newies are added. *)
-  let copy_last_newies_to_next_upper t =
-    Log.debug (fun l ->
-        l "copy %d newies in %s " (List.length !newies) (log_next_upper t));
-    let next = next_upper t in
-    List.iter (fun (k, v) -> U.unsafe_append next k v) (List.rev !newies);
-    newies := [];
-    Lwt.return_unit
 end
 
 module Pack_Maker

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -175,9 +175,9 @@ module type LAYERED = sig
     _ t ->
     (unit, Sigs.integrity_error) result
 
-  val unsafe_get_newies : unit -> key list
+  val unsafe_consume_newies : unit -> key list
 
-  val get_newies : 'a t -> key list Lwt.t
+  val consume_newies : 'a t -> key list Lwt.t
 end
 
 module type LAYERED_MAKER = sig

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -174,6 +174,10 @@ module type LAYERED = sig
     key ->
     _ t ->
     (unit, Sigs.integrity_error) result
+
+  val unsafe_get_newies : unit -> key list
+
+  val get_newies : 'a t -> key list Lwt.t
 end
 
 module type LAYERED_MAKER = sig

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -39,10 +39,6 @@ module type LAYERED_GENERAL = sig
   val update_flip : flip:bool -> _ t -> unit
 
   val flip_upper : _ t -> unit
-
-  val copy_newies_to_next_upper : _ t -> unit Lwt.t
-
-  val copy_last_newies_to_next_upper : _ t -> unit Lwt.t
 end
 
 module type LAYERED = sig
@@ -88,4 +84,8 @@ module type LAYERED_ATOMIC_WRITE_STORE = sig
   val flush_next_lower : t -> unit
 
   val clear_previous_upper : ?keep_generation:unit -> t -> unit Lwt.t
+
+  val copy_newies_to_next_upper : t -> unit Lwt.t
+
+  val copy_last_newies_to_next_upper : t -> unit Lwt.t
 end

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2272,6 +2272,7 @@ let layered_suite (speed, x) =
           ("Keep max and heads after max", speed, TL.test_keep_heads x);
           ("Test find during freeze", speed, TL.test_find_during_freeze x);
           ("Test add during freeze", speed, TL.test_add_during_freeze x);
+          ("Adds again objects deleted by freeze", speed, TL.test_add_again x);
         ] )
 
 let run name ~misc tl =

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2103,8 +2103,7 @@ module Make (S : S) = struct
       let node k =
         P.Node.find n k >|= fun t -> mem k (get t) (check_mem rev_order)
       in
-      let skip _ = Lwt.return_false in
-      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~skip ~rev:true ()
+      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~rev:true ()
       >>= fun () ->
       let inorder step =
         if !visited = [] && step = "b" then
@@ -2119,13 +2118,14 @@ module Make (S : S) = struct
           Alcotest.failf "node %a skipped twice" (Irmin.Type.pp P.Hash.t) h1;
         skipped := step :: !skipped
       in
-      let skip k =
+      let skip_nodes k =
         P.Node.find n k >|= fun t ->
         mem k (get t) check_skip;
         if List.mem "b" !skipped then true else false
       in
       visited := [];
-      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~skip ~rev:false ()
+      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~skip_nodes ~rev:false
+        ()
       >>= fun () ->
       if List.mem "b" !visited then Alcotest.fail "b should be skipped";
       visited := [];

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -371,9 +371,10 @@ module type NODE_GRAPH = sig
       the closure of [t] as specified by {{!Irmin__Object_graph.S.closure}
       Object_graph.closure}.
 
-      It applies three functions while traversing the graph: [node] on the
-      nodes; [edge n predecessor_of_n] on the directed edges and [skip n] to not
-      include a node [n], its predecessors and the outgoing edges of [n].
+      It applies the following functions while traversing the graph: [node] on
+      the nodes; [edge n predecessor_of_n] on the directed edges; [skip_nodes n]
+      to not include a node [n], its predecessors and the outgoing edges of [n]
+      and [skip_contents c] to not include content [c].
 
       If [rev] is true (the default) then the graph is traversed in the reverse
       order: [node n] is applied only after it was applied on all its

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -362,7 +362,8 @@ module type NODE_GRAPH = sig
     ?node:(node -> unit Lwt.t) ->
     ?contents:(contents * metadata -> unit Lwt.t) ->
     ?edge:(node -> node -> unit Lwt.t) ->
-    ?skip:(node -> bool Lwt.t) ->
+    ?skip_nodes:(node -> bool Lwt.t) ->
+    ?skip_contents:(contents * metadata -> bool Lwt.t) ->
     ?rev:bool ->
     unit ->
     unit Lwt.t

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -130,7 +130,8 @@ module type S = sig
       ?node:(hash -> unit Lwt.t) ->
       ?contents:(hash * metadata -> unit Lwt.t) ->
       ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip:(hash -> bool Lwt.t) ->
+      ?skip_nodes:(hash -> bool Lwt.t) ->
+      ?skip_contents:(hash * metadata -> bool Lwt.t) ->
       ?rev:bool ->
       unit ->
       unit Lwt.t


### PR DESCRIPTION
Before this PR, newies (the objects added in upper during a concurrent freeze) were copied in the next upper, without being traversed. However, a "newie" can include an object still present in upper but deleted at the end of the freeze. Therefore we have to traverse the newies as well when copying them to the next upper, to ensure the upper remains self contained.

Also included a `skip_contents` function for a node's graph traversal, to prevent unnecessary visits of contents. 

