### PR TITLE
(experiments) Call `pause` less often 

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -829,7 +829,9 @@ struct
         Some { Val.find; v }
 
   let save t v =
-    let add k v = Inode.unsafe_append ~ensure_unique:true t k v in
+    let add k v =
+      ignore (Inode.unsafe_append ~ensure_unique:true t k v : int)
+    in
     Inode.Val.save ~add ~mem:(Inode.unsafe_mem t) v
 
   let hash v = Inode.Val.hash v.Val.v

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -134,7 +134,7 @@ struct
 
   let copy_from_lower ~dst t = Inode.copy_from_lower t "Node" ~dst
 
-  let copy : type l. l layer_type * l -> [ `Read ] t -> key -> unit =
+  let copy : type l. l layer_type * l -> [ `Read ] t -> key -> int =
    fun (layer, dst) t ->
     match layer with
     | Lower -> Inode.copy (Lower, dst) t "Node"

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -22,7 +22,7 @@ module type S = sig
     | Upper : [ `Read ] U.t layer_type
     | Lower : [ `Read ] L.t layer_type
 
-  val copy : 'l layer_type * 'l -> [ `Read ] t -> key -> unit
+  val copy : 'l layer_type * 'l -> [ `Read ] t -> key -> int
 
   val mem_lower : 'a t -> key -> bool Lwt.t
 

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -47,7 +47,8 @@ struct
     | None ->
         Log.warn (fun l ->
             l "Attempt to copy %s %a not contained in upper." str
-              (Irmin.Type.pp Key.t) k)
+              (Irmin.Type.pp Key.t) k);
+        0
     | Some v ->
         stats str;
         DST.unsafe_append ~ensure_unique:false dst k v
@@ -159,7 +160,7 @@ struct
         l "unsafe_append in %a%a" pp_current_upper t pp_during_freeze freeze);
     Irmin_layers.Stats.add ();
     let upper = current_upper t in
-    U.unsafe_append ~ensure_unique upper k v;
+    ignore (U.unsafe_append ~ensure_unique upper k v : int);
     if freeze then (
       Log.debug (fun l -> l "adds during freeze");
       t.newies <- k :: t.newies)
@@ -334,7 +335,7 @@ struct
   let check t ?none ?some k =
     CopyUpper.check ~src:(current_upper t) ?none ?some k
 
-  let copy : type l. l layer_type * l -> [ `Read ] t -> string -> key -> unit =
+  let copy : type l. l layer_type * l -> [ `Read ] t -> string -> key -> int =
    fun (ltype, dst) ->
     match ltype with Lower -> copy_to_lower ~dst | Upper -> copy_to_next ~dst
 

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -245,7 +245,7 @@ struct
     let auto_flush = 1024
 
     let unsafe_append ~ensure_unique t k v =
-      if ensure_unique && unsafe_mem t k then ()
+      if ensure_unique && unsafe_mem t k then 0
       else (
         Log.debug (fun l -> l "[pack] append %a" pp_hash k);
         let offset k =
@@ -264,15 +264,16 @@ struct
         Index.add t.pack.index k (off, len, V.magic v);
         if Tbl.length t.staging >= auto_flush then flush t
         else Tbl.add t.staging k v;
-        Lru.add t.lru k v)
+        Lru.add t.lru k v;
+        len)
 
     let add t v =
       let k = V.hash v in
-      unsafe_append ~ensure_unique:true t k v;
+      ignore (unsafe_append ~ensure_unique:true t k v : int);
       Lwt.return k
 
     let unsafe_add t k v =
-      unsafe_append ~ensure_unique:true t k v;
+      ignore (unsafe_append ~ensure_unique:true t k v : int);
       Lwt.return ()
 
     let unsafe_close t =

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -57,7 +57,7 @@ module type S = sig
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 
-  val unsafe_append : ensure_unique:bool -> 'a t -> key -> value -> unit
+  val unsafe_append : ensure_unique:bool -> 'a t -> key -> value -> int
 
   val unsafe_mem : 'a t -> key -> bool
 
@@ -125,7 +125,7 @@ module type LAYERED = sig
     | Upper : [ `Read ] U.t layer_type
     | Lower : [ `Read ] L.t layer_type
 
