### PR TITLE
Remove Lwt.pause in inodes

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -587,34 +587,6 @@ struct
 
       let add ~find t s v = add ~find ~copy:true t s v
 
-      let pause = Lwt.pause
-
-      let lwt_array_iter_s arr f =
-        let rec aux i =
-          if i = Array.length arr then Lwt.return_unit
-          else
-            let entry = arr.(i) in
-            f entry >>= fun () -> aux (i + 1)
-        in
-        aux 0
-
-      let save_lwt ~add ~mem t =
-        let rec aux ~seed t =
-          Log.debug (fun l -> l "save seed:%d %a" seed pp_hash (hash t));
-          match t.v with
-          | Values _ -> add (Lazy.force t.hash) (to_bin t)
-          | Inodes n ->
-              lwt_array_iter_s n.entries (function
-                | Empty | Inode { tree = None; _ } -> Lwt.return_unit
-                | Inode ({ tree = Some t; _ } as i) -> (
-                    let hash = hash_of_inode i in
-                    mem hash >>= function
-                    | true -> pause ()
-                    | false -> aux ~seed:(seed + 1) t))
-              >>= fun () -> add (Lazy.force t.hash) (to_bin t)
-        in
-        aux ~seed:0 t
-
       let save ~add ~mem t =
         let rec aux ~seed t =
           Log.debug (fun l -> l "save seed:%d" seed);

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -69,12 +69,6 @@ module type INODE_INTER = sig
 
     val save : add:(hash -> Elt.t -> unit) -> mem:(hash -> bool) -> t -> unit
 
-    val save_lwt :
-      add:(hash -> Elt.t -> unit Lwt.t) ->
-      mem:(hash -> bool Lwt.t) ->
-      t ->
-      unit Lwt.t
-
     val hash : t -> hash
   end
 end

--- a/src/irmin-pack/inode_layers.ml
+++ b/src/irmin-pack/inode_layers.ml
@@ -93,16 +93,18 @@ struct
 
   let save t v =
     let add k v =
-      Inode.unsafe_append ~ensure_unique:true ~overcommit:false t k v;
-      Lwt.return_unit
+      Inode.unsafe_append ~ensure_unique:true ~overcommit:false t k v
     in
-    Inode.Val.save_lwt ~add ~mem:(Inode.unsafe_mem t) v
+    Inode.Val.save ~add ~mem:(Inode.unsafe_mem t) v
 
-  let add t v = save t v.Val.v >|= fun () -> hash v
+  let add t v =
+    save t v.Val.v;
+    Lwt.return (hash v)
 
   let unsafe_add t k v =
     check_hash k (hash v);
-    save t v.Val.v
+    save t v.Val.v;
+    Lwt.return ()
 
   let clear_caches_next_upper = Inode.clear_caches_next_upper
 

--- a/src/irmin-pack/layered_store.ml
+++ b/src/irmin-pack/layered_store.ml
@@ -178,11 +178,8 @@ struct
 
   let unsafe_mem t k =
     let current = current_upper t in
-    let b =
-      U.unsafe_mem current k
-      || match t.lower with None -> false | Some lower -> L.unsafe_mem lower k
-    in
-    Lwt.return b
+    U.unsafe_mem current k
+    || match t.lower with None -> false | Some lower -> L.unsafe_mem lower k
 
   (** Only flush current upper, to prevent concurrent flushing and appends
       during copy. Next upper and lower are flushed at the end of a freeze. *)

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -160,8 +160,6 @@ module type LAYERED = sig
   val unsafe_append :
     ensure_unique:bool -> overcommit:bool -> 'a t -> key -> value -> unit
 
-  val unsafe_mem : 'a t -> key -> bool Lwt.t
-
   val flush_next_lower : 'a t -> unit
 
   val integrity_check :


### PR DESCRIPTION
This causes a (very small) difference but simplifies the code.

```
# dune exec -- bench/irmin-pack/layers.exe -n 400 -d 10 --freeze-throttle=cancel
(remove-pause) [0.002s per commit, 474 commits per second]
(master) [0.002s per commit, 469 commits per second]
```
