### PR TITLE
irmin: ensure that fold functions are polymorphic in their continuation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
   - Make Tree.clear tail-recursive (#1171, @samoht)
 
   - Fix `Tree.fold ~force:(False f)` where results where partially skipped
-    (#1174, @Ngoguey42 and @samoht)
+    (#1174, @Ngoguey42, @samoht and @CraigFe )
 
 - **ppx_irmin**
   - Fix a bug causing certain type derivations to be incorrect due to unsound

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
   - Make Tree.clear tail-recursive (#1171, @samoht)
 
+  - Fix `Tree.fold ~force:(False f)` where results where partially skipped
+    (#1174, @Ngoguey42 and @samoht)
+
 - **ppx_irmin**
   - Fix a bug causing certain type derivations to be incorrect due to unsound
     namespacing. (#1083, @CraigFe)

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -714,7 +714,7 @@ module Make (P : S.PRIVATE) = struct
           | `False skip -> (
               match t.info.map with
               | Some n -> (map [@tailcall]) ~path acc d (Some n) k
-              | _ -> skip path acc)
+              | _ -> skip path acc >>= k)
         in
         match depth with
         | None -> apply acc >>= next


### PR DESCRIPTION
This adds polymorphic type annotations to many of the CPS-ed fold functions in `tree.ml`, ensuring that they call the continuation appropriately. This catches the bug fixed by https://github.com/mirage/irmin/pull/1174, and so is rebased on that.