### PR TITLE
irmin: add Repo.iter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,8 @@
   - Added `iter_commits` and `iter_nodes` functions to traverse the commits and
     nodes graphs (#1077, @icristescu)
 
+  - Added `Repo.iter` to traverse object graphs (#1128, @samoht)
+
 - **irmin-pack**:
   - Added `index_throttle` option to `Irmin_pack.config`, which exposes the
     memory throttle feature of `Index` in `Irmin-Pack`. (#1049, @icristescu)

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -622,12 +622,12 @@ struct
       let node k =
         pause () >>= fun () -> X.Node.CA.copy nodes t.X.Repo.node k >>= pause
       in
-      let contents (k, _) =
+      let contents k =
         X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
       in
-      let skip_nodes h = skip_with_stats ~skip:skip_nodes h in
+      let skip_node h = skip_with_stats ~skip:skip_nodes h in
       let skip_contents h = skip_with_stats ~skip:skip_contents h in
-      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_nodes
+      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_node
         ~skip_contents ()
 
     let copy_commit ~skip_nodes ~skip_contents contents nodes commits t k =
@@ -646,7 +646,7 @@ struct
 
       let copy_commit contents nodes commits t =
         copy_commit ~skip_nodes:(mem_node_lower t)
-          ~skip_contents:(fun (k, _) -> mem_contents_lower t k)
+          ~skip_contents:(mem_contents_lower t)
           (X.Contents.CA.Lower, contents)
           (X.Node.CA.Lower, nodes)
           (X.Commit.CA.Lower, commits)
@@ -681,7 +681,7 @@ struct
 
       let copy_commit contents nodes commits t =
         copy_commit ~skip_nodes:(mem_node_next t)
-          ~skip_contents:(fun (k, _) -> mem_contents_next t k)
+          ~skip_contents:(mem_contents_next t)
           (X.Contents.CA.Upper, contents)
           (X.Node.CA.Upper, nodes)
           (X.Commit.CA.Upper, commits)
@@ -764,7 +764,7 @@ struct
         in
         let copy_tree contents nodes t k =
           let skip_nodes k = mem_node_next t k in
-          let skip_contents (k, _) = mem_contents_next t k in
+          let skip_contents k = mem_contents_next t k in
           copy_tree ~skip_nodes ~skip_contents nodes contents t k
         in
         let copy_commit contents nodes commits t k =
@@ -837,13 +837,13 @@ struct
              read it. *)
           X.Node.CA.flush t.node
         in
-        let contents (k, _) =
+        let contents k =
           X.Contents.CA.copy_from_lower ~dst:contents t.X.Repo.contents
             "Contents" k
         in
         (* We cannot skip nodes, because a node in upper can have a predecessor
            in lower. Contents do not have predecessors, so we can skip them. *)
-        let skip_contents (k, _) = mem_contents_next t k in
+        let skip_contents k = mem_contents_next t k in
         Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_contents
           ()
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2118,14 +2118,13 @@ module Make (S : S) = struct
           Alcotest.failf "node %a skipped twice" (Irmin.Type.pp P.Hash.t) h1;
         skipped := step :: !skipped
       in
-      let skip_nodes k =
+      let skip_node k =
         P.Node.find n k >|= fun t ->
         mem k (get t) check_skip;
         if List.mem "b" !skipped then true else false
       in
       visited := [];
-      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~skip_nodes ~rev:false
-        ()
+      Graph.iter (g repo) ~min:[] ~max:[ k2; k3 ] ~node ~skip_node ~rev:false ()
       >>= fun () ->
       if List.mem "b" !visited then Alcotest.fail "b should be skipped";
       visited := [];

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -148,14 +148,11 @@ module History (S : S.COMMIT_STORE) = struct
     Log.debug (fun f -> f "parents %a" pp_key c);
     S.find t c >|= function None -> [] | Some c -> S.Val.parents c
 
-  module Graph =
-    Object_graph.Make (S.Node.Contents.Key) (S.Node.Metadata) (S.Node.Key)
-      (S.Key)
-      (struct
-        type t = unit
+  module U = struct
+    type t = unit [@@deriving irmin]
+  end
 
-        let t = Type.unit
-      end)
+  module Graph = Object_graph.Make (S.Key) (U)
 
   let edges t =
     Log.debug (fun f -> f "edges");

--- a/src/irmin/dot.ml
+++ b/src/irmin/dot.ml
@@ -53,9 +53,7 @@ module Make (S : Store.S) = struct
   module Node = S.Private.Node
   module Commit = S.Private.Commit
   module Slice = S.Private.Slice
-  module Graph =
-    Object_graph.Make (Contents.Key) (Node.Metadata) (Node.Key) (Commit.Key)
-      (Branch.Key)
+  module Graph = Object_graph.Make (S.Hash) (Branch.Key)
 
   let fprintf (t : db) ?depth ?(html = false) ?full ~date name =
     Log.debug (fun f ->
@@ -202,13 +200,8 @@ module Make (S : Store.S) = struct
             add_edge (`Branch r) [ `Style `Bold ] (`Commit k))
       bs
     >|= fun () ->
-    let map = function
-      | `Contents c -> `Contents (c, Node.Metadata.default)
-      | (`Commit _ | `Node _ | `Branch _) as k -> k
-    in
-    let vertex = Hashtbl.fold (fun k v acc -> (map k, v) :: acc) vertex [] in
-    let edges = List.map (fun (k, l, v) -> (map k, l, map v)) !edges in
-    fun ppf -> Graph.output ppf vertex edges name
+    let vertex = Hashtbl.fold (fun k v acc -> (k, v) :: acc) vertex [] in
+    fun ppf -> Graph.output ppf vertex !edges name
 
   let output_buffer t ?html ?depth ?full ~date buf =
     fprintf t ?depth ?full ?html ~date "graph" >|= fun fprintf ->

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -261,11 +261,11 @@ module Graph (S : S.NODE_STORE) = struct
     type t = unit [@@deriving irmin]
   end
 
-  module Graph = Object_graph.Make (Contents) (Metadata) (S.Key) (U) (U)
+  module Graph = Object_graph.Make (S.Key) (U)
 
   let edges t =
     List.rev_map
-      (function _, `Node n -> `Node n | _, `Contents c -> `Contents c)
+      (function _, `Node n -> `Node n | _, `Contents (c, _) -> `Contents c)
       (S.Val.list t)
 
   let pp_key = Type.pp S.Key.t
@@ -292,7 +292,7 @@ module Graph (S : S.NODE_STORE) = struct
   let ignore_lwt _ = Lwt.return_unit
 
   let iter t ~min ~max ?(node = ignore_lwt) ?(contents = ignore_lwt) ?edge
-      ?(skip_nodes = fun _ -> Lwt.return_false)
+      ?(skip_node = fun _ -> Lwt.return_false)
       ?(skip_contents = fun _ -> Lwt.return_false) ?(rev = true) () =
     let min = List.rev_map (fun x -> `Node x) min in
     let max = List.rev_map (fun x -> `Node x) max in
@@ -310,7 +310,7 @@ module Graph (S : S.NODE_STORE) = struct
         edge
     in
     let skip = function
-      | `Node x -> skip_nodes x
+      | `Node x -> skip_node x
       | `Contents c -> skip_contents c
       | _ -> Lwt.return_false
     in

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -101,15 +101,10 @@ module type S = sig
 end
 
 (** Build a graph. *)
-module Make
-    (Contents : Type.S)
-    (Metadata : Type.S)
-    (Node : Type.S)
-    (Commit : Type.S)
-    (Branch : Type.S) :
+module Make (Hash : Type.S) (Branch : Type.S) :
   S
     with type V.t =
-          [ `Contents of Contents.t * Metadata.t
-          | `Node of Node.t
-          | `Commit of Commit.t
+          [ `Contents of Hash.t
+          | `Node of Hash.t
+          | `Commit of Hash.t
           | `Branch of Branch.t ]

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -360,10 +360,10 @@ module type NODE_GRAPH = sig
     min:node list ->
     max:node list ->
     ?node:(node -> unit Lwt.t) ->
-    ?contents:(contents * metadata -> unit Lwt.t) ->
+    ?contents:(contents -> unit Lwt.t) ->
     ?edge:(node -> node -> unit Lwt.t) ->
-    ?skip_nodes:(node -> bool Lwt.t) ->
-    ?skip_contents:(contents * metadata -> bool Lwt.t) ->
+    ?skip_node:(node -> bool Lwt.t) ->
+    ?skip_contents:(contents -> bool Lwt.t) ->
     ?rev:bool ->
     unit ->
     unit Lwt.t
@@ -371,7 +371,7 @@ module type NODE_GRAPH = sig
       the closure of [t].
 
       It applies the following functions while traversing the graph: [node] on
-      the nodes; [edge n predecessor_of_n] on the directed edges; [skip_nodes n]
+      the nodes; [edge n predecessor_of_n] on the directed edges; [skip_node n]
       to not include a node [n], its predecessors and the outgoing edges of [n]
       and [skip_contents c] to not include content [c].
 


### PR DESCRIPTION
It allows to iterate efficiently over the object graph.

Extracted from #1124 