### PR TITLE
irmin-layers: define layer IDs in one place

### DIFF
--- a/src/irmin-layers/dune
+++ b/src/irmin-layers/dune
@@ -1,4 +1,6 @@
 (library
  (public_name irmin-layers)
  (name irmin_layers)
- (libraries irmin logs lwt mtime mtime.clock.os))
+ (libraries irmin logs lwt mtime mtime.clock.os)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -17,11 +17,16 @@
 open Lwt.Infix
 include Irmin_layers_intf
 
-let pp_layer_id =
-  Fmt.of_to_string (function
+module Layer_id = struct
+  type t = layer_id [@@deriving irmin]
+
+  let to_string = function
     | `Upper0 -> "upper0"
     | `Upper1 -> "upper1"
-    | `Lower -> "lower")
+    | `Lower -> "lower"
+
+  let pp = Fmt.of_to_string to_string
+end
 
 module Make_ext
     (CA : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER)

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type layer_id = [ `Upper0 | `Upper1 | `Lower ]
+type layer_id = [ `Upper0 | `Upper1 | `Lower ] [@@deriving irmin]
 
 module type S = sig
   include Irmin.S
@@ -112,9 +112,13 @@ module type S_MAKER = functor
      and type hash = H.t
 
 module type Irmin_layers = sig
-  type nonrec layer_id = layer_id
+  module Layer_id : sig
+    type t = layer_id [@@deriving irmin]
 
-  val pp_layer_id : layer_id Fmt.t
+    val pp : Format.formatter -> t -> unit
+
+    val to_string : t -> string
+  end
 
   module type S = S
 

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -16,7 +16,7 @@ module type S = sig
     add_lock:Lwt_mutex.t ->
     [ `Read ] t
 
-  val layer_id : [ `Read ] t -> key -> Irmin_layers.layer_id Lwt.t
+  val layer_id : [ `Read ] t -> key -> Irmin_layers.Layer_id.t Lwt.t
 
   type 'a layer_type =
     | Upper : [ `Read ] U.t layer_type
@@ -47,7 +47,7 @@ module type S = sig
   val integrity_check :
     offset:int64 ->
     length:int ->
-    layer:Irmin_layers.layer_id ->
+    layer:Irmin_layers.Layer_id.t ->
     key ->
     'a t ->
     (unit, S.integrity_error) result

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -39,11 +39,11 @@ module Lock = IO_layers.Lock
 module IO_layers = IO_layers.IO
 
 module Default = struct
-  let lower_root = "lower"
+  let lower_root = Irmin_layers.Layer_id.to_string `Lower
 
-  let upper_root1 = "upper1"
+  let upper0_root = Irmin_layers.Layer_id.to_string `Upper0
 
-  let upper_root0 = "upper0"
+  let upper1_root = Irmin_layers.Layer_id.to_string `Upper1
 
   let copy_in_upper = false
 
@@ -62,13 +62,13 @@ let lower_root conf = Conf.get conf lower_root_key
 
 let upper_root1_key =
   Conf.key ~doc:"The root directory for the upper layer." "root_upper"
-    Conf.string Default.upper_root1
+    Conf.string Default.upper1_root
 
 let upper_root1 conf = Conf.get conf upper_root1_key
 
 let upper_root0_key =
   Conf.key ~doc:"The root directory for the secondary upper layer."
-    "root_second" Conf.string Default.upper_root0
+    "root_second" Conf.string Default.upper0_root
 
 let upper_root0 conf = Conf.get conf upper_root0_key
 
@@ -93,7 +93,7 @@ let blocking_copy_size_key =
 let blocking_copy_size conf = Conf.get conf blocking_copy_size_key
 
 let config_layers ?(conf = Conf.empty) ?(lower_root = Default.lower_root)
-    ?(upper_root1 = Default.upper_root1) ?(upper_root0 = Default.upper_root0)
+    ?(upper_root1 = Default.upper1_root) ?(upper_root0 = Default.upper0_root)
     ?(copy_in_upper = Default.copy_in_upper) ?(with_lower = Default.with_lower)
     ?(blocking_copy_size = Default.blocking_copy_size) () =
   let config = Conf.add conf lower_root_key lower_root in
@@ -1053,7 +1053,8 @@ module type S = sig
     auto_repair:bool ->
     repo ->
     ( [> `Fixed of int | `No_error ],
-      [> `Cannot_fix of string | `Corrupted of int ] * Irmin_layers.layer_id )
+      [> `Cannot_fix of string | `Corrupted of int ] * Irmin_layers.Layer_id.t
+    )
     result
     list
 end

--- a/src/irmin-pack/irmin_pack_layers.mli
+++ b/src/irmin-pack/irmin_pack_layers.mli
@@ -49,7 +49,8 @@ module type S = sig
     auto_repair:bool ->
     repo ->
     ( [> `Fixed of int | `No_error ],
-      [> `Cannot_fix of string | `Corrupted of int ] * Irmin_layers.layer_id )
+      [> `Cannot_fix of string | `Corrupted of int ] * Irmin_layers.Layer_id.t
+    )
     result
     list
 end

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -117,7 +117,7 @@ module type LAYERED = sig
     add_lock:Lwt_mutex.t ->
     [ `Read ] t
 
