### PR TITLE
Add integrity-check command to irmin-fsck

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,9 @@
   - Added `reconstruct-index` command to `irmin-fsck` for reconstructing an index from
     the command line (#1189, @zshipko)
 
+  - Added `integrity-check` command to `irmin-fsck` for checking the integrity of
+    an `irmin-pack` store (#1196, @zshipko)
+
 - **ppx_irmin**:
 
   - Added support for deriving type representations for types with type

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -185,17 +185,17 @@ struct
       let open Cmdliner.Arg in
       value
       & flag
-        @@ info ~doc:"Automatically repair issues" ~docv:"REPAIR"
+        @@ info ~doc:"Automatically repair issues" ~docv:"AUTOREPAIR"
              [ "auto-repair" ]
 
     let run ~root ~auto_repair =
       let conf = conf root in
       Store.Repo.v conf >|= fun repo ->
       match Store.integrity_check ~auto_repair repo with
-      | Ok (`Fixed n) -> Printf.printf "OK. fixed %d\n%!" n
-      | Ok `No_error -> print_endline "OK"
-      | Error (`Cannot_fix x) -> Printf.eprintf "ERROR cannot fix: %s\n%!" x
-      | Error (`Corrupted x) -> Printf.eprintf "ErrOR corrupted: %d\n%!" x
+      | Ok (`Fixed n) -> Printf.printf "Ok -- fixed %d\n%!" n
+      | Ok `No_error -> print_endline "Ok"
+      | Error (`Cannot_fix x) -> Printf.eprintf "Error -- cannot fix: %s\n%!" x
+      | Error (`Corrupted x) -> Printf.eprintf "Error -- corrupted: %d\n%!" x
 
     let term =
       Cmdliner.Term.(

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -181,10 +181,8 @@ struct
 
     let auto_repair =
       let open Cmdliner.Arg in
-      value
-      & flag
-        @@ info ~doc:"Automatically repair issues" [ "auto-repair" ]
-
+      value & (flag @@ info ~doc:"Automatically repair issues" [ "auto-repair" ])
+ 
     let handle_result name res =
       let name = match name with Some x -> x ^ ": " | None -> "" in
       match res with

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -183,8 +183,7 @@ struct
       let open Cmdliner.Arg in
       value
       & flag
-        @@ info ~doc:"Automatically repair issues" ~docv:"AUTOREPAIR"
-             [ "auto-repair" ]
+        @@ info ~doc:"Automatically repair issues" [ "auto-repair" ]
 
     let handle_result name res =
       let name = match name with Some x -> x ^ ": " | None -> "" in

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -182,7 +182,7 @@ struct
     let auto_repair =
       let open Cmdliner.Arg in
       value & (flag @@ info ~doc:"Automatically repair issues" [ "auto-repair" ])
- 
+
     let handle_result name res =
       let name = match name with Some x -> x ^ ": " | None -> "" in
       match res with

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -33,9 +33,9 @@ module Make
     (B : Irmin.Branch.S)
     (H : Irmin.Hash.S)
     (Node : Irmin.Private.Node.S
-              with type metadata = M.t
-               and type hash = H.t
-               and type step = P.step)
+     with type metadata = M.t
+      and type hash = H.t
+      and type step = P.step)
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
@@ -52,12 +52,12 @@ struct
     match IO.exists path with
     | false -> Lwt.return_none
     | true ->
-        IO_layers.IO.v path >>= fun t ->
-        (IO_layers.IO.read_flip t >|= function
-         | true -> `Upper1
-         | false -> `Upper0)
-        >>= fun a ->
-        IO_layers.IO.close t >|= fun () -> Some a
+      IO_layers.IO.v path >>= fun t ->
+      (IO_layers.IO.read_flip t >|= function
+        | true -> `Upper1
+        | false -> `Upper0)
+      >>= fun a ->
+      IO_layers.IO.close t >|= fun () -> Some a
 
   (** Read basic metrics from an existing store. *)
   module Stat = struct
@@ -81,15 +81,15 @@ struct
     type t = { hash_size : size; files : files_store } [@@deriving irmin]
 
     let with_io : type a. string -> (IO.t -> a) -> a option =
-     fun path f ->
+      fun path f ->
       match IO.exists path with
       | false -> None
       | true ->
-          let io =
-            IO.v ~fresh:false ~readonly:true ~version:(Some current_version)
-              path
-          in
-          Fun.protect ~finally:(fun () -> IO.close io) (fun () -> Some (f io))
+        let io =
+          IO.v ~fresh:false ~readonly:true ~version:(Some current_version)
+            path
+        in
+        Fun.protect ~finally:(fun () -> IO.close io) (fun () -> Some (f io))
 
     let io path =
       with_io path @@ fun io ->
@@ -108,12 +108,12 @@ struct
       match detect_layered_store ~root with
       | false -> Lwt.return (Simple (v_simple ~root))
       | true ->
-          Logs.app (fun f -> f "Layered store detected");
-          read_flip ~root >|= fun flip ->
-          let lower = v_simple ~root:(Layout.lower ~root)
-          and upper1 = v_simple ~root:(Layout.upper1 ~root)
-          and upper0 = v_simple ~root:(Layout.upper0 ~root) in
-          Layered { flip; lower; upper1; upper0 }
+        Logs.app (fun f -> f "Layered store detected");
+        read_flip ~root >|= fun flip ->
+        let lower = v_simple ~root:(Layout.lower ~root)
+        and upper1 = v_simple ~root:(Layout.upper1 ~root)
+        and upper0 = v_simple ~root:(Layout.upper0 ~root) in
+        Layered { flip; lower; upper1; upper0 }
 
     let run ~root =
       Logs.app (fun f -> f "Getting statistics for store: `%s'@," root);
@@ -137,16 +137,16 @@ struct
     let check_store ~root (module S : Irmin_pack_layers.S) =
       S.Repo.v (conf root) >>= fun repo ->
       (S.check_self_contained repo >|= function
-       | Ok (`Msg msg) -> Logs.app (fun l -> l "Ok -- %s" msg)
-       | Error (`Msg msg) -> Logs.err (fun l -> l "Error -- %s" msg))
+        | Ok (`Msg msg) -> Logs.app (fun l -> l "Ok -- %s" msg)
+        | Error (`Msg msg) -> Logs.err (fun l -> l "Error -- %s" msg))
       >>= fun () -> S.Repo.close repo
 
     let run ~root =
       if not (detect_layered_store ~root) then
         Fmt.failwith "%s is not a layered store." root;
       (read_flip ~root >|= function
-       | None | Some `Upper1 -> Layout.upper1 ~root
-       | Some `Upper0 -> Layout.upper0 ~root)
+        | None | Some `Upper1 -> Layout.upper1 ~root
+        | Some `Upper0 -> Layout.upper0 ~root)
       >>= fun upper ->
       if detect_pack_layer ~layer_root:upper then
         check_store ~root (module Store)
@@ -165,7 +165,7 @@ struct
       let open Cmdliner.Arg in
       value
       & pos 1 (some string) None
-        @@ info ~doc:"Path to the new index file" ~docv:"DEST" []
+      @@ info ~doc:"Path to the new index file" ~docv:"DEST" []
 
     let run ~root ~output =
       let conf = conf root in
@@ -177,7 +177,6 @@ struct
   end
 
   module Integrity_check = struct
-    module Store = Ext.Make (Conf) (M) (C) (P) (B) (H) (Node) (Commit)
 
     let conf root = Config.v ~readonly:false ~fresh:false root
 
@@ -185,17 +184,40 @@ struct
       let open Cmdliner.Arg in
       value
       & flag
-        @@ info ~doc:"Automatically repair issues" ~docv:"AUTOREPAIR"
-             [ "auto-repair" ]
+      @@ info ~doc:"Automatically repair issues" ~docv:"AUTOREPAIR"
+        [ "auto-repair" ]
 
-    let run ~root ~auto_repair =
+    let handle_result name res =
+      let name = match name with Some x -> x ^ ": " | None -> "" in
+      match res with
+      | Ok (`Fixed n) -> Printf.printf "%sOk -- fixed %d\n%!" name n
+      | Ok `No_error -> Printf.printf "%sOk\n%!" name
+      | Error (`Cannot_fix x) -> Printf.eprintf "%sError -- cannot fix: %s\n%!" name x
+      | Error (`Corrupted x) -> Printf.eprintf "%sError -- corrupted: %d\n%!" name x
+
+    let run_simple ~root ~auto_repair =
+      let module Store = Ext.Make (Conf) (M) (C) (P) (B) (H) (Node) (Commit) in
       let conf = conf root in
       Store.Repo.v conf >|= fun repo ->
-      match Store.integrity_check ~auto_repair repo with
-      | Ok (`Fixed n) -> Printf.printf "Ok -- fixed %d\n%!" n
-      | Ok `No_error -> print_endline "Ok"
-      | Error (`Cannot_fix x) -> Printf.eprintf "Error -- cannot fix: %s\n%!" x
-      | Error (`Corrupted x) -> Printf.eprintf "Error -- corrupted: %d\n%!" x
+      Store.integrity_check ~auto_repair repo |> handle_result None
+
+    let run ~root ~auto_repair =
+      match detect_layered_store ~root with
+      | false ->
+        run_simple ~root ~auto_repair
+      | true ->
+        let module Store = Irmin_pack_layers.Make_ext (Conf) (M) (C) (P) (B) (H) (Node) (Commit) in
+        Logs.app (fun f -> f "Layered store detected");
+        let conf = conf root in
+        let lower_root = Layout.lower ~root in
+        let upper_root1 = Layout.upper1 ~root in
+        let upper_root0 = Layout.upper0 ~root in
+        let conf = Irmin_pack_layers.config_layers ~conf ~lower_root ~upper_root1 ~upper_root0 () in
+        Store.Repo.v conf >|= fun repo ->
+        let res = Store.integrity_check ~auto_repair repo in
+        List.iter (fun (r, id) ->
+            handle_result (Some (Irmin_layers.Layer_id.to_string id)) r) res
+
 
     let term =
       Cmdliner.Term.(
@@ -218,10 +240,10 @@ struct
             msgf @@ fun ?header:_ ?tags:_ fmt ->
             match level with
             | Logs.App ->
-                Fmt.kpf k Fmt.stderr
-                  ("@[<v 0>%a" ^^ fmt ^^ "@]@.")
-                  Fmt.(styled `Bold (styled (`Fg `Cyan) string))
-                  ">> "
+              Fmt.kpf k Fmt.stderr
+                ("@[<v 0>%a" ^^ fmt ^^ "@]@.")
+                Fmt.(styled `Bold (styled (`Fg `Cyan) string))
+                ">> "
             | _ -> Fmt.kpf k Fmt.stdout ("@[<v 0>" ^^ fmt ^^ "@]@.")
           in
           { Logs.report }

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -33,9 +33,9 @@ module Make
     (B : Irmin.Branch.S)
     (H : Irmin.Hash.S)
     (Node : Irmin.Private.Node.S
-     with type metadata = M.t
-      and type hash = H.t
-      and type step = P.step)
+              with type metadata = M.t
+               and type hash = H.t
+               and type step = P.step)
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
@@ -52,12 +52,12 @@ struct
     match IO.exists path with
     | false -> Lwt.return_none
     | true ->
-      IO_layers.IO.v path >>= fun t ->
-      (IO_layers.IO.read_flip t >|= function
-        | true -> `Upper1
-        | false -> `Upper0)
-      >>= fun a ->
-      IO_layers.IO.close t >|= fun () -> Some a
+        IO_layers.IO.v path >>= fun t ->
+        (IO_layers.IO.read_flip t >|= function
+         | true -> `Upper1
+         | false -> `Upper0)
+        >>= fun a ->
+        IO_layers.IO.close t >|= fun () -> Some a
 
   (** Read basic metrics from an existing store. *)
   module Stat = struct
@@ -81,15 +81,15 @@ struct
     type t = { hash_size : size; files : files_store } [@@deriving irmin]
 
     let with_io : type a. string -> (IO.t -> a) -> a option =
-      fun path f ->
+     fun path f ->
       match IO.exists path with
       | false -> None
       | true ->
-        let io =
-          IO.v ~fresh:false ~readonly:true ~version:(Some current_version)
-            path
-        in
-        Fun.protect ~finally:(fun () -> IO.close io) (fun () -> Some (f io))
+          let io =
+            IO.v ~fresh:false ~readonly:true ~version:(Some current_version)
+              path
+          in
+          Fun.protect ~finally:(fun () -> IO.close io) (fun () -> Some (f io))
 
     let io path =
       with_io path @@ fun io ->
@@ -108,12 +108,12 @@ struct
       match detect_layered_store ~root with
       | false -> Lwt.return (Simple (v_simple ~root))
       | true ->
-        Logs.app (fun f -> f "Layered store detected");
-        read_flip ~root >|= fun flip ->
-        let lower = v_simple ~root:(Layout.lower ~root)
-        and upper1 = v_simple ~root:(Layout.upper1 ~root)
-        and upper0 = v_simple ~root:(Layout.upper0 ~root) in
-        Layered { flip; lower; upper1; upper0 }
+          Logs.app (fun f -> f "Layered store detected");
+          read_flip ~root >|= fun flip ->
+          let lower = v_simple ~root:(Layout.lower ~root)
+          and upper1 = v_simple ~root:(Layout.upper1 ~root)
+          and upper0 = v_simple ~root:(Layout.upper0 ~root) in
+          Layered { flip; lower; upper1; upper0 }
 
     let run ~root =
       Logs.app (fun f -> f "Getting statistics for store: `%s'@," root);
@@ -137,16 +137,16 @@ struct
     let check_store ~root (module S : Irmin_pack_layers.S) =
       S.Repo.v (conf root) >>= fun repo ->
       (S.check_self_contained repo >|= function
-        | Ok (`Msg msg) -> Logs.app (fun l -> l "Ok -- %s" msg)
-        | Error (`Msg msg) -> Logs.err (fun l -> l "Error -- %s" msg))
+       | Ok (`Msg msg) -> Logs.app (fun l -> l "Ok -- %s" msg)
+       | Error (`Msg msg) -> Logs.err (fun l -> l "Error -- %s" msg))
       >>= fun () -> S.Repo.close repo
 
     let run ~root =
       if not (detect_layered_store ~root) then
         Fmt.failwith "%s is not a layered store." root;
       (read_flip ~root >|= function
-        | None | Some `Upper1 -> Layout.upper1 ~root
-        | Some `Upper0 -> Layout.upper0 ~root)
+       | None | Some `Upper1 -> Layout.upper1 ~root
+       | Some `Upper0 -> Layout.upper0 ~root)
       >>= fun upper ->
       if detect_pack_layer ~layer_root:upper then
         check_store ~root (module Store)
@@ -165,7 +165,7 @@ struct
       let open Cmdliner.Arg in
       value
       & pos 1 (some string) None
-      @@ info ~doc:"Path to the new index file" ~docv:"DEST" []
+        @@ info ~doc:"Path to the new index file" ~docv:"DEST" []
 
     let run ~root ~output =
       let conf = conf root in
@@ -177,23 +177,24 @@ struct
   end
 
   module Integrity_check = struct
-
     let conf root = Config.v ~readonly:false ~fresh:false root
 
     let auto_repair =
       let open Cmdliner.Arg in
       value
       & flag
-      @@ info ~doc:"Automatically repair issues" ~docv:"AUTOREPAIR"
-        [ "auto-repair" ]
+        @@ info ~doc:"Automatically repair issues" ~docv:"AUTOREPAIR"
+             [ "auto-repair" ]
 
     let handle_result name res =
       let name = match name with Some x -> x ^ ": " | None -> "" in
       match res with
       | Ok (`Fixed n) -> Printf.printf "%sOk -- fixed %d\n%!" name n
       | Ok `No_error -> Printf.printf "%sOk\n%!" name
-      | Error (`Cannot_fix x) -> Printf.eprintf "%sError -- cannot fix: %s\n%!" name x
-      | Error (`Corrupted x) -> Printf.eprintf "%sError -- corrupted: %d\n%!" name x
+      | Error (`Cannot_fix x) ->
+          Printf.eprintf "%sError -- cannot fix: %s\n%!" name x
+      | Error (`Corrupted x) ->
+          Printf.eprintf "%sError -- corrupted: %d\n%!" name x
 
     let run_simple ~root ~auto_repair =
       let module Store = Ext.Make (Conf) (M) (C) (P) (B) (H) (Node) (Commit) in
@@ -203,21 +204,27 @@ struct
 
     let run ~root ~auto_repair =
       match detect_layered_store ~root with
-      | false ->
-        run_simple ~root ~auto_repair
+      | false -> run_simple ~root ~auto_repair
       | true ->
-        let module Store = Irmin_pack_layers.Make_ext (Conf) (M) (C) (P) (B) (H) (Node) (Commit) in
-        Logs.app (fun f -> f "Layered store detected");
-        let conf = conf root in
-        let lower_root = Layout.lower ~root in
-        let upper_root1 = Layout.upper1 ~root in
-        let upper_root0 = Layout.upper0 ~root in
-        let conf = Irmin_pack_layers.config_layers ~conf ~lower_root ~upper_root1 ~upper_root0 () in
-        Store.Repo.v conf >|= fun repo ->
-        let res = Store.integrity_check ~auto_repair repo in
-        List.iter (fun (r, id) ->
-            handle_result (Some (Irmin_layers.Layer_id.to_string id)) r) res
-
+          let module Store =
+            Irmin_pack_layers.Make_ext (Conf) (M) (C) (P) (B) (H) (Node)
+              (Commit)
+          in
+          Logs.app (fun f -> f "Layered store detected");
+          let conf = conf root in
+          let lower_root = Layout.lower ~root in
+          let upper_root1 = Layout.upper1 ~root in
+          let upper_root0 = Layout.upper0 ~root in
+          let conf =
+            Irmin_pack_layers.config_layers ~conf ~lower_root ~upper_root1
+              ~upper_root0 ()
+          in
+          Store.Repo.v conf >|= fun repo ->
+          let res = Store.integrity_check ~auto_repair repo in
+          List.iter
+            (fun (r, id) ->
+              handle_result (Some (Irmin_layers.Layer_id.to_string id)) r)
+            res
 
     let term =
       Cmdliner.Term.(
@@ -240,10 +247,10 @@ struct
             msgf @@ fun ?header:_ ?tags:_ fmt ->
             match level with
             | Logs.App ->
-              Fmt.kpf k Fmt.stderr
-                ("@[<v 0>%a" ^^ fmt ^^ "@]@.")
-                Fmt.(styled `Bold (styled (`Fg `Cyan) string))
-                ">> "
+                Fmt.kpf k Fmt.stderr
+                  ("@[<v 0>%a" ^^ fmt ^^ "@]@.")
+                  Fmt.(styled `Bold (styled (`Fg `Cyan) string))
+                  ">> "
             | _ -> Fmt.kpf k Fmt.stdout ("@[<v 0>" ^^ fmt ^^ "@]@.")
           in
           { Logs.report }

--- a/src/irmin-pack/checks_intf.ml
+++ b/src/irmin-pack/checks_intf.ml
@@ -17,6 +17,22 @@ module type S = sig
     (** A pre-packaged [Cmdliner] term for executing {!run}. *)
   end
 
+  module Reconstruct_index : sig
+    val run : root:string -> output:string option -> unit
+    (** Rebuilds an index for an existing pack file *)
+
+    val term : (unit -> unit) Cmdliner.Term.t
+    (** A pre-packaged [Cmdliner] term for executing {!run}. *)
+  end
+
+  module Integrity_check : sig
+    val run : root:string -> auto_repair:bool -> unit Lwt.t
+    (** Checks the integrity of a store *)
+
+    val term : (unit -> unit) Cmdliner.Term.t
+    (** A pre-packaged [Cmdliner] term for executing {!run}. *)
+  end
+
   val cli : unit -> empty
   (** Run a [Cmdliner] binary containing tools for running offline checks. *)
 end

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -116,9 +116,9 @@ module Make_ext
     (B : Irmin.Branch.S)
     (H : Irmin.Hash.S)
     (Node : Irmin.Private.Node.S
-     with type metadata = M.t
-      and type hash = H.t
-      and type step = P.step)
+              with type metadata = M.t
+               and type hash = H.t
+               and type step = P.step)
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
@@ -148,28 +148,28 @@ struct
         module Val = C
 
         module CA_Pack = Pack.Make (struct
-            include Val
-            module H = Irmin.Hash.Typed (H) (Val)
+          include Val
+          module H = Irmin.Hash.Typed (H) (Val)
 
-            let hash = H.hash
+          let hash = H.hash
 
-            let magic = 'B'
+          let magic = 'B'
 
-            let value = value Val.t
+          let value = value Val.t
 
-            let encode_value = Irmin.Type.(unstage (encode_bin value))
+          let encode_value = Irmin.Type.(unstage (encode_bin value))
 
-            let decode_value = Irmin.Type.(unstage (decode_bin value))
+          let decode_value = Irmin.Type.(unstage (decode_bin value))
 
-            let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { magic; hash; v }
+          let encode_bin ~dict:_ ~offset:_ v hash =
+            encode_value { magic; hash; v }
 
-            let decode_bin ~dict:_ ~hash:_ s off =
-              let _, t = decode_value s off in
-              t.v
+          let decode_bin ~dict:_ ~hash:_ s off =
+            let _, t = decode_value s off in
+            t.v
 
-            let magic _ = magic
-          end)
+          let magic _ = magic
+        end)
 
         module CA = Closeable.Content_addressable (CA_Pack)
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
@@ -190,28 +190,28 @@ struct
         module Val = Commit
 
         module CA_Pack = Pack.Make (struct
-            include Val
-            module H = Irmin.Hash.Typed (H) (Val)
+          include Val
+          module H = Irmin.Hash.Typed (H) (Val)
 
-            let hash = H.hash
+          let hash = H.hash
 
-            let value = value Val.t
+          let value = value Val.t
 
-            let magic = 'C'
+          let magic = 'C'
 
-            let encode_value = Irmin.Type.(unstage (encode_bin value))
+          let encode_value = Irmin.Type.(unstage (encode_bin value))
 
-            let decode_value = Irmin.Type.(unstage (decode_bin value))
+          let decode_value = Irmin.Type.(unstage (decode_bin value))
 
-            let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { magic; hash; v }
+          let encode_bin ~dict:_ ~offset:_ v hash =
+            encode_value { magic; hash; v }
 
-            let decode_bin ~dict:_ ~hash:_ s off =
-              let _, v = decode_value s off in
-              v.v
+          let decode_bin ~dict:_ ~hash:_ s off =
+            let _, v = decode_value s off in
+            v.v
 
-            let magic _ = magic
-          end)
+          let magic _ = magic
+        end)
 
         module CA = Closeable.Content_addressable (CA_Pack)
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
@@ -335,7 +335,7 @@ struct
         let index =
           Index.v
             ~flush_callback:(fun () -> !f ())
-            (* backpatching to add pack flush before an index flush *)
+              (* backpatching to add pack flush before an index flush *)
             ~fresh ~readonly ~throttle ~log_size root
         in
         Contents.CA.U.v ~fresh ~readonly ~lru_size ~index root
@@ -372,10 +372,10 @@ struct
           (function
             | I.Invalid_version { expected; found }
               when expected = current_version ->
-              Log.err (fun m ->
-                  m "[%s] Attempted to open store of unsupported version %a"
-                    root pp_version found);
-              Lwt.fail (Unsupported_version found)
+                Log.err (fun m ->
+                    m "[%s] Attempted to open store of unsupported version %a"
+                      root pp_version found);
+                Lwt.fail (Unsupported_version found)
             | e -> Lwt.fail e)
 
       let freeze_info throttle =
@@ -390,8 +390,8 @@ struct
         let with_lower = with_lower config in
         let lower_root = Filename.concat root (lower_root config) in
         (if with_lower then
-           v_layer ~v:unsafe_v_lower lower_root config >|= fun lower -> Some lower
-         else Lwt.return_none)
+         v_layer ~v:unsafe_v_lower lower_root config >|= fun lower -> Some lower
+        else Lwt.return_none)
         >>= fun lower ->
         let file = Layout.flip ~root in
         IO_layers.v file >>= fun flip_file ->
