### PR TITLE
Fix opam pin

### DIFF
--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -958,7 +958,8 @@ struct
         (fun x -> Ok (`Msg x))
         "Upper layer is self contained for heads %a" pp_commits heads
     else
-      Fmt.error_msg
+      Fmt.kstrf
+        (fun x -> Error (`Msg x))
         "Upper layer is not self contained for heads %a: %n phantom objects \
          detected"
         pp_commits heads !errors


### PR DESCRIPTION
Pinning `irmin-pack` and `irmin-layers` on master on a `4.09` switch, fails due to a mismatch in the `check_self_contained` function. Also (on my machine at least) it compiles fine with `4.11`, but not with `4.09`, I'm not sure why it's not picked up by the CI. 