### PR TITLE
 irmin-pack: do not recompute hashes on copy 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,7 +127,7 @@
     number. Version 1 of irmin-pack was used for the previous format, version 2
     is used with the new format. (#1047, @icristescu, @CraigFe, @samoht)
 
-  - Use `Repo.iter` to speed-up copies between layers (#1149, @samoht)
+  - Use `Repo.iter` to speed-up copies between layers (#1149, #1150 @samoht)
 
 - **ppx_irmin**:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,8 @@
     number. Version 1 of irmin-pack was used for the previous format, version 2
     is used with the new format. (#1047, @icristescu, @CraigFe, @samoht)
 
+  - Use `Repo.iter` to speed-up copies between layers (#1149, @samoht)
+
 - **ppx_irmin**:
 
   - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (#1082,

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -281,6 +281,24 @@ struct
 
       and t = { hash : hash Lazy.t; stable : bool; v : v }
 
+      let pred t =
+        match t.v with
+        | Inodes i ->
+            Array.fold_left
+              (fun acc -> function Empty -> acc
+                | Inode i -> `Inode (Lazy.force i.i_hash) :: acc)
+              [] i.entries
+        | Values l ->
+            StepMap.fold
+              (fun _ v acc ->
+                let v =
+                  match v with
+                  | `Node k -> `Node k
+                  | `Contents (k, _) -> `Contents k
+                in
+                v :: acc)
+              l []
+
       let hash_of_inode (i : inode) = Lazy.force i.i_hash
 
       let inode_t t : inode Irmin.Type.t =
@@ -733,15 +751,19 @@ struct
 
     type inode_val = I.t
 
-    type t = { mutable find : H.t -> I.t option; v : I.t }
+    type t = { find : H.t -> I.t option; v : I.t }
+
+    let pred t = I.pred t.v
 
     let niet _ = assert false
 
-    let v l = { find = niet; v = I.v l }
+    let v l =
+      let v = I.v l in
+      { find = niet; v }
 
     let list t = I.list ~find:t.find t.v
 
-    let empty = { find = niet; v = Inode.Val.empty }
+    let empty = { find = niet; v = I.empty }
 
     let is_empty t = I.is_empty t.v
 
@@ -749,11 +771,11 @@ struct
 
     let add t s v =
       let v = I.add ~find:t.find t.v s v in
-      if v == t.v then t else { find = t.find; v }
+      if v == t.v then t else { t with v }
 
     let remove t s =
       let v = I.remove ~find:t.find t.v s in
-      if v == t.v then t else { find = t.find; v }
+      if v == t.v then t else { t with v }
 
     let pre_hash_i = Irmin.Type.(unstage (pre_hash I.t))
 

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -31,7 +31,11 @@ module type S = sig
 
   module Key : Irmin.Hash.S with type t = key
 
-  module Val : Irmin.Private.Node.S with type t = value and type hash = key
+  module Val : sig
+    include Irmin.Private.Node.S with type t = value and type hash = key
+
+    val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+  end
 
   include S.CHECKABLE with type 'a t := 'a t and type key := key
 
@@ -59,6 +63,8 @@ module type INODE_INTER = sig
   module Val : sig
     type t
 
+    val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+
     val of_bin : Elt.t -> t
 
     val save : add:(hash -> Elt.t -> unit) -> mem:(hash -> bool) -> t -> unit
@@ -78,9 +84,11 @@ module type VAL_INTER = sig
 
   type inode_val
 
-  type t = { mutable find : hash -> inode_val option; v : inode_val }
+  type t = { find : hash -> inode_val option; v : inode_val }
 
   include Irmin.Private.Node.S with type hash := hash and type t := t
+
+  val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
 end
 
 module type PACK_INTER = sig

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -134,7 +134,7 @@ struct
 
   let copy_from_lower ~dst t = Inode.copy_from_lower t "Node" ~dst
 
-  let copy : type l. l layer_type * l -> [ `Read ] t -> key -> unit Lwt.t =
+  let copy : type l. l layer_type * l -> [ `Read ] t -> key -> unit =
    fun (layer, dst) t ->
     match layer with
     | Lower -> Inode.copy (Lower, dst) t "Node"

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -128,77 +128,17 @@ struct
 
   let flush = Inode.flush
 
-  let unsafe_find t k =
-    match Inode.unsafe_find t k with
-    | None -> None
-    | Some v ->
-        let v = Inode.Val.of_bin v in
-        Some v
-
-  let lift t v =
-    let v = Inode.Val.of_bin v in
-    let find = unsafe_find t in
-    { Val.find; v }
-
   type 'a layer_type =
     | Upper : [ `Read ] U.t layer_type
     | Lower : [ `Read ] L.t layer_type
 
-  let pause = Lwt.pause
-
-  (** The object [k] can be in either lower or upper. If already in upper then
-      do not copy it. *)
-  let copy_from_lower ~dst t k =
-    let lower = lower t in
-    let current = current_upper t in
-    U.mem current k >>= function
-    | true -> Lwt.return_unit
-    | false -> (
-        L.find lower k >>= function
-        | None -> Fmt.failwith "Node %a not found" (Irmin.Type.pp H.t) k
-        | Some v ->
-            let add k v =
-              Irmin_layers.Stats.copy_nodes ();
-              Inode.U.unsafe_append dst k v
-            in
-            let mem k = Inode.U.unsafe_mem dst k in
-            let v' = lift t v in
-            List.iter ignore (Val.list v');
-            Inode.Val.save ~add ~mem v'.Val.v;
-            Lwt.return_unit)
-
-  let copy ~add ~mem t k =
-    Log.debug (fun l -> l "copy Node %a" (Irmin.Type.pp Key.t) k);
-    Inode.U.find (Inode.current_upper t) k >>= function
-    | None -> pause ()
-    | Some v ->
-        pause () >>= fun () ->
-        let v' = lift t v in
-        (* copy is called right after [of_bin] and the inodes have empty cached
-           trees. We call [list] here to add the cached tree to the inodes, so that
-           they are copied in the dst layer. *)
-        List.iter ignore (Val.list v');
-        let add k v =
-          Irmin_layers.Stats.copy_nodes ();
-          add k v;
-          pause ()
-        in
-        let mem k = mem k |> Lwt.return in
-        pause () >>= fun () -> Inode.Val.save_lwt ~add ~mem v'.Val.v
-
-  let copy_to_lower ~dst t k =
-    let add k v = Inode.L.unsafe_append dst k v in
-    let mem k = Inode.L.unsafe_mem dst k in
-    copy ~add ~mem t k
-
-  let copy_to_next ~dst t k =
-    let add k v = Inode.U.unsafe_append dst k v in
-    let mem k = Inode.U.unsafe_mem dst k in
-    copy ~add ~mem t k
+  let copy_from_lower ~dst t = Inode.copy_from_lower t "Node" ~dst
 
   let copy : type l. l layer_type * l -> [ `Read ] t -> key -> unit Lwt.t =
-   fun (ltype, dst) ->
-    match ltype with Lower -> copy_to_lower ~dst | Upper -> copy_to_next ~dst
+   fun (layer, dst) t ->
+    match layer with
+    | Lower -> Inode.copy (Lower, dst) t "Node"
+    | Upper -> Inode.copy (Upper, dst) t "Node"
 
   let check = Inode.check
 end

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -22,7 +22,7 @@ module type S = sig
     | Upper : [ `Read ] U.t layer_type
     | Lower : [ `Read ] L.t layer_type
 
-  val copy : 'l layer_type * 'l -> [ `Read ] t -> key -> unit Lwt.t
+  val copy : 'l layer_type * 'l -> [ `Read ] t -> key -> unit
 
   val mem_lower : 'a t -> key -> bool Lwt.t
 

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -629,10 +629,17 @@ struct
       (* if node or contents are already in dst then they are skipped by
          Graph.iter; there is no need to check this again when the object is
          copied *)
-      let commit k = X.Commit.CA.copy commits t.X.Repo.commit "Commit" k in
-      let node k = X.Node.CA.copy nodes t.X.Repo.node k in
+      let commit k =
+        X.Commit.CA.copy commits t.X.Repo.commit "Commit" k;
+        Lwt.pause ()
+      in
+      let node k =
+        X.Node.CA.copy nodes t.X.Repo.node k;
+        Lwt.return_unit
+      in
       let contents k =
-        X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
+        X.Contents.CA.copy contents t.X.Repo.contents "Contents" k;
+        Lwt.return_unit
       in
       let skip_node h = skip_with_stats ~skip:skip_nodes h in
       let skip_contents h = skip_with_stats ~skip:skip_contents h in

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -615,6 +615,15 @@ struct
 
     let no_skip _ = Lwt.return false
 
+    let pred_node t k =
+      let n = snd (X.Repo.node_t t) in
+      X.Node.CA.find n k >|= function
+      | None -> []
+      | Some v ->
+          List.rev_map
+            (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
+            (X.Node.CA.Val.pred v)
+
     let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
         ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
       (* if node or contents are already in dst then they are skipped by
@@ -629,7 +638,7 @@ struct
       let skip_contents h = skip_with_stats ~skip:skip_contents h in
       let skip_commit h = skip_with_stats ~skip:skip_commits h in
       Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
-        ~skip_commit ()
+        ~pred_node ~skip_commit ()
       >|= fun () -> X.Repo.flush t
 
     module CopyToLower = struct
@@ -771,7 +780,7 @@ struct
         let max = List.map (fun c -> `Commit c) cs in
         let min = List.map (fun c -> `Commit c) min in
         Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
-          ~skip_commit ()
+          ~pred_node ~skip_commit ()
         >|= fun () -> X.Repo.flush t
 
       let on_current_upper t f =

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -319,8 +319,6 @@ struct
                     let commit : 'a Commit.t = (node, commit) in
                     f contents node commit)))
 
-      let log_current_upper t = if t.flip then "upper1" else "upper0"
-
       let unsafe_v_upper root config =
         let fresh = Pack_config.fresh config in
         let lru_size = Pack_config.lru_size config in
@@ -588,6 +586,8 @@ struct
 
   let pause = Lwt.pause
 
+  let pp_commits = Fmt.Dump.list Commit.pp_hash
+
   module Copy = struct
     let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
 
@@ -613,95 +613,73 @@ struct
           true
       | false -> false
 
-    let copy_tree ~skip_nodes ~skip_contents nodes contents t root =
+    let no_skip _ = Lwt.return false
+
+    let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+        ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
       (* if node or contents are already in dst then they are skipped by
          Graph.iter; there is no need to check this again when the object is
          copied *)
-      let node k =
-        pause () >>= fun () -> X.Node.CA.copy nodes t.X.Repo.node k >>= pause
-      in
+      let commit k = X.Commit.CA.copy commits t.X.Repo.commit "Commit" k in
+      let node k = X.Node.CA.copy nodes t.X.Repo.node k in
       let contents k =
         X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
       in
       let skip_node h = skip_with_stats ~skip:skip_nodes h in
       let skip_contents h = skip_with_stats ~skip:skip_contents h in
-      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_node
-        ~skip_contents ()
-
-    let copy_commit ~skip_nodes ~skip_contents contents nodes commits t k =
-      let aux c =
-        copy_tree ~skip_nodes ~skip_contents nodes contents t
-          (X.Commit.Val.node c)
-      in
-      X.Commit.CA.copy commits t.X.Repo.commit ~aux "Commit" k
+      let skip_commit h = skip_with_stats ~skip:skip_commits h in
+      Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
+        ~skip_commit ()
+      >|= fun () -> X.Repo.flush t
 
     module CopyToLower = struct
       let on_lower t f =
-        let contents = X.Contents.CA.lower t.X.Repo.contents in
-        let nodes = X.Node.CA.lower t.X.Repo.node in
-        let commits = X.Commit.CA.lower t.X.Repo.commit in
-        f contents nodes commits
+        let contents =
+          (X.Contents.CA.Lower, X.Contents.CA.lower t.X.Repo.contents)
+        in
+        let nodes = (X.Node.CA.Lower, X.Node.CA.lower t.X.Repo.node) in
+        let commits = (X.Commit.CA.Lower, X.Commit.CA.lower t.X.Repo.commit) in
+        f (contents, nodes, commits)
 
-      let copy_commit contents nodes commits t =
-        copy_commit ~skip_nodes:(mem_node_lower t)
-          ~skip_contents:(mem_contents_lower t)
-          (X.Contents.CA.Lower, contents)
-          (X.Node.CA.Lower, nodes)
-          (X.Commit.CA.Lower, commits)
-          t
-
-      let copy_max_commits ~max t =
-        Log.debug (fun f -> f "copy max commits to lower");
-        Lwt_list.iter_s
-          (fun k ->
-            let h = Commit.hash k in
-            on_lower t (fun contents nodes commits ->
-                mem_commit_lower t h >>= function
-                | true -> Lwt.return_unit
-                | false -> copy_commit contents nodes commits t h))
-          max
-
-      let copy ~min ~max t =
-        let max = List.map (fun x -> Commit.hash x) max in
-        let min = List.map (fun x -> Commit.hash x) min in
-        let skip h = skip_with_stats ~skip:(mem_commit_lower t) h in
-        on_lower t (fun contents nodes commits ->
-            let commit = copy_commit contents nodes commits t in
-            Repo.iter_commits t ~min ~max ~commit ~skip ())
+      let copy ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to lower:@ min=%a,@ max=%a@]" pp_commits min pp_commits
+              commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        let min = List.map (fun x -> `Commit (Commit.hash x)) min in
+        on_lower t (fun l ->
+            iter_copy l ~skip_commits:(mem_commit_lower t)
+              ~skip_nodes:(mem_node_lower t)
+              ~skip_contents:(mem_contents_lower t) t ~min max)
     end
 
     module CopyToUpper = struct
       let on_next_upper t f =
-        let contents = X.Contents.CA.next_upper t.X.Repo.contents in
-        let nodes = X.Node.CA.next_upper t.X.Repo.node in
-        let commits = X.Commit.CA.next_upper t.X.Repo.commit in
-        f contents nodes commits
-
-      let copy_commit contents nodes commits t =
-        copy_commit ~skip_nodes:(mem_node_next t)
-          ~skip_contents:(mem_contents_next t)
-          (X.Contents.CA.Upper, contents)
-          (X.Node.CA.Upper, nodes)
-          (X.Commit.CA.Upper, commits)
-          t
-
-      let copy ~min ~max t =
-        let skip h = skip_with_stats ~skip:(mem_commit_next t) h in
-        on_next_upper t (fun contents nodes commits ->
-            let commit = copy_commit contents nodes commits t in
-            Repo.iter_commits t ~min ~max ~commit ~skip ())
-
-      let copy_commits ~min ~max t =
-        Log.debug (fun f ->
-            f "copy commits to next upper %s" (X.Repo.log_current_upper t));
-        let max = List.map (fun x -> Commit.hash x) max in
-        (* if min is empty then copy only the max commits *)
-        let min =
-          match min with
-          | [] -> max
-          | min -> List.map (fun x -> Commit.hash x) min
+        let contents =
+          (X.Contents.CA.Upper, X.Contents.CA.next_upper t.X.Repo.contents)
         in
-        copy ~min ~max t
+        let nodes = (X.Node.CA.Upper, X.Node.CA.next_upper t.X.Repo.node) in
+        let commits =
+          (X.Commit.CA.Upper, X.Commit.CA.next_upper t.X.Repo.commit)
+        in
+        f (contents, nodes, commits)
+
+      let copy ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to next upper:@ min=%a,@ max=%a@]" pp_commits min
+              pp_commits commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        (* When copying to next upper, if the min is empty then we copy only the
+           max. *)
+        let min =
+          List.map (fun x -> `Commit (Commit.hash x)) min |> function
+          | [] -> max
+          | min -> min
+        in
+        on_next_upper t (fun u ->
+            iter_copy u ~skip_commits:(mem_commit_next t)
+              ~skip_nodes:(mem_node_next t) ~skip_contents:(mem_contents_next t)
+              ~min t max)
 
       (** Newies are the objects added in current upper during the freeze. They
           are copied to the next upper before the freeze ends. When copying the
@@ -711,7 +689,6 @@ struct
           we have to iter over the graph of commits, iter over the graph of
           nodes, and lastly iter over contents. *)
       let copy_newies_aux ~with_lock t =
-        Log.debug (fun l -> l "copy newies");
         let newies_commits =
           if with_lock then
             X.Commit.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
@@ -727,49 +704,33 @@ struct
             X.Contents.CA.unsafe_consume_newies () |> List.rev |> Lwt.return
           else X.Contents.CA.consume_newies t.X.Repo.contents >|= List.rev
         in
-        let copy_contents contents t k =
-          X.Contents.CA.copy contents t.X.Repo.contents "Contents" k
+        newies_commits >>= fun newies_commits ->
+        newies_nodes >>= fun newies_nodes ->
+        newies_contents >>= fun newies_contents ->
+        let newies_commits = List.rev_map (fun x -> `Commit x) newies_commits in
+        let newies_nodes = List.rev_map (fun x -> `Node x) newies_nodes in
+        let newies_contents =
+          List.rev_map (fun x -> `Contents x) newies_contents
         in
-        let copy_tree contents nodes t k =
-          let skip_nodes k = mem_node_next t k in
-          let skip_contents k = mem_contents_next t k in
-          copy_tree ~skip_nodes ~skip_contents nodes contents t k
+        let newies =
+          (* mewies_node can grow very large so do not traverse it (it
+             should always be the 2nd argument of rev_append) *)
+          List.rev_append newies_commits
+            (List.rev_append newies_contents newies_nodes)
         in
-        let copy_commit contents nodes commits t k =
+        Log.debug (fun l -> l "copy newies");
+        (* we want to copy all the new commits; stop whenever one
+           commmit already in the other upper or in lower. *)
+        let skip_commits k =
           mem_commit_next t k >>= function
-          | true -> Lwt.return_unit
-          | false ->
-              let aux c = copy_tree contents nodes t (X.Commit.Val.node c) in
-              X.Commit.CA.copy commits t.X.Repo.commit ~aux "Commit" k
+          | true -> Lwt.return true
+          | false -> mem_commit_lower t k
         in
-        let iter ~mem_next ~copy t objs =
-          let rec aux objs =
-            Lwt_list.filter_s (fun k -> mem_next t k >|= not) objs >>= function
-            | [] -> Lwt.return_unit
-            | objs ->
-                Lwt_list.find_s (fun k -> mem_next t k >|= not) objs
-                >>= fun obj ->
-                copy t obj >>= fun () -> (aux objs [@tail])
-          in
-          aux objs
-        in
-        on_next_upper t (fun contents nodes commits ->
-            let contents = (X.Contents.CA.Upper, contents) in
-            let nodes = (X.Node.CA.Upper, nodes) in
-            let commits = (X.Commit.CA.Upper, commits) in
-            Log.debug (fun l -> l "copy newies: iter commits");
-            newies_commits
-            >>= Lwt_list.iter_s (fun k ->
-                    copy_commit contents nodes commits t k)
-            >>= fun () ->
-            Log.debug (fun l -> l "copy newies: iter nodes");
-            newies_nodes
-            >>= iter ~mem_next:mem_node_next ~copy:(copy_tree contents nodes) t
-            >>= fun () ->
-            Log.debug (fun l -> l "copy newies: iter contents");
-            newies_contents
-            >>= iter ~mem_next:mem_contents_next ~copy:(copy_contents contents)
-                  t)
+        (* FIXME(samoht): do we need to traverse the newies
+           recursively if we don't need self-contained uppers. *)
+        on_next_upper t (fun u ->
+            iter_copy u ~skip_commits ~skip_nodes:(mem_node_next t)
+              ~skip_contents:(mem_contents_next t) t newies)
         >>= fun () ->
         if with_lock then X.Branch.copy_last_newies_to_next_upper t.branch
         else X.Branch.copy_newies_to_next_upper t.branch
@@ -790,36 +751,34 @@ struct
     end
 
     module CopyFromLower = struct
-      let on_current_upper t f =
-        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
-        let nodes = X.Node.CA.current_upper t.X.Repo.node in
-        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
-        f contents nodes commits
-
-      let copy_tree contents nodes t root =
-        let node k =
-          X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k >|= fun () ->
-          (* We have to ensure that a node is entirely flushed to disk.
-             If we rely on the implicit flush of io, it could be that
-             only a part of a node if flushed to disk when RO tries to
-             read it. *)
-          X.Node.CA.flush t.node
+      (* FIXME(samoht): copy/paste from iter_copy with s/copy/copy_from_lower *)
+      let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+          ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) cs =
+        (* if node or contents are already in dst then they are skipped by
+           Graph.iter; there is no need to check this again when the object is
+           copied *)
+        let commit k =
+          X.Commit.CA.copy_from_lower ~dst:commits t.X.Repo.commit "Commit" k
         in
+        let node k = X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k in
         let contents k =
           X.Contents.CA.copy_from_lower ~dst:contents t.X.Repo.contents
             "Contents" k
         in
-        (* We cannot skip nodes, because a node in upper can have a predecessor
-           in lower. Contents do not have predecessors, so we can skip them. *)
-        let skip_contents k = mem_contents_next t k in
-        Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ~skip_contents
-          ()
-
-      let copy_commit contents nodes commits t hash =
-        let aux c = copy_tree contents nodes t (X.Commit.Val.node c) in
-        X.Commit.CA.copy_from_lower t.X.Repo.commit ~dst:commits ~aux "Commit"
-          hash
+        let skip_node h = skip_with_stats ~skip:skip_nodes h in
+        let skip_contents h = skip_with_stats ~skip:skip_contents h in
+        let skip_commit h = skip_with_stats ~skip:skip_commits h in
+        let max = List.map (fun c -> `Commit c) cs in
+        let min = List.map (fun c -> `Commit c) min in
+        Repo.iter t ~min ~max ~commit ~node ~contents ~skip_node ~skip_contents
+          ~skip_commit ()
         >|= fun () -> X.Repo.flush t
+
+      let on_current_upper t f =
+        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
+        let nodes = X.Node.CA.current_upper t.X.Repo.node in
+        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
+        f (contents, nodes, commits)
 
       (** The commits can be in either lower or upper. We don't skip an object
           already in upper as its predecessors could be in lower. *)
@@ -830,6 +789,8 @@ struct
           | None -> max (* if min is empty then copy only the max commits *)
           | Some min -> List.map (fun x -> Commit.hash x) min
         in
+        (* FIXME(samoht): do this in 2 steps: 1/ find the shallow
+           hashes in upper 2/ iterates with max=shallow *)
         Log.debug (fun l ->
             l
               "self_contained: copy commits min:%a; max:%a from lower into \
@@ -838,9 +799,7 @@ struct
               min
               (Fmt.list (Irmin.Type.pp H.t))
               max);
-        on_current_upper t (fun contents nodes commits ->
-            let commit h = copy_commit contents nodes commits t h in
-            Repo.iter_commits t ~min ~max ~commit ())
+        on_current_upper t (fun u -> iter_copy u ~min t max)
     end
   end
 
@@ -859,15 +818,13 @@ struct
     (* Copy commits to lower: if squash then copy only the max commits *)
     let with_lower = with_lower t.X.Repo.config in
     (if with_lower then
-     with_stats "copied in lower"
-       (if squash then Copy.CopyToLower.copy_max_commits ~max t
-       else Copy.CopyToLower.copy ~min ~max t)
+     let min = if squash then max else min in
+     with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
     else Lwt.return_unit)
     >>= fun () ->
     (* Copy [min_upper, max] to next_upper *)
     (if copy_in_upper then
-     with_stats "copied in upper"
-       (Copy.CopyToUpper.copy_commits ~min:min_upper ~max t)
+     with_stats "copied in upper" (Copy.CopyToUpper.copy t ~min:min_upper max)
     else Lwt.return_unit)
     >>= fun () ->
     (* Copy branches to both lower and next_upper *)
@@ -964,34 +921,23 @@ struct
       incr errors;
       Lwt.return_unit
     in
-    let check_tree root =
-      let node k = X.Node.CA.check t.X.Repo.node ~none k in
-      let contents k = X.Contents.CA.check t.X.Repo.contents ~none k in
-      Repo.iter_nodes t ~min:[] ~max:[ root ] ~node ~contents ()
-    in
-    let check_commit commit =
-      let some c = check_tree (X.Commit.Val.node c) in
-      X.Commit.CA.check t.X.Repo.commit ~none ~some commit
-    in
+    let node k = X.Node.CA.check t.X.Repo.node ~none k in
+    let contents k = X.Contents.CA.check t.X.Repo.contents ~none k in
+    let commit k = X.Commit.CA.check t.X.Repo.commit ~none k in
     (match heads with None -> Repo.heads t | Some m -> Lwt.return m)
     >>= fun heads ->
-    let hashes = List.map (fun x -> Commit.hash x) heads in
-    Repo.iter_commits t ~min:[] ~max:hashes ~commit:check_commit ()
-    >>= fun () ->
+    let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
+    Repo.iter t ~min:[] ~max:hashes ~commit ~node ~contents () >|= fun () ->
     let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
     if !errors = 0 then
-      Lwt.return
-        (Ok
-           (`Msg
-             (Fmt.str "Upper layer is self contained for heads %a" pp_commits
-                heads)))
+      Fmt.kstrf
+        (fun x -> Ok (`Msg x))
+        "Upper layer is self contained for heads %a" pp_commits heads
     else
-      Lwt.return_error
-        (`Msg
-          (Fmt.str
-             "Upper layer is not self contained for heads %a: %n phantom \
-              objects detected"
-             pp_commits heads !errors))
+      Fmt.error_msg
+        "Upper layer is not self contained for heads %a: %n phantom objects \
+         detected"
+        pp_commits heads !errors
 
   module PrivateLayer = struct
     module Hook = struct

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -98,7 +98,8 @@ struct
 
   let log_next_upper t = if t.flip then "upper0" else "upper1"
 
-  let mem_lower t k = Option.get t.lower |> fun lower -> L.mem lower k
+  let mem_lower t k =
+    match t.lower with None -> Lwt.return false | Some lower -> L.mem lower k
 
   let mem_next t k = U.mem (next_upper t) k
 
@@ -332,6 +333,7 @@ struct
   (** The object [k] can be in either lower or upper. If already in upper then
       do not copy it. *)
   let copy_from_lower t ~dst ?(aux = fun _ -> Lwt.return_unit) str k =
+    (* FIXME(samoht): why does this function need to be different from the previous one? *)
     let lower = lower t in
     let current = current_upper t in
     U.find current k >>= function

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -123,13 +123,7 @@ module type LAYERED = sig
     | Upper : [ `Read ] U.t layer_type
     | Lower : [ `Read ] L.t layer_type
 
-  val copy :
-    'l layer_type * 'l ->
-    [ `Read ] t ->
-    ?aux:(value -> unit Lwt.t) ->
-    string ->
-    key ->
-    unit Lwt.t
+  val copy : 'l layer_type * 'l -> [ `Read ] t -> string -> key -> unit
 
   val copy_from_lower :
     [ `Read ] t ->

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -402,10 +402,6 @@ module Make (P : S.PRIVATE) = struct
         | `Branch x -> pred_branch t x
       in
       KGraph.iter ~pred ~min ~max ~node ?edge ~skip ~rev ()
-
-    let iter_nodes t = Graph.iter (graph_t t)
-
-    let iter_commits t = H.iter (history_t t)
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -178,33 +178,6 @@ module type S = sig
         - branch objects in [min] implicitly add to [min] the commit they are
           pointing to; this allow users to define the iteration between two
           branches. *)
-
-    val iter_nodes :
-      t ->
-      min:hash list ->
-      max:hash list ->
-      ?node:(hash -> unit Lwt.t) ->
-      ?contents:(hash -> unit Lwt.t) ->
-      ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip_node:(hash -> bool Lwt.t) ->
-      ?skip_contents:(hash -> bool Lwt.t) ->
-      ?rev:bool ->
-      unit ->
-      unit Lwt.t
-    (** [iter t] iterates in reverse topological order over the closure graph of
-        [t]. *)
-
-    val iter_commits :
-      t ->
-      min:hash list ->
-      max:hash list ->
-      ?commit:(hash -> unit Lwt.t) ->
-      ?edge:(hash -> hash -> unit Lwt.t) ->
-      ?skip:(hash -> bool Lwt.t) ->
-      ?rev:bool ->
-      unit ->
-      unit Lwt.t
-    (** [iter t] iterates over the closure graph of [t]. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
(extracted from #1124)
(on top of #1150)

before:

```
▶ dune exec -- ./bench/irmin-pack/layers.exe -n 100
1500 commits completed in 9.30s.
[0.006s per commit, 161 commits per second]
```

after:
```
▶ dune exec -- ./bench/irmin-pack/layers.exe -n 100
1500 commits completed in 7.54s.
[0.005s per commit, 199 commits per second]
```