@@ -403,7 +403,7 @@ struct
         let freeze_in_progress () = freeze.state = `Running in
         let add_lock = Lwt_mutex.create () in
         (if fresh && Lock.test lock_file then Lock.unlink lock_file
-         else Lwt.return_unit)
+        else Lwt.return_unit)
         >|= fun () ->
         let lower_contents = Option.map (fun x -> x.lcontents) lower in
         let contents =
@@ -451,7 +451,7 @@ struct
           {
             f =
               (fun (type a) (module C : S.LAYERED with type t = a) (x : a) ->
-                 C.close x);
+                C.close x);
           }
         in
         Iterate.iter_lwt f t
@@ -480,7 +480,7 @@ struct
           {
             f =
               (fun (type a) (module C : S.LAYERED with type t = a) (x : a) ->
-                 C.update_flip ~flip x);
+                C.update_flip ~flip x);
           }
         in
         Iterate.iter f t
@@ -495,25 +495,25 @@ struct
         let root = Pack_config.root config in
         [ upper_root1; upper_root0; lower_root ]
         |> List.map (fun name ->
-            let root = Filename.concat root (name config) in
-            let config = Conf.add config Pack_config.root_key (Some root) in
-            try
-              let io =
-                IO.v ~version:(Some current_version) ~fresh:false
-                  ~readonly:true (Layout.pack ~root)
-              in
-              (config, Some io)
-            with
-            | I.Invalid_version _ -> (config, None)
-            | e -> raise e)
+               let root = Filename.concat root (name config) in
+               let config = Conf.add config Pack_config.root_key (Some root) in
+               try
+                 let io =
+                   IO.v ~version:(Some current_version) ~fresh:false
+                     ~readonly:true (Layout.pack ~root)
+                 in
+                 (config, Some io)
+               with
+               | I.Invalid_version _ -> (config, None)
+               | e -> raise e)
         |> List.fold_left
-          (fun to_migrate (config, io) ->
-             match io with
-             | None -> config :: to_migrate
-             | Some io ->
-               IO.close io;
-               to_migrate)
-          []
+             (fun to_migrate (config, io) ->
+               match io with
+               | None -> config :: to_migrate
+               | Some io ->
+                   IO.close io;
+                   to_migrate)
+             []
         |> List.iter (fun config -> Store.migrate config)
 
       let layer_id t store_handler =
@@ -547,7 +547,7 @@ struct
           {
             f =
               (fun (type a) (module C : S.LAYERED with type t = a) (x : a) ->
-                 C.flip_upper x);
+                C.flip_upper x);
           }
         in
         Iterate.iter f t
@@ -569,10 +569,10 @@ struct
       let check ~kind ~offset ~length k =
         match kind with
         | `Contents ->
