### PR TITLE
Add support for subtree inclusion proofs

### DIFF
--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -1,4 +1,5 @@
 open Lwt.Infix
+open Lwt.Syntax
 open Irmin
 
 module Metadata = struct
@@ -22,6 +23,36 @@ module Alcotest = struct
   include Alcotest
 
   let diffs = testable (Type.pp diffs_t) (Type.equal diffs_t)
+
+  let check_lwt typ msg expect = Lwt.map (Alcotest.check typ msg expect)
+end
+
+(* Generators for random test data *)
+module Faker = struct
+  let () = Random.self_init ()
+
+  let string () =
+    let rand_char _ =
+      match Random.int 16 with
+      | n when n < 10 -> Char.chr (n + 48)
+      | n -> Char.chr (n + 65)
+    in
+    String.init 8 rand_char
+
+  let contents () = string ()
+
+  let rec tree ?(depth = 3) ?(branching_factor = 4) () =
+    match depth with
+    | 0 -> Lwt.return (Tree.of_contents (contents ()))
+    | _ ->
+        let rec aux = function
+          | 0 -> Lwt.return Tree.empty
+          | n ->
+              let* children = aux (n - 1) in
+              let* new_child = tree ~depth:(depth - 1) ~branching_factor () in
+              Tree.add_tree children [ string () ] new_child
+        in
+        aux branching_factor
 end
 
 let ( >> ) f g x = g (f x)
@@ -32,10 +63,12 @@ let get_ok = function
 
 let c ?(info = Metadata.Default) blob = `Contents (blob, info)
 
+let n x = `Tree x
+
 let test_bindings _ () =
   let tree =
     Tree.of_concrete
-      (`Tree [ ("aa", c "0"); ("ab", c "1"); ("a", `Tree []); ("b", c "3") ])
+      (`Tree [ ("aa", c "0"); ("ab", c "1"); ("a", n []); ("b", c "3") ])
   in
   let check_sorted =
     Alcotest.(check (list string))
@@ -50,7 +83,7 @@ let test_bindings _ () =
 
 (** Basic tests of the [Tree.diff] operation. *)
 let test_diff _ () =
-  let tree bs = Tree.of_concrete (`Tree bs) in
+  let tree = n >> Tree.of_concrete in
   let empty = tree [] in
   let single = tree [ ("k", c "v") ] in
 
