### PR TITLE
doc: do not link to refer to private modules in doc strings.

### DIFF
--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -368,8 +368,7 @@ module type NODE_GRAPH = sig
     unit ->
     unit Lwt.t
   (** [iter t min max node edge skip rev ()] iterates in topological order over
-      the closure of [t] as specified by {{!Irmin__Object_graph.S.closure}
-      Object_graph.closure}.
+      the closure of [t].
 
       It applies the following functions while traversing the graph: [node] on
       the nodes; [edge n predecessor_of_n] on the directed edges; [skip_nodes n]

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -136,7 +136,7 @@ module type S = sig
       unit ->
       unit Lwt.t
     (** [iter t] iterates in reverse topological order over the closure graph of
-        [t] as specified by {{!Irmin__.S.NODE_GRAPH.iter} NODE_GRAPH.iter}. *)
+        [t]. *)
 
     val iter_commits :
       t ->
@@ -148,8 +148,7 @@ module type S = sig
       ?rev:bool ->
       unit ->
       unit Lwt.t
-    (** [iter t] iterates over the closure graph of [t] as specified by
-        {{!Irmin__.S.COMMIT_HISTORY.iter} COMMIT_HISTORY.iter}. *)
+    (** [iter t] iterates over the closure graph of [t]. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
Extracted from #1124 