### PR TITLE
irmin-pack: faster copies

### DIFF
--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -53,9 +53,9 @@ module Content_addressable (S : Pack.S) = struct
       t.closed := true;
       S.close t.t)
 
-  let unsafe_append t k v =
+  let unsafe_append ~ensure_unique t k v =
     check_not_closed t;
-    S.unsafe_append t.t k v
+    S.unsafe_append ~ensure_unique t.t k v
 
   let unsafe_mem t k =
     check_not_closed t;

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -829,7 +829,7 @@ struct
         Some { Val.find; v }
 
   let save t v =
-    let add k v = Inode.unsafe_append t k v in
+    let add k v = Inode.unsafe_append ~ensure_unique:true t k v in
     Inode.Val.save ~add ~mem:(Inode.unsafe_mem t) v
 
   let hash v = Inode.Val.hash v.Val.v

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -92,7 +92,7 @@ struct
   let clear_caches = Inode.clear_caches
 
   let save t v =
-    let add k v = Inode.unsafe_append t k v in
+    let add k v = Inode.unsafe_append ~ensure_unique:true t k v in
     Inode.Val.save_lwt ~add ~mem:(Inode.unsafe_mem t) v
 
   let add t v = save t v.Val.v >|= fun () -> hash v

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -51,7 +51,7 @@ module type S = sig
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 
-  val unsafe_append : 'a t -> key -> value -> unit
+  val unsafe_append : ensure_unique:bool -> 'a t -> key -> value -> unit
 
   val add : 'a t -> value -> key Lwt.t
 
@@ -155,7 +155,7 @@ module type LAYERED = sig
 
   val clear_caches_next_upper : 'a t -> unit
 
-  val unsafe_append : 'a t -> key -> value -> unit Lwt.t
+  val unsafe_append : ensure_unique:bool -> 'a t -> key -> value -> unit Lwt.t
 
   val unsafe_mem : 'a t -> key -> bool Lwt.t
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -261,7 +261,9 @@ module Pack = struct
     Context.get_pack () >>= fun t ->
     t.clone_index_pack ~readonly:true >>= fun (i, r) ->
     let test w =
-      let adds l = List.iter (fun (k, v) -> Pack.unsafe_append w k v) l in
+      let adds l =
+        List.iter (fun (k, v) -> Pack.unsafe_append ~ensure_unique:true w k v) l
+      in
       let x1 = "foo" in
       let x2 = "bar" in
       let h1 = sha1 x1 in
@@ -295,7 +297,7 @@ module Pack = struct
     Pack.v ~fresh:true ~index (Context.fresh_name "pack") >>= fun w1 ->
     let x1 = "foo" in
     let h1 = sha1 x1 in
-    Pack.unsafe_append w1 h1 x1;
+    Pack.unsafe_append ~ensure_unique:true w1 h1 x1;
     Pack.find w1 h1 >|= get >>= fun y1 ->
     Alcotest.(check string) "x1" x1 y1;
     Index.close index;
@@ -307,7 +309,7 @@ module Pack = struct
     let w = t.pack in
     let x1 = "foo" in
     let h1 = sha1 x1 in
-    Pack.unsafe_append w h1 x1;
+    Pack.unsafe_append ~ensure_unique:true w h1 x1;
     Pack.flush w;
     Index.close t.index;
     Pack.close w >>= fun () ->
@@ -349,7 +351,7 @@ module Pack = struct
     (*open and close two packs *)
     let x3 = "toto" in
     let h3 = sha1 x3 in
-    Pack.unsafe_append w h3 x3;
+    Pack.unsafe_append ~ensure_unique:true w h3 x3;
     t.clone_pack ~readonly:false >>= fun w2 ->
     Pack.close w >>= fun () ->
     Pack.find w2 h2 >|= get >>= fun y2 ->
@@ -384,7 +386,7 @@ module Pack = struct
     let test w =
       let x1 = "foo" in
       let h1 = sha1 x1 in
