### PR TITLE
irmin: always use short hashes for in-memory caches

### DIFF
--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -13,15 +13,7 @@
 (* Extracted from https://github.com/pqwy/lru
    Copyright (c) 2016 David Kaloper Meršinjak *)
 
-module Make (K : Type.S) = struct
-  module H = struct
-    type t = K.t
-
-    let hash = Type.(unstage (short_hash K.t)) ?seed:None
-
-    let equal = Type.(unstage (equal K.t))
-  end
-
+module Make (H : Hashtbl.HashedType) = struct
   module HT = Hashtbl.Make (H)
 
   module Q = struct

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -13,7 +13,7 @@
 (* Extracted from https://github.com/pqwy/lru
    Copyright (c) 2016 David Kaloper Meršinjak *)
 
-module Make (H : Type.S) : sig
+module Make (H : Hashtbl.HashedType) : sig
   type 'a t
 
   val create : int -> 'a t

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -84,7 +84,13 @@ module type S = sig
   module Dump : Type.S with type t = dump
 end
 
-module Make (Hash : Type.S) (Branch : Type.S) = struct
+module type HASH = sig
+  include Type.S
+
+  val short_hash : t -> int
+end
+
+module Make (Hash : HASH) (Branch : Type.S) = struct
   module X = struct
     type t =
       [ `Contents of Hash.t
@@ -97,17 +103,15 @@ module Make (Hash : Type.S) (Branch : Type.S) = struct
 
     let compare = Type.(unstage (compare t))
 
-    let short_hash = Type.(unstage (short_hash Hash.t))
-
     let hash_branch = Type.(unstage (short_hash Branch.t))
 
     (* we are using cryptographic hashes here, so the first bytes
        are good enough to be used as short hashes. *)
     let hash (t : t) : int =
       match t with
-      | `Contents c -> short_hash c
-      | `Node n -> short_hash n
-      | `Commit c -> short_hash c
+      | `Contents c -> Hash.short_hash c
+      | `Node n -> Hash.short_hash n
+      | `Commit c -> Hash.short_hash c
       | `Branch b -> hash_branch b
   end
 

--- a/src/irmin/object_graph.mli
+++ b/src/irmin/object_graph.mli
@@ -105,8 +105,14 @@ module type S = sig
   (** The base functions over graph internals. *)
 end
 
+module type HASH = sig
+  include Type.S
+
+  val short_hash : t -> int
+end
+
 (** Build a graph. *)
-module Make (Hash : Type.S) (Branch : Type.S) :
+module Make (Hash : HASH) (Branch : Type.S) :
   S
     with type V.t =
           [ `Contents of Hash.t


### PR DESCRIPTION
This is an alternative implementation of #1166 but where only the in-memory structures are using the optimised hash. That'll ensure that the order of index entries is not modified (e.g. no diff in `irmin-pack/pack_index.ml`)