### PR TITLE
Recovery mechanism for freeze

### DIFF
--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -132,7 +132,7 @@ struct
   include Irmin.Of_private (X)
 
   let freeze ?min:_ ?max:_ ?squash:_ ?copy_in_upper:_ ?min_upper:_ ?heads:_
-      _repo =
+      ?recovery:_ _repo =
     Lwt.fail_with "not implemented"
 
   type store_handle =
@@ -160,7 +160,7 @@ struct
     let wait_for_freeze _ = Lwt.fail_with "not implemented"
 
     let freeze' ?min:_ ?max:_ ?squash:_ ?copy_in_upper:_ ?min_upper:_ ?heads:_
-        ?hook:_ _repo =
+        ?recovery:_ ?hook:_ _repo =
       Lwt.fail_with "not implemented"
 
     let upper_in_use = upper_in_use

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -148,6 +148,8 @@ struct
 
   let self_contained ?min:_ ~max:_ _repo = failwith "not implemented"
 
+  let needs_recovery _ = failwith "not implemented"
+
   module PrivateLayer = struct
     module Hook = struct
       type 'a t = unit

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -49,6 +49,11 @@ module type S = sig
       from lower into upper, in order to make the upper self contained. If [min]
       is missing then only the [max] commits are copied. *)
 
+  val needs_recovery : repo -> bool
+  (** [needs_recovery repo] detects if an ongoing freeze was interrupted during
+      the last node crash. If it returns [true] then the next call to freeze
+      needs to have its [recovery] flag set. *)
+
   (** These modules should not be used. They are exposed purely for testing
       purposes. *)
   module PrivateLayer : sig

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -26,6 +26,7 @@ module type S = sig
     ?copy_in_upper:bool ->
     ?min_upper:commit list ->
     ?heads:commit list ->
+    ?recovery:bool ->
     repo ->
     unit Lwt.t
 
@@ -72,6 +73,7 @@ module type S = sig
       ?copy_in_upper:bool ->
       ?min_upper:commit list ->
       ?heads:commit list ->
+      ?recovery:bool ->
       ?hook:
         [ `After_Clear
         | `Before_Clear

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -58,7 +58,7 @@ module type S = sig
 
   val name : t -> string
 
-  val clear : t -> unit
+  val clear : ?keep_generation:bool -> t -> unit
 
   val append : t -> string -> unit
 
@@ -209,7 +209,7 @@ module Unix : S = struct
     Raw.Header.set raw header;
     raw
 
-  let unsafe_clear t =
+  let unsafe_clear ?(keep_generation = false) t =
     if t.readonly then invalid_arg "Read-only IO cannot be cleared";
     Log.debug (fun l -> l "clear %s" t.file);
     Buffer.clear t.buf;
@@ -218,7 +218,7 @@ module Unix : S = struct
     if t.offset = 0L then ()
     else (
       t.offset <- 0L;
-      t.generation <- Int64.succ t.generation;
+      if not keep_generation then t.generation <- Int64.succ t.generation;
       t.flushed <- header t.version;
       (* update the generation for concurrent readonly instance to
          notice that the file has been clear when they next sync. *)
@@ -232,10 +232,10 @@ module Unix : S = struct
           ~flags:Unix.[ O_CREAT; O_RDWR; O_CLOEXEC ]
           t.file)
 
-  let clear t =
+  let clear ?keep_generation t =
     match t.version with
     | `V1 -> invalid_arg "V1 stores cannot be cleared"
-    | `V2 -> unsafe_clear t
+    | `V2 -> unsafe_clear ?keep_generation t
 
   let v ~version ~fresh ~readonly file =
     let get_version () =

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -58,7 +58,7 @@ module type S = sig
 
   val name : t -> string
 
-  val clear : ?keep_generation:bool -> t -> unit
+  val clear : ?keep_generation:unit -> t -> unit
 
   val append : t -> string -> unit
 
@@ -209,7 +209,7 @@ module Unix : S = struct
     Raw.Header.set raw header;
     raw
 
-  let unsafe_clear ?(keep_generation = false) t =
+  let unsafe_clear ?keep_generation t =
     if t.readonly then invalid_arg "Read-only IO cannot be cleared";
     Log.debug (fun l -> l "clear %s" t.file);
     Buffer.clear t.buf;
@@ -218,7 +218,7 @@ module Unix : S = struct
     if t.offset = 0L then ()
     else (
       t.offset <- 0L;
-      if not keep_generation then t.generation <- Int64.succ t.generation;
+      if keep_generation = None then t.generation <- Int64.succ t.generation;
       t.flushed <- header t.version;
       (* update the generation for concurrent readonly instance to
          notice that the file has been clear when they next sync. *)

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -31,7 +31,7 @@ module type S = sig
 
   val name : t -> string
 
-  val clear : t -> unit
+  val clear : ?keep_generation:bool -> t -> unit
 
   val append : t -> string -> unit
 

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -31,7 +31,7 @@ module type S = sig
 
   val name : t -> string
 
-  val clear : ?keep_generation:bool -> t -> unit
+  val clear : ?keep_generation:unit -> t -> unit
 
   val append : t -> string -> unit
 

--- a/src/irmin-pack/IO_layers.mli
+++ b/src/irmin-pack/IO_layers.mli
@@ -27,3 +27,15 @@ module type S = sig
 end
 
 module IO : S
+
+module Lock : sig
+  type t
+
+  val v : string -> t Lwt.t
+
+  include S.CLOSEABLE with type _ t := t
+
+  val unlink : string -> unit Lwt.t
+
+  val test : string -> bool
+end

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -96,6 +96,10 @@ module Content_addressable (S : Pack.S) = struct
   let offset t =
     check_not_closed t;
     S.offset t.t
+
+  let clear_keep_generation t =
+    check_not_closed t;
+    S.clear_keep_generation t.t
 end
 
 module Atomic_write (AW : S.ATOMIC_WRITE_STORE) = struct
@@ -161,4 +165,8 @@ module Atomic_write (AW : S.ATOMIC_WRITE_STORE) = struct
   let flush t =
     check_not_closed t;
     AW.flush t.t
+
+  let clear_keep_generation t =
+    check_not_closed t;
+    AW.clear_keep_generation t.t
 end

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -91,7 +91,7 @@ module type PACK_INTER = sig
 
   val version : 'a t -> IO.version
 
-  val clear : 'a t -> unit Lwt.t
+  val clear : ?keep_generation:bool -> 'a t -> unit Lwt.t
 
   val clear_caches : 'a t -> unit
 

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -91,7 +91,7 @@ module type PACK_INTER = sig
 
   val version : 'a t -> IO.version
 
-  val clear : ?keep_generation:bool -> 'a t -> unit Lwt.t
+  val clear : ?keep_generation:unit -> 'a t -> unit Lwt.t
 
   val clear_caches : 'a t -> unit
 

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -124,8 +124,6 @@ struct
 
   let update_flip = Inode.update_flip
 
-  let clear_previous_upper = Inode.clear_previous_upper
-
   let flush = Inode.flush
 
   let unsafe_find t k =

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -34,8 +34,6 @@ module type S = sig
 
   val lower : 'a t -> [ `Read ] L.t
 
