### PR TITLE
irmin-pack: try to call merges less often

### DIFF
--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -32,7 +32,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "index.dev" "git+https://github.com/mirage/index#57f050412836c3c6f8b0ee4c00f403b21453483c" ]
+  [ "index.dev" "git+https://github.com/mirage/index#aaa27d3b7b7a876ed9d21db50433847d8e9498ff" ]
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -125,7 +125,7 @@ struct
       else false
 
     let flush ?(index = true) ?(index_merge = false) t =
-      if index_merge then Index.merge t.pack.index;
+      if index_merge then Index.try_merge t.pack.index;
       Dict.flush t.pack.dict;
       IO.flush t.pack.block;
       if index then Index.flush ~no_callback:() t.pack.index;
@@ -240,7 +240,7 @@ struct
       f (cast t) >>= fun r ->
       if Tbl.length t.staging = 0 then Lwt.return r
       else (
-        flush t;
+        flush ~index_merge:true t;
         Lwt.return r)
 
     let auto_flush = 1024
@@ -269,11 +269,11 @@ struct
 
     let add t v =
       let k = V.hash v in
-      unsafe_append ~ensure_unique:true ~overcommit:false t k v;
+      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
       Lwt.return k
 
     let unsafe_add t k v =
-      unsafe_append ~ensure_unique:true ~overcommit:false t k v;
+      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
       Lwt.return ()
 
     let unsafe_close t =


### PR DESCRIPTION
Always add entries with overcommit=true and try to do a merge at the end of a
batch. This ensures writes are done in "batches" without index locks
interfering.