-          X.Contents.CA.integrity_check ~offset ~length ~layer k contents
+            X.Contents.CA.integrity_check ~offset ~length ~layer k contents
         | `Node -> X.Node.CA.integrity_check ~offset ~length ~layer k nodes
         | `Commit ->
-          X.Commit.CA.integrity_check ~offset ~length ~layer k commits
+            X.Commit.CA.integrity_check ~offset ~length ~layer k commits
       in
       Checks.integrity_check ?ppf ~auto_repair ~check index
     in
@@ -582,10 +582,9 @@ struct
       (`Lower, t.lower_index);
     ]
     |> List.map (fun (layer, index) ->
-        match index with
-        | Some index ->
-          (integrity_check_layer ~layer index), layer
-        | None -> (Ok `No_error), layer)
+           match index with
+           | Some index -> (integrity_check_layer ~layer index, layer)
+           | None -> (Ok `No_error, layer))
 
   include Irmin.Of_private (X)
 
@@ -622,8 +621,8 @@ struct
       pause () >>= fun () ->
       skip h >|= function
       | true ->
-        Irmin_layers.Stats.skip ();
-        true
+          Irmin_layers.Stats.skip ();
+          true
       | false -> false
 
     let no_skip _ = Lwt.return false
@@ -633,9 +632,9 @@ struct
       X.Node.CA.find n k >|= function
       | None -> []
       | Some v ->
-        List.rev_map
-          (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
-          (X.Node.CA.Val.pred v)
+          List.rev_map
+            (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
+            (X.Node.CA.Val.pred v)
 
     let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
         ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
@@ -853,14 +852,14 @@ struct
     (* Copy commits to lower: if squash then copy only the max commits *)
     let with_lower = with_lower t.X.Repo.config in
     (if with_lower then
-       let min = if squash then max else min in
-       with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
-     else Lwt.return_unit)
+     let min = if squash then max else min in
+     with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
+    else Lwt.return_unit)
     >>= fun () ->
     (* Copy [min_upper, max] to next_upper *)
     (if copy_in_upper then
-       with_stats "copied in upper" (Copy.CopyToUpper.copy t ~min:min_upper max)
-     else Lwt.return_unit)
+     with_stats "copied in upper" (Copy.CopyToUpper.copy t ~min:min_upper max)
+    else Lwt.return_unit)
     >>= fun () ->
     (* Copy branches to both lower and next_upper *)
     Copy.copy_branches t
@@ -951,15 +950,15 @@ struct
   let freeze' ?(min = []) ?(max = []) ?(squash = false) ?copy_in_upper
       ?(min_upper = []) ?(recovery = false) ?hook t =
     (if recovery then X.Repo.clear_previous_upper ~keep_generation:() t
-     else Lwt.return_unit)
+    else Lwt.return_unit)
     >>= fun () ->
     let freeze () =
       let id = freeze_counter () in
       let start_time = Mtime_clock.counter () in
       let upper =
         ( (match copy_in_upper with
-              | None -> get_copy_in_upper t.X.Repo.config
-              | Some b -> b),
+          | None -> get_copy_in_upper t.X.Repo.config
+          | Some b -> b),
           min_upper )
       in
       Irmin_layers.Stats.with_timer `Waiting (fun () ->
@@ -1039,10 +1038,10 @@ module type S = sig
     auto_repair:bool ->
     repo ->
     (( [> `Fixed of int | `No_error ],
-       [> `Cannot_fix of string | `Corrupted of int ]
-     )
-       result * Irmin_layers.Layer_id.t)
-      list
+       [> `Cannot_fix of string | `Corrupted of int ] )
+     result
+    * Irmin_layers.Layer_id.t)
+    list
 end
 
 module Make

