### PR TITLE
irmin-pack: expose Checks module and Layered.S module type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,10 +70,10 @@
 
   - Added a `flush` function for a repo (#1092, @icristescu)
 
-  - Added `Make_layered` functor, to construct layered stores from irmin-pack.
+  - Added `Layered.Make functor, to construct layered stores from irmin-pack.
     (#882, @icristescu)
 
-  - Added `Make_checks`, which provides some offline checks for irmin-pack
+  - Added `Checks.Make which provides some offline checks for irmin-pack
     stores. (#1117, @icristescu, @CraigFe)
 
   - Added `reconstruct_index` to reconstruct an index from a pack file. (#1097,

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -61,7 +61,7 @@ end
 
 module Hash = Irmin.Hash.SHA1
 module Store =
-  Irmin_pack.Make_layered (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -384,14 +384,12 @@ module KV (Config : Config.S) (C : Irmin.Contents.S) =
   Make (Config) (Metadata) (C) (Path) (Irmin.Branch.String) (Hash)
 module Stats = Stats
 module Layout = Layout
+module Checks = Checks
 
 module Private = struct
   module Utils = Utils
 end
 
-module Make_ext_layered = Irmin_pack_layers.Make_ext
-module Make_layered = Irmin_pack_layers.Make
+module Layered = Irmin_pack_layers
 
 let config_layers = Irmin_pack_layers.config_layers
-
-module Make_checks = Checks.Make

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -101,6 +101,7 @@ end
 
 module Stats = Stats
 module Layout = Layout
+module Checks = Checks
 
 module Private : sig
   module Utils = Utils
@@ -117,6 +118,9 @@ val config_layers :
   unit ->
   Irmin.config
 
-module Make_ext_layered = Irmin_pack_layers.Make_ext
-module Make_layered = Irmin_pack_layers.Make
-module Make_checks = Checks.Make
+module Layered : sig
+  module type S = Irmin_pack_layers.S
+
+  module Make = Irmin_pack_layers.Make
+  module Make_ext = Irmin_pack_layers.Make_ext
+end

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -16,7 +16,7 @@ module Conf = struct
 end
 
 module Store =
-  Irmin_pack.Make_layered (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Irmin.Hash.BLAKE2B)

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -11,7 +11,7 @@ module Conf = struct
 end
 
 module Store =
-  Irmin_pack.Make_checks (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Checks.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Path)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -32,7 +32,7 @@ end
 
 module Hash = Irmin.Hash.SHA1
 module Store =
-  Irmin_pack.Make_layered (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -268,7 +268,7 @@ module Config_layered_store = struct
 end
 
 module Make_layered =
-  Irmin_pack.Make_layered (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -33,7 +33,7 @@ let suite =
   in
   let layered_store =
     Irmin_test.layered_store
-      (module Irmin_pack.Make_layered (Config))
+      (module Irmin_pack.Layered.Make (Config))
       (module Irmin.Metadata.None)
   in
   let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_dir in


### PR DESCRIPTION
- exposes the `Checks` module, which I forgot to do in https://github.com/mirage/irmin/pull/1141;
- exposes a module type for the layered store, and moves this into its own `Layered` namespace.

This is the necessary counterpart of https://github.com/tarides/tezos/pull/7.