### PR TITLE
Add json output and make target for benchmarking layered store.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 - **irmin-bench** (_new_):
   - Created a new package to contain benchmarks for Irmin and its various
     backends. (#1142, @CraigFe)
+  - Added ability to get json output and a make target to run layers benchmark.
+    (#1146, @gs0510)
 
 - **irmin**
   - Added `Tree.{Contents,Node}` modules exposing operations over lazy tree

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test fuzz bench-mem bench-pack bench doc examples
+.PHONY: all clean test fuzz bench-mem bench-pack bench-layers bench doc examples
 
 all:
 	dune build
@@ -12,7 +12,10 @@ bench-mem:
 bench-pack:
 	dune exec ./test/irmin-pack/bench.exe
 
-bench: bench-mem bench-pack
+bench-layers:
+	dune exec -- ./bench/irmin-pack/layers.exe -n 2005 -b 2 -j
+
+bench: bench-mem bench-pack bench-layers
 
 fuzz:
 	dune build @fuzz --no-buffer

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -1,6 +1,9 @@
 (executables
  (names main layers)
- (libraries irmin-pack irmin-test.bench irmin-layers lwt unix cmdliner logs))
+ (preprocess
+  (pps ppx_deriving_yojson))
+ (libraries irmin-pack irmin-test.bench irmin-layers lwt unix cmdliner logs
+   yojson ppx_deriving_yojson))
 
 ;; Require the above executables to compile during tests
 

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -319,7 +319,13 @@ let ncommits =
   Arg.(value @@ opt int 4096 doc)
 
 let ncycles =
-  let doc = Arg.info ~doc:"Number of cycles." [ "b"; "ncycles" ] in
+  let doc =
+    Arg.info
+      ~doc:
+        "Number of cycles. This will be in addition to the 5 cycles that run \
+         to emulate freeze."
+      [ "b"; "ncycles" ]
+  in
   Arg.(value @@ opt int 10 doc)
 
 let depth =

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -229,7 +229,7 @@ let first_5_cycles config repo =
   print_commit_stats config c 0 0.0;
   let rec aux i c =
     add_min c;
-    if i >= 4 then Lwt.return c
+    if i > 4 then Lwt.return c
     else write_cycle config repo c >>= fun c -> aux (i + 1) c
   in
   aux 0 c
@@ -268,17 +268,14 @@ let run config =
     FSHelper.print_size config.root)
 
 type result = {
-  number_of_commits : int;
   total_time : float;
   time_per_commit : float;
   commits_per_sec : float;
 }
 [@@deriving yojson]
 
-let get_json_str number_of_commits total_time time_per_commit commits_per_sec =
-  let res =
-    { number_of_commits; total_time; time_per_commit; commits_per_sec }
-  in
+let get_json_str total_time time_per_commit commits_per_sec =
+  let res = { total_time; time_per_commit; commits_per_sec } in
   let obj =
     `Assoc
       [
@@ -305,10 +302,10 @@ let main () ncommits ncycles depth clear no_freeze show_stats json =
   in
   init config;
   let d, _ = Lwt_main.run (with_timer (fun () -> run config)) in
-  let all_commits = ncommits * ncycles in
+  let all_commits = ncommits * (ncycles + 5) in
   let rate = d /. float all_commits in
   let freq = 1. /. rate in
-  if json then Logs.app (fun l -> l "%s" (get_json_str all_commits d rate freq))
+  if json then Logs.app (fun l -> l "%s" (get_json_str d rate freq))
   else
     Logs.app (fun l ->
         l

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -19,6 +19,8 @@ depends: [
   "cmdliner"
   "logs"
   "lwt"
+  "ppx_deriving_yojson"
+  "yojson"
 ]
 
 synopsis: "Irmin benchmarking suite"


### PR DESCRIPTION
@icristescu suggested 2005 as the number of commits since every 1000 commits, a tree is committed and there's 2 freeze cycles so that time can also be taken into account, I'd be open to just using the default value as well.

