### PR TITLE
irmin-pack: add a memory overcommit option for freeze

### DIFF
--- a/src/irmin-pack/config.ml
+++ b/src/irmin-pack/config.ml
@@ -14,6 +14,8 @@ module Default = struct
   let readonly = false
 
   let index_throttle = `Block_writes
+
+  let freeze_throttle = `Block_writes
 end
 
 let fresh_key =
@@ -32,18 +34,20 @@ let readonly_key =
   Irmin.Private.Conf.key ~doc:"Start with a read-only disk." "readonly"
     Irmin.Private.Conf.bool Default.readonly
 
-let throttle_converter =
+type throttle = [ `Block_writes | `Overcommit_memory ]
+
+let throttle_converter : throttle Irmin.Private.Conf.converter =
   let parse = function
-    | "Block_writes" -> Ok `Block_writes
-    | "Overcommit_memory" -> Ok `Overcommit_memory
+    | "block-writes" -> Ok `Block_writes
+    | "overcommit-memory" -> Ok `Overcommit_memory
     | s ->
         Fmt.error_msg
-          "invalid %s, expected one of: Block_writes Overcommit_memory" s
+          "invalid %s, expected one of: `block-writes' or `overcommit-memory'" s
   in
   let print =
     Fmt.of_to_string (function
-      | `Block_writes -> "Block_writes"
-      | `Overcommit_memory -> "Overcommit_memory")
+      | `Block_writes -> "block-writes"
+      | `Overcommit_memory -> "overcommit-memory")
   in
   (parse, print)
 
@@ -51,6 +55,10 @@ let index_throttle_key =
   Irmin.Private.Conf.key
     ~doc:"Strategy to use for large writes when index caches are full."
     "index-throttle" throttle_converter Default.index_throttle
+
+let freeze_throttle_key =
+  Irmin.Private.Conf.key ~doc:"Strategy to use for long-running freezes."
+    "freeze-throttle" throttle_converter Default.freeze_throttle
 
 let fresh config = Irmin.Private.Conf.get config fresh_key
 
@@ -62,6 +70,8 @@ let index_log_size config = Irmin.Private.Conf.get config index_log_size_key
 
 let index_throttle config = Irmin.Private.Conf.get config index_throttle_key
 
+let freeze_throttle config = Irmin.Private.Conf.get config freeze_throttle_key
+
 let root_key = Irmin.Private.Conf.root
 
 let root config =
@@ -71,7 +81,8 @@ let root config =
 
 let v ?(fresh = Default.fresh) ?(readonly = Default.readonly)
     ?(lru_size = Default.lru_size) ?(index_log_size = Default.index_log_size)
-    ?(index_throttle = Default.index_throttle) root =
+    ?(index_throttle = Default.index_throttle)
+    ?(freeze_throttle = Default.freeze_throttle) root =
   let config = Irmin.Private.Conf.empty in
   let config = Irmin.Private.Conf.add config fresh_key fresh in
   let config = Irmin.Private.Conf.add config root_key (Some root) in
@@ -82,5 +93,8 @@ let v ?(fresh = Default.fresh) ?(readonly = Default.readonly)
   let config = Irmin.Private.Conf.add config readonly_key readonly in
   let config =
     Irmin.Private.Conf.add config index_throttle_key index_throttle
+  in
+  let config =
+    Irmin.Private.Conf.add config freeze_throttle_key freeze_throttle
   in
   config

--- a/src/irmin-pack/config.mli
+++ b/src/irmin-pack/config.mli
@@ -25,8 +25,11 @@ val index_log_size : Irmin.Private.Conf.t -> int
 
 val readonly : Irmin.Private.Conf.t -> bool
 
-val index_throttle :
-  Irmin.Private.Conf.t -> [ `Block_writes | `Overcommit_memory ]
+type throttle = [ `Block_writes | `Overcommit_memory ]
+
+val index_throttle : Irmin.Private.Conf.t -> throttle
+
+val freeze_throttle : Irmin.Private.Conf.t -> throttle
 
 val root : Irmin.Private.Conf.t -> string
 
@@ -35,6 +38,7 @@ val v :
   ?readonly:bool ->
   ?lru_size:int ->
   ?index_log_size:int ->
-  ?index_throttle:[ `Overcommit_memory | `Block_writes ] ->
+  ?index_throttle:throttle ->
+  ?freeze_throttle:throttle ->
   string ->
   Irmin.config

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -30,6 +30,8 @@ exception RO_Not_Allowed = IO.Unix.RO_Not_Allowed
 
 exception Unsupported_version = Store.Unsupported_version
 
+type throttle = [ `Overcommit_memory | `Block_writes ] [@@deriving irmin]
+
 let ( ++ ) = Int64.add
 
 let () =

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -14,12 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type throttle = [ `Overcommit_memory | `Block_writes ] [@@deriving irmin]
+
 val config :
   ?fresh:bool ->
   ?readonly:bool ->
   ?lru_size:int ->
   ?index_log_size:int ->
-  ?index_throttle:[ `Overcommit_memory | `Block_writes ] ->
+  ?index_throttle:throttle ->
+  ?freeze_throttle:throttle ->
   string ->
   Irmin.config
 (** Configuration options for stores.


### PR DESCRIPTION
This simply discard new `freeze` operations until the current freeze is completed.

Fixes #1156 

The results are impressive, as we are doing way less freezes:

```
» time dune exec -- ./bench/irmin-pack/layers.exe -n 300
Running benchmarks in bench/irmin-pack/layers.ml:

  { ncommits = 300;
    ncycles = 10;
    depth = 10;
    root = "test-bench";
    clear = false;
    no_freeze = false;
    show_stats = false;
    freeze_throttle = Block_writes }

+1607450672us [WARNING] irmin.layers freeze blocked for 1.382350 seconds due to a previous unfinished freeze
+1607450675us [WARNING] irmin.layers freeze blocked for 1.879525 seconds due to a previous unfinished freeze
+1607450677us [WARNING] irmin.layers freeze blocked for 2.189845 seconds due to a previous unfinished freeze
+1607450680us [WARNING] irmin.layers freeze blocked for 2.489503 seconds due to a previous unfinished freeze
+1607450683us [WARNING] irmin.layers freeze blocked for 2.507450 seconds due to a previous unfinished freeze
+1607450686us [WARNING] irmin.layers freeze blocked for 2.893117 seconds due to a previous unfinished freeze
+1607450690us [WARNING] irmin.layers freeze blocked for 3.733707 seconds due to a previous unfinished freeze
+1607450694us [WARNING] irmin.layers freeze blocked for 3.533506 seconds due to a previous unfinished freeze
+1607450698us [WARNING] irmin.layers freeze blocked for 3.788449 seconds due to a previous unfinished freeze
+1607450703us  application 4500 commits completed in 32.33s.
[0.007s per commit, 139 commits per second]
dune exec -- ./bench/irmin-pack/layers.exe -n 300  26.29s user 6.64s system 96% cpu 34.058 total
```
vs.

```
» time dune exec -- ./bench/irmin-pack/layers.exe -n 300 --f
reeze-throttle=overcommit-memory
Running benchmarks in bench/irmin-pack/layers.ml:

  { ncommits = 300;
    ncycles = 10;
    depth = 10;
    root = "test-bench";
    clear = false;
    no_freeze = false;
    show_stats = false;
    freeze_throttle = Overcommit_memory }

+1607450783us  application 4500 commits completed in 6.92s.
[0.002s per commit, 650 commits per second]
dune exec -- ./bench/irmin-pack/layers.exe -n 300   6.33s user 1.09s system 98% cpu 7.517 total
```