--- a/src/irmin-pack/irmin_pack_layers.ml
+++ b/src/irmin-pack/irmin_pack_layers.ml
@@ -116,9 +116,9 @@ module Make_ext
     (B : Irmin.Branch.S)
     (H : Irmin.Hash.S)
     (Node : Irmin.Private.Node.S
-              with type metadata = M.t
-               and type hash = H.t
-               and type step = P.step)
+     with type metadata = M.t
+      and type hash = H.t
+      and type step = P.step)
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
@@ -148,28 +148,28 @@ struct
         module Val = C
 
         module CA_Pack = Pack.Make (struct
-          include Val
-          module H = Irmin.Hash.Typed (H) (Val)
+            include Val
+            module H = Irmin.Hash.Typed (H) (Val)
 
-          let hash = H.hash
+            let hash = H.hash
 
-          let magic = 'B'
+            let magic = 'B'
 
-          let value = value Val.t
+            let value = value Val.t
 
-          let encode_value = Irmin.Type.(unstage (encode_bin value))
+            let encode_value = Irmin.Type.(unstage (encode_bin value))
 
-          let decode_value = Irmin.Type.(unstage (decode_bin value))
+            let decode_value = Irmin.Type.(unstage (decode_bin value))
 
-          let encode_bin ~dict:_ ~offset:_ v hash =
-            encode_value { magic; hash; v }
+            let encode_bin ~dict:_ ~offset:_ v hash =
+              encode_value { magic; hash; v }
 
-          let decode_bin ~dict:_ ~hash:_ s off =
-            let _, t = decode_value s off in
-            t.v
+            let decode_bin ~dict:_ ~hash:_ s off =
+              let _, t = decode_value s off in
+              t.v
 
-          let magic _ = magic
-        end)
+            let magic _ = magic
+          end)
 
         module CA = Closeable.Content_addressable (CA_Pack)
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
@@ -190,28 +190,28 @@ struct
         module Val = Commit
 
         module CA_Pack = Pack.Make (struct
-          include Val
-          module H = Irmin.Hash.Typed (H) (Val)
+            include Val
+            module H = Irmin.Hash.Typed (H) (Val)
 
-          let hash = H.hash
+            let hash = H.hash
 
-          let value = value Val.t
+            let value = value Val.t
 
-          let magic = 'C'
+            let magic = 'C'
 
-          let encode_value = Irmin.Type.(unstage (encode_bin value))
+            let encode_value = Irmin.Type.(unstage (encode_bin value))
 
-          let decode_value = Irmin.Type.(unstage (decode_bin value))
+            let decode_value = Irmin.Type.(unstage (decode_bin value))
 
-          let encode_bin ~dict:_ ~offset:_ v hash =
-            encode_value { magic; hash; v }
+            let encode_bin ~dict:_ ~offset:_ v hash =
+              encode_value { magic; hash; v }
 
-          let decode_bin ~dict:_ ~hash:_ s off =
-            let _, v = decode_value s off in
-            v.v
+            let decode_bin ~dict:_ ~hash:_ s off =
+              let _, v = decode_value s off in
+              v.v
 
-          let magic _ = magic
-        end)
+            let magic _ = magic
+          end)
 
         module CA = Closeable.Content_addressable (CA_Pack)
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
@@ -335,7 +335,7 @@ struct
         let index =
           Index.v
             ~flush_callback:(fun () -> !f ())
