### PR TITLE
Revert "irmin: use an optimized short hash function for crypto hashes"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,11 +111,6 @@
   - `Irmin.Type` uses staging for `equal`, `short_hash` and `compare` to
     speed-up generic operations (#1130, #1131, #1132, @samoht)
 
-  - Change the function used by `Type.short_hash ~seed:None` for hashes to
-    be more efficient. This changes the outputs of that function. The outputs
-    of the seeded hash function (as used by irmin-pack's inodes) is not
-    modified. (#1143, @samoht @CraigFe)
-
 - **irmin-pack**:
   - `sync` has to be called by the read-only instance to synchronise with the
     files on disk. (#1008, @icristescu)

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -17,15 +17,9 @@
 module Make (H : Digestif.S) = struct
   type t = H.t
 
-  let short_hash c =
-    let buf = Bytes.unsafe_of_string (H.to_raw_string c) in
-    Int32.to_int (Bytes.get_int32_be buf 0)
+  external get_64 : string -> int -> int64 = "%caml_string_get64u"
 
-  let short_hash_seeded =
-    Type.stage @@ fun ?seed c ->
-    match seed with
-    | None -> short_hash c
-    | Some seed -> Hashtbl.seeded_hash seed (H.to_raw_string c)
+  let short_hash c = Int64.to_int (get_64 (H.to_raw_string c) 0)
 
   let hash_size = H.digest_size
 
@@ -37,7 +31,7 @@ module Make (H : Digestif.S) = struct
   let pp_hex ppf x = Fmt.string ppf (H.to_hex x)
 
   let t =
-    Type.map ~pp:pp_hex ~of_string:of_hex ~short_hash:short_hash_seeded
+    Type.map ~pp:pp_hex ~of_string:of_hex
       Type.(string_of (`Fixed hash_size))
       H.of_raw_string H.to_raw_string
 

--- a/test/irmin/test_hash.ml
+++ b/test/irmin/test_hash.ml
@@ -4,7 +4,7 @@ let test_short_hash () =
   let h = Hash.BLAKE2B.hash (fun f -> f "") in
   let () =
     Hash.BLAKE2B.short_hash h
-    |> Alcotest.(check int) "Specialised short hash" 2020213495
+    |> Alcotest.(check int) "Specialised short hash" 241225442164632184
   in
   let () =
     Type.(unstage (short_hash Hash.BLAKE2B.t)) ~seed:0 h
@@ -12,7 +12,7 @@ let test_short_hash () =
   in
   let () =
     Type.(unstage (short_hash Hash.BLAKE2B.t)) ?seed:None h
-    |> Alcotest.(check int) "Generic unseeded short hash" 2020213495
+    |> Alcotest.(check int) "Generic unseeded short hash" 674923654
   in
   ()
 


### PR DESCRIPTION
This reverts commit bd53984a9390c953bab523a4768edde1c562c781.

See #1164 