-  val clear_previous_upper : 'a t -> unit Lwt.t
-
   include S.LAYERED_GENERAL with type 'a t := 'a t
 
   val clear_caches_next_upper : 'a t -> unit

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -886,12 +886,7 @@ struct
       simultaneously. *)
   let freeze' ?(min = []) ?(max = []) ?(squash = false) ?copy_in_upper
       ?(min_upper = []) ?(heads = []) ?(recovery = false) ?hook t =
-    let lock_file = lock_path t.X.Repo.config in
-    if recovery && not (Lock.test lock_file) then
-      Log.warn (fun l ->
-          l "No lock file detected, ignoring the recovery set flag");
-    (if recovery && Lock.test lock_file then
-     X.Repo.clear_previous_upper ~keep_generation:true t
+    (if recovery then X.Repo.clear_previous_upper ~keep_generation:() t
     else Lwt.return_unit)
     >>= fun () ->
     let copy_in_upper =

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -265,12 +265,13 @@ struct
 
   (** After clearing the previous upper, we also needs to flush current upper to
       disk, otherwise values are not found by the RO. *)
-  let clear_previous_upper ?(keep_generation = false) t =
+  let clear_previous_upper ?keep_generation t =
     let previous = next_upper t in
     let current = current_upper t in
     U.flush current;
-    if keep_generation then U.clear_keep_generation previous
-    else U.clear previous
+    match keep_generation with
+    | Some () -> U.clear_keep_generation previous
+    | None -> U.clear previous
 
   let version t = U.version (fst t.uppers)
 
@@ -550,12 +551,13 @@ struct
 
   (** After clearing the previous upper, we also needs to flush current upper to
       disk, otherwise values are not found by the RO. *)
-  let clear_previous_upper ?(keep_generation = false) t =
+  let clear_previous_upper ?keep_generation t =
     let current = current_upper t in
     let previous = next_upper t in
     U.flush current;
-    if keep_generation then U.clear_keep_generation previous
-    else U.clear previous
+    match keep_generation with
+    | Some () -> U.clear_keep_generation previous
+    | None -> U.clear previous
 
   let flush_next_lower t =
     let next = next_upper t in

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -303,7 +303,7 @@ struct
 
     let clear_keep_generation t =
       Lwt_mutex.with_lock t.pack.lock (fun () ->
-          unsafe_clear ~keep_generation:true t;
+          unsafe_clear ~keep_generation:() t;
           pause ())
 
     let clear_caches t =

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -60,9 +60,9 @@ struct
     mutable open_instances : int;
   }
 