-  val layer_id : [ `Read ] t -> key -> Irmin_layers.layer_id Lwt.t
+  val layer_id : [ `Read ] t -> key -> Irmin_layers.Layer_id.t Lwt.t
 
   type 'a layer_type =
     | Upper : [ `Read ] U.t layer_type
@@ -170,7 +170,7 @@ module type LAYERED = sig
   val integrity_check :
     offset:int64 ->
     length:int ->
-    layer:Irmin_layers.layer_id ->
+    layer:Irmin_layers.Layer_id.t ->
     key ->
     _ t ->
     (unit, Sigs.integrity_error) result

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -243,10 +243,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
     run x test
 
   let check_layer repo handler msg exp =
-    S.layer_id repo handler >|= fun got ->
-    if not (got = exp) then
-      Alcotest.failf "%s expected %a got %a" msg Irmin_layers.pp_layer_id exp
-        Irmin_layers.pp_layer_id got
+    S.layer_id repo handler >|= check Irmin_layers.Layer_id.t msg exp
 
   let check_layer_for_commits repo commit msg exp =
     check_layer repo (S.Commit_t (S.Commit.hash commit)) msg exp

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -23,7 +23,7 @@ module Conf = struct
 
   let lower_root = "_lower"
 
-  let upper_root0 = "0"
+  let upper0_root = "0"
 
   let copy_in_upper = true
 
@@ -44,7 +44,7 @@ module StoreSimple =
 
 let config ?(readonly = false) ?(fresh = true)
     ?(copy_in_upper = Conf.copy_in_upper) ?(lower_root = Conf.lower_root)
-    ?(upper_root0 = Conf.upper_root0) ?(with_lower = Conf.with_lower) root =
+    ?(upper_root0 = Conf.upper0_root) ?(with_lower = Conf.with_lower) root =
   let conf = Irmin_pack.config ~readonly ?index_log_size ~fresh root in
   Irmin_pack.config_layers ~conf ~copy_in_upper ~lower_root ~upper_root0
     ~with_lower ()
@@ -331,7 +331,7 @@ module Test = struct
     commit_block1 ctxt >>= fun (ctxt, block1) ->
     Store.Repo.close ctxt.index.repo >>= fun () ->
     rm_store_from_disk store_name Conf.lower_root;
-    rm_store_from_disk store_name Conf.upper_root0;
+    rm_store_from_disk store_name Conf.upper0_root;
     clone ~readonly:false store_name >>= fun ctxt ->
     check_block1 ctxt.index.repo block1 >>= fun () ->
     freeze ctxt block1 >>= fun ctxt ->
@@ -344,7 +344,7 @@ module Test = struct
     freeze ctxt block1a >>= fun ctxt ->
     Store.Repo.close ctxt.index.repo >>= fun () ->
     rm_store_from_disk store_name Conf.lower_root;
-    rm_store_from_disk store_name Conf.upper_root0;
+    rm_store_from_disk store_name Conf.upper0_root;
     clone ~readonly:false store_name >>= fun ctxt ->
     check_block1a ctxt.index.repo block1a >>= fun () ->
     check_removed ctxt block1 "block1" >>= fun () ->
@@ -467,10 +467,7 @@ module Test = struct
     Store.PrivateLayer.wait_for_freeze () >>= fun () ->
     let check_layer block msg exp =
       Store.layer_id ctxt.index.repo (Store.Commit_t (Store.Commit.hash block))
-      >|= fun got ->
-      if not (got = exp) then
-        Alcotest.failf "%s expected %a got %a" msg Irmin_layers.pp_layer_id exp
-          Irmin_layers.pp_layer_id got
+      >|= Irmin_test.check Irmin_layers.Layer_id.t msg exp
     in
     check_layer block1 "check layer of block1" `Lower >>= fun () ->
     check_layer block1a "check layer of block1a" `Upper1 >>= fun () ->

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -326,8 +326,8 @@ module Test_corrupted_stores = struct
       let got = S.PrivateLayer.upper_in_use repo in
       let cast x = (x :> [ `Upper0 | `Upper1 | `Lower ]) in
       if not (got = exp) then
-        Alcotest.failf "%s expected %a got %a" msg Irmin_layers.pp_layer_id
-          (cast exp) Irmin_layers.pp_layer_id (cast got)
+        Alcotest.failf "%s expected %a got %a" msg Irmin_layers.Layer_id.pp
+          (cast exp) Irmin_layers.Layer_id.pp (cast got)
     in
     let* rw = S.Repo.v (config ~fresh:false root) in
     let* ro = S.Repo.v (config ~fresh:false ~readonly:true root) in


### PR DESCRIPTION
Just refactoring to avoid duplication of layer IDs and cleanup some testing logic.