-              (* backpatching to add pack flush before an index flush *)
+            (* backpatching to add pack flush before an index flush *)
             ~fresh ~readonly ~throttle ~log_size root
         in
         Contents.CA.U.v ~fresh ~readonly ~lru_size ~index root
@@ -372,10 +372,10 @@ struct
           (function
             | I.Invalid_version { expected; found }
               when expected = current_version ->
-                Log.err (fun m ->
-                    m "[%s] Attempted to open store of unsupported version %a"
-                      root pp_version found);
-                Lwt.fail (Unsupported_version found)
+              Log.err (fun m ->
+                  m "[%s] Attempted to open store of unsupported version %a"
+                    root pp_version found);
+              Lwt.fail (Unsupported_version found)
             | e -> Lwt.fail e)
 
       let freeze_info throttle =
@@ -390,8 +390,8 @@ struct
         let with_lower = with_lower config in
         let lower_root = Filename.concat root (lower_root config) in
         (if with_lower then
-         v_layer ~v:unsafe_v_lower lower_root config >|= fun lower -> Some lower
-        else Lwt.return_none)
+           v_layer ~v:unsafe_v_lower lower_root config >|= fun lower -> Some lower
+         else Lwt.return_none)
         >>= fun lower ->
         let file = Layout.flip ~root in
         IO_layers.v file >>= fun flip_file ->
@@ -403,7 +403,7 @@ struct
         let freeze_in_progress () = freeze.state = `Running in
         let add_lock = Lwt_mutex.create () in
         (if fresh && Lock.test lock_file then Lock.unlink lock_file
-        else Lwt.return_unit)
+         else Lwt.return_unit)
         >|= fun () ->
         let lower_contents = Option.map (fun x -> x.lcontents) lower in
         let contents =
@@ -451,7 +451,7 @@ struct
           {
             f =
               (fun (type a) (module C : S.LAYERED with type t = a) (x : a) ->
-                C.close x);
+                 C.close x);
           }
         in
         Iterate.iter_lwt f t
@@ -480,7 +480,7 @@ struct
           {
             f =
               (fun (type a) (module C : S.LAYERED with type t = a) (x : a) ->
-                C.update_flip ~flip x);
+                 C.update_flip ~flip x);
           }
         in
         Iterate.iter f t
@@ -495,25 +495,25 @@ struct
         let root = Pack_config.root config in
         [ upper_root1; upper_root0; lower_root ]
         |> List.map (fun name ->
-               let root = Filename.concat root (name config) in
-               let config = Conf.add config Pack_config.root_key (Some root) in
-               try
-                 let io =
-                   IO.v ~version:(Some current_version) ~fresh:false
-                     ~readonly:true (Layout.pack ~root)
-                 in
-                 (config, Some io)
-               with
-               | I.Invalid_version _ -> (config, None)
-               | e -> raise e)
+            let root = Filename.concat root (name config) in
+            let config = Conf.add config Pack_config.root_key (Some root) in
+            try
+              let io =
+                IO.v ~version:(Some current_version) ~fresh:false
+                  ~readonly:true (Layout.pack ~root)
+              in
+              (config, Some io)
+            with
+            | I.Invalid_version _ -> (config, None)
+            | e -> raise e)
         |> List.fold_left
-             (fun to_migrate (config, io) ->
-               match io with
-               | None -> config :: to_migrate
-               | Some io ->
-                   IO.close io;
-                   to_migrate)
-             []
+          (fun to_migrate (config, io) ->
+             match io with
+             | None -> config :: to_migrate
+             | Some io ->
+               IO.close io;
+               to_migrate)
+          []
         |> List.iter (fun config -> Store.migrate config)
 
       let layer_id t store_handler =
@@ -547,7 +547,7 @@ struct
           {
             f =
               (fun (type a) (module C : S.LAYERED with type t = a) (x : a) ->
-                C.flip_upper x);
+                 C.flip_upper x);
           }
         in
         Iterate.iter f t
@@ -569,10 +569,10 @@ struct
       let check ~kind ~offset ~length k =
         match kind with
         | `Contents ->
-            X.Contents.CA.integrity_check ~offset ~length ~layer k contents
+          X.Contents.CA.integrity_check ~offset ~length ~layer k contents
         | `Node -> X.Node.CA.integrity_check ~offset ~length ~layer k nodes
         | `Commit ->
-            X.Commit.CA.integrity_check ~offset ~length ~layer k commits
+          X.Commit.CA.integrity_check ~offset ~length ~layer k commits
       in
       Checks.integrity_check ?ppf ~auto_repair ~check index
     in