-      Pack.unsafe_append w h1 x1;
+      Pack.unsafe_append ~ensure_unique:true w h1 x1;
       Pack.sync r;
       Pack.find r h1 >>= fun y1 ->
       Alcotest.(check (option string)) "sync before filter" None y1;
@@ -394,7 +396,7 @@ module Pack = struct
       Alcotest.(check (option string)) "sync after filter" (Some x1) y1;
       let x2 = "foo" in
       let h2 = sha1 x2 in
-      Pack.unsafe_append w h2 x2;
+      Pack.unsafe_append ~ensure_unique:true w h2 x2;
       Index.flush t.index;
       Pack.find r h2 >|= fun y2 ->
       Alcotest.(check (option string)) "sync after flush" (Some x2) y2
@@ -411,7 +413,7 @@ module Pack = struct
     let test w =
       let x1 = "foo" in
       let h1 = sha1 x1 in
-      Pack.unsafe_append w h1 x1;
+      Pack.unsafe_append ~ensure_unique:true w h1 x1;
       Pack.flush t.pack;
       Pack.sync r;
       check h1 x1 "find before filter" >>= fun () ->
@@ -419,13 +421,13 @@ module Pack = struct
       check h1 x1 "find after filter" >>= fun () ->
       let x2 = "bar" in
       let h2 = sha1 x2 in
-      Pack.unsafe_append w h2 x2;
+      Pack.unsafe_append ~ensure_unique:true w h2 x2;
       Pack.flush t.pack;
       Pack.sync r;
       check h2 x2 "find before flush" >>= fun () ->
       let x3 = "toto" in
       let h3 = sha1 x3 in
-      Pack.unsafe_append w h3 x3;
+      Pack.unsafe_append ~ensure_unique:true w h3 x3;
       Index.flush t.index;
       check h2 x2 "find after flush" >>= fun () ->
       Pack.flush t.pack;
@@ -439,7 +441,7 @@ module Pack = struct
     Context.get_pack ~lru_size:10 () >>= fun t ->
     let v = "foo" in
     let k = sha1 v in
-    Pack.unsafe_append t.pack k v;
+    Pack.unsafe_append ~ensure_unique:true t.pack k v;
     Pack.flush t.pack;
     Pack.find t.pack k >>= fun v1 ->
     Alcotest.(check (option string)) "before clear" (Some v) v1;
@@ -461,7 +463,7 @@ module Pack = struct
     let x1 = "foo" in
     let h1 = sha1 x1 in
     let find_before_and_after_sync persist file =
-      Pack.unsafe_append t.pack h1 x1;
+      Pack.unsafe_append ~ensure_unique:true t.pack h1 x1;
       persist ();
       Pack.sync r;
       Pack.clear t.pack >>= fun () ->
@@ -492,11 +494,11 @@ module Pack = struct
     let x2 = "bar" in
     let h2 = sha1 x2 in
     let find_before_and_after_sync persist file =
-      Pack.unsafe_append t.pack h1 x1;
+      Pack.unsafe_append ~ensure_unique:true t.pack h1 x1;
       persist ();
       Pack.sync r;
       Pack.clear t.pack >>= fun () ->
-      Pack.unsafe_append t.pack h2 x2;
+      Pack.unsafe_append ~ensure_unique:true t.pack h2 x2;
       persist ();
       check h1 (Some x1)
         ("find old values in " ^ file ^ " after clear but before sync")


### PR DESCRIPTION
before:
```
▶ time dune exec -- ./bench/irmin-pack/layers.exe -n 300
4500 commits completed in 30.63s.
[0.007s per commit, 147 commits per second]
dune exec -- ./bench/irmin-pack/layers.exe -n 300  24.61s user 6.61s system 97% cpu 32.100 total
```

after:
```
▶ time dune exec -- ./bench/irmin-pack/layers.exe -n 300
4500 commits completed in 27.53s.
[0.006s per commit, 163 commits per second]
dune exec -- ./bench/irmin-pack/layers.exe -n 300  21.97s user 6.12s system 99% cpu 28.245 total
```