### PR TITLE
Small optimisation of the graph traversal for freeze 

### DIFF
--- a/src/irmin-test/store_graph.ml
+++ b/src/irmin-test/store_graph.ml
@@ -6,81 +6,159 @@ module Make (S : S) = struct
 
   let test_iter x () =
     let test repo =
-      let n = n repo in
-      let check_key = check P.Node.Key.t in
-      let check_val = check Graph.value_t in
-      let foo = normal (P.Contents.Key.hash "foo") in
-      let v = P.Node.Val.add P.Node.Val.empty "b" foo in
-      with_node repo (fun n -> P.Node.add n v) >>= fun k1 ->
-      with_node repo (fun g -> Graph.v g [ ("a", `Node k1) ]) >>= fun k2 ->
-      with_node repo (fun g -> Graph.v g [ ("c", `Node k1) ]) >>= fun k3 ->
+      let eq = Irmin.Type.(unstage (equal P.Hash.t)) in
+      let mem k ls = List.exists (fun k' -> eq k k') ls in
       let visited = ref [] in
-      let check_mem order_test step h1 h2 v1 v2 =
-        check_key "find key" h1 h2;
-        check_val "find value" v1 v2;
-        if List.mem step !visited then
-          Alcotest.failf "node %a visited twice" (Irmin.Type.pp P.Hash.t) h1;
-        order_test step;
-        visited := step :: !visited
-      in
-      let mem hash value check_node =
-        match P.Node.Val.find value "a" with
-        | Some k -> check_node "a" hash k2 k (`Node k1)
-        | None -> (
-            match P.Node.Val.find value "c" with
-            | Some k -> check_node "c" hash k3 k (`Node k1)
-            | None -> (
-                match P.Node.Val.find value "b" with
-                | Some k -> check_node "b" hash k1 k foo
-                | None -> Alcotest.fail "unexpected node"))
-      in
-      let rev_order step =
-        if !visited = [] && step <> "b" then
+      let skipped = ref [] in
+      let rev_order oldest k =
+        if !visited = [] && not (eq k oldest) then
           Alcotest.fail "traversal should start with oldest node"
       in
-      let node k =
-        P.Node.find n k >|= fun t -> mem k (Option.get t) (check_mem rev_order)
-      in
-      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~rev:true ()
-      >>= fun () ->
-      let inorder step =
-        if !visited = [] && step = "b" then
-          Alcotest.fail "traversal should start with newest nodes"
+      let in_order oldest k =
+        if !visited = [] && eq k oldest then
+          Alcotest.fail "traversal shouldn't start with oldest node"
       in
       let node k =
-        P.Node.find n k >|= fun t -> mem k (Option.get t) (check_mem inorder)
+        if mem k !visited then
+          Alcotest.failf "node %a visited twice" (Irmin.Type.pp P.Hash.t) k;
+        visited := k :: !visited;
+        Lwt.return_unit
       in
-      let skipped = ref [] in
-      let check_skip step h1 _ _ _ =
-        if List.mem step !skipped then
-          Alcotest.failf "node %a skipped twice" (Irmin.Type.pp P.Hash.t) h1;
-        skipped := step :: !skipped
+      let contents ?order k =
+        if mem k !visited then
+          Alcotest.failf "contents %a visited twice" (Irmin.Type.pp P.Hash.t) k;
+        (match order with None -> () | Some f -> f k);
+        visited := k :: !visited;
+        Lwt.return_unit
       in
-      let skip_node k =
-        P.Node.find n k >|= fun t ->
-        mem k (Option.get t) check_skip;
-        if List.mem "b" !skipped then true else false
+      let test_rev_order ~nodes ~max =
+        let oldest = List.hd nodes in
+        let contents = contents ~order:(rev_order oldest) in
+        Graph.iter_track_visited (g repo) ~min:[] ~max ~node ~contents ~rev:true
+          ()
+        >|= fun () ->
+        List.iter
+          (fun k ->
+            if not (mem k !visited) then
+              Alcotest.failf "%a should be visited" (Irmin.Type.pp P.Hash.t) k)
+          nodes
       in
