### PR TITLE
Considering key creation case in last_modified

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 - **irmin***
   - Improve performance of `last_modified` (#948, @pascutto)
 
+  - Changed the pattern matching of the function `last_modified`. The case of a
+    created key is now considered a modification by the function. (#1167,
+    @clecat)
+
 - **ppx_irmin**
   - Fix a bug causing certain type derivations to be incorrect due to unsound
     namespacing. (#1083, @CraigFe)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -1086,6 +1086,7 @@ module Make (P : S.PRIVATE) = struct
                   match (e, current_value) with
                   | Some x, Some y -> not (equal_contents x y)
                   | Some _, None -> true
+                  | None, Some _ -> true
                   | _, _ -> false)
               | None -> Lwt.return_false)
             parents


### PR DESCRIPTION
As explained in this [issue](https://github.com/mirage/irmin/issues/1109), the current implementation of the function `last_modified` doesn't consider the case of a key creation as a modification.

After discussing a bit about it with @pascutto, it seems that this was not the intended behaviour. This PR simply adds the case in the pattern matching.