### PR TITLE
irmin-pack: use Repo.iter to speed-up copies between layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,8 @@
     number. Version 1 of irmin-pack was used for the previous format, version 2
     is used with the new format. (#1047, @icristescu, @CraigFe, @samoht)
 
+  - Use `Repo.iter` to speed-up copies between layers (#1149, @samoht)
+
 - **ppx_irmin**:
 
   - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (#1082,

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -319,8 +319,6 @@ struct
                     let commit : 'a Commit.t = (node, commit) in
                     f contents node commit)))
 
-      let log_current_upper t = if t.flip then "upper1" else "upper0"
-
       let unsafe_v_upper root config =
         let fresh = Pack_config.fresh config in
         let lru_size = Pack_config.lru_size config in
@@ -588,6 +586,8 @@ struct
 
   let pause = Lwt.pause
 
+  let pp_commits = Fmt.Dump.list Commit.pp_hash
+
   module Copy = struct
     let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
 
@@ -613,95 +613,73 @@ struct
           true
       | false -> false
 
-    let copy_tree ~skip_nodes ~skip_contents nodes contents t root =
+    let no_skip _ = Lwt.return false
+
+    let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+        ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
       (* if node or contents are already in dst then they are skipped by
          Graph.iter; there is no need to check this again when the object is
          copied *)
-      let node k =
-        pause () >>= fun () -> X.Node.CA.copy nodes t.X.Repo.node k >>= pause
-      in
+      let commit k = X.Commit.CA.copy commits t.X.Repo.commit "Commit" k in
+      let node k = X.Node.CA.copy nodes t.X.Repo.node k in
       let contents k =
         X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
       in
       let skip_node h = skip_with_stats ~skip:skip_nodes h in
       let skip_contents h = skip_with_stats ~skip:skip_contents h in
-      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_node
-        ~skip_contents ()
-
-    let copy_commit ~skip_nodes ~skip_contents contents nodes commits t k =
-      let aux c =
-        copy_tree ~skip_nodes ~skip_contents nodes contents t
-          (X.Commit.Val.node c)
-      in
-      X.Commit.CA.copy commits t.X.Repo.commit ~aux "Commit" k
+      let skip_commit h = skip_with_stats ~skip:skip_commits h in
+      Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
+        ~skip_commit ()
+      >|= fun () -> X.Repo.flush t
 
     module CopyToLower = struct
       let on_lower t f =
-        let contents = X.Contents.CA.lower t.X.Repo.contents in
-        let nodes = X.Node.CA.lower t.X.Repo.node in
-        let commits = X.Commit.CA.lower t.X.Repo.commit in
-        f contents nodes commits
+        let contents =
+          (X.Contents.CA.Lower, X.Contents.CA.lower t.X.Repo.contents)
+        in
+        let nodes = (X.Node.CA.Lower, X.Node.CA.lower t.X.Repo.node) in
+        let commits = (X.Commit.CA.Lower, X.Commit.CA.lower t.X.Repo.commit) in
+        f (contents, nodes, commits)
 
