### PR TITLE
irmin: use an optimized short hash function for crypto hashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,11 @@
   - `Irmin.Type` uses staging for `equal`, `short_hash` and `compare` to
     speed-up generic operations (#1130, #1131, #1132, @samoht)
 
+  - Change the function used by `Type.short_hash ~seed:None` for hashes to
+    be more efficient. This changes the outputs of that function. The outputs
+    of the seeded hash function (as used by irmin-pack's inodes) is not
+    modified. (#1143, @samoht @CraigFe)
+
 - **irmin-pack**:
   - `sync` has to be called by the read-only instance to synchronise with the
     files on disk. (#1008, @icristescu)

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1,3 +1,3 @@
-let suite = [ ("tree", Test_tree.suite) ]
+let suite = [ ("tree", Test_tree.suite); ("hash", Test_hash.suite) ]
 
 let () = Lwt_main.run (Alcotest_lwt.run "irmin" suite)

--- a/test/irmin/test_hash.ml
+++ b/test/irmin/test_hash.ml
@@ -1,0 +1,19 @@
+open Irmin
+
+let test_short_hash () =
+  let h = Hash.BLAKE2B.hash (fun f -> f "") in
+  let () =
+    Hash.BLAKE2B.short_hash h
+    |> Alcotest.(check int) "Specialised short hash" 241225442164632184
+  in
+  let () =
+    Type.(unstage (short_hash Hash.BLAKE2B.t)) ~seed:0 h
+    |> Alcotest.(check int) "Generic seeded short hash" 674923654
+  in
+  let () =
+    Type.(unstage (short_hash Hash.BLAKE2B.t)) ?seed:None h
+    |> Alcotest.(check int) "Generic unseeded short hash" 674923654
+  in
+  ()
+
+let suite = [ Alcotest_lwt.test_case_sync "short_hash" `Quick test_short_hash ]

--- a/test/irmin/test_hash.ml
+++ b/test/irmin/test_hash.ml
@@ -4,7 +4,7 @@ let test_short_hash () =
   let h = Hash.BLAKE2B.hash (fun f -> f "") in
   let () =
     Hash.BLAKE2B.short_hash h
-    |> Alcotest.(check int) "Specialised short hash" 241225442164632184
+    |> Alcotest.(check int) "Specialised short hash" 2020213495
   in
   let () =
     Type.(unstage (short_hash Hash.BLAKE2B.t)) ~seed:0 h
@@ -12,7 +12,7 @@ let test_short_hash () =
   in
   let () =
     Type.(unstage (short_hash Hash.BLAKE2B.t)) ?seed:None h
-    |> Alcotest.(check int) "Generic unseeded short hash" 674923654
+    |> Alcotest.(check int) "Generic unseeded short hash" 2020213495
   in
   ()
 

--- a/test/irmin/test_hash.mli
+++ b/test/irmin/test_hash.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest_lwt.test_case list


### PR DESCRIPTION
This changes the function used to compute `short_hash ~seed:None` to be more efficient.