### PR TITLE
irmin-pack: remove dependency on memtrace

### DIFF
--- a/test/irmin-pack/bench_layers.ml
+++ b/test/irmin-pack/bench_layers.ml
@@ -255,7 +255,6 @@ let close config repo =
 let run config =
   rw config >>= fun repo ->
   first_5_cycles config repo >>= fun c ->
-  Memtrace.trace_if_requested ();
   run_cycles config repo c >>= fun _ ->
   close config repo >|= fun () ->
   if config.show_stats then (

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -28,4 +28,4 @@
 (executable
  (name bench_layers)
  (modules bench_layers)
- (libraries irmin-pack common logs memtrace))
+ (libraries irmin-pack common logs))


### PR DESCRIPTION
Looks like we've recently added a dependency on the `memtrace` package (without adding it into an `opam` file). Unfortunately, we can't afford this dependency on the main `irmin-pack.opam` file (even as a test dependency), since it would prevent us from being able to test on the version of OCaml currently used in Tezos.