-      visited := [];
-      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~skip_node ~rev:false ()
-      >>= fun () ->
-      if List.mem "b" !visited then Alcotest.fail "b should be skipped";
-      visited := [];
-      let node k =
-        P.Node.find n k >|= fun t -> mem k (Option.get t) (check_mem inorder)
+      let test_in_order ~nodes ~max =
+        let oldest = List.hd nodes in
+        let contents = contents ~order:(in_order oldest) in
+        Graph.iter_track_visited (g repo) ~min:[] ~max ~node ~contents
+          ~rev:false ()
+        >|= fun () ->
+        List.iter
+          (fun k ->
+            if not (mem k !visited) then
+              Alcotest.failf "%a should be visited" (Irmin.Type.pp P.Hash.t) k)
+          nodes
       in
-      Graph.iter (g repo) ~min:[ k1 ] ~max:[ k2 ] ~node ~rev:false ()
-      >>= fun () ->
-      if not (List.mem "b" !visited) then
-        Alcotest.fail "k1 should have been visited";
-      if List.mem "c" !visited then
-        Alcotest.fail "k3 shouldn't have been visited";
-      visited := [];
-      Graph.iter (g repo) ~min:[ k2; k3 ] ~max:[ k2; k3 ] ~node ~rev:false ()
-      >>= fun () ->
-      if (not (List.mem "a" !visited)) || not (List.mem "c" !visited) then
-        Alcotest.fail "k1, k2 should have been visited";
-      P.Repo.close repo
+      let test_skip ~max ~to_skip ~not_visited =
+        let skip_node k =
+          if mem k to_skip then (
+            skipped := k :: !skipped;
+            Lwt.return_true)
+          else Lwt.return_false
+        in
+        Graph.iter_track_visited (g repo) ~min:[] ~max ~node ~contents
+          ~skip_node ~rev:false ()
+        >|= fun () ->
+        List.iter
+          (fun k ->
+            if mem k !visited || not (mem k !skipped) then
+              Alcotest.failf "%a should be skipped" (Irmin.Type.pp P.Hash.t) k)
+          to_skip;
+        List.iter
+          (fun k ->
+            if mem k !visited || mem k !skipped then
+              Alcotest.failf "%a should not be skipped nor visited"
+                (Irmin.Type.pp P.Hash.t) k)
+          not_visited
+      in
+      let test_min_max ~nodes ~min ~max ~not_visited =
+        Graph.iter_track_visited (g repo) ~min ~max ~node ~contents ~rev:false
+          ()
+        >|= fun () ->
+        List.iter
+          (fun k ->
+            if mem k not_visited && mem k !visited then
+              Alcotest.failf "%a should not be visited" (Irmin.Type.pp P.Hash.t)
+                k;
+            if (not (mem k not_visited)) && not (mem k !visited) then
+              Alcotest.failf "%a should not be visited" (Irmin.Type.pp P.Hash.t)
+                k)
+          nodes
+      in
+      let test1 () =
+        let foo = P.Contents.Key.hash "foo" in
+        with_node repo (fun g -> Graph.v g [ ("b", normal foo) ]) >>= fun k1 ->
+        with_node repo (fun g -> Graph.v g [ ("a", `Node k1) ]) >>= fun k2 ->
+        with_node repo (fun g -> Graph.v g [ ("c", `Node k1) ]) >>= fun k3 ->
+        let nodes = [ foo; k1; k2; k3 ] in
+        visited := [];
+        test_rev_order ~nodes ~max:[ k2; k3 ] >>= fun () ->
+        visited := [];
+        test_in_order ~nodes ~max:[ k2; k3 ] >>= fun () ->
+        visited := [];
+        skipped := [];
+        test_skip ~max:[ k2; k3 ] ~to_skip:[ k1 ] ~not_visited:[] >>= fun () ->
+        visited := [];
+        test_min_max ~nodes ~min:[ k1 ] ~max:[ k2 ] ~not_visited:[ foo; k3 ]
+        >>= fun () ->
+        visited := [];
+        test_min_max ~nodes ~min:[ k2; k3 ] ~max:[ k2; k3 ]
+          ~not_visited:[ foo; k1 ]
+      in
+      let test2 () =
+        (* Graph.iter requires a node as max, we cannot test a graph with only
+           contents. *)
+        let foo = P.Contents.Key.hash "foo" in
+        with_node repo (fun g -> Graph.v g [ ("b", normal foo) ]) >>= fun k1 ->
+        visited := [];
+        test_rev_order ~nodes:[ foo; k1 ] ~max:[ k1 ] >>= fun () ->
+        visited := [];
+        skipped := [];
+        test_skip ~max:[ k1 ] ~to_skip:[ k1 ] ~not_visited:[ foo ]
+      in
+      let test3 () =
+        let foo = P.Contents.Key.hash "foo" in
+        with_node repo (fun g -> Graph.v g [ ("b1", normal foo) ])
+        >>= fun kb1 ->
+        with_node repo (fun g -> Graph.v g [ ("a1", `Node kb1) ]) >>= fun ka1 ->
+        with_node repo (fun g -> Graph.v g [ ("a2", `Node kb1) ]) >>= fun ka2 ->
+        with_node repo (fun g -> Graph.v g [ ("b2", normal foo) ])
+        >>= fun kb2 ->
+        with_node repo (fun g ->
+            Graph.v g
+              [ ("c1", `Node ka1); ("c2", `Node ka2); ("c3", `Node kb2) ])
+        >>= fun kc ->
+        let nodes = [ foo; kb1; ka1; ka2; kb2; kc ] in
+        visited := [];
+        test_rev_order ~nodes ~max:[ kc ] >>= fun () ->
+        visited := [];
+        test_in_order ~nodes ~max:[ kc ] >>= fun () ->
+        visited := [];
+        skipped := [];
+        test_skip ~max:[ kc ] ~to_skip:[ ka1; ka2 ] ~not_visited:[ kb1 ]
+        >>= fun () ->
+        visited := [];
+        skipped := [];
+        test_skip ~max:[ kc ] ~to_skip:[ ka1; ka2; kb2 ]
+          ~not_visited:[ kb1; foo ]
+        >>= fun () ->
+        visited := [];
+        test_min_max ~nodes ~min:[ kb1 ] ~max:[ ka1 ]
+          ~not_visited:[ foo; ka2; kb2; kc ]
+        >>= fun () ->
+        visited := [];
+        test_min_max ~nodes ~min:[ kc ] ~max:[ kc ]
+          ~not_visited:[ foo; kb1; ka1; ka2; kb2 ]
+      in
+      test1 () >>= fun () ->
+      test2 () >>= fun () ->
+      test3 () >>= fun () -> P.Repo.close repo
     in
     run x test
 

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -291,8 +291,8 @@ module Graph (S : S.NODE_STORE) = struct
 
   let ignore_lwt _ = Lwt.return_unit
 
-  let iter t ~min ~max ?(node = ignore_lwt) ?(contents = ignore_lwt) ?edge
-      ?(skip_node = fun _ -> Lwt.return_false)
+  let iter' ~graph_iter (t : [> `Read ] t) ~min ~max ?(node = ignore_lwt)
+      ?(contents = ignore_lwt) ?edge ?(skip_node = fun _ -> Lwt.return_false)
       ?(skip_contents = fun _ -> Lwt.return_false) ?(rev = true) () =
     let min = List.rev_map (fun x -> `Node x) min in
     let max = List.rev_map (fun x -> `Node x) max in
@@ -314,7 +314,12 @@ module Graph (S : S.NODE_STORE) = struct
       | `Contents c -> skip_contents c
       | _ -> Lwt.return_false
     in
-    Graph.iter ~pred:(pred t) ~min ~max ~node ?edge ~skip ~rev ()
+    graph_iter ~pred:(pred t) ~min ~max ~node ?edge ~skip ~rev ()
+
+  let iter t = iter' ~graph_iter:(Graph.iter ?depth:None) t
+
+  let iter_track_visited t =
+    iter' ~graph_iter:(Graph.iter_track_visited ?depth:None) t
 
   let v t xs = S.add t (S.Val.v xs)
 

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -51,6 +51,18 @@ module type S = sig
     unit ->
     t Lwt.t
 
+  val iter_track_visited :
+    ?depth:int ->
+    pred:(vertex -> vertex list Lwt.t) ->
+    min:vertex list ->
+    max:vertex list ->
+    node:(vertex -> unit Lwt.t) ->
+    ?edge:(vertex -> vertex -> unit Lwt.t) ->
+    skip:(vertex -> bool Lwt.t) ->
+    rev:bool ->
+    unit ->
+    unit Lwt.t
+
   val iter :
     ?depth:int ->
     pred:(vertex -> vertex list Lwt.t) ->
@@ -137,9 +149,6 @@ module Make (Hash : Type.S) (Branch : Type.S) = struct
     Log.debug (fun f ->
         f "@[<2>iter:@ %arev=%b,@ min=%a,@ max=%a@]" pp_depth depth rev
           pp_vertices min pp_vertices max);
-    let marks = Table.create 1024 in
-    let mark key level = Table.add marks key level in
-    let has_mark key = Table.mem marks key in
     let todo = Stack.create () in
     (* if a branch is in [min], add the commit it is pointing to too. *)
     Lwt_list.fold_left_s
@@ -148,7 +157,6 @@ module Make (Hash : Type.S) (Branch : Type.S) = struct
         | x -> Lwt.return (x :: acc))
       [] min
     >>= fun min ->
-    List.iter (fun k -> Stack.push (k, 0) todo) max;
     let treat key =
       Log.debug (fun f -> f "TREAT %a" Type.(pp X.t) key);
       node key >>= fun () ->
@@ -161,46 +169,67 @@ module Make (Hash : Type.S) (Branch : Type.S) = struct
             pred key >>= fun keys -> Lwt_list.iter_p (fun k -> edge key k) keys
       else Lwt.return_unit
     in
-    let rec pop key level =
-      ignore (Stack.pop todo);
-      mark key level;
-      visit ()
-    and visit () =
-      match Stack.top todo with
-      | exception Stack.Empty -> Lwt.return_unit
-      | key, level -> (
-          if level >= depth then pop key level
-          else if has_mark key then (
-            (if rev then treat key else Lwt.return_unit) >>= fun () ->
-            ignore (Stack.pop todo);
-            visit ())
-          else
-            skip key >>= function
-            | true -> pop key level
-            | false -> (
-                Log.debug (fun f -> f "VISIT %a %d" Type.(pp X.t) key level);
-                (if not rev then treat key else Lwt.return_unit) >>= fun () ->
-                mark key level;
-                let push_pred ~filter_history () =
-                  pred key >>= fun keys ->
-                  (*if a commit is in [min] cut the history but still visit
-                     its nodes. *)
-                  List.iter
-                    (function
-                      | `Commit _ when filter_history -> ()
-                      | k ->
-                          if not (has_mark k) then
-                            Stack.push (k, level + 1) todo)
-                    keys;
-                  visit ()
-                in
-                match key with
-                | `Commit _ -> push_pred ~filter_history:(List.mem key min) ()
-                | _ ->
-                    if List.mem key min then visit ()
-                    else push_pred ~filter_history:false ()))
+    let rec visit parent = function
+      | [] -> (
+          (if rev then treat parent else Lwt.return_unit) >>= fun () ->
+          match Stack.pop todo with
+          | exception Stack.Empty -> Lwt.return_unit
+          | parent, children -> ( visit parent children [@tail]))
+      | (key, level) :: tl -> (
+          skip key >>= function
+          | true -> ( visit parent tl [@tail])
+          | false ->
+              if level >= depth then Lwt.return_unit
+              else (
+                Log.debug (fun f -> f "VISIT %a" Type.(pp X.t) key);
+                if List.mem key min then
+                  treat key >>= fun () -> (visit parent tl [@tail])
+                else
+                  (if not rev then treat key else Lwt.return_unit) >>= fun () ->
+                  Stack.push (parent, tl) todo;
+                  let prepare_pred ~filter_history () =
+                    pred key >|= fun keys ->
+                    (*if a commit is in [min] cut the history but still visit
+                       its nodes. *)
+                    List.filter
+                      (function
+                        | `Commit _ when filter_history -> false | _ -> true)
+                      keys
+                  in
+                  (match key with
+                  | `Commit _ ->
+                      prepare_pred ~filter_history:(List.mem key min) ()
+                  | _ -> prepare_pred ~filter_history:false ())
+                  >>= fun keys ->
+                  let keys = List.map (fun k -> (k, level + 1)) keys in
+                  (visit key keys [@tail])))
     in
-    visit ()
+    let visit_max key =
+      skip key >>= function
+      | true -> Lwt.return_unit
+      | false ->
+          if depth = 0 then Lwt.return_unit
+          else (
+            Log.debug (fun f -> f "VISIT %a" Type.(pp X.t) key);
+            if List.mem key min then treat key
+            else
+              (if not rev then treat key else Lwt.return_unit) >>= fun () ->
+              pred key >>= fun keys ->
+              List.map (fun k -> (k, 1)) keys |> visit key)
+    in
+    Lwt_list.iter_s (fun m -> visit_max m) max
+
+  let iter_track_visited ?(depth = max_int) ~pred ~min ~max ~node ?edge ~skip
+      ~rev () =
+    let marks = Table.create 1024 in
+    let mark key = Table.add marks key () in
+    let has_mark key = Table.mem marks key in
+    let node k =
+      mark k;
+      node k
+    in
+    let skip k = if has_mark k then Lwt.return_true else skip k in
+    iter ~depth ~pred ~min ~max ~node ?edge ~skip ~rev ()
 
   let closure ?(depth = max_int) ~pred ~min ~max () =
     let g = G.create ~size:1024 () in
@@ -214,7 +243,8 @@ module Make (Hash : Type.S) (Branch : Type.S) = struct
       Lwt.return_unit
     in
     let skip _ = Lwt.return_false in
-    iter ~depth ~pred ~min ~max ~node ~edge ~skip ~rev:false () >|= fun () -> g
+    iter_track_visited ~depth ~pred ~min ~max ~node ~edge ~skip ~rev:false ()
+    >|= fun () -> g
 
   let min g =
     G.fold_vertex

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -47,6 +47,18 @@ module type S = sig
 
       {b Note:} Both [min] and [max] are subsets of [n]. *)
 
+  val iter_track_visited :
+    ?depth:int ->
+    pred:(vertex -> vertex list Lwt.t) ->
+    min:vertex list ->
+    max:vertex list ->
+    node:(vertex -> unit Lwt.t) ->
+    ?edge:(vertex -> vertex -> unit Lwt.t) ->
+    skip:(vertex -> bool Lwt.t) ->
+    rev:bool ->
+    unit ->
+    unit Lwt.t
+
   val iter :
     ?depth:int ->
     pred:(vertex -> vertex list Lwt.t) ->

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -380,6 +380,19 @@ module type NODE_GRAPH = sig
       predecessors; [edge n p] is applied after [node n]. Note that [edge n p]
       is applied even if [p] is skipped. *)
 
+  val iter_track_visited :
+    [> `Read ] t ->
+    min:node list ->
+    max:node list ->
+    ?node:(node -> unit Lwt.t) ->
+    ?contents:(contents -> unit Lwt.t) ->
+    ?edge:(node -> node -> unit Lwt.t) ->
+    ?skip_node:(node -> bool Lwt.t) ->
+    ?skip_contents:(contents -> bool Lwt.t) ->
+    ?rev:bool ->
+    unit ->
+    unit Lwt.t
+
   (** {1 Value Types} *)
 
   val metadata_t : metadata Type.t

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -402,6 +402,10 @@ module Make (P : S.PRIVATE) = struct
         | `Branch x -> pred_branch t x
       in
       KGraph.iter ~pred ~min ~max ~node ?edge ~skip ~rev ()
+
+    let iter_nodes t = Graph.iter ?edge:None ~rev:true (graph_t t)
+
+    let iter_commits t = H.iter ?edge:None ~rev:true (history_t t)
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -178,6 +178,29 @@ module type S = sig
         - branch objects in [min] implicitly add to [min] the commit they are
           pointing to; this allow users to define the iteration between two
           branches. *)
+
+    val iter_nodes :
+      t ->
+      min:hash list ->
+      max:hash list ->
+      ?node:(hash -> unit Lwt.t) ->
+      ?contents:(hash -> unit Lwt.t) ->
+      ?skip_node:(hash -> bool Lwt.t) ->
+      ?skip_contents:(hash -> bool Lwt.t) ->
+      unit ->
+      unit Lwt.t
+    (** [iter t] iterates in reverse topological order over the closure graph of
+        [t]. *)
+
+    val iter_commits :
+      t ->
+      min:hash list ->
+      max:hash list ->
+      ?commit:(hash -> unit Lwt.t) ->
+      ?skip:(hash -> bool Lwt.t) ->
+      unit ->
+      unit Lwt.t
+    (** [iter t] iterates over the closure graph of [t]. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
When traversing the closure graph of a commit during a freeze we don't need to remember the visited objects: those are already copied in their destination layer, and the skip function will skip them anyway. It is only a small optimisation (it saves ~4min out of 30min for the first freeze in bench_layers) and it saves a bit of memory allocations as well. 
This PR:
<img width="499" alt="no_hashtbl" src="https://user-images.githubusercontent.com/16655454/98693421-8e8f5700-2370-11eb-944c-5dcc935de7e3.png">
vs master:
<img width="512" alt="with_hashtbl" src="https://user-images.githubusercontent.com/16655454/98693435-95b66500-2370-11eb-8074-a003d87165dd.png">
