### PR TITLE
Preview of ocamlformat.0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.15.0
+version = 0.16.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -1237,13 +1237,13 @@ struct
      probably not necessary and we could use Git.Value.Raw instead. *)
   module G = Mem
   module S = Make (G) (No_sync (G)) (C) (P) (B)
-  include Irmin.Make_ext (CA) (AW) (S.Private.Node.Metadata)
-            (S.Private.Contents.Val)
-            (S.Private.Node.Path)
-            (S.Branch)
-            (S.Private.Hash)
-            (S.Private.Node.Val)
-            (S.Private.Commit.Val)
+  include
+    Irmin.Make_ext (CA) (AW) (S.Private.Node.Metadata) (S.Private.Contents.Val)
+      (S.Private.Node.Path)
+      (S.Branch)
+      (S.Private.Hash)
+      (S.Private.Node.Val)
+      (S.Private.Commit.Val)
 end
 
 module Generic_KV

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -705,8 +705,9 @@ struct
             field "commit"
               ~typ:(non_null Lazy.(force commit))
               ~args:[]
-              ~resolve:(fun _ctx -> function
-                | `Added c | `Removed c | `Updated (_, c) -> c);
+              ~resolve:
+                (fun _ctx -> function
+                  | `Added c | `Removed c | `Updated (_, c) -> c);
           ]))
 
   let map_diff diff ~added ~removed ~updated =

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -350,7 +350,8 @@ struct
         | Inodes t ->
             let _, entries =
               Array.fold_left
-                (fun (i, acc) -> function Empty -> (i + 1, acc)
+                (fun (i, acc) -> function
+                  | Empty -> (i + 1, acc)
                   | Inode inode ->
                       let hash = hash_of_inode inode in
                       (i + 1, { Bin.index = i; hash } :: acc))

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1355,7 +1355,8 @@ module Make (S : S) = struct
 
   let inspect =
     Alcotest.testable
-      (fun ppf -> function `Contents -> Fmt.string ppf "contents"
+      (fun ppf -> function
+        | `Contents -> Fmt.string ppf "contents"
         | `Node `Hash -> Fmt.string ppf "hash"
         | `Node `Map -> Fmt.string ppf "map"
         | `Node `Value -> Fmt.string ppf "value")

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -576,8 +576,7 @@ let dot =
                         your system and be sure it is available in your $PATH.");
                let i =
                  Sys.command
-                   (Printf.sprintf "dot -Tpng %s.dot -o%s.png" basename
-                      basename)
+                   (Printf.sprintf "dot -Tpng %s.dot -o%s.png" basename basename)
                in
                if i <> 0 then
                  Logs.err (fun f -> f "The %s.dot is corrupted" basename));

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -61,11 +61,12 @@ module Mem (C : Irmin.Contents.S) = struct
 end
 
 module Generic (C : Irmin.Contents.S) = struct
-  include Irmin_git.Generic_KV
-            (Irmin.Content_addressable
-               (Irmin_mem.Append_only))
-               (Irmin_mem.Atomic_write)
-            (C)
+  include
+    Irmin_git.Generic_KV
+      (Irmin.Content_addressable
+         (Irmin_mem.Append_only))
+         (Irmin_mem.Atomic_write)
+      (C)
 
   let init () =
     Repo.v config >>= fun repo ->


### PR DESCRIPTION
Hi, this pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main changes in this diff are:
- the indentation of module includes has been fixed;
- the cases of anonymous functions are all properly broken.

Let me now if you notice any regressions.