### PR TITLE
irmin-pack: improve log messages

### DIFF
--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -58,7 +58,7 @@ let pp_during_freeze ppf = function
   | true -> Fmt.string ppf " during freeze"
   | false -> ()
 
-let pp_layer_id = Irmin.Type.pp Irmin_layers.Layer_id.t
+let pp_layer_id = Irmin_layers.Layer_id.pp
 
 let pp_current_upper ppf t = pp_layer_id ppf (if t then `Upper1 else `Upper0)
 

--- a/src/irmin-pack/layered_store.mli
+++ b/src/irmin-pack/layered_store.mli
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+val pp_current_upper : bool Fmt.t
+
 module Content_addressable
     (H : Irmin.Hash.S)
     (Index : Pack_index.S)


### PR DESCRIPTION
Show on which upper a freeze take places.

e.g.:

```
+1608311296us [INFO] irmin-pack [upper1] freeze cancelled { id=9; total-duration=17.824ms; freeze-lock=893us }
```