-      let copy_commit contents nodes commits t =
-        copy_commit ~skip_nodes:(mem_node_lower t)
-          ~skip_contents:(mem_contents_lower t)
-          (X.Contents.CA.Lower, contents)
-          (X.Node.CA.Lower, nodes)
-          (X.Commit.CA.Lower, commits)
-          t
-
-      let copy_max_commits ~max t =
-        Log.debug (fun f -> f "copy max commits to lower");
-        Lwt_list.iter_s
-          (fun k ->
-            let h = Commit.hash k in
-            on_lower t (fun contents nodes commits ->
-                mem_commit_lower t h >>= function
-                | true -> Lwt.return_unit
-                | false -> copy_commit contents nodes commits t h))
-          max
-
-      let copy ~min ~max t =
-        let max = List.map (fun x -> Commit.hash x) max in
-        let min = List.map (fun x -> Commit.hash x) min in
-        let skip h = skip_with_stats ~skip:(mem_commit_lower t) h in
-        on_lower t (fun contents nodes commits ->
-            let commit = copy_commit contents nodes commits t in
-            Repo.iter_commits t ~min ~max ~commit ~skip ())
+      let copy ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to lower:@ min=%a,@ max=%a@]" pp_commits min pp_commits
+              commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        let min = List.map (fun x -> `Commit (Commit.hash x)) min in
+        on_lower t (fun l ->
+            iter_copy l ~skip_commits:(mem_commit_lower t)
+              ~skip_nodes:(mem_node_lower t)
+              ~skip_contents:(mem_contents_lower t) t ~min max)
     end
 
     module CopyToUpper = struct
       let on_next_upper t f =
-        let contents = X.Contents.CA.next_upper t.X.Repo.contents in
-        let nodes = X.Node.CA.next_upper t.X.Repo.node in
-        let commits = X.Commit.CA.next_upper t.X.Repo.commit in
-        f contents nodes commits
-
-      let copy_commit contents nodes commits t =
-        copy_commit ~skip_nodes:(mem_node_next t)
-          ~skip_contents:(mem_contents_next t)
-          (X.Contents.CA.Upper, contents)
-          (X.Node.CA.Upper, nodes)
-          (X.Commit.CA.Upper, commits)
-          t
-
-      let copy ~min ~max t =
-        let skip h = skip_with_stats ~skip:(mem_commit_next t) h in
-        on_next_upper t (fun contents nodes commits ->
-            let commit = copy_commit contents nodes commits t in
-            Repo.iter_commits t ~min ~max ~commit ~skip ())
-
-      let copy_commits ~min ~max t =
-        Log.debug (fun f ->
-            f "copy commits to next upper %s" (X.Repo.log_current_upper t));
-        let max = List.map (fun x -> Commit.hash x) max in
-        (* if min is empty then copy only the max commits *)
-        let min =
-          match min with
-          | [] -> max
-          | min -> List.map (fun x -> Commit.hash x) min
+        let contents =
+          (X.Contents.CA.Upper, X.Contents.CA.next_upper t.X.Repo.contents)
         in
-        copy ~min ~max t
+        let nodes = (X.Node.CA.Upper, X.Node.CA.next_upper t.X.Repo.node) in
+        let commits =
+          (X.Commit.CA.Upper, X.Commit.CA.next_upper t.X.Repo.commit)
+        in
+        f (contents, nodes, commits)
+
+      let copy ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to next upper:@ min=%a,@ max=%a@]" pp_commits min
+              pp_commits commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        (* When copying to next upper, if the min is empty then we copy only the
+           max. *)
+        let min =
+          List.map (fun x -> `Commit (Commit.hash x)) min |> function
+          | [] -> max
+          | min -> min
+        in
+        on_next_upper t (fun u ->
+            iter_copy u ~skip_commits:(mem_commit_next t)
+              ~skip_nodes:(mem_node_next t) ~skip_contents:(mem_contents_next t)
+              ~min t max)
 
       (** Newies are the objects added in current upper during the freeze. They
           are copied to the next upper before the freeze ends. When copying the
@@ -711,7 +689,6 @@ struct
           we have to iter over the graph of commits, iter over the graph of
           nodes, and lastly iter over contents. *)
       let copy_newies_aux ~with_lock t =
-        Log.debug (fun l -> l "copy newies");
         let newies_commits =
           if with_lock then
             X.Commit.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
@@ -727,49 +704,33 @@ struct
             X.Contents.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
           else X.Contents.CA.consume_newies t.X.Repo.contents >|= List.rev
         in
