### PR TITLE
irmin-pack: add an (unsafe) option to bypass data integrity checks on reads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,6 +129,8 @@
 
   - Use `Repo.iter` to speed-up copies between layers (#1149, #1150 @samoht)
 
+  - Add an option to bypass data integrity checks on reads (#1154, @samoht)
+
 - **ppx_irmin**:
 
   - The `[@generic ...]` attribute has been renamed to `[@repr ...]`. (#1082,

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -61,9 +61,9 @@ module Content_addressable (S : Pack.S) = struct
     check_not_closed t;
     S.unsafe_mem t.t k
 
-  let unsafe_find t k =
+  let unsafe_find ~check_integrity t k =
     check_not_closed t;
-    S.unsafe_find t.t k
+    S.unsafe_find ~check_integrity t.t k
 
   let flush ?index t =
     check_not_closed t;

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -813,8 +813,8 @@ struct
 
   let mem t k = Inode.mem t k
 
-  let unsafe_find t k =
-    match Inode.unsafe_find t k with
+  let unsafe_find ~check_integrity t k =
+    match Inode.unsafe_find ~check_integrity t k with
     | None -> None
     | Some v ->
         let v = Inode.Val.of_bin v in
@@ -825,7 +825,7 @@ struct
     | None -> None
     | Some v ->
         let v = Inode.Val.of_bin v in
-        let find = unsafe_find t in
+        let find = unsafe_find ~check_integrity:true t in
         Some { Val.find; v }
 
   let save t v =

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -52,8 +52,8 @@ struct
 
   let mem t k = Inode.mem t k
 
-  let unsafe_find t k =
-    match Inode.unsafe_find t k with
+  let unsafe_find ~check_integrity t k =
+    match Inode.unsafe_find ~check_integrity t k with
     | None -> None
     | Some v ->
         let v = Inode.Val.of_bin v in
@@ -64,7 +64,7 @@ struct
     | None -> None
     | Some v ->
         let v = Inode.Val.of_bin v in
-        let find = unsafe_find t in
+        let find = unsafe_find ~check_integrity:true t in
         Some { Val.find; v }
 
   let hash v = Inode.Val.hash v.Val.v

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -43,7 +43,7 @@ struct
 
   let copy ~src ~dst str k =
     Log.debug (fun l -> l "copy %s %a" str (Irmin.Type.pp Key.t) k);
-    match SRC.unsafe_find src k with
+    match SRC.unsafe_find ~check_integrity:false src k with
     | None ->
         Log.warn (fun l ->
             l "Attempt to copy %s %a not contained in upper." str
@@ -170,17 +170,17 @@ struct
             Log.debug (fun l -> l "find in lower");
             L.find lower k)
 
-  let unsafe_find t k =
+  let unsafe_find ~check_integrity t k =
     let current = current_upper t in
     Log.debug (fun l -> l "unsafe_find in %s" (log_current_upper t));
-    match U.unsafe_find current k with
+    match U.unsafe_find ~check_integrity current k with
     | Some v -> Some v
     | None -> (
         match t.lower with
         | None -> None
         | Some lower ->
             Log.debug (fun l -> l "unsafe_find in lower");
-            L.unsafe_find lower k)
+            L.unsafe_find ~check_integrity lower k)
 
   let mem t k =
     let current = current_upper t in

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -59,7 +59,7 @@ module type S = sig
 
   val unsafe_mem : 'a t -> key -> bool
 
-  val unsafe_find : 'a t -> key -> value option
+  val unsafe_find : check_integrity:bool -> 'a t -> key -> value option
 
   val flush : ?index:bool -> 'a t -> unit
 


### PR DESCRIPTION
(on top of #1153)

