### PR TITLE
irmin: add a LRU cache to Repo.iter

### DIFF
--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -34,14 +34,6 @@ module Table (K : Irmin.Type.S) = Hashtbl.Make (struct
   let equal = Irmin.Type.(unstage (equal K.t))
 end)
 
-module Cache (K : Irmin.Type.S) = Lru.Make (struct
-  type t = K.t
-
-  let hash = Irmin.Type.(unstage (short_hash K.t)) ?seed:None
-
-  let equal = Irmin.Type.(unstage (equal K.t))
-end)
-
 module IO_cache = IO.Cache
 module IO = IO.Unix
 
@@ -90,7 +82,7 @@ struct
 
   module Make (V : ELT with type hash := K.t) = struct
     module Tbl = Table (K)
-    module Lru = Cache (K)
+    module Lru = Irmin.Private.Lru.Make (K)
 
     type nonrec 'a t = {
       pack : 'a t;

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -356,6 +356,7 @@ module Private = struct
 
   module Watch = Watch
   module Lock = Lock
+  module Lru = Lru
 end
 
 let version = Version.current

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -254,6 +254,7 @@ module Private : sig
       stores. *)
 
   module Lock = Lock
+  module Lru = Lru
 
   (** [Node] provides functions to describe the graph-like structured values.
 

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -13,7 +13,15 @@
 (* Extracted from https://github.com/pqwy/lru
    Copyright (c) 2016 David Kaloper Meršinjak *)
 
-module Make (H : Hashtbl.HashedType) = struct
+module Make (K : Type.S) = struct
+  module H = struct
+    type t = K.t
+
+    let hash = Type.(unstage (short_hash K.t)) ?seed:None
+
+    let equal = Type.(unstage (equal K.t))
+  end
+
   module HT = Hashtbl.Make (H)
 
   module Q = struct

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -13,7 +13,7 @@
 (* Extracted from https://github.com/pqwy/lru
    Copyright (c) 2016 David Kaloper Meršinjak *)
 
-module Make (H : Hashtbl.HashedType) : sig
+module Make (H : Type.S) : sig
   type 'a t
 
   val create : int -> 'a t

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -48,6 +48,7 @@ module type S = sig
       {b Note:} Both [min] and [max] are subsets of [n]. *)
 
   val iter :
+    ?cache_size:int ->
     ?depth:int ->
     pred:(vertex -> vertex list Lwt.t) ->
     min:vertex list ->
@@ -69,7 +70,11 @@ module type S = sig
       If [rev] is true (the default) then the graph is traversed in the reverse
       order: [node n] is applied only after it was applied on all its
       predecessors; [edge n p] is applied after [node n]. Note that [edge n p]
-      is applied even if [p] is skipped. *)
+      is applied even if [p] is skipped.
+
+      [cache_size] is the size of the LRU cache used to store nodes already
+      seen. If [None] (by default) every traversed nodes is stored (and thus no
+      entries are never removed from the LRU). *)
 
   val output :
     Format.formatter ->

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -376,13 +376,13 @@ module Make (P : S.PRIVATE) = struct
           []
       | Some b -> [ `Commit b ]
 
-    let iter t ~min ~max ?edge ?(branch = ignore_lwt) ?(commit = ignore_lwt)
-        ?(node = ignore_lwt) ?(contents = ignore_lwt)
+    let iter ?cache_size ~min ~max ?edge ?(branch = ignore_lwt)
+        ?(commit = ignore_lwt) ?(node = ignore_lwt) ?(contents = ignore_lwt)
         ?(skip_branch = return_false) ?(skip_commit = return_false)
         ?(skip_node = return_false) ?(skip_contents = return_false)
         ?(pred_branch = default_pred_branch)
         ?(pred_commit = default_pred_commit) ?(pred_node = default_pred_node)
-        ?(pred_contents = default_pred_contents) ?(rev = true) () =
+        ?(pred_contents = default_pred_contents) ?(rev = true) t =
       let node = function
         | `Commit x -> commit x
         | `Node x -> node x
@@ -401,7 +401,7 @@ module Make (P : S.PRIVATE) = struct
         | `Contents x -> pred_contents t x
         | `Branch x -> pred_branch t x
       in
-      KGraph.iter ~pred ~min ~max ~node ?edge ~skip ~rev ()
+      KGraph.iter ?cache_size ~pred ~min ~max ~node ?edge ~skip ~rev ()
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -129,7 +129,7 @@ module type S = sig
     (** The type for elements iterated over by {!iter}. *)
 
     val iter :
-      t ->
+      ?cache_size:int ->
       min:elt list ->
       max:elt list ->
       ?edge:(elt -> elt -> unit Lwt.t) ->
@@ -146,7 +146,7 @@ module type S = sig
       ?pred_node:(t -> hash -> elt list Lwt.t) ->
       ?pred_contents:(t -> hash -> elt list Lwt.t) ->
       ?rev:bool ->
-      unit ->
+      t ->
       unit Lwt.t
     (** [iter t] iterates in topological order over the closure graph of [t]. If
         [rev] is set (by default it is) the traversal is done in reverse order.
@@ -177,7 +177,13 @@ module type S = sig
           users to define an inclusive range of commit to iterate over.
         - branch objects in [min] implicitly add to [min] the commit they are
           pointing to; this allow users to define the iteration between two
-          branches. *)
+          branches.
+
+        [cache_size] is the size of the LRU used to store traversed objects. If
+        an entry is evicted from the LRU, it can be traversed multiple times by
+        {!Repo.iter}. When [cache_size] is [None] (the default), no entries is
+        ever evicted from the cache; hence every object is only traversed once,
+        at the cost of having to store all the traversed objects in memory. *)
   end
 
   val empty : repo -> t Lwt.t


### PR DESCRIPTION
Alternative implementation of #1122 ; that seems to work as expected but I haven't benchmarked / tested this extensively.