-        let copy_contents contents t k =
-          X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
+        newies_commits >>= fun newies_commits ->
+        newies_nodes >>= fun newies_nodes ->
+        newies_contents >>= fun newies_contents ->
+        let newies_commits = List.rev_map (fun x -> `Commit x) newies_commits in
+        let newies_nodes = List.rev_map (fun x -> `Node x) newies_nodes in
+        let newies_contents =
+          List.rev_map (fun x -> `Contents x) newies_contents
         in
-        let copy_tree contents nodes t k =
-          let skip_nodes k = mem_node_next t k in
-          let skip_contents k = mem_contents_next t k in
-          copy_tree ~skip_nodes ~skip_contents nodes contents t k
+        let newies =
+          (* mewies_node can grow very large so do not traverse it (it
+             should always be the 2nd argument of rev_append) *)
+          List.rev_append newies_commits
+            (List.rev_append newies_contents newies_nodes)
         in
-        let copy_commit contents nodes commits t k =
+        Log.debug (fun l -> l "copy newies");
+        (* we want to copy all the new commits; stop whenever one
+           commmit already in the other upper or in lower. *)
+        let skip_commits k =
           mem_commit_next t k >>= function
-          | true -> Lwt.return_unit
-          | false ->
-              let aux c = copy_tree contents nodes t (X.Commit.Val.node c) in
-              X.Commit.CA.copy commits t.X.Repo.commit ~aux "Commit" k
+          | true -> Lwt.return true
+          | false -> mem_commit_lower t k
         in
-        let iter ~mem_next ~copy t objs =
-          let rec aux objs =
-            Lwt_list.filter_s (fun k -> mem_next t k >|= not) objs >>= function
-            | [] -> Lwt.return_unit
-            | objs ->
-                Lwt_list.find_s (fun k -> mem_next t k >|= not) objs
-                >>= fun obj ->
-                copy t obj >>= fun () -> (aux objs [@tail])
-          in
-          aux objs
-        in
-        on_next_upper t (fun contents nodes commits ->
-            let contents = (X.Contents.CA.Upper, contents) in
-            let nodes = (X.Node.CA.Upper, nodes) in
-            let commits = (X.Commit.CA.Upper, commits) in
-            Log.debug (fun l -> l "copy newies: iter commits");
-            newies_commits
-            >>= Lwt_list.iter_s (fun k ->
-                    copy_commit contents nodes commits t k)
-            >>= fun () ->
-            Log.debug (fun l -> l "copy newies: iter nodes");
-            newies_nodes
-            >>= iter ~mem_next:mem_node_next ~copy:(copy_tree contents nodes) t
-            >>= fun () ->
-            Log.debug (fun l -> l "copy newies: iter contents");
-            newies_contents
-            >>= iter ~mem_next:mem_contents_next ~copy:(copy_contents contents)
-                  t)
+        (* FIXME(samoht): do we need to traverse the newies
+           recursively if we don't need self-contained uppers. *)
+        on_next_upper t (fun u ->
+            iter_copy u ~skip_commits ~skip_nodes:(mem_node_next t)
+              ~skip_contents:(mem_contents_next t) t newies)
         >>= fun () ->
         if with_lock then X.Branch.copy_last_newies_to_next_upper t.branch
         else X.Branch.copy_newies_to_next_upper t.branch
@@ -790,36 +751,34 @@ struct
     end
 
     module CopyFromLower = struct
-      let on_current_upper t f =
-        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
-        let nodes = X.Node.CA.current_upper t.X.Repo.node in
-        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
-        f contents nodes commits
-
-      let copy_tree contents nodes t root =
-        let node k =
-          X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k >|= fun () ->
-          (* We have to ensure that a node is entirely flushed to disk.
-             If we rely on the implicit flush of io, it could be that
-             only a part of a node if flushed to disk when RO tries to
-             read it. *)
-          X.Node.CA.flush t.node
+      (* FIXME(samoht): copy/paste from iter_copy with s/copy/copy_from_lower *)
+      let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+          ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) cs =
+        (* if node or contents are already in dst then they are skipped by
+           Graph.iter; there is no need to check this again when the object is
+           copied *)
+        let commit k =
+          X.Commit.CA.copy_from_lower ~dst:commits t.X.Repo.commit "Commit" k
         in
+        let node k = X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k in
         let contents k =
           X.Contents.CA.copy_from_lower ~dst:contents t.X.Repo.contents
             "Contents" k
         in
-        (* We cannot skip nodes, because a node in upper can have a predecessor
-           in lower. Contents do not have predecessors, so we can skip them. *)
-        let skip_contents k = mem_contents_next t k in
-        Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_contents
-          ()
-
-      let copy_commit contents nodes commits t hash =
-        let aux c = copy_tree contents nodes t (X.Commit.Val.node c) in
-        X.Commit.CA.copy_from_lower t.X.Repo.commit ~dst:commits ~aux "Commit"
-          hash
+        let skip_node h = skip_with_stats ~skip:skip_nodes h in
+        let skip_contents h = skip_with_stats ~skip:skip_contents h in
+        let skip_commit h = skip_with_stats ~skip:skip_commits h in
+        let max = List.map (fun c -> `Commit c) cs in
+        let min = List.map (fun c -> `Commit c) min in
+        Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
+          ~skip_commit ()
         >|= fun () -> X.Repo.flush t
+
+      let on_current_upper t f =
+        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
+        let nodes = X.Node.CA.current_upper t.X.Repo.node in
+        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
+        f (contents, nodes, commits)
 
       (** The commits can be in either lower or upper. We don't skip an object
           already in upper as its predecessors could be in lower. *)
@@ -830,6 +789,8 @@ struct
           | None -> max (* if min is empty then copy only the max commits *)
           | Some min -> List.map (fun x -> Commit.hash x) min
         in
+        (* FIXME(samoht): do this in 2 steps: 1/ find the shallow
+           hashes in upper 2/ iterates with max=shallow *)
         Log.debug (fun l ->
             l
               "self_contained: copy commits min:%a; max:%a from lower into \
@@ -838,9 +799,7 @@ struct
               min
               (Fmt.list (Irmin.Type.pp H.t))
               max);
-        on_current_upper t (fun contents nodes commits ->
-            let commit h = copy_commit contents nodes commits t h in
-            Repo.iter_commits t ~min ~max ~commit ())
+        on_current_upper t (fun u -> iter_copy u ~min t max)
     end
   end
 
@@ -859,15 +818,13 @@ struct
     (* Copy commits to lower: if squash then copy only the max commits *)
     let with_lower = with_lower t.X.Repo.config in
     (if with_lower then
-     with_stats "copied in lower"
-       (if squash then Copy.CopyToLower.copy_max_commits ~max t
-       else Copy.CopyToLower.copy ~min ~max t)
+     let min = if squash then max else min in
+     with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
     else Lwt.return_unit)
     >>= fun () ->
     (* Copy [min_upper, max] to next_upper *)
     (if copy_in_upper then
-     with_stats "copied in upper"
-       (Copy.CopyToUpper.copy_commits ~min:min_upper ~max t)
+     with_stats "copied in upper" (Copy.CopyToUpper.copy t ~min:min_upper max)
     else Lwt.return_unit)
     >>= fun () ->
     (* Copy branches to both lower and next_upper *)
@@ -964,34 +921,23 @@ struct
       incr errors;
       Lwt.return_unit
     in
-    let check_tree root =
-      let node k = X.Node.CA.check t.X.Repo.node ~none k in
-      let contents k = X.Contents.CA.check t.X.Repo.contents ~none k in
-      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ()
-    in
-    let check_commit commit =
-      let some c = check_tree (X.Commit.Val.node c) in
-      X.Commit.CA.check t.X.Repo.commit ~none ~some commit
-    in
+    let node k = X.Node.CA.check t.X.Repo.node ~none k in
+    let contents k = X.Contents.CA.check t.X.Repo.contents ~none k in
+    let commit k = X.Commit.CA.check t.X.Repo.commit ~none k in
     (match heads with None -> Repo.heads t | Some m -> Lwt.return m)
     >>= fun heads ->
-    let hashes = List.map (fun x -> Commit.hash x) heads in
-    Repo.iter_commits t ~min:[] ~max:hashes ~commit:check_commit ()
-    >>= fun () ->
+    let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
+    Repo.iter t ~min:[] ~max:hashes ~commit ~node ~contents () >|= fun () ->
     let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
     if !errors = 0 then
-      Lwt.return
-        (Ok
-           (`Msg
-             (Fmt.str "Upper layer is self contained for heads %a" pp_commits
-                heads)))
+      Fmt.kstrf
+        (fun x -> Ok (`Msg x))
+        "Upper layer is self contained for heads %a" pp_commits heads
     else
-      Lwt.return_error
-        (`Msg
-          (Fmt.str
-             "Upper layer is not self contained for heads %a: %n phantom \
-              objects detected"
-             pp_commits heads !errors))
+      Fmt.error_msg
+        "Upper layer is not self contained for heads %a: %n phantom objects \
+         detected"
+        pp_commits heads !errors
 
   module PrivateLayer = struct
     module Hook = struct

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -98,7 +98,8 @@ struct
 
   let log_next_upper t = if t.flip then "upper0" else "upper1"
 
-  let mem_lower t k = Option.get t.lower |> fun lower -> L.mem lower k
+  let mem_lower t k =
+    match t.lower with None -> Lwt.return false | Some lower -> L.mem lower k
 
   let mem_next t k = U.mem (next_upper t) k
 
@@ -332,6 +333,7 @@ struct
   (** The object [k] can be in either lower or upper. If already in upper then
       do not copy it. *)
   let copy_from_lower t ~dst ?(aux = fun _ -> Lwt.return_unit) str k =
+    (* FIXME(samoht): why does this function need to be different from the previous one? *)
     let lower = lower t in
     let current = current_upper t in
     U.find current k >>= function

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -402,10 +402,6 @@ module Make (P : S.PRIVATE) = struct
         | `Branch x -> pred_branch t x
       in
       KGraph.iter ~pred ~min ~max ~node ?edge ~skip ~rev ()
-
-    let iter_nodes t = Graph.iter (graph_t t)
-
-    let iter_commits t = H.iter (history_t t)
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -178,33 +178,6 @@ module type S = sig
         - branch objects in [min] implicitly add to [min] the commit they are
           pointing to; this allow users to define the iteration between two
           branches. *)
-
-    val iter_nodes :
-      t ->
-      min:hash list ->
-      max:hash list ->
-      ?node:(hash -> unit Lwt.t) ->
-      ?contents:(hash -> unit Lwt.t) ->
-      ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip_node:(hash -> bool Lwt.t) ->
-      ?skip_contents:(hash -> bool Lwt.t) ->
-      ?rev:bool ->
-      unit ->
-      unit Lwt.t
-    (** [iter t] iterates in reverse topological order over the closure graph of
-        [t]. *)
-
-    val iter_commits :
-      t ->
-      min:hash list ->
-      max:hash list ->
-      ?commit:(hash -> unit Lwt.t) ->
-      ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip:(hash -> bool Lwt.t) ->
-      ?rev:bool ->
-      unit ->
-      unit Lwt.t
-    (** [iter t] iterates over the closure graph of [t]. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
Extracted from #1124