### PR TITLE
Iterate better over the object graph and use it to improve copies

### DIFF
--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -31,7 +31,11 @@ module type S = sig
 
   module Key : Irmin.Hash.S with type t = key
 
-  module Val : Irmin.Private.Node.S with type t = value and type hash = key
+  module Val : sig
+    include Irmin.Private.Node.S with type t = value and type hash = key
+
+    val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+  end
 
   include S.CHECKABLE with type 'a t := 'a t and type key := key
 
@@ -52,6 +56,8 @@ module type INODE_INTER = sig
   module Val : sig
     type t
 
+    val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+
     val of_bin : Elt.t -> t
 
     val save : add:(hash -> Elt.t -> unit) -> mem:(hash -> bool) -> t -> unit
@@ -71,9 +77,11 @@ module type VAL_INTER = sig
 
   type inode_val
 
-  type t = { mutable find : hash -> inode_val option; v : inode_val }
+  type t = { find : hash -> inode_val option; v : inode_val }
 
   include Irmin.Private.Node.S with type hash := hash and type t := t
+
+  val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
 end
 
 module type PACK_INTER = sig

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -56,7 +56,7 @@ module type S = sig
 
   val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
 
-  val unsafe_consume_newies : unit -> key list
+  val unsafe_consume_newies : 'a t -> key list
 
   val consume_newies : 'a t -> key list Lwt.t
 end

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -590,6 +590,10 @@ struct
 
   let pause = Lwt.pause
 
+  let pp_commits = Fmt.Dump.list Commit.pp_hash
+
+  let pp_elts = Fmt.Dump.list (Irmin.Type.pp Repo.elt_t)
+
   module Copy = struct
     let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
 
@@ -615,95 +619,73 @@ struct
           true
       | false -> false
 
-    let copy_tree ~skip_nodes ~skip_contents nodes contents t root =
+    let no_skip _ = Lwt.return false
+
+    let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+        ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
       (* if node or contents are already in dst then they are skipped by
          Graph.iter; there is no need to check this again when the object is
          copied *)
-      let node k =
-        pause () >>= fun () -> X.Node.CA.copy nodes t.X.Repo.node k >>= pause
-      in
+      let commit k = X.Commit.CA.copy commits t.X.Repo.commit "Commit" k in
+      let node k = X.Node.CA.copy nodes t.X.Repo.node k in
       let contents k =
         X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
       in
       let skip_node h = skip_with_stats ~skip:skip_nodes h in
       let skip_contents h = skip_with_stats ~skip:skip_contents h in
-      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_node
-        ~skip_contents ()
-
-    let copy_commit ~skip_nodes ~skip_contents contents nodes commits t k =
-      let aux c =
-        copy_tree ~skip_nodes ~skip_contents nodes contents t
-          (X.Commit.Val.node c)
-      in
-      X.Commit.CA.copy commits t.X.Repo.commit ~aux "Commit" k
+      let skip_commit h = skip_with_stats ~skip:skip_commits h in
+      Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
+        ~skip_commit ()
+      >|= fun () -> X.Repo.flush t
 
     module CopyToLower = struct
       let on_lower t f =
-        let contents = X.Contents.CA.lower t.X.Repo.contents in
-        let nodes = X.Node.CA.lower t.X.Repo.node in
-        let commits = X.Commit.CA.lower t.X.Repo.commit in
-        f contents nodes commits
+        let contents =
+          (X.Contents.CA.Lower, X.Contents.CA.lower t.X.Repo.contents)
+        in
+        let nodes = (X.Node.CA.Lower, X.Node.CA.lower t.X.Repo.node) in
+        let commits = (X.Commit.CA.Lower, X.Commit.CA.lower t.X.Repo.commit) in
+        f (contents, nodes, commits)
 
