### PR TITLE
irmin-pack: allocate less

### DIFF
--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -609,8 +609,6 @@ struct
 
   let flush = X.Repo.flush
 
-  let pause = Lwt.pause
-
   let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash
 
   module Copy = struct
@@ -631,7 +629,6 @@ struct
         ~mem_commit_upper:(mem_commit_next t) t.X.Repo.branch
 
     let skip_with_stats ~skip h =
-      pause () >>= fun () ->
       skip h >|= function
       | true ->
           Irmin_layers.Stats.skip ();


### PR DESCRIPTION
These seem to be the last remaining hotspots of allocation in the recent traces.

Not totally sure about all of the changes, but they seem to make a difference.

Before:
```
▶ dune exec -- ./bench/irmin-pack/layers.exe -n 300
4500 commits completed in 28.02s.
[0.006s per commit, 161 commits per second]
```

After:
```
▶ dune exec -- ./bench/irmin-pack/layers.exe -n 300
4500 commits completed in 24.35s.
[0.005s per commit, 185 commits per second]
```