-  val copy : 'l layer_type * 'l -> [ `Read ] t -> string -> key -> unit
+  val copy : 'l layer_type * 'l -> [ `Read ] t -> string -> key -> int
 
   val copy_from_lower :
     [ `Read ] t ->

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -262,7 +262,10 @@ module Pack = struct
     t.clone_index_pack ~readonly:true >>= fun (i, r) ->
     let test w =
       let adds l =
-        List.iter (fun (k, v) -> Pack.unsafe_append ~ensure_unique:true w k v) l
+        List.iter
+          (fun (k, v) ->
+            ignore (Pack.unsafe_append ~ensure_unique:true w k v : int))
+          l
       in
       let x1 = "foo" in
       let x2 = "bar" in
@@ -297,7 +300,7 @@ module Pack = struct
     Pack.v ~fresh:true ~index (Context.fresh_name "pack") >>= fun w1 ->
     let x1 = "foo" in
     let h1 = sha1 x1 in
-    Pack.unsafe_append ~ensure_unique:true w1 h1 x1;
+    ignore (Pack.unsafe_append ~ensure_unique:true w1 h1 x1 : int);
     Pack.find w1 h1 >|= get >>= fun y1 ->
     Alcotest.(check string) "x1" x1 y1;
     Index.close index;
@@ -309,7 +312,7 @@ module Pack = struct
     let w = t.pack in
     let x1 = "foo" in
     let h1 = sha1 x1 in
-    Pack.unsafe_append ~ensure_unique:true w h1 x1;
+    ignore (Pack.unsafe_append ~ensure_unique:true w h1 x1 : int);
     Pack.flush w;
     Index.close t.index;
     Pack.close w >>= fun () ->
@@ -351,7 +354,7 @@ module Pack = struct
     (*open and close two packs *)
     let x3 = "toto" in
     let h3 = sha1 x3 in
-    Pack.unsafe_append ~ensure_unique:true w h3 x3;
+    ignore (Pack.unsafe_append ~ensure_unique:true w h3 x3 : int);
     t.clone_pack ~readonly:false >>= fun w2 ->
     Pack.close w >>= fun () ->
     Pack.find w2 h2 >|= get >>= fun y2 ->
@@ -386,7 +389,7 @@ module Pack = struct
     let test w =
       let x1 = "foo" in
       let h1 = sha1 x1 in
-      Pack.unsafe_append ~ensure_unique:true w h1 x1;
+      ignore (Pack.unsafe_append ~ensure_unique:true w h1 x1 : int);
       Pack.sync r;
       Pack.find r h1 >>= fun y1 ->
       Alcotest.(check (option string)) "sync before filter" None y1;
@@ -396,7 +399,7 @@ module Pack = struct
       Alcotest.(check (option string)) "sync after filter" (Some x1) y1;
       let x2 = "foo" in
       let h2 = sha1 x2 in
-      Pack.unsafe_append ~ensure_unique:true w h2 x2;
+      ignore (Pack.unsafe_append ~ensure_unique:true w h2 x2 : int);
       Index.flush t.index;
       Pack.find r h2 >|= fun y2 ->
       Alcotest.(check (option string)) "sync after flush" (Some x2) y2
@@ -413,7 +416,7 @@ module Pack = struct
     let test w =
       let x1 = "foo" in
       let h1 = sha1 x1 in
-      Pack.unsafe_append ~ensure_unique:true w h1 x1;
+      ignore (Pack.unsafe_append ~ensure_unique:true w h1 x1 : int);
       Pack.flush t.pack;
       Pack.sync r;
       check h1 x1 "find before filter" >>= fun () ->
@@ -421,13 +424,13 @@ module Pack = struct
       check h1 x1 "find after filter" >>= fun () ->
       let x2 = "bar" in
       let h2 = sha1 x2 in
-      Pack.unsafe_append ~ensure_unique:true w h2 x2;
+      ignore (Pack.unsafe_append ~ensure_unique:true w h2 x2 : int);
       Pack.flush t.pack;
       Pack.sync r;
       check h2 x2 "find before flush" >>= fun () ->
       let x3 = "toto" in
       let h3 = sha1 x3 in
-      Pack.unsafe_append ~ensure_unique:true w h3 x3;
+      ignore (Pack.unsafe_append ~ensure_unique:true w h3 x3 : int);
       Index.flush t.index;
       check h2 x2 "find after flush" >>= fun () ->
       Pack.flush t.pack;
@@ -441,7 +444,7 @@ module Pack = struct
     Context.get_pack ~lru_size:10 () >>= fun t ->
     let v = "foo" in
     let k = sha1 v in
-    Pack.unsafe_append ~ensure_unique:true t.pack k v;
+    ignore (Pack.unsafe_append ~ensure_unique:true t.pack k v : int);
     Pack.flush t.pack;
     Pack.find t.pack k >>= fun v1 ->
     Alcotest.(check (option string)) "before clear" (Some v) v1;
@@ -463,7 +466,7 @@ module Pack = struct
     let x1 = "foo" in
     let h1 = sha1 x1 in
     let find_before_and_after_sync persist file =
-      Pack.unsafe_append ~ensure_unique:true t.pack h1 x1;
+      ignore (Pack.unsafe_append ~ensure_unique:true t.pack h1 x1 : int);
       persist ();
       Pack.sync r;
       Pack.clear t.pack >>= fun () ->
@@ -494,11 +497,11 @@ module Pack = struct
     let x2 = "bar" in
     let h2 = sha1 x2 in
     let find_before_and_after_sync persist file =
-      Pack.unsafe_append ~ensure_unique:true t.pack h1 x1;
+      ignore (Pack.unsafe_append ~ensure_unique:true t.pack h1 x1 : int);
       persist ();
       Pack.sync r;
       Pack.clear t.pack >>= fun () ->
-      Pack.unsafe_append ~ensure_unique:true t.pack h2 x2;
+      ignore (Pack.unsafe_append ~ensure_unique:true t.pack h2 x2 : int);
       persist ();
       check h1 (Some x1)
         ("find old values in " ^ file ^ " after clear but before sync")


### PR DESCRIPTION
As suggested in https://github.com/mirage/irmin/pull/1159#discussion_r539336914, this PR replaces the `Lwt.pause` called when in `skip` with calls to `Lwt.pause` every 1KB. 
(We can also use `Lwt_main.yield` instead of `Lwt.pause`, I don't think it makes a big difference, but haven't tried). 

Here are some graphs, where we only plot the commit time and not the call to freeze that are blocking:

![without_pauses](https://user-images.githubusercontent.com/16655454/102479326-0c750b00-405f-11eb-8a0f-e1b164117a3f.png)

So no call to `pause` at all is the fastest but also the less fair (as already shown by the graphs in https://github.com/mirage/irmin/pull/1159#discussion_r538847674). 

![with_pauses](https://user-images.githubusercontent.com/16655454/102479584-5f4ec280-405f-11eb-8a10-a0a2235633f2.png)

If we do call `pause`, it seems that calling `pauses` at every skip call is still the fairer? but as suggested by @pascutto there is a lot of variance in these benchmarks, so I'm not sure how conclusive these graphs are.