-      let copy_commit contents nodes commits t =
-        copy_commit ~skip_nodes:(mem_node_lower t)
-          ~skip_contents:(mem_contents_lower t)
-          (X.Contents.CA.Lower, contents)
-          (X.Node.CA.Lower, nodes)
-          (X.Commit.CA.Lower, commits)
-          t
-
-      let copy_max_commits ~max t =
-        Log.debug (fun f -> f "copy max commits to lower");
-        Lwt_list.iter_s
-          (fun k ->
-            let h = Commit.hash k in
-            on_lower t (fun contents nodes commits ->
-                mem_commit_lower t h >>= function
-                | true -> Lwt.return_unit
-                | false -> copy_commit contents nodes commits t h))
-          max
-
-      let copy ~min ~max t =
-        let max = List.map (fun x -> Commit.hash x) max in
-        let min = List.map (fun x -> Commit.hash x) min in
-        let skip h = skip_with_stats ~skip:(mem_commit_lower t) h in
-        on_lower t (fun contents nodes commits ->
-            let commit = copy_commit contents nodes commits t in
-            Repo.iter_commits t ~min ~max ~commit ~skip ())
+      let copy ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to lower:@ min=%a,@ max=%a@]" pp_commits min pp_commits
+              commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        let min = List.map (fun x -> `Commit (Commit.hash x)) min in
+        on_lower t (fun l ->
+            iter_copy l ~skip_commits:(mem_commit_lower t)
+              ~skip_nodes:(mem_node_lower t)
+              ~skip_contents:(mem_contents_lower t) t ~min max)
     end
 
     module CopyToUpper = struct
       let on_next_upper t f =
-        let contents = X.Contents.CA.next_upper t.X.Repo.contents in
-        let nodes = X.Node.CA.next_upper t.X.Repo.node in
-        let commits = X.Commit.CA.next_upper t.X.Repo.commit in
-        f contents nodes commits
-
-      let copy_commit contents nodes commits t =
-        copy_commit ~skip_nodes:(mem_node_next t)
-          ~skip_contents:(mem_contents_next t)
-          (X.Contents.CA.Upper, contents)
-          (X.Node.CA.Upper, nodes)
-          (X.Commit.CA.Upper, commits)
-          t
-
-      let copy ~min ~max t =
-        let skip h = skip_with_stats ~skip:(mem_commit_next t) h in
-        on_next_upper t (fun contents nodes commits ->
-            let commit = copy_commit contents nodes commits t in
-            Repo.iter_commits t ~min ~max ~commit ~skip ())
-
-      let copy_commits ~min ~max t =
-        Log.debug (fun f ->
-            f "copy commits to next upper %s" (X.Repo.log_current_upper t));
-        let max = List.map (fun x -> Commit.hash x) max in
-        (* if min is empty then copy only the max commits *)
-        let min =
-          match min with
-          | [] -> max
-          | min -> List.map (fun x -> Commit.hash x) min
+        let contents =
+          (X.Contents.CA.Upper, X.Contents.CA.next_upper t.X.Repo.contents)
         in
-        copy ~min ~max t
+        let nodes = (X.Node.CA.Upper, X.Node.CA.next_upper t.X.Repo.node) in
+        let commits =
+          (X.Commit.CA.Upper, X.Commit.CA.next_upper t.X.Repo.commit)
+        in
+        f (contents, nodes, commits)
+
+      let copy ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to next upper:@ min=%a,@ max=%a@]" pp_commits min
+              pp_commits commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        (* When copying to next upper, if the min is empty then we copy only the
+           max. *)
+        let min =
+          List.map (fun x -> `Commit (Commit.hash x)) min |> function
+          | [] -> max
+          | min -> min
+        in
+        on_next_upper t (fun u ->
+            iter_copy u ~skip_commits:(mem_commit_next t)
+              ~skip_nodes:(mem_node_next t) ~skip_contents:(mem_contents_next t)
+              ~min t max)
 
       let equal_hash = Irmin.Type.(unstage (equal Hash.t))
 
@@ -715,25 +697,30 @@ struct
           if includes min x then ok := true;
           Lwt.return_unit
         in