@@ -582,11 +582,10 @@ struct
       (`Lower, t.lower_index);
     ]
     |> List.map (fun (layer, index) ->
-           match index with
-           | Some index ->
-               integrity_check_layer ~layer index
-               |> Result.map_error (function e -> (e, layer))
-           | None -> Ok `No_error)
+        match index with
+        | Some index ->
+          (integrity_check_layer ~layer index), layer
+        | None -> (Ok `No_error), layer)
 
   include Irmin.Of_private (X)
 
@@ -623,8 +622,8 @@ struct
       pause () >>= fun () ->
       skip h >|= function
       | true ->
-          Irmin_layers.Stats.skip ();
-          true
+        Irmin_layers.Stats.skip ();
+        true
       | false -> false
 
     let no_skip _ = Lwt.return false
@@ -634,9 +633,9 @@ struct
       X.Node.CA.find n k >|= function
       | None -> []
       | Some v ->
-          List.rev_map
-            (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
-            (X.Node.CA.Val.pred v)
+        List.rev_map
+          (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
+          (X.Node.CA.Val.pred v)
 
     let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
         ?(skip_nodes = no_skip) ?(skip_contents = no_skip) t ?(min = []) max =
@@ -854,14 +853,14 @@ struct
     (* Copy commits to lower: if squash then copy only the max commits *)
     let with_lower = with_lower t.X.Repo.config in
     (if with_lower then
-     let min = if squash then max else min in
-     with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
-    else Lwt.return_unit)
+       let min = if squash then max else min in
+       with_stats "copied in lower" (Copy.CopyToLower.copy t ~min max)
+     else Lwt.return_unit)
     >>= fun () ->
     (* Copy [min_upper, max] to next_upper *)
     (if copy_in_upper then
-     with_stats "copied in upper" (Copy.CopyToUpper.copy t ~min:min_upper max)
-    else Lwt.return_unit)
+       with_stats "copied in upper" (Copy.CopyToUpper.copy t ~min:min_upper max)
+     else Lwt.return_unit)
     >>= fun () ->
     (* Copy branches to both lower and next_upper *)
     Copy.copy_branches t
@@ -952,15 +951,15 @@ struct
   let freeze' ?(min = []) ?(max = []) ?(squash = false) ?copy_in_upper
       ?(min_upper = []) ?(recovery = false) ?hook t =
     (if recovery then X.Repo.clear_previous_upper ~keep_generation:() t
-    else Lwt.return_unit)
+     else Lwt.return_unit)
     >>= fun () ->
     let freeze () =
       let id = freeze_counter () in
       let start_time = Mtime_clock.counter () in
       let upper =
         ( (match copy_in_upper with
-          | None -> get_copy_in_upper t.X.Repo.config
-          | Some b -> b),
+              | None -> get_copy_in_upper t.X.Repo.config
+              | Some b -> b),
           min_upper )
       in
       Irmin_layers.Stats.with_timer `Waiting (fun () ->
@@ -1039,11 +1038,11 @@ module type S = sig
     ?ppf:Format.formatter ->
     auto_repair:bool ->
     repo ->
-    ( [> `Fixed of int | `No_error ],
-      [> `Cannot_fix of string | `Corrupted of int ] * Irmin_layers.Layer_id.t
-    )
-    result
-    list
+    (( [> `Fixed of int | `No_error ],
+       [> `Cannot_fix of string | `Corrupted of int ]
+     )
+       result * Irmin_layers.Layer_id.t)
+      list
 end
 
 module Make

--- a/src/irmin-pack/irmin_pack_layers.mli
+++ b/src/irmin-pack/irmin_pack_layers.mli
@@ -48,11 +48,11 @@ module type S = sig
     ?ppf:Format.formatter ->
     auto_repair:bool ->
     repo ->
-    ( [> `Fixed of int | `No_error ],
-      [> `Cannot_fix of string | `Corrupted of int ] * Irmin_layers.Layer_id.t
-    )
-    result
-    list
+    (( [> `Fixed of int | `No_error ],
+       [> `Cannot_fix of string | `Corrupted of int ]
+     )
+       result * Irmin_layers.Layer_id.t)
+      list
 end
 
 module Make_ext
@@ -63,18 +63,18 @@ module Make_ext
     (Branch : Irmin.Branch.S)
     (Hash : Irmin.Hash.S)
     (N : Irmin.Private.Node.S
-           with type metadata = Metadata.t
-            and type hash = Hash.t
-            and type step = Path.step)
+     with type metadata = Metadata.t
+      and type hash = Hash.t
+      and type step = Path.step)
     (CT : Irmin.Private.Commit.S with type hash = Hash.t) :
   S
-    with type key = Path.t
-     and type contents = Contents.t
-     and type branch = Branch.t
-     and type hash = Hash.t
-     and type step = Path.step
-     and type metadata = Metadata.t
-     and type Key.step = Path.step
+  with type key = Path.t
+   and type contents = Contents.t
+   and type branch = Branch.t
+   and type hash = Hash.t
+   and type step = Path.step
+   and type metadata = Metadata.t
+   and type Key.step = Path.step
 
 module Make
     (Config : Config.S)
@@ -84,9 +84,9 @@ module Make
     (B : Irmin.Branch.S)
     (H : Irmin.Hash.S) :
   S
-    with type key = P.t
-     and type step = P.step
-     and type metadata = M.t
-     and type contents = C.t
-     and type branch = B.t
-     and type hash = H.t
+  with type key = P.t
+   and type step = P.step
+   and type metadata = M.t
+   and type contents = C.t
+   and type branch = B.t
+   and type hash = H.t

--- a/src/irmin-pack/irmin_pack_layers.mli
+++ b/src/irmin-pack/irmin_pack_layers.mli
@@ -49,10 +49,10 @@ module type S = sig
     auto_repair:bool ->
     repo ->
     (( [> `Fixed of int | `No_error ],
-       [> `Cannot_fix of string | `Corrupted of int ]
-     )
-       result * Irmin_layers.Layer_id.t)
-      list
+       [> `Cannot_fix of string | `Corrupted of int ] )
+     result
+    * Irmin_layers.Layer_id.t)
+    list
 end
 
 module Make_ext
@@ -63,18 +63,18 @@ module Make_ext
     (Branch : Irmin.Branch.S)
     (Hash : Irmin.Hash.S)
     (N : Irmin.Private.Node.S
-     with type metadata = Metadata.t
-      and type hash = Hash.t
-      and type step = Path.step)
+           with type metadata = Metadata.t
+            and type hash = Hash.t
+            and type step = Path.step)
     (CT : Irmin.Private.Commit.S with type hash = Hash.t) :
   S
-  with type key = Path.t
-   and type contents = Contents.t
-   and type branch = Branch.t
-   and type hash = Hash.t
-   and type step = Path.step
-   and type metadata = Metadata.t
-   and type Key.step = Path.step
+    with type key = Path.t
+     and type contents = Contents.t
+     and type branch = Branch.t
+     and type hash = Hash.t
+     and type step = Path.step
+     and type metadata = Metadata.t
+     and type Key.step = Path.step
 
 module Make
     (Config : Config.S)
@@ -84,9 +84,9 @@ module Make
     (B : Irmin.Branch.S)
     (H : Irmin.Hash.S) :
   S
-  with type key = P.t
-   and type step = P.step
-   and type metadata = M.t
-   and type contents = C.t
-   and type branch = B.t
-   and type hash = H.t
+    with type key = P.t
+     and type step = P.step
+     and type metadata = M.t
+     and type contents = C.t
+     and type branch = B.t
+     and type hash = H.t

--- a/test/irmin-pack/cli/irmin-fsck-help.txt
+++ b/test/irmin-pack/cli/irmin-fsck-help.txt
@@ -8,6 +8,9 @@ COMMANDS
        check-self-contained
            Check that the upper layer of the store is self contained.
 
+       integrity-check
+           Check integrity of an existing store.
+
        reconstruct-index
            Reconstruct index from an existing pack file.
 

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -23,8 +23,8 @@ let goto_project_root () =
   let cwd = Fpath.v (Sys.getcwd ()) in
   match cwd |> Fpath.segs |> List.rev with
   | "irmin-pack" :: "test" :: "default" :: "_build" :: _ ->
-    let root = cwd |> repeat 4 Fpath.parent in
-    Unix.chdir (Fpath.to_string root)
+      let root = cwd |> repeat 4 Fpath.parent in
+      Unix.chdir (Fpath.to_string root)
   | _ -> ()
 
 let archive =
@@ -38,50 +38,50 @@ let exec_cmd cmd =
   match Sys.command cmd with
   | 0 -> ()
   | n ->
-    Fmt.failwith
-      "Failed to set up the test environment: command `%s' exited with \
-       non-zero exit code %d"
-      cmd n
+      Fmt.failwith
+        "Failed to set up the test environment: command `%s' exited with \
+         non-zero exit code %d"
+        cmd n
 
 module type Migrate_store = sig
   include
     Irmin.S
-    with type step = string
-     and type key = string list
-     and type contents = string
-     and type branch = string
+      with type step = string
+       and type key = string list
+       and type contents = string
+       and type branch = string
 
   val migrate : Irmin.config -> unit
 end
 
 module Test
     (S : Migrate_store) (Config : sig
-                           val setup_test_env : unit -> unit
+      val setup_test_env : unit -> unit
 
-                           val root_v1 : string
-                         end) =
+      val root_v1 : string
+    end) =
 struct
   let check_commit repo commit bindings =
     commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
     | None ->
