### PR TITLE
irmin-pack: allocate less in inodes

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -293,7 +293,7 @@ struct
               (fun _ v acc ->
                 let v =
                   match v with
-                  | `Node k -> `Node k
+                  | `Node _ as k -> k
                   | `Contents (k, _) -> `Contents k
                 in
                 v :: acc)
@@ -722,7 +722,7 @@ struct
               (name, `Node node)
         in
         let t : Compress.v -> Bin.v = function
-          | Values vs -> Values (List.map value vs)
+          | Values vs -> Values (List.rev_map value (List.rev vs))
           | Inodes { seed; length; entries } ->
               let entries = List.map inode entries in
               Inodes { seed; length; entries }


### PR DESCRIPTION
before:
```
▶ dune exec -- ./bench/irmin-pack/layers.exe -n 300
4500 commits completed in 29.51s.
[0.007s per commit, 153 commits per second]
```

after:
```
▶ dune exec -- ./bench/irmin-pack/layers.exe -n 300
4500 commits completed in 27.66s.
[0.006s per commit, 163 commits per second]
```