-        Repo.iter_commits t ~min ~max:[ head ] ~commit () >|= fun () -> !ok
+        Repo.iter t
+          ~skip_node:(fun _ -> Lwt.return true)
+          ~skip_contents:(fun _ -> Lwt.return true)
+          ~min:(List.map (fun x -> `Commit x) min)
+          ~max:[ `Commit head ] ~commit ()
+        >|= fun () -> !ok
 
       (** Copy the heads that include a max commit *)
       let copy_heads ~max ~heads t =
         Log.debug (fun f ->
             f "copy heads to current %s" (X.Repo.log_current_upper t));
-        let max = List.map (fun x -> Commit.hash x) max in
-        let heads = List.map (fun x -> Commit.hash x) heads in
+        let max_hashes = List.map (fun x -> Commit.hash x) max in
         Lwt_list.fold_left_s
           (fun acc head ->
+            let head_hash = Commit.hash head in
             (*if a head is a max commit then already copied*)
-            if includes max head then Lwt.return acc
+            if includes max_hashes head_hash then Lwt.return acc
             else
               (*if a head is after the max commit then copy it*)
-              non_empty_intersection t max head >|= function
+              non_empty_intersection t max_hashes head_hash >|= function
               | true -> head :: acc
               | false -> acc)
           [] heads
-        >>= fun heads -> copy ~min:max ~max:heads t
+        >>= fun heads -> copy ~min:max t heads
 
       (** Newies are the objects added in current upper during the freeze. They
           are copied to the next upper before the freeze ends. When copying the
@@ -743,7 +730,6 @@ struct
           we have to iter over the graph of commits, iter over the graph of
           nodes, and lastly iter over contents. *)
       let copy_newies_aux ~with_lock t =
-        Log.debug (fun l -> l "copy newies");
         let newies_commits =
           if with_lock then
             X.Commit.CA.unsafe_consume_newies t.X.Repo.commit
@@ -765,49 +751,31 @@ struct
             |> Lwt.return
           else X.Contents.CA.consume_newies t.X.Repo.contents >|= List.rev
         in
-        let copy_contents contents t k =
-          X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
+        newies_commits >>= fun newies_commits ->
+        newies_nodes >>= fun newies_nodes ->
+        newies_contents >>= fun newies_contents ->
+        let newies_commits = List.rev_map (fun x -> `Commit x) newies_commits in
+        let newies_nodes = List.rev_map (fun x -> `Node x) newies_nodes in
+        let newies_contents = List.map (fun x -> `Contents x) newies_contents in
+        let newies =
+          (* mewies_node can grow very large so do not traverse it (it
+             should always be the 2nd argument of rev_append) *)
+          List.rev_append newies_commits
+            (List.rev_append newies_contents newies_nodes)
         in
-        let copy_tree contents nodes t k =
-          let skip_nodes k = mem_node_next t k in
-          let skip_contents k = mem_contents_next t k in
-          copy_tree ~skip_nodes ~skip_contents nodes contents t k
-        in
-        let copy_commit contents nodes commits t k =
+        Log.debug (fun l -> l "copy newies: %a" pp_elts newies);
+        (* we want to copy all the new commits; stop whenever one
+           commmit already in the other upper or in lower. *)
+        let skip_commits k =
           mem_commit_next t k >>= function
-          | true -> Lwt.return_unit
-          | false ->
-              let aux c = copy_tree contents nodes t (X.Commit.Val.node c) in
-              X.Commit.CA.copy commits t.X.Repo.commit ~aux "Commit" k
+          | true -> Lwt.return true
+          | false -> mem_commit_lower t k
         in
-        let iter ~mem_next ~copy t objs =
-          let rec aux objs =
-            Lwt_list.filter_s (fun k -> mem_next t k >|= not) objs >>= function
-            | [] -> Lwt.return_unit
-            | objs ->
-                Lwt_list.find_s (fun k -> mem_next t k >|= not) objs
-                >>= fun obj ->
-                copy t obj >>= fun () -> (aux objs [@tail])
-          in
-          aux objs
-        in
-        on_next_upper t (fun contents nodes commits ->
-            let contents = (X.Contents.CA.Upper, contents) in
-            let nodes = (X.Node.CA.Upper, nodes) in
-            let commits = (X.Commit.CA.Upper, commits) in
-            Log.debug (fun l -> l "copy newies: iter commits");
-            newies_commits
-            >>= Lwt_list.iter_s (fun k ->
-                    copy_commit contents nodes commits t k)
-            >>= fun () ->
-            Log.debug (fun l -> l "copy newies: iter nodes");
-            newies_nodes
-            >>= iter ~mem_next:mem_node_next ~copy:(copy_tree contents nodes) t
-            >>= fun () ->
-            Log.debug (fun l -> l "copy newies: iter contents");
-            newies_contents
-            >>= iter ~mem_next:mem_contents_next ~copy:(copy_contents contents)
-                  t)
+        (* FIXME(samoht): do we need to traverse the newies
+           recursively if we don't need self-contained uppers. *)
+        on_next_upper t (fun u ->
+            iter_copy u ~skip_commits ~skip_nodes:(mem_node_next t)
+              ~skip_contents:(mem_contents_next t) t newies)
         >>= fun () ->
         if with_lock then X.Branch.copy_last_newies_to_next_upper t.branch
         else X.Branch.copy_newies_to_next_upper t.branch
@@ -828,36 +796,34 @@ struct
     end
 
     module CopyFromLower = struct
-      let on_current_upper t f =
-        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
-        let nodes = X.Node.CA.current_upper t.X.Repo.node in
-        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
-        f contents nodes commits
-
-      let copy_tree contents nodes t root =
-        let node k =
-          X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k >|= fun () ->
-          (* We have to ensure that a node is entirely flushed to disk.
-             If we rely on the implicit flush of io, it could be that
-             only a part of a node if flushed to disk when RO tries to
-             read it. *)
-          X.Node.CA.flush t.node
+      (* FIXME(samoht): copy/paste from iter_copy with s/copy/copy_from_lower *)
+      let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+          ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) cs =
+        (* if node or contents are already in dst then they are skipped by
+           Graph.iter; there is no need to check this again when the object is
+           copied *)
+        let commit k =
+          X.Commit.CA.copy_from_lower ~dst:commits t.X.Repo.commit "Commit" k
         in
+        let node k = X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k in
         let contents k =
           X.Contents.CA.copy_from_lower ~dst:contents t.X.Repo.contents
             "Contents" k
         in
-        (* We cannot skip nodes, because a node in upper can have a predecessor
-           in lower. Contents do not have predecessors, so we can skip them. *)
-        let skip_contents k = mem_contents_next t k in
-        Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_contents
-          ()
-
-      let copy_commit contents nodes commits t hash =
-        let aux c = copy_tree contents nodes t (X.Commit.Val.node c) in
-        X.Commit.CA.copy_from_lower t.X.Repo.commit ~dst:commits ~aux "Commit"
-          hash
+        let skip_node h = skip_with_stats ~skip:skip_nodes h in
+        let skip_contents h = skip_with_stats ~skip:skip_contents h in
+        let skip_commit h = skip_with_stats ~skip:skip_commits h in
+        let max = List.map (fun c -> `Commit c) cs in
+        let min = List.map (fun c -> `Commit c) min in
+        Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
+          ~skip_commit ()
         >|= fun () -> X.Repo.flush t
+
+      let on_current_upper t f =
+        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
+        let nodes = X.Node.CA.current_upper t.X.Repo.node in
+        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
+        f (contents, nodes, commits)
 
       (** The commits can be in either lower or upper. We don't skip an object
           already in upper as its predecessors could be in lower. *)
@@ -868,6 +834,8 @@ struct
           | None -> max (* if min is empty then copy only the max commits *)
           | Some min -> List.map (fun x -> Commit.hash x) min
         in
+        (* FIXME(samoht): do this in 2 steps: 1/ find the shallow
+           hashes in upper 2/ iterates with max=shallow *)
         Log.debug (fun l ->
             l
               "self_contained: copy commits min:%a; max:%a from lower into \
@@ -876,9 +844,7 @@ struct
               min
               (Fmt.list (Irmin.Type.pp H.t))
               max);
-        on_current_upper t (fun contents nodes commits ->
-            let commit h = copy_commit contents nodes commits t h in
-            Repo.iter_commits t ~min ~max ~commit ())
+        on_current_upper t (fun u -> iter_copy u ~min t max)
     end
   end
 
@@ -897,15 +863,15 @@ struct
     (* Copy commits to lower: if squash then copy only the max commits *)
     let with_lower = with_lower t.X.Repo.config in
     (if with_lower then
-     with_stats "copied in lower"
-       (if squash then Copy.CopyToLower.copy_max_commits ~max t
-       else Copy.CopyToLower.copy ~min ~max t)
+     let min = if squash then max else min in
+     with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
     else Lwt.return_unit)
     >>= fun () ->
     (* Copy [min_upper, max] and [max, heads] to next_upper *)
+    (* FIXME(samoht): not sure to understand why *)
     (if copy_in_upper then
      with_stats "copied in upper"
-       ( Copy.CopyToUpper.copy_commits ~min:min_upper ~max t >>= fun () ->
+       ( Copy.CopyToUpper.copy ~min:min_upper t max >>= fun () ->
          Copy.CopyToUpper.copy_heads ~max ~heads t )
     else Lwt.return_unit)
     >>= fun () ->

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -746,17 +746,23 @@ struct
         Log.debug (fun l -> l "copy newies");
         let newies_commits =
           if with_lock then
-            X.Commit.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
+            X.Commit.CA.unsafe_consume_newies t.X.Repo.commit
+            |> List.rev
+            |> Lwt.return
           else X.Commit.CA.consume_newies t.X.Repo.commit >|= List.rev
         in
         let newies_nodes =
           if with_lock then
-            X.Node.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
+            X.Node.CA.unsafe_consume_newies t.X.Repo.node
+            |> List.rev
+            |> Lwt.return
           else X.Node.CA.consume_newies t.X.Repo.node >|= List.rev
         in
         let newies_contents =
           if with_lock then
-            X.Contents.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
+            X.Contents.CA.unsafe_consume_newies t.X.Repo.contents
+            |> List.rev
+            |> Lwt.return
           else X.Contents.CA.consume_newies t.X.Repo.contents >|= List.rev
         in
         let copy_contents contents t k =

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -621,6 +621,15 @@ struct
 
     let no_skip _ = Lwt.return false
 
+    let pred_node t k =
+      let n = snd (X.Repo.node_t t) in
+      X.Node.CA.find n k >|= function
+      | None -> []
+      | Some v ->
+          List.rev_map
+            (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
+            (X.Node.CA.Val.pred v)
+
     let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
         ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
       (* if node or contents are already in dst then they are skipped by
@@ -635,7 +644,7 @@ struct
       let skip_contents h = skip_with_stats ~skip:skip_contents h in
       let skip_commit h = skip_with_stats ~skip:skip_commits h in
       Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
-        ~skip_commit ()
+        ~pred_node ~skip_commit ()
       >|= fun () -> X.Repo.flush t
 
     module CopyToLower = struct
@@ -816,7 +825,7 @@ struct
         let max = List.map (fun c -> `Commit c) cs in
         let min = List.map (fun c -> `Commit c) min in
         Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
-          ~skip_commit ()
+          ~pred_node ~skip_commit ()
         >|= fun () -> X.Repo.flush t
 
       let on_current_upper t f =

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -741,24 +741,18 @@ struct
       let copy_newies_aux ~with_lock t =
         let newies_commits =
           if with_lock then
-            X.Commit.CA.unsafe_consume_newies t.X.Repo.commit
-            |> List.rev
-            |> Lwt.return
-          else X.Commit.CA.consume_newies t.X.Repo.commit >|= List.rev
+            X.Commit.CA.unsafe_consume_newies t.X.Repo.commit |> Lwt.return
+          else X.Commit.CA.consume_newies t.X.Repo.commit
         in
         let newies_nodes =
           if with_lock then
-            X.Node.CA.unsafe_consume_newies t.X.Repo.node
-            |> List.rev
-            |> Lwt.return
-          else X.Node.CA.consume_newies t.X.Repo.node >|= List.rev
+            X.Node.CA.unsafe_consume_newies t.X.Repo.node |> Lwt.return
+          else X.Node.CA.consume_newies t.X.Repo.node
         in
         let newies_contents =
           if with_lock then
-            X.Contents.CA.unsafe_consume_newies t.X.Repo.contents
-            |> List.rev
-            |> Lwt.return
-          else X.Contents.CA.consume_newies t.X.Repo.contents >|= List.rev
+            X.Contents.CA.unsafe_consume_newies t.X.Repo.contents |> Lwt.return
+          else X.Contents.CA.consume_newies t.X.Repo.contents
         in
         newies_commits >>= fun newies_commits ->
         newies_nodes >>= fun newies_nodes ->

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -954,6 +954,7 @@ struct
     (match heads with [] -> Repo.heads t | m -> Lwt.return m) >>= fun heads ->
     if t.X.Repo.closed then Lwt.fail_with "store is closed"
     else if Pack_config.readonly t.X.Repo.config then raise RO_Not_Allowed
+    else if Lwt_mutex.is_locked freeze_lock then Lwt.return ()
     else
       Irmin_layers.Stats.with_timer `Waiting (fun () ->
           Lwt_mutex.lock freeze_lock)

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -41,15 +41,16 @@ module Copy
 struct
   let copy ~src ~dst str k =
     Log.debug (fun l -> l "copy %s %a" str (Irmin.Type.pp Key.t) k);
-    SRC.find src k >>= function
+    match SRC.unsafe_find src k with
     | None ->
         Log.warn (fun l ->
             l "Attempt to copy %s %a not contained in upper." str
               (Irmin.Type.pp Key.t) k);
-        pause ()
+        Lwt.return_unit
     | Some v ->
         stats str;
-        DST.unsafe_add dst k v
+        DST.unsafe_append dst k v;
+        Lwt.return_unit
 end
 
 module Content_addressable

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -175,7 +175,7 @@ module type LAYERED = sig
     _ t ->
     (unit, Sigs.integrity_error) result
 
-  val unsafe_consume_newies : unit -> key list
+  val unsafe_consume_newies : _ t -> key list
 
   val consume_newies : 'a t -> key list Lwt.t
 end

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -123,21 +123,9 @@ module type LAYERED = sig
     | Upper : [ `Read ] U.t layer_type
     | Lower : [ `Read ] L.t layer_type
 
-  val copy :
-    'l layer_type * 'l ->
-    [ `Read ] t ->
-    ?aux:(value -> unit Lwt.t) ->
-    string ->
-    key ->
-    unit Lwt.t
+  val copy : 'l layer_type * 'l -> [ `Read ] t -> string -> key -> unit Lwt.t
 
-  val copy_from_lower :
-    [ `Read ] t ->
-    dst:'a U.t ->
-    ?aux:(value -> unit Lwt.t) ->
-    string ->
-    key ->
-    unit Lwt.t
+  val copy_from_lower : [ `Read ] t -> dst:'a U.t -> string -> key -> unit Lwt.t
 
   val mem_lower : 'a t -> key -> bool Lwt.t
 

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -402,10 +402,6 @@ module Make (P : S.PRIVATE) = struct
         | `Branch x -> pred_branch t x
       in
       KGraph.iter ~pred ~min ~max ~node ?edge ~skip ~rev ()
-
-    let iter_nodes t = Graph.iter (graph_t t)
-
-    let iter_commits t = H.iter (history_t t)
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -178,33 +178,6 @@ module type S = sig
         - branch objects in [min] implicitly add to [min] the commit they are
           pointing to; this allow users to define the iteration between two
           branches. *)
-
-    val iter_nodes :
-      t ->
-      min:hash list ->
-      max:hash list ->
-      ?node:(hash -> unit Lwt.t) ->
-      ?contents:(hash -> unit Lwt.t) ->
-      ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip_node:(hash -> bool Lwt.t) ->
-      ?skip_contents:(hash -> bool Lwt.t) ->
-      ?rev:bool ->
-      unit ->
-      unit Lwt.t
-    (** [iter t] iterates in reverse topological order over the closure graph of
-        [t]. *)
-
-    val iter_commits :
-      t ->
-      min:hash list ->
-      max:hash list ->
-      ?commit:(hash -> unit Lwt.t) ->
-      ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip:(hash -> bool Lwt.t) ->
-      ?rev:bool ->
-      unit ->
-      unit Lwt.t
-    (** [iter t] iterates over the closure graph of [t]. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
I have tried to replace all the custom composition of `iter_node` and `iter_commit` by a global iterator. I then specialised that iterator to iterate over inodes too, to speed-up copies.

The early results are encouraging:

```
▶ time dune exec -- ./test/irmin-pack/bench_layers.exe -n 100 > logs 2>&1
dune exec -- ./test/irmin-pack/bench_layers.exe -n 100 > logs 2>&1 
7.65s user 1.84s system 98% cpu 9.617 total
```
vs.
```
▶ time dune exec -- ./test/irmin-pack/bench_layers.exe -n 100 > logs 2>&1
dune exec -- ./test/irmin-pack/bench_layers.exe -n 100 > logs 2>&1 
25.20s user 9.84s system 98% cpu 35.469 total
```

But some of the tests are actually broken so there are very early results which can still change. 
There is a few more possible optimisation, but will focus first on upstreaming these changes properly (and fixing the tests).