### PR TITLE
Log maxrss in the layer benchmarks

### DIFF
--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -7,7 +7,7 @@
   (pps ppx_deriving_yojson ppx_repr))
  (libraries irmin-pack irmin-pack.layered irmin-test.bench irmin-layers lwt
    unix cmdliner logs yojson ppx_deriving_yojson memtrace repr ppx_repr
-   bench_common))
+   bench_common rusage))
 
 (library
  (name bench_common)

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -32,6 +32,7 @@ depends: [
   "bentov" {with-test}
   "mtime" {with-test}
   "ppx_deriving" {with-test}
+  "rusage"
 ]
 
 synopsis: "Irmin benchmarking suite"


### PR DESCRIPTION
I added a slow mode to the benchmarks and removed the overcommit option, to highlight two issues that occur in the tezos benchmarks: 
- without the overcommit option, the merge blocks sometimes;
- we need to add thread yields in the freeze thread to ensure fairness. 

![no_freeze](https://user-images.githubusercontent.com/16655454/101523799-5ee06880-3989-11eb-94ec-d596fea2a77a.png)