@@ -74,8 +107,108 @@ let test_diff _ () =
         "Changed metadata"
         [ ([ "k" ], `Updated (("v", Left), ("v", Right))) ]
 
+type kind = [ `Contents of Store.metadata | `Node ] [@@deriving irmin]
+
+type binding = kind * Store.Hash.t [@@deriving irmin]
+
+type error =
+  [ `Dangling_hash of Store.Hash.t
+  | `Invalid_path
+  | `Different_hashes of Store.Tree.Proof.path_diff ]
+[@@deriving irmin]
+
+let ok x = Alcotest.(result x reject)
+
+let proof_result =
+  Alcotest.(
+    result reject
+      (testable (Irmin.Type.pp_dump error_t) (Irmin.Type.equal error_t)))
+
+let verify_result = Irmin.Type.(result unit) error_t
+
+module Proof = struct
+  let tree = n >> Tree.of_concrete
+
+  let test_non_existent_path _ () =
+    let t = tree [ ("a", c "1") ] in
+    let* () =
+      Alcotest.(check_lwt proof_result)
+        "cannot construct proof for a non-existent path"
+        (Error `Invalid_path)
+        (Tree.Proof.of_path t [ "a"; "not_present" ])
+    in
+    Lwt.return ()
+
+  let test_verify_path _ () =
+    Alcotest.(check_lwt (ok unit))
+      "Empty proof is valid for the empty tree" (Ok ())
+      Tree.(Proof.(verify_on_path empty) empty [])
+
+  let test_basic _ () =
+    let t1, t1', t2 =
+      let f dist =
+        tree
+          [
+            ("alpha", c "1");
+            ("gamma", `Tree []);
+            ("delta", c "3");
+            ("differing", n [ ("path", n [ (dist, c "0") ]) ]);
+          ]
+      in
+      (f "one", f "one", f "two")
+    in
+    let* () =
+      Alcotest.(check_lwt (ok unit))
+        "Empty proof is valid for the empty tree" (Ok ())
+        Tree.(Proof.(verify empty) empty)
+    in
+    let* () =
+      let* tree = Faker.tree () in
+      Alcotest.(check_lwt (ok unit))
+        "Empty proof is valid for a random tree" (Ok ())
+        Tree.(Proof.(verify empty tree))
+    in
+    let* proof_alpha = Tree.Proof.of_path t1 [ "alpha" ] >|= Result.get_ok in
+    let* () =
+      Alcotest.(check_lwt (ok unit))
+        "Content proof is verifiable on the tree from which it was constructed"
+        (Ok ())
+        (Tree.Proof.verify proof_alpha t1)
+    in
+    let* () =
+      Alcotest.(check_lwt (ok unit))
+        "Content proof is verifiable on a tree that is equal to the one from \
+         which it was constructed"
+        (Ok ())
+        (Tree.Proof.verify proof_alpha t1')
+    in
+    let* () =
+      Tree.Proof.verify proof_alpha t2 >|= function
+      | Error
+          (`Different_hashes
+            {
+              Tree.Proof.path = [ "differing" ];
+              computed = `Node, h1;
+              required = `Node, h2;
+            })
+        when not (Irmin.Type.equal Store.Hash.t h1 h2) ->
+          ()
+      | r ->
+          Alcotest.failf
+            "Content proof is not verifiable on a different tree containing \
+             the same path: %a"
+            (Irmin.Type.pp_dump verify_result)
+            r
+    in
+    Lwt.return ()
+end
+
 let suite =
+  let tc n f = Alcotest_lwt.test_case n `Quick f in
   [
-    Alcotest_lwt.test_case "bindings" `Quick test_bindings;
-    Alcotest_lwt.test_case "diff" `Quick test_diff;
+    tc "bindings" test_bindings;
+    tc "diff" test_diff;
+    tc "Proof.test_basic" Proof.test_basic;
+    tc "Proof.test_non_existent_path" Proof.test_non_existent_path;
+    tc "Proof.test_verify_path" Proof.test_verify_path;
   ]


### PR DESCRIPTION
This is a draft of initial support for Merkle proofs, which is still partially implemented and requires more testing. The API used here is taken from [[Lochbihler & Marić, 2020]](http://www.andreas-lochbihler.de/pub/lochbihler2020iw.pdf), which describes a generic signature for inclusion proofs that fits well with Irmin generally by making them inherently merge-able entities. In particular:

- we define an "inclusion proof" as a witness that certain subtrees exist within a given tree (at specific positions;)
- we define an partial ordering relation `⊑` on proofs, called the "_blinding relation_", such that `p1 ⊑ p2` iff `p1` witnesses a subset of the inclusion properties that `p2` does;
- we provide a partial merge operation that provides the least-upper-bound of the blinding relation.

```ocaml
type proof

(* Constructing proofs *)
val empty   : proof
val of_path : tree -> key -> proof option
val full    : tree -> proof

(* Comparing and combining proofs

   [blinding_of p1 p2] is true iff [p1] asserts a subset of the inclusion
   properties that [p2] asserts. That is, if [p1] is consistent with [p2] and
   does not reveal any more information than [p2]. {!merge} computes the
   least-upper-bound of this relation. 
*)
val blinding_of : proof -> proof -> bool
val merge       : proof -> proof -> proof option

(* Verifying proofs *)

val verify : proof -> tree -> (unit, [> verify_errors]) result
(* Ensure that a proof is consistent with a tree:
 
     [verify p t] ≡ [blinding_of p (full t)] 
*)

val verify_on_path : proof -> tree -> key -> (unit, [> verify_errors]) result
(* Ensure that a proof is consistent with a particular path in a tree:

     [verify_on_path p t k] ≡ [blinding_of (of_path t k) p] 
 *)
```