### PR TITLE
irmin: add tests of `Tree.fold ~force`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,7 +94,7 @@
 - **ppx_irmin**:
 
   - Added support for deriving type representations for types with type
-    parameters. Type `'a t` generateseara representation of type
+    parameters. Type `'a t` generates a representation of type
     `'a Type.t -> 'a t Type.t` (#1085, @CraigFe)
 
   - Added a `--lib` command-line option which has the same behaviour as the
@@ -109,6 +109,8 @@
 
 - **irmin**
   - Renamed the `Tree.tree` type to `Tree.t`. (#1022, @CraigFe)
+
+  - Replaced `Tree.pp_stats` with the type representation `Tree.stats_t`. (#TODO, @CraigFe)
 
   - Changed the JSON encoding of special floats. `Float.nan`, `Float.infinity`
     and `Float.neg_infinity` are now encoded as `"nan"`, `"inf"` and `"-inf"`

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1372,7 +1372,7 @@ module Make (S : S) = struct
     in
     run x test
 
-  let stats_t = Alcotest.testable S.Tree.pp_stats ( = )
+  let stats_t = Alcotest.testable (Irmin.Type.pp_dump S.Tree.stats_t) ( = )
 
   let empty_stats =
     { S.Tree.nodes = 0; leafs = 0; skips = 0; depth = 0; width = 0 }

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -986,12 +986,9 @@ module Make (P : S.PRIVATE) = struct
     depth : int;
     width : int;
   }
+  [@@deriving irmin]
 
   let empty_stats = { nodes = 0; leafs = 0; skips = 0; depth = 0; width = 0 }
-
-  let pp_stats ppf { nodes; leafs; skips; depth; width } =
-    Fmt.pf ppf "{@[nodes=%d; leafs=%d; skips=%d; depth=%d; width=%d]}" nodes
-      leafs skips depth width
 
   let incr_nodes s = { s with nodes = s.nodes + 1 }
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -231,10 +231,8 @@ module type S = sig
     depth : int;  (** Maximal depth. *)
     width : int;  (** Maximal width. *)
   }
+  [@@deriving irmin]
   (** The type for tree stats. *)
-
-  val pp_stats : stats Fmt.t
-  (** [pp_stats] is the pretty printer for tree statistics. *)
 
   val stats : ?force:bool -> t -> stats Lwt.t
   (** [stats ~force t] are [t]'s statistics. If [force] is true, this will force
@@ -250,16 +248,16 @@ module type S = sig
   (** The value-type for {!concrete}. *)
 
   val of_concrete : concrete -> t
-  (** [of_concrete c] is the subtree equivalent to the concrete tree [c]. *)
+  (** [of_concrete c] is the subtree equivalent of the concrete tree [c]. *)
 
   val to_concrete : t -> concrete Lwt.t
-  (** [to_concrete t] is the concrete tree equivalent to the subtree [t]. *)
+  (** [to_concrete t] is the concrete tree equivalent of the subtree [t]. *)
 
   (** {1 Caches} *)
 
   val clear : ?depth:int -> t -> unit
-  (** [clear ?depth t] clears all the cache in the tree [t] for subtrees with a
-      depth higher than [depth]. If [depth] is not set, all the subtrees are
+  (** [clear ?depth t] clears all caches in the tree [t] for subtrees with a
+      depth higher than [depth]. If [depth] is not set, all of the subtrees are
       cleared. *)
 
   (** {1 Performance counters} *)


### PR DESCRIPTION
This adds various tests of `Tree.fold` (particularly of the `~force` parameter), and strengthens the test of `Tree.clear`. Like https://github.com/mirage/irmin/pull/1180, this witnesses the bug fixed by https://github.com/mirage/irmin/pull/1174 and so is based on that.

Fix https://github.com/mirage/irmin/issues/1175.