-      Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash commit
+        Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash commit
     | Some commit ->
-      let tree = S.Commit.tree commit in
-      bindings
-      |> Lwt_list.iter_s (fun (key, value) ->
-          S.Tree.find tree key
-          >|= Alcotest.(check (option string))
-            (Fmt.strf "Expected binding [%a ↦ %s]"
-               Fmt.(Dump.list string)
-               key value)
-            (Some value))
+        let tree = S.Commit.tree commit in
+        bindings
+        |> Lwt_list.iter_s (fun (key, value) ->
+               S.Tree.find tree key
+               >|= Alcotest.(check (option string))
+                     (Fmt.strf "Expected binding [%a ↦ %s]"
+                        Fmt.(Dump.list string)
+                        key value)
+                     (Some value))
 
   let check_repo repo structure =
     structure
     |> Lwt_list.iter_s @@ fun (branch, bindings) ->
-    S.Branch.find repo branch >>= function
-    | None -> Alcotest.failf "Couldn't find expected branch `%s'" branch
-    | Some commit -> check_commit repo commit bindings
+       S.Branch.find repo branch >>= function
+       | None -> Alcotest.failf "Couldn't find expected branch `%s'" branch
+       | Some commit -> check_commit repo commit bindings
 
   let pair_map f (a, b) = (f a, f b)
 
@@ -145,10 +145,10 @@ module Config_store = struct
     match Sys.command cmd with
     | 0 -> ()
     | n ->
-      Fmt.failwith
-        "Failed to set up the test environment: command `%s' exited with \
-         non-zero exit code %d"
-        cmd n
+        Fmt.failwith
+          "Failed to set up the test environment: command `%s' exited with \
+           non-zero exit code %d"
+          cmd n
 end
 
 module Hash = Irmin.Hash.SHA1
@@ -199,10 +199,10 @@ module Test_reconstruct = struct
     match Sys.command cmd with
     | 0 -> ()
     | n ->
-      Fmt.failwith
-        "Failed to set up the test environment: command `%s' exited with \
-         non-zero exit code %d"
-        cmd n
+        Fmt.failwith
+          "Failed to set up the test environment: command `%s' exited with \
+           non-zero exit code %d"
+          cmd n
 
   let test_reconstruct () =
     setup_test_env ();
@@ -218,16 +218,16 @@ module Test_reconstruct = struct
     in
     Index.iter
       (fun k (offset, length, magic) ->
-         Log.debug (fun l ->
-             l "index find k = %a (off, len, magic) = (%Ld, %d, %c)"
-               (Irmin.Type.pp Hash.t) k offset length magic);
-         match Index.find index_new k with
-         | Some (offset', length', magic') ->
-           Alcotest.(check int64) "check offset" offset offset';
-           Alcotest.(check int) "check length" length length';
-           Alcotest.(check char) "check magic" magic magic'
-         | None ->
-           Alcotest.failf "expected to find hash %a" (Irmin.Type.pp Hash.t) k)
+        Log.debug (fun l ->
+            l "index find k = %a (off, len, magic) = (%Ld, %d, %c)"
+              (Irmin.Type.pp Hash.t) k offset length magic);
+        match Index.find index_new k with
+        | Some (offset', length', magic') ->
+            Alcotest.(check int64) "check offset" offset offset';
+            Alcotest.(check int) "check length" length length';
+            Alcotest.(check char) "check magic" magic magic'
+        | None ->
+            Alcotest.failf "expected to find hash %a" (Irmin.Type.pp Hash.t) k)
       index_old;
     Index.close index_old;
     Index.close index_new;
@@ -308,15 +308,15 @@ module Test_corrupted_stores = struct
     Log.app (fun l ->
         l "integrity check on a store where 3 entries are missing from pack");
     (match S.integrity_check ~auto_repair:false rw with
-     | Ok `No_error -> Alcotest.fail "Store is corrupted, the check should fail"
-     | Error (`Corrupted 3) -> ()
-     | _ -> Alcotest.fail "With auto_repair:false should not match");
+    | Ok `No_error -> Alcotest.fail "Store is corrupted, the check should fail"
+    | Error (`Corrupted 3) -> ()
+    | _ -> Alcotest.fail "With auto_repair:false should not match");
     (match S.integrity_check ~auto_repair:true rw with
-     | Ok (`Fixed 3) -> ()
-     | _ -> Alcotest.fail "Integrity check should repair the store");
+    | Ok (`Fixed 3) -> ()
+    | _ -> Alcotest.fail "Integrity check should repair the store");
     (match S.integrity_check ~auto_repair:false rw with
-     | Ok `No_error -> ()
-     | _ -> Alcotest.fail "Store is repaired, should return Ok");
+    | Ok `No_error -> ()
+    | _ -> Alcotest.fail "Store is repaired, should return Ok");
     S.Repo.close rw
 
   let test_layered_store () =
@@ -329,18 +329,18 @@ module Test_corrupted_stores = struct
            the pack file of each layer");
     S.integrity_check ~auto_repair:false rw
     |> List.iter (function
-        | Ok `No_error, _ ->
-          Alcotest.fail "Store is corrupted, the check should fail"
-        | Error (`Corrupted 3), _ -> ()
-        | _ -> Alcotest.fail "With auto_repair:false should not match");
+         | Ok `No_error, _ ->
+             Alcotest.fail "Store is corrupted, the check should fail"
+         | Error (`Corrupted 3), _ -> ()
+         | _ -> Alcotest.fail "With auto_repair:false should not match");
     S.integrity_check ~auto_repair:true rw
     |> List.iter (function
-        | Ok (`Fixed 3), _ -> ()
-        | _ -> Alcotest.fail "Integrity check should repair the store");
+         | Ok (`Fixed 3), _ -> ()
+         | _ -> Alcotest.fail "Integrity check should repair the store");
     S.integrity_check ~auto_repair:false rw
     |> List.iter (function
-        | Ok `No_error, _ -> ()
-        | _ -> Alcotest.fail "Store is repaired, should return Ok");
+         | Ok `No_error, _ -> ()
+         | _ -> Alcotest.fail "Store is repaired, should return Ok");
     S.Repo.close rw
 
   let empty_store, root, lock_file =
@@ -367,16 +367,16 @@ module Test_corrupted_stores = struct
     let check_commit repo commit k v =
       commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
       | None ->
-        Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash
-          commit
+          Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash
+            commit
       | Some commit ->
-        let tree = S.Commit.tree commit in
-        S.Tree.find tree k
-        >|= Alcotest.(check (option string))
-          (Fmt.strf "Expected binding [%a ↦ %s]"
-             Fmt.(Dump.list string)
-             k v)
-          (Some v)
+          let tree = S.Commit.tree commit in
+          S.Tree.find tree k
+          >|= Alcotest.(check (option string))
+                (Fmt.strf "Expected binding [%a ↦ %s]"
+                   Fmt.(Dump.list string)
+                   k v)
+                (Some v)
     in
     let check_upper repo msg exp =
       let got = S.PrivateLayer.upper_in_use repo in

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -23,8 +23,8 @@ let goto_project_root () =
   let cwd = Fpath.v (Sys.getcwd ()) in
   match cwd |> Fpath.segs |> List.rev with
   | "irmin-pack" :: "test" :: "default" :: "_build" :: _ ->
-      let root = cwd |> repeat 4 Fpath.parent in
-      Unix.chdir (Fpath.to_string root)
+    let root = cwd |> repeat 4 Fpath.parent in
+    Unix.chdir (Fpath.to_string root)
   | _ -> ()
 
 let archive =
@@ -38,50 +38,50 @@ let exec_cmd cmd =
   match Sys.command cmd with
   | 0 -> ()
   | n ->
-      Fmt.failwith
-        "Failed to set up the test environment: command `%s' exited with \
-         non-zero exit code %d"
-        cmd n
+    Fmt.failwith
+      "Failed to set up the test environment: command `%s' exited with \
+       non-zero exit code %d"
+      cmd n
 
 module type Migrate_store = sig
   include
     Irmin.S
