### PR TITLE
Fix irmin-unix config path to respect XDG_CONFIG_HOME

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
   - Fix a bug causing certain type derivations to be incorrect due to unsound
     namespacing. (#1083, @CraigFe)
 
+- **irmin-unix**
+  - Update irmin config path to respect `XDG_CONFIG_HOME`. (#1168, @zshipko)
+
 #### Added
 
 - **irmin-layers** (_new_):

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -601,8 +601,8 @@ let config_man =
         "An $(b,irmin.yml) file lets the user specify repetitve command-line \
          options in a YAML file. The $(b,irmin.yml) is read by default if it \
          is found in the current working directory or defined globally as \
-         \\$HOME/.irmin/config.yml. The configuration file path can also be \
-         set using the $(b,--config) command-line flag. \n\
+         \\$HOME/.config/irmin/config.yml. The configuration file path can also be \
+         set using the $(b,--config) command-line flag or by setting \\$XDG_CONFIG_HOME \n\
         \        The following keys are allowed: $(b,contents), $(b,store), \
          $(b,branch), $(b,root), $(b,bare), $(b,head), or $(b,uri). These \
          correspond to the irmin options of the same names.";

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -601,8 +601,9 @@ let config_man =
         "An $(b,irmin.yml) file lets the user specify repetitve command-line \
          options in a YAML file. The $(b,irmin.yml) is read by default if it \
          is found in the current working directory or defined globally as \
-         \\$HOME/.config/irmin/config.yml. The configuration file path can also be \
-         set using the $(b,--config) command-line flag or by setting \\$XDG_CONFIG_HOME \n\
+         \\$HOME/.config/irmin/config.yml. The configuration file path can \
+         also be set using the $(b,--config) command-line flag or by setting \
+         \\$XDG_CONFIG_HOME. \n\
         \        The following keys are allowed: $(b,contents), $(b,store), \
          $(b,branch), $(b,root), $(b,bare), $(b,head), or $(b,uri). These \
          correspond to the irmin options of the same names.";

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -338,12 +338,17 @@ end
 
 (* Config *)
 
+let home =
+  try Sys.getenv "HOME"
+  with Not_found -> (
+    try (Unix.getpwuid (Unix.getuid ())).Unix.pw_dir
+    with Unix.Unix_error _ | Not_found ->
+      if Sys.win32 then try Sys.getenv "AppData" with Not_found -> "" else "")
+
 let config_root () =
-  let xdg_config_home = Unix.getenv "XDG_CONFIG_HOME" in
-  if xdg_config_home = "" then
-    Unix.getenv "HOME" / ".config"
-  else
-    xdg_config_home
+  try Sys.getenv "XDG_CONFIG_HOME"
+  with Not_found ->
+    if Sys.win32 then home / "Local Settings" else home / ".config"
 
 let rec read_config_file path =
   let home = config_root () / global_config_path in

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -57,7 +57,7 @@ let config_path_key =
 
 let ( / ) = Filename.concat
 
-let global_config_path = ".irmin" / "config.yml"
+let global_config_path = "irmin" / "config.yml"
 
 let add_opt k v config =
   match v with None -> config | Some _ -> Irmin.Private.Conf.add config k v
@@ -338,8 +338,15 @@ end
 
 (* Config *)
 
+let config_root () =
+  let xdg_config_home = Unix.getenv "XDG_CONFIG_HOME" in
+  if xdg_config_home = "" then
+    Unix.getenv "HOME" / ".config"
+  else
+    xdg_config_home
+
 let rec read_config_file path =
-  let home = Unix.getenv "HOME" / global_config_path in
+  let home = config_root () / global_config_path in
   let global = if String.equal path home then [] else read_config_file home in
   if not (Sys.file_exists path) then global
   else


### PR DESCRIPTION
Fixes #934

I re-used some code from the internal dune XDG library since it seemed to handle Windows correctly, but I don't have a Windows machine and can't verify. If Windows support isn't necessary then I can remove that part altogether.