### PR TITLE
Revert log size to normal value

### DIFF
--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -96,8 +96,7 @@ end
 
 let configure_store root freeze_throttle =
   let conf =
-    Irmin_pack.config ~readonly:false ~fresh:true
-      ~index_throttle:`Overcommit_memory ~freeze_throttle root
+    Irmin_pack.config ~readonly:false ~fresh:true ~freeze_throttle root
   in
   Irmin_pack.config_layers ~conf ~with_lower:false ~blocking_copy_size:1000
     ~copy_in_upper:true ()

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -329,7 +329,7 @@ struct
         let fresh = Pack_config.fresh config in
         let lru_size = Pack_config.lru_size config in
         let readonly = Pack_config.readonly config in
-        let log_size = 4 * Pack_config.index_log_size config in
+        let log_size = Pack_config.index_log_size config in
         let throttle = Pack_config.index_throttle config in
         let f = ref (fun () -> ()) in
         let index =


### PR DESCRIPTION
The layered store used the index with a `log_size` 4 times larger than the one passed on as argument. This was to prevent blocking merges during a freeze without using `index_throttle:Overcommit_memory`. 
In PR https://github.com/mirage/irmin/pull/1183 no merge is triggered during a freeze; a merge is called only at the end of the freeze. So we can revert the `log_size` to its normal value, for all operations not caused by freeze.

I also removed `index_throttle:Overcommit_memory` from the layers benchmark: we are not using this option in tezos; and we cannot see the effects when reducing the `log_size` with this option on. 