-  let clear t =
+  let clear ?keep_generation t =
     Index.clear t.index;
-    IO.clear t.block;
+    IO.clear ?keep_generation t.block;
     Dict.clear t.dict
 
   let valid t =
@@ -110,8 +110,8 @@ struct
 
     type index = Index.t
 
-    let unsafe_clear t =
-      clear t.pack;
+    let unsafe_clear ?keep_generation t =
+      clear ?keep_generation t.pack;
       Tbl.clear t.staging;
       Lru.clear t.lru
 
@@ -299,6 +299,11 @@ struct
     let clear t =
       Lwt_mutex.with_lock t.pack.lock (fun () ->
           unsafe_clear t;
+          pause ())
+
+    let clear_keep_generation t =
+      Lwt_mutex.with_lock t.pack.lock (fun () ->
+          unsafe_clear ~keep_generation:true t;
           pause ())
 
     let clear_caches t =

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -86,6 +86,8 @@ module type S = sig
   include Sigs.CHECKABLE with type 'a t := 'a t and type key := key
 
   include Sigs.CLOSEABLE with type 'a t := 'a t
+
+  val clear_keep_generation : 'a t -> unit Lwt.t
 end
 
 module type MAKER = sig
@@ -147,7 +149,7 @@ module type LAYERED = sig
 
   val lower : 'a t -> [ `Read ] L.t
 
-  val clear_previous_upper : 'a t -> unit Lwt.t
+  val clear_previous_upper : ?keep_generation:bool -> 'a t -> unit Lwt.t
 
   val sync :
     ?on_generation_change:(unit -> unit) ->

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -149,7 +149,7 @@ module type LAYERED = sig
 
   val lower : 'a t -> [ `Read ] L.t
 
-  val clear_previous_upper : ?keep_generation:bool -> 'a t -> unit Lwt.t
+  val clear_previous_upper : ?keep_generation:unit -> 'a t -> unit Lwt.t
 
   val sync :
     ?on_generation_change:(unit -> unit) ->

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -87,5 +87,5 @@ module type LAYERED_ATOMIC_WRITE_STORE = sig
 
   val flush_next_lower : t -> unit
 
-  val clear_previous_upper : ?keep_generation:bool -> t -> unit Lwt.t
+  val clear_previous_upper : ?keep_generation:unit -> t -> unit Lwt.t
 end

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -57,6 +57,8 @@ module type ATOMIC_WRITE_STORE = sig
   val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t
 
   val flush : t -> unit
+
+  val clear_keep_generation : t -> unit Lwt.t
 end
 
 module type LAYERED_ATOMIC_WRITE_STORE = sig
@@ -83,7 +85,7 @@ module type LAYERED_ATOMIC_WRITE_STORE = sig
 
   include LAYERED with type t := t
 
-  val clear_previous_upper : t -> unit Lwt.t
-
   val flush_next_lower : t -> unit
+
+  val clear_previous_upper : ?keep_generation:bool -> t -> unit Lwt.t
 end

--- a/src/irmin-pack/store.ml
+++ b/src/irmin-pack/store.ml
@@ -157,9 +157,9 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
         Lwt.return_unit)
     >>= fun () -> W.notify t.w k None
 
-  let unsafe_clear t =
+  let unsafe_clear ?keep_generation t =
     Lwt.async (fun () -> W.clear t.w);
-    IO.clear t.block;
+    IO.clear ?keep_generation t.block;
     Tbl.clear t.cache;
     Tbl.clear t.index
 
@@ -167,6 +167,12 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Log.debug (fun l -> l "[branches] clear");
     Lwt_mutex.with_lock t.lock (fun () ->
         unsafe_clear t;
+        Lwt.return_unit)
+
+  let clear_keep_generation t =
+    Log.debug (fun l -> l "[branches] clear");
+    Lwt_mutex.with_lock t.lock (fun () ->
+        unsafe_clear ~keep_generation:true t;
         Lwt.return_unit)
 
   let create = Lwt_mutex.create ()