-      with type step = string
-       and type key = string list
-       and type contents = string
-       and type branch = string
+    with type step = string
+     and type key = string list
+     and type contents = string
+     and type branch = string
 
   val migrate : Irmin.config -> unit
 end
 
 module Test
     (S : Migrate_store) (Config : sig
-      val setup_test_env : unit -> unit
+                           val setup_test_env : unit -> unit
 
-      val root_v1 : string
-    end) =
+                           val root_v1 : string
+                         end) =
 struct
   let check_commit repo commit bindings =
     commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
     | None ->
-        Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash commit
+      Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash commit
     | Some commit ->
-        let tree = S.Commit.tree commit in
-        bindings
-        |> Lwt_list.iter_s (fun (key, value) ->
-               S.Tree.find tree key
-               >|= Alcotest.(check (option string))
-                     (Fmt.strf "Expected binding [%a ↦ %s]"
-                        Fmt.(Dump.list string)
-                        key value)
-                     (Some value))
+      let tree = S.Commit.tree commit in
+      bindings
+      |> Lwt_list.iter_s (fun (key, value) ->
+          S.Tree.find tree key
+          >|= Alcotest.(check (option string))
+            (Fmt.strf "Expected binding [%a ↦ %s]"
+               Fmt.(Dump.list string)
+               key value)
+            (Some value))
 
   let check_repo repo structure =
     structure
     |> Lwt_list.iter_s @@ fun (branch, bindings) ->
-       S.Branch.find repo branch >>= function
-       | None -> Alcotest.failf "Couldn't find expected branch `%s'" branch
-       | Some commit -> check_commit repo commit bindings
+    S.Branch.find repo branch >>= function
+    | None -> Alcotest.failf "Couldn't find expected branch `%s'" branch
+    | Some commit -> check_commit repo commit bindings
 
   let pair_map f (a, b) = (f a, f b)
 
@@ -145,10 +145,10 @@ module Config_store = struct
     match Sys.command cmd with
     | 0 -> ()
     | n ->
-        Fmt.failwith
-          "Failed to set up the test environment: command `%s' exited with \
-           non-zero exit code %d"
-          cmd n
+      Fmt.failwith
+        "Failed to set up the test environment: command `%s' exited with \
+         non-zero exit code %d"
+        cmd n
 end
 
 module Hash = Irmin.Hash.SHA1
@@ -199,10 +199,10 @@ module Test_reconstruct = struct
     match Sys.command cmd with
     | 0 -> ()
     | n ->
-        Fmt.failwith
-          "Failed to set up the test environment: command `%s' exited with \
-           non-zero exit code %d"
-          cmd n
+      Fmt.failwith
+        "Failed to set up the test environment: command `%s' exited with \
+         non-zero exit code %d"
+        cmd n
 
   let test_reconstruct () =
     setup_test_env ();
@@ -218,16 +218,16 @@ module Test_reconstruct = struct
     in
     Index.iter
       (fun k (offset, length, magic) ->
-        Log.debug (fun l ->
-            l "index find k = %a (off, len, magic) = (%Ld, %d, %c)"
-              (Irmin.Type.pp Hash.t) k offset length magic);
-        match Index.find index_new k with
-        | Some (offset', length', magic') ->
-            Alcotest.(check int64) "check offset" offset offset';
-            Alcotest.(check int) "check length" length length';
-            Alcotest.(check char) "check magic" magic magic'
-        | None ->
-            Alcotest.failf "expected to find hash %a" (Irmin.Type.pp Hash.t) k)
+         Log.debug (fun l ->
+             l "index find k = %a (off, len, magic) = (%Ld, %d, %c)"
+               (Irmin.Type.pp Hash.t) k offset length magic);
+         match Index.find index_new k with
+         | Some (offset', length', magic') ->
+           Alcotest.(check int64) "check offset" offset offset';
+           Alcotest.(check int) "check length" length length';
+           Alcotest.(check char) "check magic" magic magic'
+         | None ->
+           Alcotest.failf "expected to find hash %a" (Irmin.Type.pp Hash.t) k)
       index_old;
     Index.close index_old;
     Index.close index_new;
@@ -308,15 +308,15 @@ module Test_corrupted_stores = struct
     Log.app (fun l ->
         l "integrity check on a store where 3 entries are missing from pack");
     (match S.integrity_check ~auto_repair:false rw with
-    | Ok `No_error -> Alcotest.fail "Store is corrupted, the check should fail"
-    | Error (`Corrupted 3) -> ()
-    | _ -> Alcotest.fail "With auto_repair:false should not match");
+     | Ok `No_error -> Alcotest.fail "Store is corrupted, the check should fail"
+     | Error (`Corrupted 3) -> ()
+     | _ -> Alcotest.fail "With auto_repair:false should not match");
     (match S.integrity_check ~auto_repair:true rw with
-    | Ok (`Fixed 3) -> ()
-    | _ -> Alcotest.fail "Integrity check should repair the store");
+     | Ok (`Fixed 3) -> ()
+     | _ -> Alcotest.fail "Integrity check should repair the store");
     (match S.integrity_check ~auto_repair:false rw with
-    | Ok `No_error -> ()
-    | _ -> Alcotest.fail "Store is repaired, should return Ok");
+     | Ok `No_error -> ()
+     | _ -> Alcotest.fail "Store is repaired, should return Ok");
     S.Repo.close rw
 
   let test_layered_store () =
@@ -329,18 +329,18 @@ module Test_corrupted_stores = struct
            the pack file of each layer");
     S.integrity_check ~auto_repair:false rw
     |> List.iter (function
-         | Ok `No_error ->
-             Alcotest.fail "Store is corrupted, the check should fail"
-         | Error (`Corrupted 3, _) -> ()
-         | _ -> Alcotest.fail "With auto_repair:false should not match");
+        | Ok `No_error, _ ->
+          Alcotest.fail "Store is corrupted, the check should fail"
+        | Error (`Corrupted 3), _ -> ()
+        | _ -> Alcotest.fail "With auto_repair:false should not match");
     S.integrity_check ~auto_repair:true rw
     |> List.iter (function
-         | Ok (`Fixed 3) -> ()
-         | _ -> Alcotest.fail "Integrity check should repair the store");
+        | Ok (`Fixed 3), _ -> ()
+        | _ -> Alcotest.fail "Integrity check should repair the store");
     S.integrity_check ~auto_repair:false rw
     |> List.iter (function
-         | Ok `No_error -> ()
-         | _ -> Alcotest.fail "Store is repaired, should return Ok");
+        | Ok `No_error, _ -> ()
+        | _ -> Alcotest.fail "Store is repaired, should return Ok");
     S.Repo.close rw
 
   let empty_store, root, lock_file =
@@ -367,16 +367,16 @@ module Test_corrupted_stores = struct
     let check_commit repo commit k v =
       commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
       | None ->
-          Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash
-            commit
+        Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash
+          commit
       | Some commit ->
-          let tree = S.Commit.tree commit in
-          S.Tree.find tree k
-          >|= Alcotest.(check (option string))
-                (Fmt.strf "Expected binding [%a ↦ %s]"
-                   Fmt.(Dump.list string)
-                   k v)
-                (Some v)
+        let tree = S.Commit.tree commit in
+        S.Tree.find tree k
+        >|= Alcotest.(check (option string))
+          (Fmt.strf "Expected binding [%a ↦ %s]"
+             Fmt.(Dump.list string)
+             k v)
+          (Some v)
     in
     let check_upper repo msg exp =
       let got = S.PrivateLayer.upper_in_use repo in


### PR DESCRIPTION
- Adds an `integrity-check` command to `irmin-fsck`
- Updates `src/irmin-pack/checks_intf.ml` with `Integrity_check` and `Reconstruct_index` definitions
    * Needed for https://github.com/tarides/tezos/issues/8
- Closes #1195 
- Updates `Irmin_pack_layers.S.check_integrity` function return type