### PR TITLE
irmin-pack: only remember commits in `newies'

### DIFF
--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -93,7 +93,8 @@ struct
 
   let save t v =
     let add k v =
-      Inode.unsafe_append ~ensure_unique:true ~overcommit:false t k v
+      Inode.unsafe_append ~ensure_unique:true ~overcommit:false t k v;
+      Lwt.return_unit
     in
     Inode.Val.save_lwt ~add ~mem:(Inode.unsafe_mem t) v
 
@@ -121,8 +122,6 @@ struct
   let next_upper = Inode.next_upper
 
   let current_upper = Inode.current_upper
-
-  let unsafe_consume_newies = Inode.unsafe_consume_newies
 
   let consume_newies = Inode.consume_newies
 

--- a/src/irmin-pack/inode_layers_intf.ml
+++ b/src/irmin-pack/inode_layers_intf.ml
@@ -13,7 +13,6 @@ module type S = sig
     [ `Read ] L.t option ->
     flip:bool ->
     freeze_in_progress:(unit -> bool) ->
-    add_lock:Lwt_mutex.t ->
     [ `Read ] t
 
   val layer_id : [ `Read ] t -> key -> Irmin_layers.Layer_id.t Lwt.t
@@ -56,9 +55,7 @@ module type S = sig
 
   val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
 
-  val unsafe_consume_newies : 'a t -> key list
-
-  val consume_newies : 'a t -> key list Lwt.t
+  val consume_newies : 'a t -> key list
 
   val check :
     'a t ->

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -117,7 +117,6 @@ module type LAYERED = sig
     [ `Read ] L.t option ->
     flip:bool ->
     freeze_in_progress:(unit -> bool) ->
-    add_lock:Lwt_mutex.t ->
     [ `Read ] t
 
   val layer_id : [ `Read ] t -> key -> Irmin_layers.Layer_id.t Lwt.t
@@ -159,7 +158,7 @@ module type LAYERED = sig
   val clear_caches_next_upper : 'a t -> unit
 
   val unsafe_append :
-    ensure_unique:bool -> overcommit:bool -> 'a t -> key -> value -> unit Lwt.t
+    ensure_unique:bool -> overcommit:bool -> 'a t -> key -> value -> unit
 
   val unsafe_mem : 'a t -> key -> bool Lwt.t
 
@@ -173,9 +172,7 @@ module type LAYERED = sig
     _ t ->
     (unit, Sigs.integrity_error) result
 
-  val unsafe_consume_newies : _ t -> key list
-
-  val consume_newies : 'a t -> key list Lwt.t
+  val consume_newies : 'a t -> key list
 
   val check :
     'a t ->

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -70,7 +70,6 @@ module type LAYERED_ATOMIC_WRITE_STORE = sig
     L.t option ->
     flip:bool ->
     freeze_in_progress:(unit -> bool) ->
-    add_lock:Lwt_mutex.t ->
     t
 
   val copy :
@@ -86,6 +85,4 @@ module type LAYERED_ATOMIC_WRITE_STORE = sig
   val clear_previous_upper : ?keep_generation:unit -> t -> unit Lwt.t
 
   val copy_newies_to_next_upper : t -> unit Lwt.t
-
-  val copy_last_newies_to_next_upper : t -> unit Lwt.t
 end


### PR DESCRIPTION
Experimenting with another way to reduce the number of `newies`: only track the new commits and let `Repo.iter` complete the missing ones :-)

But this doesn't pass the tests and I am not sure why..