--- a/src/irmin-pack/store.ml
+++ b/src/irmin-pack/store.ml
@@ -172,7 +172,7 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
   let clear_keep_generation t =
     Log.debug (fun l -> l "[branches] clear");
     Lwt_mutex.with_lock t.lock (fun () ->
-        unsafe_clear ~keep_generation:true t;
+        unsafe_clear ~keep_generation:() t;
         Lwt.return_unit)
 
   let create = Lwt_mutex.create ()

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -286,6 +286,78 @@ module Test_corrupted_stores = struct
          | Ok `No_error -> ()
          | _ -> Alcotest.fail "Store is repaired, should return Ok");
     S.Repo.close rw
+
+  let empty_store, root, lock_file =
+    let open Fpath in
+    ( v "test" / "irmin-pack" / "data" / "empty_store" |> to_string,
+      v "_build" / "test_freeze_lock" |> to_string,
+      v "_build" / "test_freeze_lock" / "lock" |> to_string )
+
+  let setup_test () =
+    goto_project_root ();
+    rm_dir root;
+    let cmd = Filename.quote_command "cp" [ "-R"; "-p"; empty_store; root ] in
+    exec_cmd cmd;
+    let cmd = Filename.quote_command "touch" [ lock_file ] in
+    exec_cmd cmd
+
+  let test_freeze_lock () =
+    setup_test ();
+    let module S = Make_layered in
+    let add_commit repo k v =
+      S.Tree.add S.Tree.empty k v >>= fun tree ->
+      S.Commit.v repo ~parents:[] ~info:(info ()) tree
+    in
+    let check_commit repo commit k v =
+      commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
+      | None ->
+          Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash
+            commit
+      | Some commit ->
+          let tree = S.Commit.tree commit in
+          S.Tree.find tree k
+          >|= Alcotest.(check (option string))
+                (Fmt.strf "Expected binding [%a ↦ %s]"
+                   Fmt.(Dump.list string)
+                   k v)
+                (Some v)
+    in
+    let check_upper repo msg exp =
+      let got = S.PrivateLayer.upper_in_use repo in
+      let cast x = (x :> [ `Upper0 | `Upper1 | `Lower ]) in
+      if not (got = exp) then
+        Alcotest.failf "%s expected %a got %a" msg Irmin_layers.pp_layer_id
+          (cast exp) Irmin_layers.pp_layer_id (cast got)
+    in
+    let* rw = S.Repo.v (config ~fresh:false root) in
+    let* ro = S.Repo.v (config ~fresh:false ~readonly:true root) in
+    Log.app (fun l -> l "Open a layered store aborted during a freeze");
+    Alcotest.(check bool) "Store needs recovery" (S.needs_recovery rw) true;
+    check_upper rw "Upper before recovery" `Upper1;
+    add_commit rw [ "a" ] "x" >>= fun c ->
+    S.sync ro;
+    check_commit ro c [ "a" ] "x" >>= fun () ->
+    Log.app (fun l -> l "Freeze with recovery flag set");
+    S.freeze ~recovery:true ~max:[ c ] rw >>= fun () ->
+    S.PrivateLayer.wait_for_freeze () >>= fun () ->
+    Alcotest.(check bool)
+      "Store doesn't need recovery" (S.needs_recovery rw) false;
+    check_upper rw "Upper after recovery" `Upper0;
+    check_commit rw c [ "a" ] "x" >>= fun () ->
+    S.sync ro;
+    check_commit ro c [ "a" ] "x" >>= fun () ->
+    check_upper ro "RO upper after recovery" `Upper0;
+    add_commit rw [ "b" ] "y" >>= fun c ->
+    Log.app (fun l ->
+        l "Freeze ignores the recovery flag when it doesn't need recovery ");
+    S.freeze ~recovery:true ~max:[ c ] rw >>= fun () ->
+    S.PrivateLayer.wait_for_freeze () >>= fun () ->
+    check_upper rw "Upper after freeze" `Upper1;
+    check_commit rw c [ "b" ] "y" >>= fun () ->
+    S.sync ro;
+    check_upper ro "RO upper after freeze" `Upper1;
+    check_commit ro c [ "b" ] "y" >>= fun () ->
+    S.Repo.close rw >>= fun () -> S.Repo.close ro
 end
 
 let tests =
@@ -298,4 +370,6 @@ let tests =
         Lwt_main.run (Test_corrupted_stores.test ()));
     Alcotest.test_case "Test integrity check on layered stores" `Quick
       (fun () -> Lwt_main.run (Test_corrupted_stores.test_layered_store ()));
+    Alcotest.test_case "Test freeze lock on layered stores" `Quick (fun () ->
+        Lwt_main.run (Test_corrupted_stores.test_freeze_lock ()));
   ]


### PR DESCRIPTION
The recovery mechanism needs a `clear` that does not change the generation for the files on disk. 
I had to introduce an extra `clear_keep_generation` function in the pack to avoid adding a `keep_generation` argument to clear functions for backends other than irmin-pack. 