### PR TITLE
fmt: use module-item-spacing = compact

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -2,4 +2,3 @@ version = 0.16.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
-indicate-multiline-delimiters = no

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -2,3 +2,4 @@ version = 0.16.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
+module-item-spacing = compact

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -38,15 +38,10 @@ type config = {
 [@@deriving repr]
 
 let () = Random.self_init ()
-
 let random_char () = char_of_int (Random.int 256)
-
 let random_string n = String.init n (fun _i -> random_char ())
-
 let long_random_blob () = random_string 100
-
 let random_blob () = random_string 10
-
 let random_key () = random_string 3
 
 let rm_dir root =
@@ -58,11 +53,11 @@ let rm_dir root =
 
 module Conf = struct
   let entries = 32
-
   let stable_hash = 256
 end
 
 module Hash = Irmin.Hash.SHA1
+
 module Store =
   Irmin_pack_layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
@@ -74,7 +69,6 @@ module FSHelper = struct
     try (Unix.stat f).st_size with Unix.Unix_error (Unix.ENOENT, _, _) -> 0
 
   let dict root = file (Irmin_pack.Layout.dict ~root) / 1024 / 1024
-
   let pack root = file (Irmin_pack.Layout.pack ~root) / 1024 / 1024
 
   let index root =
@@ -220,9 +214,7 @@ let freeze ~min_upper ~max config repo =
   else Store.freeze ~max ~min_upper repo
 
 let min_uppers = Queue.create ()
-
 let add_min c = Queue.add c min_uppers
-
 let consume_min () = Queue.pop min_uppers
 
 let first_5_cycles config repo =

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -18,7 +18,6 @@ let config ~root = Irmin_pack.config ~fresh:false root
 
 module Config = struct
   let entries = 2
-
   let stable_hash = 3
 end
 

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -13,7 +13,6 @@ open Lwt.Infix
 open Astring
 
 let time = ref 0L
-
 let failure fmt = Fmt.kstrf failwith fmt
 
 (* A log entry *)
@@ -21,7 +20,6 @@ module Entry : sig
   include Irmin.Type.S
 
   val v : string -> t
-
   val timestamp : t -> int64
 end = struct
   type t = { timestamp : int64; message : string } [@@deriving irmin]
@@ -34,7 +32,6 @@ end = struct
     { timestamp = !time; message }
 
   let timestamp t = t.timestamp
-
   let pp ppf { timestamp; message } = Fmt.pf ppf "%04Ld: %s" timestamp message
 
   let of_string str =
@@ -52,15 +49,12 @@ module Log : sig
   include Irmin.Contents.S
 
   val add : t -> Entry.t -> t
-
   val empty : t
 end = struct
   type t = Entry.t list [@@deriving irmin]
 
   let empty = []
-
   let pp_entry = Irmin.Type.pp Entry.t
-
   let lines ppf l = List.iter (Fmt.pf ppf "%a\n" pp_entry) (List.rev l)
 
   let of_string str =
@@ -76,7 +70,6 @@ end = struct
     with Failure e -> Error (`Msg e)
 
   let t = Irmin.Type.like ~pp:lines ~of_string t
-
   let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 
   let newer_than timestamp file =
@@ -100,7 +93,6 @@ end = struct
     Irmin.Merge.ok (List.rev_append t3 old)
 
   let merge = Irmin.Merge.(option (v t merge))
-
   let add t e = e :: t
 end
 
@@ -112,7 +104,6 @@ let config = Irmin_git.config ~bare:true Config.root
 
 (* Convenient alias for the info function for commit messages *)
 let info = Irmin_unix.info
-
 let log_file = [ "local"; "debug" ]
 
 let all_logs t =

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -83,13 +83,11 @@ let mysql =
   }
 
 let branch image = String.map (function ':' -> '/' | c -> c) image.name
-
 let images = [| (*ubuntu; *) wordpress; mysql |]
 
 module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
 let head = Store.Git.Reference.of_string ("refs/heads/" ^ branch images.(0))
-
 let config = Irmin_git.config ~bare:true ~head Config.root
 
 let info image msg () =
@@ -109,7 +107,6 @@ let init () =
     (Array.to_list images)
 
 let random_array a = a.(Random.int (Array.length a))
-
 let random_list l = random_array (Array.of_list l)
 
 let rec process image =

--- a/examples/trees.ml
+++ b/examples/trees.ml
@@ -6,9 +6,7 @@ module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 module Tree = Store.Tree
 
 type t1 = int
-
 type t2 = { x : string; y : t1 }
-
 type t = t2 list
 
 let tree_of_t t =

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -85,18 +85,14 @@ module Chunk (K : Irmin.Hash.S) = struct
   type t = { len : int; v : v }
 
   let size_of = Irmin.Type.unstage (Irmin.Type.size_of v)
-
   let to_bin_string = Irmin.Type.unstage (Irmin.Type.to_bin_string v)
-
   let decode_bin = Irmin.Type.unstage (Irmin.Type.decode_bin v)
-
   let encode_bin = Irmin.Type.unstage (Irmin.Type.encode_bin v)
 
   let size_of_v t =
     match size_of t with Some n -> n | None -> String.length (to_bin_string t)
 
   let size_of_data_header = size_of_v (Data "")
-
   let size_of_index_header = size_of_v (Index [])
 
   let of_string b =
@@ -216,9 +212,7 @@ struct
     { chunking; db; chunk_size; max_children; max_data }
 
   let close _ = Lwt.return_unit
-
   let clear t = CA.clear t.db
-
   let batch t f = CA.batch t.db (fun db -> f { t with db })
 
   let find_leaves t key =

--- a/src/irmin-containers/blob_log.ml
+++ b/src/irmin-containers/blob_log.ml
@@ -18,7 +18,6 @@
 open Lwt.Infix
 
 let return = Lwt.return
-
 let empty_info = Irmin.Info.none
 
 module Blob_log (T : Time.S) (V : Irmin.Type.S) :
@@ -26,7 +25,6 @@ module Blob_log (T : Time.S) (V : Irmin.Type.S) :
   type t = (V.t * T.t) list [@@deriving irmin]
 
   let compare_t = Irmin.Type.(unstage (compare T.t))
-
   let compare (_, t1) (_, t2) = compare_t t1 t2
 
   let newer_than timestamp entries =
@@ -59,7 +57,6 @@ module type S = sig
   type value
 
   val append : path:Store.key -> Store.t -> value -> unit Lwt.t
-
   val read_all : path:Store.key -> Store.t -> value list Lwt.t
 end
 

--- a/src/irmin-containers/counter.ml
+++ b/src/irmin-containers/counter.ml
@@ -18,14 +18,12 @@
 open Lwt.Infix
 
 let return = Lwt.return
-
 let empty_info = Irmin.Info.none
 
 module Counter : Irmin.Contents.S with type t = int64 = struct
   type t = int64
 
   let t = Irmin.Type.int64
-
   let merge = Irmin.Merge.(option counter)
 end
 

--- a/src/irmin-containers/linked_log.ml
+++ b/src/irmin-containers/linked_log.ml
@@ -18,7 +18,6 @@
 open Lwt.Infix
 
 let return = Lwt.return
-
 let empty_info = Irmin.Info.none
 
 module Log_item (T : Time.S) (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
@@ -64,9 +63,7 @@ struct
     Store.add store (Value { time = T.now (); msg; prev })
 
   let read_key k = Store.get_store () >>= fun store -> Store.read_exn store k
-
   let compare_t = Irmin.Type.(unstage (compare T.t))
-
   let sort l = List.sort (fun i1 i2 -> compare_t i2.L.time i1.L.time) l
 
   let merge ~old:_ v1 v2 =
@@ -92,7 +89,6 @@ module type S = sig
   type cursor
 
   val get_cursor : path:Store.key -> Store.t -> cursor Lwt.t
-
   val read : num_items:int -> cursor -> (value list * cursor) Lwt.t
 end
 
@@ -159,7 +155,6 @@ struct
                   (num_items - 1) (msg :: acc))
 
   let read ~num_items cursor = read_log cursor num_items []
-
   let read_all ~path t = get_cursor t ~path >>= read ~num_items:max_int >|= fst
 end
 

--- a/src/irmin-containers/lww_register.ml
+++ b/src/irmin-containers/lww_register.ml
@@ -24,7 +24,6 @@ module LWW (T : Time.S) (V : Irmin.Type.S) :
   type t = V.t * T.t [@@deriving irmin]
 
   let compare_t = Irmin.Type.(unstage (compare T.t))
-
   let compare_v = Irmin.Type.(unstage (compare V.t))
 
   let compare (v1, t1) (v2, t2) =

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -25,9 +25,7 @@ let ( / ) = Filename.concat
 
 module type Config = sig
   val dir : string -> string
-
   val file_of_key : string -> string
-
   val key_of_file : string -> string
 end
 
@@ -35,17 +33,13 @@ module type IO = sig
   type path = string
 
   val rec_files : path -> string list Lwt.t
-
   val file_exists : path -> bool Lwt.t
-
   val read_file : path -> string option Lwt.t
-
   val mkdir : path -> unit Lwt.t
 
   type lock
 
   val lock_file : string -> lock
-
   val write_file : ?temp_dir:path -> ?lock:lock -> path -> string -> unit Lwt.t
 
   val test_and_set_file :
@@ -72,9 +66,7 @@ module Read_only_ext
     (V : Irmin.Type.S) =
 struct
   type key = K.t
-
   type value = V.t
-
   type 'a t = { path : string }
 
   let get_path config =
@@ -87,9 +79,7 @@ struct
     IO.mkdir path >|= fun () -> { path }
 
   let close _ = Lwt.return_unit
-
   let cast t = (t :> [ `Read | `Write ] t)
-
   let batch t f = f (cast t)
 
   let file_of_key { path; _ } key =
@@ -159,7 +149,6 @@ struct
   include Read_only_ext (IO) (S) (K) (V)
 
   let temp_dir t = t.path / "tmp"
-
   let to_bin_string = Irmin.Type.(unstage (to_bin_string V.t))
 
   let add t key value =
@@ -183,11 +172,8 @@ struct
   module W = Irmin.Private.Watch.Make (K) (V)
 
   type t = { t : unit RO.t; w : W.t }
-
   type key = RO.key
-
   type value = RO.value
-
   type watch = W.watch * (unit -> unit Lwt.t)
 
   let temp_dir t = t.t.RO.path / "tmp"
@@ -196,7 +182,6 @@ struct
     type t = string
 
     let equal x y = compare x y = 0
-
     let hash = Hashtbl.hash
   end)
 
@@ -215,11 +200,8 @@ struct
     { t; w }
 
   let close t = W.clear t.w >>= fun () -> RO.close t.t
-
   let find t = RO.find t.t
-
   let mem t = RO.mem t.t
-
   let list t = RO.list t.t
 
   let listen_dir t =
@@ -242,7 +224,6 @@ struct
     W.watch t.w ?init f >|= fun w -> (w, stop)
 
   let unwatch t (id, stop) = stop () >>= fun () -> W.unwatch t.w id
-
   let raw_value = Irmin.Type.(unstage (to_bin_string V.t))
 
   let set t key value =
@@ -334,6 +315,7 @@ end
 module Append_only (IO : IO) = Append_only_ext (IO) (Obj)
 module Atomic_write (IO : IO) = Atomic_write_ext (IO) (Ref)
 module Make (IO : IO) = Make_ext (IO) (Obj) (Ref)
+
 module KV (IO : IO) (C : Irmin.Contents.S) =
   Make (IO) (Irmin.Metadata.None) (C) (Irmin.Path.String_list)
     (Irmin.Branch.String)
@@ -348,7 +330,6 @@ module IO_mem = struct
   let t = { watches = Hashtbl.create 3; files = Hashtbl.create 13 }
 
   type path = string
-
   type lock = Lwt_mutex.t
 
   let locks = Hashtbl.create 10

--- a/src/irmin-fs/irmin_fs.mli
+++ b/src/irmin-fs/irmin_fs.mli
@@ -67,11 +67,8 @@ module type IO = sig
 end
 
 module Append_only (IO : IO) : Irmin.APPEND_ONLY_STORE_MAKER
-
 module Atomic_write (IO : IO) : Irmin.ATOMIC_WRITE_STORE_MAKER
-
 module Make (IO : IO) : Irmin.S_MAKER
-
 module KV (IO : IO) : Irmin.KV_MAKER
 
 (** {2 Advanced configuration} *)
@@ -90,9 +87,7 @@ module type Config = sig
 end
 
 module Append_only_ext (IO : IO) (C : Config) : Irmin.APPEND_ONLY_STORE_MAKER
-
 module Atomic_write_ext (IO : IO) (C : Config) : Irmin.ATOMIC_WRITE_STORE_MAKER
-
 module Make_ext (IO : IO) (Obj : Config) (Ref : Config) : Irmin.S_MAKER
 
 (** {1 In-memory IO mocks} *)
@@ -101,6 +96,5 @@ module IO_mem : sig
   include IO
 
   val clear : unit -> unit Lwt.t
-
   val set_listen_hook : unit -> unit
 end

--- a/src/irmin-git/closeable.ml
+++ b/src/irmin-git/closeable.ml
@@ -16,9 +16,7 @@
 
 module Content_addressable (S : Irmin.CONTENT_ADDRESSABLE_STORE) = struct
   type 'a t = bool ref * 'a S.t
-
   type key = S.key
-
   type value = S.value
 
   let check_not_closed t = if !(fst t) then raise Irmin.Closed

--- a/src/irmin-git/irmin_git.mli
+++ b/src/irmin-git/irmin_git.mli
@@ -31,11 +31,8 @@ val config :
   Irmin.config
 
 val bare : bool Irmin.Private.Conf.key
-
 val head : Git.Reference.t option Irmin.Private.Conf.key
-
 val level : int option Irmin.Private.Conf.key
-
 val dot_git : string option Irmin.Private.Conf.key
 
 module Content_addressable (G : Git.S) (V : Irmin.Type.S) :
@@ -134,21 +131,17 @@ module type REF_MAKER = functor
      and type Private.Sync.endpoint = S.Endpoint.t
 
 module Make : S_MAKER
-
 module Ref : REF_MAKER
-
 module KV : KV_MAKER
 
 module type BRANCH = sig
   include Irmin.Branch.S
 
   val pp_ref : t Fmt.t
-
   val of_ref : string -> (t, [ `Msg of string ]) result
 end
 
 module Branch (B : Irmin.Branch.S) : BRANCH
-
 module Reference : BRANCH with type t = reference
 
 module Make_ext

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -5,7 +5,6 @@ module type S = sig
   module IO : Cohttp_lwt.S.IO
 
   type repo
-
   type server
 
   type response_action =
@@ -46,29 +45,20 @@ module type CUSTOM_TYPE = sig
   type t
 
   val schema_typ : (unit, t option) Schema.typ
-
   val arg_typ : t option Schema.Arg.arg_typ
 end
 
 module type CUSTOM_TYPES = sig
   type key
-
   type metadata
-
   type contents
-
   type hash
-
   type branch
 
   module Key : CUSTOM_TYPE with type t := key
-
   module Metadata : CUSTOM_TYPE with type t := metadata
-
   module Contents : CUSTOM_TYPE with type t := contents
-
   module Hash : CUSTOM_TYPE with type t := hash
-
   module Branch : CUSTOM_TYPE with type t := branch
 end
 
@@ -138,7 +128,6 @@ struct
   module Graphql_server = Graphql_cohttp.Make (Schema) (IO) (Cohttp_lwt.Body)
 
   type repo = Store.repo
-
   type server = Server.t
 
   type txn_args = {
@@ -198,15 +187,10 @@ struct
       | _ -> Error "Invalid input value"
 
     let remote = Schema.Arg.(scalar "Remote" ~coerce:coerce_remote)
-
     let key = Types.Key.arg_typ
-
     let commit_hash = Types.Hash.arg_typ
-
     let branch = Types.Branch.arg_typ
-
     let value = Types.Contents.arg_typ
-
     let metadata = Types.Metadata.arg_typ
 
     let info =
@@ -386,15 +370,12 @@ struct
             ]))
 
   and node = Schema.union "Node"
-
   and tree_as_node = lazy (Schema.add_type node (Lazy.force tree))
-
   and contents_as_node = lazy (Schema.add_type node (Lazy.force contents))
 
   [@@@ocaml.warning "-5"]
 
   let _ = Lazy.force tree_as_node
-
   let _ = Lazy.force contents_as_node
 
   let err_write e =

--- a/src/irmin-graphql/server.mli
+++ b/src/irmin-graphql/server.mli
@@ -5,7 +5,6 @@ module type S = sig
   module IO : Cohttp_lwt.S.IO
 
   type repo
-
   type server
 
   type response_action =
@@ -36,30 +35,21 @@ module type CUSTOM_TYPE = sig
   type t
 
   val schema_typ : (unit, t option) Schema.typ
-
   val arg_typ : t option Schema.Arg.arg_typ
 end
 
 (** GraphQL types for Irmin concepts (key, metadata, contents, hash and branch). *)
 module type CUSTOM_TYPES = sig
   type key
-
   type metadata
-
   type contents
-
   type hash
-
   type branch
 
   module Key : CUSTOM_TYPE with type t := key
-
   module Metadata : CUSTOM_TYPE with type t := metadata
-
   module Contents : CUSTOM_TYPE with type t := contents
-
   module Hash : CUSTOM_TYPE with type t := hash
-
   module Branch : CUSTOM_TYPE with type t := branch
 end
 

--- a/src/irmin-http/closeable.ml
+++ b/src/irmin-http/closeable.ml
@@ -18,11 +18,8 @@ open Lwt.Infix
 
 module Append_only (S : S.APPEND_ONLY_STORE) = struct
   type 'a t = { closed : bool ref; t : 'a S.t }
-
   type key = S.key
-
   type value = S.value
-
   type ctx = S.ctx
 
   let check_not_closed t = if !(t.closed) then raise Irmin.Closed
@@ -63,11 +60,8 @@ end
 
 module Atomic_write (S : S.ATOMIC_WRITE_STORE) = struct
   type t = { closed : bool ref; t : S.t }
-
   type key = S.key
-
   type value = S.value
-
   type ctx = S.ctx
 
   let check_not_closed t = if !(t.closed) then raise Irmin.Closed

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -21,7 +21,6 @@ open Lwt.Infix
 let src = Logs.Src.create "irmin.http" ~doc:"Irmin HTTP REST interface"
 
 module Log = (val Logs.src_log src : Logs.LOG)
-
 module T = Irmin.Type
 
 (* ~uri *)
@@ -120,7 +119,6 @@ let json_stream (stream : string Lwt_stream.t) : Jsonm.lexeme list Lwt_stream.t
   Lwt_stream.from open_and_get
 
 let of_json = Irmin.Type.of_json_string
-
 let to_json = Irmin.Type.to_json_string
 
 module Helper (Client : Cohttp_lwt.S.Client) :
@@ -213,17 +211,13 @@ module RO (Client : Cohttp_lwt.S.Client) (K : Irmin.Type.S) (V : Irmin.Type.S) :
   }
 
   let uri t = t.uri
-
   let item t = t.item
-
   let items t = t.items
 
   type key = K.t
-
   type value = V.t
 
   let key_str = Irmin.Type.to_string K.t
-
   let val_of_str = Irmin.Type.of_string V.t
 
   let find t key =
@@ -280,11 +274,8 @@ functor
     module W = Irmin.Private.Watch.Make (K) (V)
 
     type key = RO.key
-
     type value = RO.value
-
     type watch = W.watch
-
     type ctx = Client.ctx
 
     (* cache the stream connections to the server: we open only one
@@ -296,11 +287,8 @@ functor
     type t = { t : unit RO.t; w : W.t; keys : cache; glob : cache }
 
     let get t = HTTP.call `GET (RO.uri t.t) t.t.ctx
-
     let put t = HTTP.call `PUT (RO.uri t.t) t.t.ctx
-
     let get_stream t = HTTP.call_stream `GET (RO.uri t.t) t.t.ctx
-
     let post_stream t = HTTP.call_stream `POST (RO.uri t.t) t.t.ctx
 
     let v ?ctx uri item items =
@@ -311,11 +299,8 @@ functor
       Lwt.return { t; w; keys; glob }
 
     let find t = RO.find t.t
-
     let mem t = RO.mem t.t
-
     let key_str = Irmin.Type.to_string K.t
-
     let list t = get t [ RO.items t.t ] (of_json T.(list K.t))
 
     let set t key value =
@@ -345,7 +330,6 @@ functor
               Fmt.kstrf Lwt.fail_with "cannot remove %a: %s" pp_key key b)
 
     let nb_keys t = fst (W.stats t.w)
-
     let nb_glob t = snd (W.stats t.w)
 
     (* run [t] and returns an handler to stop the task. *)
@@ -423,7 +407,6 @@ functor
       Lwt.return_unit
 
     let close _ = Lwt.return_unit
-
     let clear t = RO.clear t.t
   end
 
@@ -509,11 +492,8 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
       }
 
       let branch_t t = t.branch
-
       let commit_t t = t.commit
-
       let node_t t = t.node
-
       let contents_t t = t.contents
 
       let batch t f =

--- a/src/irmin-http/irmin_http.mli
+++ b/src/irmin-http/irmin_http.mli
@@ -17,7 +17,6 @@
 (** JSON REST/CRUD interface. *)
 
 val config : ?config:Irmin.config -> Uri.t -> Irmin.config
-
 val uri : Uri.t option Irmin.Private.Conf.key
 
 module type HTTP_CLIENT = sig

--- a/src/irmin-http/irmin_http_common.mli
+++ b/src/irmin-http/irmin_http_common.mli
@@ -21,7 +21,6 @@ val irmin_version : string
 type 'a set = { test : 'a option; set : 'a option; v : 'a option }
 
 val status_t : string Irmin.Type.t
-
 val set_t : 'a Irmin.Type.t -> 'a set Irmin.Type.t
 
 val event_t :

--- a/src/irmin-http/irmin_http_server.ml
+++ b/src/irmin-http/irmin_http_server.ml
@@ -19,16 +19,13 @@ open Irmin_http_common
 module T = Irmin.Type
 
 let to_json = Irmin.Type.to_json_string
-
 let of_json = Irmin.Type.of_json_string
-
 let src = Logs.Src.create "irmin.http-srv" ~doc:"Irmin REST API server"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module type S = sig
   type repo
-
   type t
 
   val v : ?strict:bool -> repo -> t
@@ -380,7 +377,6 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
   module Branch = Atomic_write (P.Branch) (P.Branch.Key) (P.Branch.Val)
 
   type repo = S.Repo.t
-
   type t = HTTP.t
 
   let v ?strict:_ db =

--- a/src/irmin-http/s.ml
+++ b/src/irmin-http/s.ml
@@ -20,9 +20,7 @@ module type HELPER = sig
   type ctx
 
   val err_bad_version : string option -> 'a Lwt.t
-
   val check_version : Cohttp.Response.t -> unit Lwt.t
-
   val is_success : Cohttp.Response.t -> bool
 
   val map_string_response :
@@ -66,61 +64,38 @@ end
 
 module type READ_ONLY_STORE = sig
   type ctx
-
   type 'a t = { uri : Uri.t; item : string; items : string; ctx : ctx option }
-
   type key
-
   type value
 
   module HTTP : HELPER with type ctx = ctx
 
   val uri : 'a t -> Uri.t
-
   val item : 'a t -> string
-
   val items : 'a t -> string
-
   val key_str : key -> string
-
   val val_of_str : value T.of_string
-
   val find : 'a t -> key -> value option Lwt.t
-
   val mem : 'a t -> key -> bool Lwt.t
-
   val cast : 'a t -> [ `Read | `Write ] t
-
   val batch : 'a t -> ([ `Read | `Write ] t -> 'b) -> 'b
-
   val v : ?ctx:ctx -> Uri.t -> string -> string -> 'a t Lwt.t
-
   val clear : 'a t -> unit Lwt.t
 end
 
 module type APPEND_ONLY_STORE = sig
   type 'a t
-
   type key
-
   type value
-
   type ctx
 
   val mem : [> `Read ] t -> key -> bool Lwt.t
-
   val find : [> `Read ] t -> key -> value option Lwt.t
-
   val add : 'a t -> value -> key Lwt.t
-
   val unsafe_add : 'a t -> key -> value -> unit Lwt.t
-
   val v : ?ctx:ctx -> Uri.t -> string -> string -> 'a t Lwt.t
-
   val close : 'a t -> unit Lwt.t
-
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
   val clear : 'a t -> unit Lwt.t
 end
 
@@ -148,9 +123,7 @@ module type ATOMIC_WRITE_STORE_MAKER = functor
   (V : Irmin.Hash.S)
   -> sig
   module W : Irmin.Private.Watch.S with type key = K.t and type value = V.t
-
   module RO : READ_ONLY_STORE
-
   module HTTP = RO.HTTP
 
   include

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -102,11 +102,8 @@ struct
       }
 
       let contents_t t = t.contents
-
       let node_t t = t.nodes
-
       let commit_t t = t.commits
-
       let branch_t t = t.branch
 
       let batch t f =
@@ -146,15 +143,10 @@ struct
     | Content_t : hash -> store_handle
 
   let layer_id _repo _store_handle = Lwt.fail_with "not implemented"
-
   let async_freeze _ = failwith "not implemented"
-
   let upper_in_use _repo = failwith "not implemented"
-
   let self_contained ?min:_ ~max:_ _repo = failwith "not implemented"
-
   let check_self_contained ?heads:_ _ = failwith "not implemented"
-
   let needs_recovery _ = failwith "not implemented"
 
   module PrivateLayer = struct

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -114,12 +114,10 @@ module type Irmin_layers = sig
     type t = layer_id [@@deriving irmin]
 
     val pp : Format.formatter -> t -> unit
-
     val to_string : t -> string
   end
 
   module type S = S
-
   module type S_MAKER = S_MAKER
 
   module Make_ext

--- a/src/irmin-layers/layered_store.ml
+++ b/src/irmin-layers/layered_store.ml
@@ -22,9 +22,7 @@ module type CA = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
   val v : Irmin.Private.Conf.t -> [ `Read ] t Lwt.t
-
   val close : 'a t -> unit Lwt.t
 end
 

--- a/src/irmin-layers/layered_store.mli
+++ b/src/irmin-layers/layered_store.mli
@@ -18,9 +18,7 @@ module type CA = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
   val v : Irmin.Private.Conf.t -> [ `Read ] t Lwt.t
-
   val close : 'a t -> unit Lwt.t
 end
 

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -50,7 +50,6 @@ let fresh_stats_i () =
   { contents = 0; nodes = 0; commits = 0; branches = 0; adds = 0 }
 
 let stats_t = fresh_stats_t ()
-
 let stats_i = fresh_stats_i ()
 
 let reset_stats_i () =
@@ -111,19 +110,12 @@ let freeze () =
     drop_last_elements (limit_length_list / 2)
 
 let copy_contents () = stats_i.contents <- succ stats_i.contents
-
 let copy_nodes () = stats_i.nodes <- succ stats_i.nodes
-
 let copy_commits () = stats_i.commits <- succ stats_i.commits
-
 let copy_branches () = stats_i.branches <- succ stats_i.branches
-
 let skip () = stats_t.skips <- succ stats_t.skips
-
 let add () = stats_i.adds <- succ stats_i.adds
-
 let get_adds () = stats_i.adds
-
 let reset_adds () = stats_i.adds <- 0
 
 let with_timer (operation : [ `Freeze | `Waiting ]) f =

--- a/src/irmin-layers/stats.mli
+++ b/src/irmin-layers/stats.mli
@@ -42,7 +42,6 @@ type t = {
     the case, you should discard the last 0.*)
 
 val reset_stats : unit -> unit
-
 val get : unit -> t
 
 val copy_contents : unit -> unit

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -28,13 +28,10 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
   end)
 
   type key = K.t
-
   type value = V.t
-
   type 'a t = { mutable t : value KMap.t }
 
   let map = { t = KMap.empty }
-
   let v _config = Lwt.return map
 
   let clear t =
@@ -47,9 +44,7 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
     Lwt.return_unit
 
   let cast t = (t :> [ `Read | `Write ] t)
-
   let batch t f = f (cast t)
-
   let pp_key = Irmin.Type.pp K.t
 
   let find { t; _ } key =
@@ -76,29 +71,18 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
   module L = Irmin.Private.Lock.Make (K)
 
   type t = { t : unit RO.t; w : W.t; lock : L.t }
-
   type key = RO.key
-
   type value = RO.value
-
   type watch = W.watch
 
   let watches = W.v ()
-
   let lock = L.v ()
-
   let v config = RO.v config >>= fun t -> Lwt.return { t; w = watches; lock }
-
   let close t = W.clear t.w >>= fun () -> RO.close t.t
-
   let find t = RO.find t.t
-
   let mem t = RO.mem t.t
-
   let watch_key t = W.watch_key t.w
-
   let watch t = W.watch t.w
-
   let unwatch t = W.unwatch t.w
 
   let list t =
@@ -144,6 +128,7 @@ let config () = Irmin.Private.Conf.empty
 
 module Make =
   Irmin.Make (Irmin.Content_addressable (Append_only)) (Atomic_write)
+
 module KV (C : Irmin.Contents.S) =
   Make (Irmin.Metadata.None) (C) (Irmin.Path.String_list) (Irmin.Branch.String)
     (Irmin.Hash.BLAKE2B)

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -116,7 +116,6 @@ module KV_RO (G : Git.S) = struct
     | #S.write_error as e -> Irmin.Type.pp S.write_error_t ppf e
 
   let err e : ('a, error) result = Error e
-
   let err_not_found k = err (`Not_found k)
 
   let path x =
@@ -191,11 +190,8 @@ module KV_RO (G : Git.S) = struct
     >|= fun tree -> { Tree.repo; tree }
 
   let exists t k = tree t >>= fun t -> Tree.exists t k
-
   let get t k = tree t >>= fun t -> Tree.get t k
-
   let list t k = tree t >>= fun t -> Tree.list t k
-
   let digest t k = tree t >>= fun t -> Tree.digest t k
 
   let get t k =
@@ -246,11 +242,9 @@ module KV_RW (G : Irmin_git.G) (C : Mirage_clock.PCLOCK) = struct
   }
 
   type key = RO.key
-
   type error = RO.error
 
   let pp_error = RO.pp_error
-
   let default_author () = "irmin <irmin@mirage.io>"
 
   let default_msg = function
@@ -285,11 +279,8 @@ module KV_RW (G : Irmin_git.G) (C : Mirage_clock.PCLOCK) = struct
     | Batch b -> Lwt.return { Tree.tree = b.tree; repo = repo t }
 
   let digest t k = tree t >>= fun t -> Tree.digest t k
-
   let exists t k = tree t >>= fun t -> Tree.exists t k
-
   let get t k = tree t >>= fun t -> Tree.get t k
-
   let list t k = tree t >>= fun t -> Tree.list t k
 
   type write_error = [ RO.error | Mirage_kv.write_error | RO.Sync.push_error ]
@@ -304,7 +295,6 @@ module KV_RW (G : Irmin_git.G) (C : Mirage_clock.PCLOCK) = struct
     | #Mirage_kv.write_error as e -> Mirage_kv.pp_write_error ppf e
 
   let info t op = Info.f ~author:(t.author ()) "%s" (t.msg op)
-
   let path = RO.path
 
   let set t k v =

--- a/src/irmin-mirage/git/irmin_mirage_git.mli
+++ b/src/irmin-mirage/git/irmin_mirage_git.mli
@@ -40,9 +40,7 @@ module type REF_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
      and module Git = G
 
 module Make : S_MAKER
-
 module KV : KV_MAKER
-
 module Ref : REF_MAKER
 
 module type KV_RO = sig
@@ -131,6 +129,5 @@ module Mem : sig
        and module Git = G
 
   module KV_RO : KV_RO with type git := G.t
-
   module KV_RW (C : Mirage_clock.PCLOCK) : KV_RW with type git := G.t
 end

--- a/src/irmin-mirage/graphql/irmin_mirage_graphql.ml
+++ b/src/irmin-mirage/graphql/irmin_mirage_graphql.ml
@@ -1,9 +1,7 @@
 module Server = struct
   module type S = sig
     module Pclock : Mirage_clock.PCLOCK
-
     module Http : Cohttp_lwt.S.Server
-
     module Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
 
     val start : http:(Http.t -> unit Lwt.t) -> Store.repo -> unit Lwt.t

--- a/src/irmin-mirage/graphql/irmin_mirage_graphql.mli
+++ b/src/irmin-mirage/graphql/irmin_mirage_graphql.mli
@@ -1,9 +1,7 @@
 module Server : sig
   module type S = sig
     module Pclock : Mirage_clock.PCLOCK
-
     module Http : Cohttp_lwt.S.Server
-
     module Store : Irmin.S with type Private.Sync.endpoint = Git_mirage.endpoint
 
     val start : http:(Http.t -> unit Lwt.t) -> Store.repo -> unit Lwt.t

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -25,9 +25,7 @@ module Version = struct
   type t = [ `V1 | `V2 ]
 
   let enum = [ (`V1, "00000001"); (`V2, "00000002") ]
-
   let pp = Fmt.of_to_string (function `V1 -> "v1" | `V2 -> "v2")
-
   let to_bin v = List.assoc v enum
 
   let raise_invalid v =
@@ -53,35 +51,20 @@ module type S = sig
   exception RO_Not_Allowed
 
   val v : version:version option -> fresh:bool -> readonly:bool -> string -> t
-
   val name : t -> string
-
   val clear : ?keep_generation:unit -> t -> unit
-
   val append : t -> string -> unit
-
   val set : t -> off:int64 -> string -> unit
-
   val read : t -> off:int64 -> bytes -> int
-
   val offset : t -> int64
-
   val force_offset : t -> int64
-
   val generation : t -> int64
-
   val force_generation : t -> int64
-
   val readonly : t -> bool
-
   val version : t -> version
-
   val flush : t -> unit
-
   val close : t -> unit
-
   val exists : string -> bool
-
   val size : t -> int
 
   val migrate :
@@ -94,7 +77,6 @@ module type S = sig
 end
 
 external ( ++ ) : int64 -> int64 -> int64 = "%int64_add"
-
 external ( -- ) : int64 -> int64 -> int64 = "%int64_sub"
 
 module Unix : S = struct
@@ -190,7 +172,6 @@ module Unix : S = struct
     | e -> raise e
 
   let protect f x = try f x with e -> protect_unix_exn e
-
   let safe f x = try f x with e -> ignore_enoent e
 
   let mkdir dirname =
@@ -309,9 +290,7 @@ module Unix : S = struct
               v ~offset ~version:`V2 ~generation raw)
 
   let close t = Raw.close t.raw
-
   let exists file = Sys.file_exists file
-
   let size { raw; _ } = (Raw.fstat raw).st_size
 
   (* From a given offset in [src], transfer all data to [dst] (starting at

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -28,35 +28,20 @@ module type S = sig
   exception RO_Not_Allowed
 
   val v : version:version option -> fresh:bool -> readonly:bool -> path -> t
-
   val name : t -> string
-
   val clear : ?keep_generation:unit -> t -> unit
-
   val append : t -> string -> unit
-
   val set : t -> off:int64 -> string -> unit
-
   val read : t -> off:int64 -> bytes -> int
-
   val offset : t -> int64
-
   val force_offset : t -> int64
-
   val generation : t -> int64
-
   val force_generation : t -> int64
-
   val readonly : t -> bool
-
   val version : t -> version
-
   val flush : t -> unit
-
   val close : t -> unit
-
   val exists : string -> bool
-
   val size : t -> int
 
   val migrate :

--- a/src/irmin-pack/checks_intf.ml
+++ b/src/irmin-pack/checks_intf.ml
@@ -59,7 +59,6 @@ module type Make_args = sig
 
   module Store : sig
     include Irmin.S with type hash = Hash.t
-
     include Store.S with type repo := repo
 
     (* TODO(craigfe): avoid redefining this extension to [Store] repeatedly *)
@@ -71,13 +70,10 @@ module type Checks = sig
   type nonrec empty = empty
 
   val setup_log : unit Cmdliner.Term.t
-
   val path : string Cmdliner.Term.t
 
   module type Subcommand = Subcommand
-
   module type S = S
-
   module type Make_args = Make_args
 
   module Make (_ : Make_args) : S

--- a/src/irmin-pack/closeable.ml
+++ b/src/irmin-pack/closeable.ml
@@ -14,11 +14,8 @@ open Lwt.Infix
 
 module Content_addressable (S : Pack.S) = struct
   type 'a t = { closed : bool ref; t : 'a S.t }
-
   type key = S.key
-
   type value = S.value
-
   type index = S.index
 
   let check_not_closed t = if !(t.closed) then raise Irmin.Closed
@@ -104,9 +101,7 @@ end
 
 module Atomic_write (AW : S.ATOMIC_WRITE_STORE) = struct
   type t = { closed : bool ref; t : AW.t }
-
   type key = AW.key
-
   type value = AW.value
 
   let check_not_closed t = if !(t.closed) then raise Irmin.Closed

--- a/src/irmin-pack/config.ml
+++ b/src/irmin-pack/config.ml
@@ -1,20 +1,14 @@
 module type S = sig
   val entries : int
-
   val stable_hash : int
 end
 
 module Default = struct
   let fresh = false
-
   let lru_size = 100_000
-
   let index_log_size = 500_000
-
   let readonly = false
-
   let merge_throttle = `Block_writes
-
   let freeze_throttle = `Block_writes
 end
 
@@ -83,17 +77,11 @@ let freeze_throttle_key =
     "freeze-throttle" freeze_throttle_converter Default.freeze_throttle
 
 let fresh config = Irmin.Private.Conf.get config fresh_key
-
 let lru_size config = Irmin.Private.Conf.get config lru_size_key
-
 let readonly config = Irmin.Private.Conf.get config readonly_key
-
 let index_log_size config = Irmin.Private.Conf.get config index_log_size_key
-
 let merge_throttle config = Irmin.Private.Conf.get config merge_throttle_key
-
 let freeze_throttle config = Irmin.Private.Conf.get config freeze_throttle_key
-
 let root_key = Irmin.Private.Conf.root
 
 let root config =

--- a/src/irmin-pack/config.mli
+++ b/src/irmin-pack/config.mli
@@ -1,39 +1,27 @@
 module type S = sig
   val entries : int
-
   val stable_hash : int
 end
 
 val fresh_key : bool Irmin.Private.Conf.key
-
 val lru_size_key : int Irmin.Private.Conf.key
-
 val index_log_size_key : int Irmin.Private.Conf.key
-
 val readonly_key : bool Irmin.Private.Conf.key
-
 val root_key : string option Irmin.Private.Conf.key
-
 val fresh : Irmin.Private.Conf.t -> bool
-
 val lru_size : Irmin.Private.Conf.t -> int
-
 val index_log_size : Irmin.Private.Conf.t -> int
-
 val readonly : Irmin.Private.Conf.t -> bool
 
 type merge_throttle = [ `Block_writes | `Overcommit_memory ] [@@deriving irmin]
 
 val merge_throttle_key : merge_throttle Irmin.Private.Conf.key
-
 val merge_throttle : Irmin.Private.Conf.t -> merge_throttle
 
 type freeze_throttle = [ merge_throttle | `Cancel_existing ] [@@deriving irmin]
 
 val freeze_throttle_key : freeze_throttle Irmin.Private.Conf.key
-
 val freeze_throttle : Irmin.Private.Conf.t -> freeze_throttle
-
 val root : Irmin.Private.Conf.t -> string
 
 val v :

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -22,7 +22,6 @@ let src =
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let current_version = `V2
-
 let ( -- ) = Int64.sub
 
 module Make (IO : IO.S) : S = struct
@@ -35,7 +34,6 @@ module Make (IO : IO.S) : S = struct
   }
 
   let int32_to_bin = Irmin.Type.(unstage (to_bin_string int32))
-
   let decode_int32 = Irmin.Type.(unstage (decode_bin int32))
 
   let append_string t v =

--- a/src/irmin-pack/dict_intf.ml
+++ b/src/irmin-pack/dict_intf.ml
@@ -18,20 +18,15 @@ module type S = sig
   type t
 
   val find : t -> int -> string option
-
   val index : t -> string -> int option
-
   val flush : t -> unit
 
   val sync : t -> unit
   (** syncs a readonly dict with the file on disk. *)
 
   val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
-
   val clear : t -> unit
-
   val close : t -> unit
-
   val valid : t -> bool
 end
 

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -24,11 +24,9 @@ let src = Logs.Src.create "irmin.pack" ~doc:"irmin-pack backend"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let current_version = `V2
-
 let pp_version = IO.pp_version
 
 exception Unsupported_version = Store.Unsupported_version
-
 exception RO_Not_Allowed = IO.Unix.RO_Not_Allowed
 
 let ( ++ ) = Int64.add
@@ -73,13 +71,9 @@ struct
           module H = Irmin.Hash.Typed (H) (Val)
 
           let hash = H.hash
-
           let magic = 'B'
-
           let value = value_t Val.t
-
           let encode_value = Irmin.Type.(unstage (encode_bin value))
-
           let decode_value = Irmin.Type.(unstage (decode_bin value))
 
           let encode_bin ~dict:_ ~offset:_ v hash =
@@ -113,13 +107,9 @@ struct
           module H = Irmin.Hash.Typed (H) (Val)
 
           let hash = H.hash
-
           let value = value_t Val.t
-
           let magic = 'C'
-
           let encode_value = Irmin.Type.(unstage (encode_bin value))
-
           let decode_value = Irmin.Type.(unstage (decode_bin value))
 
           let encode_bin ~dict:_ ~offset:_ v hash =
@@ -159,11 +149,8 @@ struct
       }
 
       let contents_t t : 'a Contents.t = t.contents
-
       let node_t t : 'a Node.t = (contents_t t, t.node)
-
       let commit_t t : 'a Commit.t = (node_t t, t.commit)
-
       let branch_t t = t.branch
 
       let batch t f =
@@ -244,7 +231,6 @@ struct
           Irmin.Type.(unstage (decode_bin (value_t Commit.Val.t)))
 
         let decode_key = Irmin.Type.(unstage (decode_bin Hash.t))
-
         let decode_magic = Irmin.Type.(unstage (decode_bin char))
 
         let decode_buffer ~progress ~total pack dict index =
@@ -353,12 +339,8 @@ struct
   include Irmin.Of_private (X)
 
   let sync = X.Repo.sync
-
   let clear = X.Repo.clear
-
   let migrate = Store.migrate
-
   let flush = X.Repo.flush
-
   let reconstruct_index = X.Repo.Reconstruct_index.reconstruct
 end

--- a/src/irmin-pack/ext.mli
+++ b/src/irmin-pack/ext.mli
@@ -19,7 +19,6 @@ module Dict = Pack_dict
 module Index = Pack_index
 
 exception RO_Not_Allowed
-
 exception Unsupported_version of IO.version
 
 module Make

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -36,9 +36,7 @@ struct
 
   module T = struct
     type hash = H.t [@@deriving irmin]
-
     type step = Node.step [@@deriving irmin]
-
     type metadata = Node.metadata [@@deriving irmin]
 
     let default = Node.default
@@ -46,7 +44,6 @@ struct
     type value = Node.value
 
     let value_t = Node.value_t
-
     let pp_hash = Irmin.Type.(pp hash_t)
   end
 
@@ -70,9 +67,7 @@ struct
       open T
 
       type inode = { index : int; hash : H.t }
-
       type inodes = { seed : int; length : int; entries : inode list }
-
       type v = Values of (step * value) list | Inodes of inodes
 
       let inode : inode Irmin.Type.t =
@@ -123,9 +118,7 @@ struct
         |> like ~pre_hash
 
       let node ~hash v = { stable = true; hash; v }
-
       let inode ~hash v = { stable = false; hash; v }
-
       let hash t = Lazy.force t.hash
     end
 
@@ -134,7 +127,6 @@ struct
       open T
 
       type name = Indirect of int | Direct of step
-
       type address = Indirect of int64 | Direct of H.t
 
       let address : address Irmin.Type.t =
@@ -243,11 +235,8 @@ struct
       type t = { hash : H.t; stable : bool; v : v }
 
       let node ~hash v = { hash; stable = true; v }
-
       let inode ~hash v = { hash; stable = false; v }
-
       let magic_node = 'N'
-
       let magic_inode = 'I'
 
       let stable : bool Irmin.Type.t =
@@ -268,7 +257,6 @@ struct
       open T
 
       let equal_hash = Irmin.Type.(unstage (equal hash_t))
-
       let equal_value = Irmin.Type.(unstage (equal value_t))
 
       type inode = { i_hash : hash Lazy.t; mutable tree : t option }
@@ -360,7 +348,6 @@ struct
         | Inodes t -> list_inodes ~find acc t
 
       let compare_step = Irmin.Type.(unstage (compare step_t))
-
       let compare_entry x y = compare_step (fst x) (fst y)
 
       let list ~find t =
@@ -404,9 +391,7 @@ struct
             { hash; stable = true; v = t.v }
 
       let hash_key = Irmin.Type.(unstage (short_hash step_t))
-
       let index ~seed k = abs (hash_key ~seed k) mod Conf.entries
-
       let inode ?tree i_hash = Inode { tree; i_hash }
 
       let of_bin t =
@@ -614,13 +599,9 @@ struct
         if t.stable then Compress.magic_node else Compress.magic_inode
 
       let hash t = Bin.hash t
-
       let step_to_bin = Irmin.Type.(unstage (to_bin_string T.step_t))
-
       let step_of_bin = Irmin.Type.(unstage (of_bin_string T.step_t))
-
       let encode_compress = Irmin.Type.(unstage (encode_bin Compress.t))
-
       let decode_compress = Irmin.Type.(unstage (decode_bin Compress.t))
 
       let encode_bin ~dict ~offset (t : t) k =
@@ -724,11 +705,9 @@ struct
     module I = Inode.Val
 
     type inode_val = I.t
-
     type t = { find : H.t -> I.t option; v : I.t }
 
     let pred t = I.pred t.v
-
     let niet _ = assert false
 
     let v l =
@@ -736,11 +715,8 @@ struct
       { find = niet; v }
 
     let list t = I.list ~find:t.find t.v
-
     let empty = { find = niet; v = I.empty }
-
     let is_empty t = I.is_empty t.v
-
     let find t s = I.find ~find:t.find t.v s
 
     let add t s v =
@@ -752,7 +728,6 @@ struct
       if v == t.v then t else { t with v }
 
     let pre_hash_i = Irmin.Type.(unstage (pre_hash I.t))
-
     let pre_hash_node = Irmin.Type.(unstage (pre_hash Node.t))
 
     let t : t Irmin.Type.t =
@@ -780,9 +755,7 @@ struct
   module Key = H
 
   type 'a t = 'a Inode.t
-
   type key = Key.t
-
   type value = Val.t
 
   let mem t k = Inode.mem t k
@@ -828,17 +801,11 @@ struct
     Lwt.return_unit
 
   let batch = Inode.batch
-
   let v = Inode.v
-
   let integrity_check = Inode.integrity_check
-
   let close = Inode.close
-
   let sync = Inode.sync
-
   let clear = Inode.clear
-
   let clear_caches = Inode.clear_caches
 
   let decode_bin ~dict ~hash buff off =

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -40,9 +40,7 @@ module type S = sig
   include S.CHECKABLE with type 'a t := 'a t and type key := key
 
   val close : 'a t -> unit Lwt.t
-
   val sync : ?on_generation_change:(unit -> unit) -> 'a t -> unit
-
   val clear_caches : 'a t -> unit
 end
 
@@ -64,20 +62,15 @@ module type INODE_INTER = sig
     type t
 
     val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
-
     val of_bin : Elt.t -> t
-
     val save : add:(hash -> Elt.t -> unit) -> mem:(hash -> bool) -> t -> unit
-
     val hash : t -> hash
   end
 end
 
 module type VAL_INTER = sig
   type hash
-
   type inode_val
-
   type t = { find : hash -> inode_val option; v : inode_val }
 
   include Irmin.Private.Node.S with type hash := hash and type t := t
@@ -89,29 +82,20 @@ module type PACK_INTER = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
   val add : 'a t -> value -> key Lwt.t
-
   val unsafe_add : 'a t -> key -> value -> unit Lwt.t
-
   val unsafe_find : 'a t -> key -> value option
-
   val flush : ?index:bool -> 'a t -> unit
-
   val version : 'a t -> IO.version
-
   val clear : ?keep_generation:unit -> 'a t -> unit Lwt.t
-
   val clear_caches : 'a t -> unit
 
   include S.CHECKABLE with type 'a t := 'a t and type key := key
-
   include S.CLOSEABLE with type 'a t := 'a t
 end
 
 module type INODE_EXT = sig
   include INODE_INTER
-
   include Pack.S with type value = Elt.t and type key = hash
 end
 
@@ -121,25 +105,18 @@ module type S_EXT = sig
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 
   module Key : Irmin.Hash.S with type t = key
-
   include S.CHECKABLE with type 'a t := 'a t and type key := key
-
   include S.CLOSEABLE with type 'a t := 'a t
 
   val clear_caches : 'a t -> unit
-
   val hash : value -> key
-
   val check_hash : key -> key -> unit
 end
 
 module type Inode = sig
   module type S = S
-
   module type INODE_EXT = INODE_EXT
-
   module type VAL_INTER = VAL_INTER
-
   module type S_EXT = S_EXT
 
   module Make_intermediate

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -42,6 +42,7 @@ end
 
 module KV (Config : Config.S) (C : Irmin.Contents.S) =
   Make (Config) (Metadata) (C) (Path) (Irmin.Branch.String) (Hash)
+
 module Stats = Stats
 module Layout = Layout
 module Checks = Checks

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -40,7 +40,6 @@ val config :
     not block but indefinitely expands the in-memory cache. *)
 
 exception RO_Not_Allowed
-
 exception Unsupported_version of IO.version
 
 module Make_ext

--- a/src/irmin-pack/layered/IO_layers.ml
+++ b/src/irmin-pack/layered/IO_layers.ml
@@ -28,7 +28,6 @@ module type S = sig
   include S.CLOSEABLE with type _ t := t
 
   val read_flip : t -> bool Lwt.t
-
   val write_flip : bool -> t -> unit Lwt.t
 end
 
@@ -90,8 +89,6 @@ module Lock = struct
     else Lwt.return { file; fd }
 
   let test = Sys.file_exists
-
   let unlink = Lwt_unix.unlink
-
   let close { fd; file } = Lwt_unix.close fd >>= fun () -> unlink file
 end

--- a/src/irmin-pack/layered/IO_layers.mli
+++ b/src/irmin-pack/layered/IO_layers.mli
@@ -22,7 +22,6 @@ module type S = sig
   include S.CLOSEABLE with type _ t := t
 
   val read_flip : t -> bool Lwt.t
-
   val write_flip : bool -> t -> unit Lwt.t
 end
 
@@ -36,6 +35,5 @@ module Lock : sig
   include S.CLOSEABLE with type _ t := t
 
   val unlink : string -> unit Lwt.t
-
   val test : string -> bool
 end

--- a/src/irmin-pack/layered/checks.ml
+++ b/src/irmin-pack/layered/checks.ml
@@ -3,7 +3,6 @@ open Irmin_pack.Checks
 module IO = Irmin_pack.Private.IO.Unix
 
 let ( let+ ) x f = Lwt.map f x
-
 let ( let* ) = Lwt.bind
 
 module type S = sig
@@ -37,7 +36,6 @@ end
 
 module Make (Args : sig
   module Hash : Irmin.Hash.S
-
   module Store : S.STORE with type hash = Hash.t
 end) =
 struct
@@ -52,7 +50,6 @@ struct
 
       (* Quick hack to shim functionality that we don't intend to use. *)
       let integrity_check ?ppf:_ ~auto_repair:_ _ = assert false
-
       let reconstruct_index ?output:_ _ = assert false
     end
   end)

--- a/src/irmin-pack/layered/config.ml
+++ b/src/irmin-pack/layered/config.ml
@@ -1,14 +1,9 @@
 module Default = struct
   let lower_root = Irmin_layers.Layer_id.to_string `Lower
-
   let upper0_root = Irmin_layers.Layer_id.to_string `Upper0
-
   let upper1_root = Irmin_layers.Layer_id.to_string `Upper1
-
   let copy_in_upper = false
-
   let with_lower = true
-
   let blocking_copy_size = 64
 end
 

--- a/src/irmin-pack/layered/config.mli
+++ b/src/irmin-pack/layered/config.mli
@@ -1,15 +1,10 @@
 type config := Irmin.Private.Conf.t
 
 val lower_root : config -> string
-
 val upper_root0 : config -> string
-
 val upper_root1 : config -> string
-
 val with_lower : config -> bool
-
 val copy_in_upper : config -> bool
-
 val blocking_copy_size : config -> int
 
 val v :

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -22,7 +22,6 @@ let src =
     ~doc:"layered inodes for the irmin-pack backend"
 
 module Log = (val Logs.src_log src : Logs.LOG)
-
 module I = Inode
 
 module Make
@@ -45,9 +44,7 @@ struct
   module Key = H
 
   type 'a t = 'a Inode.t
-
   type key = Key.t
-
   type value = Val.t
 
   let mem t k = Inode.mem t k
@@ -68,7 +65,6 @@ struct
         Some { Val.find; v }
 
   let hash v = Inode.Val.hash v.Val.v
-
   let equal_hash = Irmin.Type.(unstage (equal H.t))
 
   let check_hash expected got =
@@ -78,17 +74,11 @@ struct
         expected Inode.pp_hash got
 
   let batch = Inode.batch
-
   let v = Inode.v
-
   let integrity_check = Inode.integrity_check
-
   let close = Inode.close
-
   let sync = Inode.sync
-
   let clear = Inode.clear
-
   let clear_caches = Inode.clear_caches
 
   let save t v =
@@ -112,23 +102,14 @@ struct
   module L = Inode.L
 
   let layer_id = Inode.layer_id
-
   let mem_lower = Inode.mem_lower
-
   let lower = Inode.lower
-
   let mem_next = Inode.mem_next
-
   let flip_upper = Inode.flip_upper
-
   let next_upper = Inode.next_upper
-
   let current_upper = Inode.current_upper
-
   let consume_newies = Inode.consume_newies
-
   let update_flip = Inode.update_flip
-
   let flush ?index t = Inode.flush ?index t
 
   type 'a layer_type =

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -4,9 +4,7 @@ module Pack = Irmin_pack.Pack
 
 module type S = sig
   include Inode.S
-
   module U : Pack.S
-
   module L : Pack.S
 
   val v :
@@ -24,15 +22,10 @@ module type S = sig
     | Lower : [ `Read ] L.t layer_type
 
   val copy : 'l layer_type * 'l -> [ `Read ] t -> key -> unit
-
   val mem_lower : 'a t -> key -> bool Lwt.t
-
   val mem_next : [> `Read ] t -> key -> bool Lwt.t
-
   val next_upper : 'a t -> [ `Read ] U.t
-
   val current_upper : 'a t -> [ `Read ] U.t
-
   val lower : 'a t -> [ `Read ] L.t
 
   include S.LAYERED_GENERAL with type 'a t := 'a t
@@ -54,9 +47,7 @@ module type S = sig
     (unit, S.integrity_error) result
 
   val flush : ?index:bool -> 'a t -> unit
-
   val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
-
   val consume_newies : 'a t -> key list
 
   val check :

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -17,7 +17,6 @@
 module Checks = Checks
 
 let config = Config.v
-
 let src = Logs.Src.create "irmin-pack" ~doc:"irmin-pack backend"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -29,13 +28,10 @@ open Irmin_pack
 open Private
 
 let current_version = `V2
-
 let pp_version = IO.pp_version
-
 let ( -- ) = Int64.sub
 
 exception RO_Not_Allowed = IO.Unix.RO_Not_Allowed
-
 exception Unsupported_version = Store.Unsupported_version
 
 let cache_size = 10_000
@@ -51,7 +47,6 @@ module Lock = IO_layers.Lock
 module IO_layers = IO_layers.IO
 
 let may f = function None -> Lwt.return_unit | Some bf -> f bf
-
 let lock_path root = Filename.concat root "lock"
 
 module Make_ext
@@ -98,13 +93,9 @@ struct
           module H = Irmin.Hash.Typed (H) (Val)
 
           let hash = H.hash
-
           let magic = 'B'
-
           let value = value Val.t
-
           let encode_value = Irmin.Type.(unstage (encode_bin value))
-
           let decode_value = Irmin.Type.(unstage (decode_bin value))
 
           let encode_bin ~dict:_ ~offset:_ v hash =
@@ -140,13 +131,9 @@ struct
           module H = Irmin.Hash.Typed (H) (Val)
 
           let hash = H.hash
-
           let value = value Val.t
-
           let magic = 'C'
-
           let encode_value = Irmin.Type.(unstage (encode_bin value))
-
           let decode_value = Irmin.Type.(unstage (decode_bin value))
 
           let encode_bin ~dict:_ ~offset:_ v hash =
@@ -220,11 +207,8 @@ struct
       }
 
       let contents_t t = t.contents
-
       let node_t t = (contents_t t, t.node)
-
       let commit_t t = (node_t t, t.commit)
-
       let branch_t t = t.branch
 
       module Iterate = struct
@@ -514,9 +498,7 @@ struct
         Iterate.iter f t
 
       let write_flip t = IO_layers.write_flip t.flip t.flip_file
-
       let upper_in_use t = if t.flip then `Upper1 else `Upper0
-
       let offset t = Contents.CA.offset t.contents
     end
   end
@@ -550,26 +532,17 @@ struct
   include Irmin.Of_private (X)
 
   let sync = X.Repo.sync
-
   let clear = X.Repo.clear
-
   let migrate = X.Repo.migrate
-
   let flush = X.Repo.flush
-
   let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash
 
   module Copy = struct
     let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
-
     let mem_commit_next t = X.Commit.CA.mem_next t.X.Repo.commit
-
     let mem_node_lower t = X.Node.CA.mem_lower t.X.Repo.node
-
     let mem_node_next t = X.Node.CA.mem_next t.X.Repo.node
-
     let mem_contents_lower t = X.Contents.CA.mem_lower t.X.Repo.contents
-
     let mem_contents_next t = X.Contents.CA.mem_next t.X.Repo.contents
 
     let copy_branches t =
@@ -595,7 +568,6 @@ struct
             (X.Node.CA.Val.pred v)
 
     let always_false _ = false
-
     let with_cancel cancel f = if cancel () then Lwt.fail Cancelled else f ()
 
     let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
@@ -803,9 +775,7 @@ struct
       Fmt.list ~sep:(Fmt.unit "; ") pp ppf (List.filter (fun x -> x <> E) t)
 
     let commits k = function [] -> E | v -> F (pp_commits, k, v)
-
     let bool k v = if not v then E else F (Fmt.bool, k, v)
-
     let int k v = F (Fmt.int, k, v)
 
     let span k v =
@@ -925,15 +895,10 @@ struct
       | _ -> freeze ()
 
   let layer_id = X.Repo.layer_id
-
   let freeze = freeze' ?hook:None
-
   let async_freeze (t : Repo.t) = t.freeze.state = `Running
-
   let upper_in_use = X.Repo.upper_in_use
-
   let self_contained = Copy.CopyFromLower.self_contained
-
   let needs_recovery t = Lock.test (lock_path t.X.Repo.root)
 
   let check_self_contained ?heads t =
@@ -974,14 +939,12 @@ struct
       Lwt_mutex.with_lock t.freeze.lock (fun () -> Lwt.return_unit)
 
     let freeze' = freeze'
-
     let upper_in_use = upper_in_use
   end
 end
 
 module type S = sig
   include Irmin_layers.S
-
   include Store.S with type repo := repo
 
   val integrity_check :

--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -19,12 +19,10 @@ open Irmin_pack
 let src = Logs.Src.create "irmin.layers" ~doc:"Irmin layered store"
 
 module Log = (val Logs.src_log src : Logs.LOG)
-
 open Lwt.Infix
 
 module type CA = sig
   include Pack.S
-
   module Key : Irmin.Hash.TYPED with type t = key and type value = value
 end
 
@@ -61,9 +59,7 @@ let pp_during_freeze ppf = function
   | false -> ()
 
 let pp_layer_id = Irmin_layers.Layer_id.pp
-
 let pp_current_upper ppf t = pp_layer_id ppf (if t then `Upper1 else `Upper0)
-
 let pp_next_upper ppf t = pp_layer_id ppf (if t then `Upper0 else `Upper1)
 
 module Content_addressable
@@ -76,9 +72,7 @@ module Content_addressable
             and type value = U.value) =
 struct
   type index = U.index
-
   type key = U.key
-
   type value = U.value
 
   type 'a t = {
@@ -97,13 +91,9 @@ struct
     { lower; flip; uppers = (upper1, upper0); freeze_in_progress; newies = [] }
 
   let next_upper t = if t.flip then snd t.uppers else fst t.uppers
-
   let current_upper t = if t.flip then fst t.uppers else snd t.uppers
-
   let lower t = Option.get t.lower
-
   let pp_current_upper ppf t = pp_current_upper ppf t.flip
-
   let pp_next_upper ppf t = pp_next_upper ppf t.flip
 
   let mem_lower t k =
@@ -333,7 +323,6 @@ module Pack_Maker
     (P : Pack.MAKER with type key = H.t and type index = Index.t) =
 struct
   type index = P.index
-
   type key = P.key
 
   module Make (V : Pack.ELT with type hash := key) = struct
@@ -348,7 +337,6 @@ module Atomic_write
     (L : S.ATOMIC_WRITE_STORE with type key = U.key and type value = U.value) =
 struct
   type key = U.key
-
   type value = U.value
 
   module U = U
@@ -363,13 +351,9 @@ struct
   }
 
   let current_upper t = if t.flip then fst t.uppers else snd t.uppers
-
   let next_upper t = if t.flip then snd t.uppers else fst t.uppers
-
   let pp_current_upper ppf t = pp_current_upper ppf t.flip
-
   let pp_next_upper ppf t = pp_next_upper ppf t.flip
-
   let pp_branch = Irmin.Type.pp K.t
 
   let mem t k =
@@ -453,9 +437,7 @@ struct
   type watch = U.watch
 
   let watch t = U.watch (current_upper t)
-
   let watch_key t = U.watch_key (current_upper t)
-
   let unwatch t = U.unwatch (current_upper t)
 
   let close t =

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -2,7 +2,6 @@ include Irmin_pack.Private.Sigs
 
 module type STORE = sig
   include Irmin_layers.S
-
   include Irmin_pack.Store.S with type repo := repo
 
   val integrity_check :
@@ -22,7 +21,6 @@ module type LAYERED_GENERAL = sig
   include CLOSEABLE with type 'a t := 'a t
 
   val update_flip : flip:bool -> _ t -> unit
-
   val flip_upper : _ t -> unit
 end
 
@@ -34,9 +32,7 @@ end
 
 module type LAYERED_ATOMIC_WRITE_STORE = sig
   include ATOMIC_WRITE_STORE
-
   module U : ATOMIC_WRITE_STORE
-
   module L : ATOMIC_WRITE_STORE
 
   val v :
@@ -56,19 +52,14 @@ module type LAYERED_ATOMIC_WRITE_STORE = sig
   include LAYERED with type t := t
 
   val flush_next_lower : t -> unit
-
   val clear_previous_upper : ?keep_generation:unit -> t -> unit Lwt.t
-
   val copy_newies_to_next_upper : t -> unit Lwt.t
 end
 
 module type LAYERED_PACK = sig
   open Irmin_pack.Pack
-
   include S
-
   module U : S with type value = value
-
   module L : S
 
   val v :
@@ -96,15 +87,10 @@ module type LAYERED_PACK = sig
     unit Lwt.t
 
   val mem_lower : 'a t -> key -> bool Lwt.t
-
   val mem_next : [> `Read ] t -> key -> bool Lwt.t
-
   val current_upper : 'a t -> [ `Read ] U.t
-
   val next_upper : 'a t -> [ `Read ] U.t
-
   val lower : 'a t -> [ `Read ] L.t
-
   val clear_previous_upper : ?keep_generation:unit -> 'a t -> unit Lwt.t
 
   val sync :
@@ -144,7 +130,6 @@ module type LAYERED_PACK_MAKER = sig
   open Irmin_pack.Pack
 
   type key
-
   type index
 
   module Make (V : ELT with type hash := key) :

--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -1,9 +1,5 @@
 let toplevel name ~root = Filename.(concat root name)
-
 let pack = toplevel "store.pack"
-
 let branch = toplevel "store.branches"
-
 let dict = toplevel "store.dict"
-
 let stores ~root = [ pack ~root; branch ~root; dict ~root ]

--- a/src/irmin-pack/layout.mli
+++ b/src/irmin-pack/layout.mli
@@ -7,9 +7,6 @@ val toplevel : string -> path
 (** A file in the top-level directory of a store *)
 
 val pack : path
-
 val branch : path
-
 val dict : path
-
 val stores : root:string -> string list

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -21,7 +21,6 @@ let src = Logs.Src.create "irmin.pack" ~doc:"irmin-pack backend"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let current_version = `V2
-
 let ( -- ) = Int64.sub
 
 open Lwt.Infix
@@ -30,7 +29,6 @@ module Table (K : Irmin.Hash.S) = Hashtbl.Make (struct
   type t = K.t
 
   let hash = K.short_hash
-
   let equal = Irmin.Type.(unstage (equal K.t))
 end)
 
@@ -85,7 +83,6 @@ struct
       include K
 
       let hash = K.short_hash
-
       let equal = Irmin.Type.(unstage (equal K.t))
     end
 
@@ -105,7 +102,6 @@ struct
     let equal_key = Irmin.Type.(unstage (equal K.t))
 
     type value = V.t
-
     type index = Index.t
 
     let unsafe_clear ?keep_generation t =
@@ -158,7 +154,6 @@ struct
       Lwt.return t
 
     let pp_hash = Irmin.Type.pp K.t
-
     let decode_key = Irmin.Type.(unstage (decode_bin K.t))
 
     let io_read_and_decode_hash ~off t =
@@ -318,9 +313,7 @@ struct
       Index.sync t.pack.index
 
     let version t = IO.version t.pack.block
-
     let generation t = IO.generation t.pack.block
-
     let offset t = IO.offset t.pack.block
   end
 end

--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -23,11 +23,8 @@ module type S = sig
     t
 
   val find : t -> key -> value option
-
   val add : ?overcommit:bool -> t -> key -> value -> unit
-
   val close : t -> unit
-
   val merge : t -> unit
 
   module Stats = Index.Stats
@@ -38,15 +35,10 @@ module Make (K : Irmin.Hash.S) = struct
     type t = K.t [@@deriving irmin]
 
     let hash = Irmin.Type.(unstage (short_hash K.t)) ?seed:None
-
     let hash_size = 30
-
     let equal = Irmin.Type.(unstage (equal K.t))
-
     let encode = Irmin.Type.(unstage (to_bin_string K.t))
-
     let encoded_size = K.hash_size
-
     let decode_bin = Irmin.Type.(unstage (decode_bin K.t))
 
     let decode s off =
@@ -61,7 +53,6 @@ module Make (K : Irmin.Hash.S) = struct
       Irmin.Type.(unstage (to_bin_string (triple int64 int32 char)))
 
     let encode (off, len, kind) = to_bin_string (off, Int32.of_int len, kind)
-
     let decode_bin = Irmin.Type.(unstage (decode_bin (triple int64 int32 char)))
 
     let decode s off =
@@ -81,10 +72,7 @@ module Make (K : Irmin.Hash.S) = struct
   let cache = Index.empty_cache ()
 
   let v = Index.v ~cache
-
   let add ?overcommit t k v = replace ?overcommit t k v
-
   let find t k = match find t k with exception Not_found -> None | h -> Some h
-
   let close t = Index.close t
 end

--- a/src/irmin-pack/pack_index.mli
+++ b/src/irmin-pack/pack_index.mli
@@ -24,11 +24,8 @@ module type S = sig
   (** Constructor for indices, memoized by [(path, readonly)] pairs. *)
 
   val find : t -> key -> value option
-
   val add : ?overcommit:bool -> t -> key -> value -> unit
-
   val close : t -> unit
-
   val merge : t -> unit
 
   module Stats = Index.Stats

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -21,7 +21,6 @@ module type ELT = sig
   type hash
 
   val hash : t -> hash
-
   val magic : t -> char
 
   val encode_bin :
@@ -61,9 +60,7 @@ module type S = sig
     ensure_unique:bool -> overcommit:bool -> 'a t -> key -> value -> unit
 
   val unsafe_mem : 'a t -> key -> bool
-
   val unsafe_find : check_integrity:bool -> 'a t -> key -> value option
-
   val flush : ?index:bool -> ?index_merge:bool -> 'a t -> unit
 
   val sync : ?on_generation_change:(unit -> unit) -> 'a t -> unit
@@ -74,9 +71,7 @@ module type S = sig
       generation change. *)
 
   val version : 'a t -> IO.version
-
   val generation : 'a t -> int64
-
   val offset : 'a t -> int64
 
   val clear : 'a t -> unit Lwt.t
@@ -87,7 +82,6 @@ module type S = sig
       are not removed. *)
 
   include Sigs.CHECKABLE with type 'a t := 'a t and type key := key
-
   include Sigs.CLOSEABLE with type 'a t := 'a t
 
   val clear_keep_generation : 'a t -> unit Lwt.t
@@ -95,7 +89,6 @@ end
 
 module type MAKER = sig
   type key
-
   type index
 
   (** Save multiple kind of values in the same pack file. Values will be
@@ -106,9 +99,7 @@ end
 
 module type Pack = sig
   module type ELT = ELT
-
   module type S = S
-
   module type MAKER = MAKER
 
   module File (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -24,7 +24,6 @@ end
 
 module type CHECKABLE = sig
   type 'a t
-
   type key
 
   val integrity_check :
@@ -35,8 +34,6 @@ module type ATOMIC_WRITE_STORE = sig
   include Irmin.ATOMIC_WRITE_STORE
 
   val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t
-
   val flush : t -> unit
-
   val clear_keep_generation : t -> unit Lwt.t
 end

--- a/src/irmin-pack/stats.ml
+++ b/src/irmin-pack/stats.ml
@@ -18,9 +18,7 @@ let reset_stats () =
   ()
 
 let get () = stats
-
 let incr_finds () = stats.finds <- succ stats.finds
-
 let incr_cache_misses () = stats.cache_misses <- succ stats.cache_misses
 
 let incr_appended_hashes () =
@@ -30,7 +28,6 @@ let incr_appended_offsets () =
   stats.appended_offsets <- succ stats.appended_offsets
 
 type cache_stats = { cache_misses : float }
-
 type offset_stats = { offset_ratio : float; offset_significance : int }
 
 let div_or_zero a b = if b = 0 then 0. else float_of_int a /. float_of_int b

--- a/src/irmin-pack/stats.mli
+++ b/src/irmin-pack/stats.mli
@@ -17,21 +17,14 @@ type t = {
     [appended_hashes] + [appended_offsets] = the number of calls to [add] *)
 
 val reset_stats : unit -> unit
-
 val get : unit -> t
-
 val incr_finds : unit -> unit
-
 val incr_cache_misses : unit -> unit
-
 val incr_appended_hashes : unit -> unit
-
 val incr_appended_offsets : unit -> unit
 
 type cache_stats = { cache_misses : float }
-
 type offset_stats = { offset_ratio : float; offset_significance : int }
 
 val get_cache_stats : unit -> cache_stats
-
 val get_offset_stats : unit -> offset_stats

--- a/src/irmin-pack/store.ml
+++ b/src/irmin-pack/store.ml
@@ -5,11 +5,9 @@ let src = Logs.Src.create "irmin.pack" ~doc:"irmin-pack backend"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let current_version = `V2
-
 let pp_version = IO.pp_version
 
 exception RO_Not_Allowed = IO.Unix.RO_Not_Allowed
-
 exception Unsupported_version of IO.version
 
 let ( ++ ) = Int64.add
@@ -25,7 +23,6 @@ module Table (K : Irmin.Type.S) = Hashtbl.Make (struct
   type t = K.t
 
   let hash = Irmin.Type.(unstage (short_hash K.t)) ?seed:None
-
   let equal = Irmin.Type.(unstage (equal K.t))
 end)
 
@@ -34,9 +31,7 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
   module W = Irmin.Private.Watch.Make (K) (V)
 
   type key = K.t
-
   type value = V.t
-
   type watch = W.watch
 
   type t = {
@@ -58,15 +53,10 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Int32.to_int v
 
   let entry = Irmin.Type.(pair (string_of `Int32) V.t)
-
   let key_to_bin_string = Irmin.Type.(unstage (to_bin_string K.t))
-
   let key_of_bin_string = Irmin.Type.(unstage (of_bin_string K.t))
-
   let entry_to_bin_string = Irmin.Type.(unstage (to_bin_string entry))
-
   let value_of_bin_string = Irmin.Type.(unstage (of_bin_string V.t))
-
   let value_decode_bin = Irmin.Type.(unstage (decode_bin V.t))
 
   let set_entry t ?off k v =
@@ -232,9 +222,7 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     Lwt.return keys
 
   let watch_key t = W.watch_key t.w
-
   let watch t = W.watch t.w
-
   let unwatch t = W.unwatch t.w
 
   let unsafe_close t =
@@ -248,7 +236,6 @@ module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) = struct
     else Lwt.return_unit
 
   let close t = unsafe_close t
-
   let flush t = IO.flush t.block
 end
 

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -17,7 +17,6 @@
 open Lwt.Infix
 
 let () = Random.self_init ()
-
 let random_char () = char_of_int (Random.int 256)
 
 let random_ascii () =
@@ -25,11 +24,8 @@ let random_ascii () =
   chars.[Random.int @@ String.length chars]
 
 let random_string n = String.init n (fun _i -> random_char ())
-
 let long_random_string = random_string (* 1024_000 *) 10
-
 let random_ascii_string n = String.init n (fun _i -> random_ascii ())
-
 let long_random_ascii_string = random_ascii_string 1024_000
 
 let merge_exn msg x =
@@ -98,35 +94,20 @@ module Make_helpers (S : S) = struct
   module Graph = Irmin.Private.Node.Graph (P.Node)
 
   let v repo = P.Repo.contents_t repo
-
   let n repo = P.Repo.node_t repo
-
   let ct repo = P.Repo.commit_t repo
-
   let g repo = P.Repo.node_t repo
-
   let h repo = P.Repo.commit_t repo
-
   let b repo = P.Repo.branch_t repo
-
   let v1 = long_random_string
-
   let v2 = ""
-
   let with_contents repo f = P.Repo.batch repo (fun t _ _ -> f t)
-
   let with_node repo f = P.Repo.batch repo (fun _ t _ -> f t)
-
   let with_commit repo f = P.Repo.batch repo (fun _ _ t -> f t)
-
   let kv1 ~repo = with_contents repo (fun t -> P.Contents.add t v1)
-
   let kv2 ~repo = with_contents repo (fun t -> P.Contents.add t v2)
-
   let normal x = `Contents (x, S.Metadata.default)
-
   let b1 = "foo"
-
   let b2 = "bar/toto"
 
   let n1 ~repo =

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -25,7 +25,6 @@ type t = {
 }
 
 val line : string -> unit
-
 val store : (module Irmin.S_MAKER) -> (module Irmin.Metadata.S) -> (module S)
 
 val layered_store :
@@ -34,9 +33,7 @@ val layered_store :
   (module LAYERED_STORE)
 
 val testable : 'a Irmin.Type.t -> 'a Alcotest.testable
-
 val check : 'a Irmin.Type.t -> string -> 'a -> 'a -> unit
-
 val checks : 'a Irmin.Type.t -> string -> 'a list -> 'a list -> unit
 
 module Store : sig

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -11,33 +11,19 @@ module Make_Layered (S : LAYERED_STORE) = struct
   module History = Irmin.Private.Commit.History (P.Commit)
 
   let v1 = "X1"
-
   let v2 = "X2"
-
   let v3 = "X3"
-
   let v4 = "X4"
-
   let v5 = "X5"
-
   let v6 = "X6"
-
   let b1 = "foo"
-
   let b2 = "bar/toto"
-
   let with_contents repo f = P.Repo.batch repo (fun t _ _ -> f t)
-
   let with_node repo f = P.Repo.batch repo (fun _ t _ -> f t)
-
   let with_commit repo f = P.Repo.batch repo (fun _ _ t -> f t)
-
   let with_info repo n f = with_commit repo (fun h -> f h ~info:(info n))
-
   let normal x = `Contents (x, S.Metadata.default)
-
   let h repo = P.Repo.commit_t repo
-
   let n repo = P.Repo.node_t repo
 
   let n1 ~repo =

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -18,7 +18,6 @@ open Lwt.Infix
 open Common
 
 let ( let* ) x f = Lwt.bind x f
-
 let src = Logs.Src.create "test" ~doc:"Irmin tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -1523,7 +1522,6 @@ module Make (S : S) = struct
     run x test
 
   let pp_write_error = Irmin.Type.pp S.write_error_t
-
   let tree_t = testable S.tree_t
 
   let test_with_tree x () =

--- a/src/irmin-test/store_watch.ml
+++ b/src/irmin-test/store_watch.ml
@@ -144,13 +144,9 @@ module Make (Log : Logs.LOG) (S : S) = struct
         t.removes <- t.removes + 1
 
       let pretty ppf t = Fmt.pf ppf "%d/%d/%d" t.adds t.updates t.removes
-
       let xpp ppf (a, u, r) = Fmt.pf ppf "%d/%d/%d" a u r
-
       let xadd (a, u, r) = (a + 1, u, r)
-
       let xupdate (a, u, r) = (a, u + 1, r)
-
       let xremove (a, u, r) = (a, u, r + 1)
 
       let less_than a b =

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -19,7 +19,6 @@ open Cmdliner
 open Resolver
 
 let () = Hook.init ()
-
 let info ?(author = "irmin") fmt = Info.v ~author fmt
 
 (* Help sections common to all commands *)
@@ -86,7 +85,6 @@ let print_exc exc =
   exit 1
 
 let run t = Lwt_main.run (Lwt.catch (fun () -> t) print_exc)
-
 let mk (fn : 'a) : 'a Term.t = Term.(const (fun () -> fn) $ setup_log)
 
 (* INIT *)
@@ -158,11 +156,8 @@ let get name f x =
   | Error (`Msg e) -> Fmt.kstrf invalid_arg "invalid %s: %s" name e
 
 let key f x = get "key" f x
-
 let value f x = get "value" f x
-
 let branch f x = get "branch" f x
-
 let commit f x = get "commit" f x
 
 (* GET *)

--- a/src/irmin-unix/fs.ml
+++ b/src/irmin-unix/fs.ml
@@ -22,7 +22,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module IO = struct
   let mkdir_pool = Lwt_pool.create 1 (fun () -> Lwt.return_unit)
-
   let mmap_threshold = 4096
 
   (* Files smaller than this are loaded using [read].  Use of mmap is
@@ -46,7 +45,6 @@ module IO = struct
     | e -> Lwt.fail e
 
   let protect f x = Lwt.catch (fun () -> f x) protect_unix_exn
-
   let safe f x = Lwt.catch (fun () -> f x) ignore_enoent
 
   let mkdir dirname =
@@ -131,7 +129,6 @@ module IO = struct
   type lock = path
 
   let lock_file x = x
-
   let file_exists = file_exists
 
   let list_files kind dir =

--- a/src/irmin-unix/fs.mli
+++ b/src/irmin-unix/fs.mli
@@ -15,15 +15,9 @@
  *)
 
 module Append_only : Irmin.APPEND_ONLY_STORE_MAKER
-
 module Atomic_write : Irmin.ATOMIC_WRITE_STORE_MAKER
-
 module Make : Irmin.S_MAKER
-
 module KV : Irmin.KV_MAKER
-
 module Append_only_ext (C : Irmin_fs.Config) : Irmin.APPEND_ONLY_STORE_MAKER
-
 module Atomic_write_ext (C : Irmin_fs.Config) : Irmin.ATOMIC_WRITE_STORE_MAKER
-
 module Make_ext (Obj : Irmin_fs.Config) (Ref : Irmin_fs.Config) : Irmin.S_MAKER

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -19,7 +19,6 @@ module Server = struct
       (Cohttp_lwt_unix.Server)
       (struct
         let info = Info.v
-
         let remote = Remote.remote
       end)
       (S)
@@ -33,7 +32,6 @@ module Server = struct
       (Cohttp_lwt_unix.Server)
       (struct
         let info = Info.v
-
         let remote = Remote.remote
       end)
       (S)

--- a/src/irmin-unix/irmin_unix.ml
+++ b/src/irmin-unix/irmin_unix.ml
@@ -15,7 +15,6 @@
  *)
 
 let info = Info.v
-
 let set_listen_dir_hook = Hook.init
 
 module Git = Xgit

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -56,7 +56,6 @@ let config_path_key =
     "config" Irmin.Private.Conf.string "irmin.yml"
 
 let ( / ) = Filename.concat
-
 let global_config_path = "irmin" / "config.yml"
 
 let add_opt k v config =
@@ -113,7 +112,6 @@ type contents = Contents.t
 
 module Hash = struct
   type t = (module Irmin.Hash.S)
-
   type hash_function = Fixed of t | Variable_size of (int option -> t)
 
   module type SIZEABLE = functor
@@ -247,7 +245,6 @@ type hash = Hash.t
 
 module Store = struct
   type remote_fn = ?headers:Cohttp.Header.t -> string -> Irmin.remote
-
   type t = T : (module Irmin.S) * remote_fn option -> t
 
   type store_functor =
@@ -261,7 +258,6 @@ module Store = struct
   end
 
   let v ?remote s = T (s, remote)
-
   let v_git (module S : G) = v (module S) ~remote:S.remote
 
   let create : (module Irmin.S_MAKER) -> hash -> contents -> t =
@@ -273,18 +269,13 @@ module Store = struct
     T ((module S), None)
 
   let mem = create (module Irmin_mem.Make)
-
   let irf = create (module Fs.Make)
-
   let http = function T ((module S), x) -> T ((module Http.Client (S)), x)
-
   let git (module C : Irmin.Contents.S) = v_git (module Xgit.FS.KV (C))
-
   let git_mem (module C : Irmin.Contents.S) = v_git (module Xgit.Mem.KV (C))
 
   module Inode_config = struct
     let entries = 32
-
     let stable_hash = 256
   end
 

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -17,7 +17,6 @@
 (** Irmin store resolver. *)
 
 val global_option_section : string
-
 val branch : string option Cmdliner.Term.t
 
 (** {1 Hash} *)
@@ -25,9 +24,7 @@ module Hash : sig
   type t = (module Irmin.Hash.S)
 
   val add : string -> ?default:bool -> (module Irmin.Hash.S) -> unit
-
   val find : string -> t
-
   val term : t option Cmdliner.Term.t
 end
 
@@ -38,9 +35,7 @@ module Contents : sig
   type t = (module Irmin.Contents.S)
 
   val add : string -> ?default:bool -> (module Irmin.Contents.S) -> unit
-
   val find : string -> t
-
   val term : string option Cmdliner.Term.t
 end
 
@@ -62,17 +57,11 @@ module Store : sig
   type remote_fn = ?headers:Cohttp.Header.t -> string -> Irmin.remote
 
   val v : ?remote:remote_fn -> (module Irmin.S) -> t
-
   val mem : hash -> contents -> t
-
   val irf : hash -> contents -> t
-
   val http : t -> t
-
   val git : contents -> t
-
   val find : string -> store_functor
-
   val add : string -> ?default:bool -> store_functor -> unit
 end
 

--- a/src/irmin-unix/xgit.mli
+++ b/src/irmin-unix/xgit.mli
@@ -51,9 +51,7 @@ module type REF_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
      and module Git = G
 
 module Make : S_MAKER
-
 module KV : KV_MAKER
-
 module Ref : REF_MAKER
 
 module FS : sig

--- a/src/irmin/branch.ml
+++ b/src/irmin/branch.ml
@@ -18,7 +18,6 @@ module String = struct
   type t = string
 
   let t = Type.string
-
   let master = "master"
 
   let is_valid s =

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -28,11 +28,8 @@ module Make (K : Type.S) = struct
   [@@deriving irmin]
 
   let parents t = t.parents
-
   let node t = t.node
-
   let info t = t.info
-
   let compare_hash = Type.(unstage (compare K.t))
 
   let v ~info ~node ~parents =
@@ -43,32 +40,22 @@ end
 module Store
     (N : S.NODE_STORE) (S : sig
       include S.CONTENT_ADDRESSABLE_STORE with type key = N.key
-
       module Key : S.HASH with type t = key
-
       module Val : S.COMMIT with type t = value and type hash = key
     end) =
 struct
   module Node = N
 
   type 'a t = 'a N.t * 'a S.t
-
   type key = S.key
-
   type value = S.value
 
   let add (_, t) = S.add t
-
   let unsafe_add (_, t) = S.unsafe_add t
-
   let mem (_, t) = S.mem t
-
   let find (_, t) = S.find t
-
   let clear (_, t) = S.clear t
-
   let merge_node (t, _) = Merge.f (N.merge t)
-
   let pp_key = Type.pp S.Key.t
 
   let err_not_found k =
@@ -123,11 +110,8 @@ end
 
 module History (S : S.COMMIT_STORE) = struct
   type commit = S.Key.t [@@deriving irmin]
-
   type node = S.Node.key
-
   type 'a t = 'a S.t
-
   type v = S.Val.t
 
   let merge t ~info =
@@ -199,9 +183,7 @@ module History (S : S.COMMIT_STORE) = struct
     type t = S.Key.t
 
     let compare = Type.(unstage (compare S.Key.t))
-
     let hash = S.Key.short_hash
-
     let equal = Type.(unstage (equal S.Key.t))
   end
 
@@ -214,9 +196,7 @@ module History (S : S.COMMIT_STORE) = struct
     | Some c -> KSet.of_list (S.Val.parents c)
 
   let equal_keys = Type.(unstage (equal S.Key.t))
-
   let str_key k = String.sub (Type.to_string S.Key.t k) 0 4
-
   let pp_key = Fmt.of_to_string str_key
 
   let pp_keys ppf keys =
@@ -224,7 +204,6 @@ module History (S : S.COMMIT_STORE) = struct
     Fmt.pf ppf "[%a]" Fmt.(list ~sep:(unit " ") pp_key) keys
 
   let str_keys = Fmt.to_to_string pp_keys
-
   let lca_calls = ref 0
 
   let rec unqueue todo seen =
@@ -311,11 +290,8 @@ module History (S : S.COMMIT_STORE) = struct
                t.layers [])))
 
   let get_mark_exn t elt = KHashtbl.find t.marks elt
-
   let get_mark t elt = try Some (get_mark_exn t elt) with Not_found -> None
-
   let set_mark t elt mark = KHashtbl.replace t.marks elt mark
-
   let get_layer t d = try Hashtbl.find t.layers d with Not_found -> KSet.empty
 
   let add_to_layer t d k =
@@ -327,7 +303,6 @@ module History (S : S.COMMIT_STORE) = struct
     try KHashtbl.find t.parents c with Not_found -> KSet.empty
 
   let incr_lcas t = t.lcas <- t.lcas + 1
-
   let decr_lcas t = t.lcas <- t.lcas - 1
 
   let both_seen t k =
@@ -500,9 +475,7 @@ end
 module V1 (C : S.COMMIT) = struct
   module K = struct
     let h = Type.string_of `Int64
-
     let hash_to_bin_string = Type.(unstage (to_bin_string C.hash_t))
-
     let hash_of_bin_string = Type.(unstage (of_bin_string C.hash_t))
 
     let size_of =
@@ -526,21 +499,14 @@ module V1 (C : S.COMMIT) = struct
   end
 
   type hash = C.hash [@@deriving irmin]
-
   type t = { parents : hash list; c : C.t }
 
   let import c = { c; parents = C.parents c }
-
   let export t = t.c
-
   let node t = C.node t.c
-
   let parents t = t.parents
-
   let info t = C.info t.c
-
   let v ~info ~node ~parents = { parents; c = C.v ~node ~parents ~info }
-
   let make = v
 
   let info_t : Info.t Type.t =

--- a/src/irmin/commit.mli
+++ b/src/irmin/commit.mli
@@ -21,9 +21,7 @@ module Make (K : Type.S) : S.COMMIT with type hash = K.t
 module Store
     (N : S.NODE_STORE) (C : sig
       include S.CONTENT_ADDRESSABLE_STORE with type key = N.key
-
       module Key : S.HASH with type t = key
-
       module Val : S.COMMIT with type t = value and type hash = key
     end) :
   S.COMMIT_STORE
@@ -44,6 +42,5 @@ module V1 (C : S.COMMIT) : sig
   include S.COMMIT with type hash = C.hash
 
   val import : C.t -> t
-
   val export : t -> C.t
 end

--- a/src/irmin/conf.ml
+++ b/src/irmin/conf.ml
@@ -16,17 +16,12 @@
  *)
 
 type 'a parser = string -> ('a, [ `Msg of string ]) result
-
 type 'a printer = 'a Fmt.t
-
 type 'a converter = 'a parser * 'a printer
 
 let parser (p, _) = p
-
 let printer (_, p) = p
-
 let str = Printf.sprintf
-
 let quote s = str "`%s'" s
 
 module Err = struct
@@ -35,7 +30,6 @@ module Err = struct
     | alts -> str "one of: %s" (String.concat ", " alts)
 
   let invalid kind s exp = str "invalid %s %s, %s" kind (quote s) exp
-
   let invalid_val = invalid "value"
 end
 
@@ -50,7 +44,6 @@ let parse_with t_of_str exp s =
   try Ok (t_of_str s) with Failure _ -> Error (`Msg (Err.invalid_val s exp))
 
 let int = (parse_with int_of_string "expected an integer", Fmt.int)
-
 let string = ((fun s -> Ok s), Fmt.string)
 
 let some (parse, print) =
@@ -87,15 +80,10 @@ type 'a key = {
 }
 
 let name t = t.name
-
 let doc t = t.doc
-
 let docv t = t.docv
-
 let docs t = t.docs
-
 let conv t = t.conv
-
 let default t = t.default
 
 let key ?docs ?docv ?doc name conv default =
@@ -121,19 +109,12 @@ module M = Map.Make (Id)
 type t = Univ.t M.t
 
 let empty = M.empty
-
 let singleton k v = M.singleton k.id (k.to_univ v)
-
 let is_empty = M.is_empty
-
 let mem d k = M.mem k.id d
-
 let add d k v = M.add k.id (k.to_univ v) d
-
 let union r s = M.fold M.add r s
-
 let rem d k = M.remove k.id d
-
 let find d k = try k.of_univ (M.find k.id d) with Not_found -> None
 
 let get d k =

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -90,7 +90,6 @@ module Json_value = struct
     match decode_json decoder with Ok obj -> Ok obj | Error _ as err -> err
 
   let equal_bool = Type.(unstage (equal bool))
-
   let equal_float = Type.(unstage (equal float))
 
   let rec equal a b =
@@ -162,7 +161,6 @@ module Json_value = struct
     | _, _, _ -> Merge.conflict "Conflicting JSON datatypes"
 
   let merge_json = Merge.(v t merge_value)
-
   let merge = Merge.(option merge_json)
 end
 
@@ -185,7 +183,6 @@ module Json = struct
     | Error _ as err -> err
 
   let equal a b = Json_value.equal (`O a) (`O b)
-
   let t = Type.like ~equal:(Type.stage equal) ~pp ~of_string t
 
   let merge =
@@ -248,9 +245,7 @@ module type STORE = S.CONTENTS_STORE
 
 module Store (S : sig
   include S.CONTENT_ADDRESSABLE_STORE
-
   module Key : S.HASH with type t = key
-
   module Val : S.CONTENTS with type t = value
 end) =
 struct
@@ -258,21 +253,14 @@ struct
   module Val = S.Val
 
   type 'a t = 'a S.t
-
   type key = S.key
-
   type value = S.value
 
   let find = S.find
-
   let add = S.add
-
   let unsafe_add = S.unsafe_add
-
   let mem = S.mem
-
   let clear = S.clear
-
   let read_opt t = function None -> Lwt.return_none | Some k -> find t k
 
   let add_opt t = function
@@ -288,15 +276,10 @@ module V1 = struct
     include String
 
     let t = Type.(boxed (string_of `Int64))
-
     let size_of = Type.size_of t
-
     let decode_bin = Type.decode_bin t
-
     let encode_bin = Type.encode_bin t
-
     let pre_hash = Type.pre_hash t
-
     let t = Type.like t ~bin:(encode_bin, decode_bin, size_of) ~pre_hash
   end
 end

--- a/src/irmin/contents.mli
+++ b/src/irmin/contents.mli
@@ -25,24 +25,17 @@ type json =
   | `A of json list ]
 
 module String : S.CONTENTS with type t = string
-
 module Json : S.CONTENTS with type t = (string * json) list
-
 module Json_value : S.CONTENTS with type t = json
 
 module Json_tree (Store : Store.S with type contents = json) : sig
   include S.CONTENTS with type t = json
 
   val to_concrete_tree : t -> Store.Tree.concrete
-
   val of_concrete_tree : Store.Tree.concrete -> t
-
   val get_tree : Store.tree -> Store.key -> json Lwt.t
-
   val set_tree : Store.tree -> Store.key -> json -> Store.tree Lwt.t
-
   val get : Store.t -> Store.key -> json Lwt.t
-
   val set : Store.t -> Store.key -> json -> info:Info.f -> unit Lwt.t
 end
 
@@ -52,9 +45,7 @@ end
 
 module Store (C : sig
   include S.CONTENT_ADDRESSABLE_STORE
-
   module Key : S.HASH with type t = key
-
   module Val : S.CONTENTS with type t = value
 end) :
   S.CONTENTS_STORE

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -20,7 +20,6 @@ module Make (H : Digestif.S) = struct
   external get_64 : string -> int -> int64 = "%caml_string_get64u"
 
   let short_hash c = Int64.to_int (get_64 (H.to_raw_string c) 0)
-
   let hash_size = H.digest_size
 
   let of_hex s =
@@ -42,10 +41,12 @@ module Make_BLAKE2B (D : sig
   val digest_size : int
 end) =
   Make (Digestif.Make_BLAKE2B (D))
+
 module Make_BLAKE2S (D : sig
   val digest_size : int
 end) =
   Make (Digestif.Make_BLAKE2S (D))
+
 module SHA1 = Make (Digestif.SHA1)
 module RMD160 = Make (Digestif.RMD160)
 module SHA224 = Make (Digestif.SHA224)
@@ -61,7 +62,6 @@ module Typed (K : S.HASH) (V : Type.S) = struct
   type value = V.t
 
   let pre_hash = Type.unstage (Type.pre_hash V.t)
-
   let hash v = K.hash (pre_hash v)
 end
 
@@ -69,15 +69,10 @@ module V1 (K : S.HASH) : S.HASH with type t = K.t = struct
   type t = K.t
 
   let hash = K.hash
-
   let short_hash = K.short_hash
-
   let hash_size = K.hash_size
-
   let h = Type.string_of `Int64
-
   let to_bin_key = Type.unstage (Type.to_bin_string K.t)
-
   let of_bin_key = Type.unstage (Type.of_bin_string K.t)
 
   let size_of =

--- a/src/irmin/hash.mli
+++ b/src/irmin/hash.mli
@@ -26,19 +26,12 @@ module Make_BLAKE2S (D : sig
 end) : S.HASH
 
 module SHA1 : S.HASH
-
 module RMD160 : S.HASH
-
 module SHA224 : S.HASH
-
 module SHA256 : S.HASH
-
 module SHA384 : S.HASH
-
 module SHA512 : S.HASH
-
 module BLAKE2B : S.HASH
-
 module BLAKE2S : S.HASH
 
 (** v1 serialisation *)

--- a/src/irmin/info.ml
+++ b/src/irmin/info.ml
@@ -15,11 +15,9 @@
  *)
 
 type t = { date : int64; author : string; message : string } [@@deriving irmin]
-
 type f = unit -> t
 
 let create ~date ~author message = { date; message; author }
-
 let empty = { date = 0L; author = ""; message = "" }
 
 let v ~date ~author message =
@@ -27,9 +25,6 @@ let v ~date ~author message =
   else create ~date ~author message
 
 let date t = t.date
-
 let author t = t.author
-
 let message t = t.message
-
 let none () = empty

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -23,7 +23,6 @@ module Contents = struct
   include Contents
 
   module type S = S.CONTENTS
-
   module type STORE = S.CONTENTS_STORE
 end
 
@@ -33,7 +32,6 @@ module Branch = struct
   include Branch
 
   module type S = S.BRANCH
-
   module type STORE = S.BRANCH_STORE
 end
 
@@ -44,7 +42,6 @@ module Hash = struct
   include Hash
 
   module type S = S.HASH
-
   module type TYPED = S.TYPED_HASH
 end
 
@@ -66,9 +63,7 @@ functor
     module S = CA (K) (V)
 
     type 'a t = { closed : bool ref; t : 'a S.t }
-
     type key = S.key
-
     type value = S.value
 
     let check_not_closed t = if !(t.closed) then raise Closed
@@ -116,9 +111,7 @@ functor
     module S = AW (K) (V)
 
     type t = { closed : bool ref; t : S.t }
-
     type key = S.key
-
     type value = S.value
 
     let check_not_closed t = if !(t.closed) then raise Closed
@@ -243,11 +236,8 @@ struct
       }
 
       let contents_t t = t.contents
-
       let node_t t = t.nodes
-
       let commit_t t = t.commits
-
       let branch_t t = t.branch
 
       let batch t f =
@@ -295,25 +285,17 @@ end
 module Of_private = Store.Make
 
 module type CONTENT_ADDRESSABLE_STORE = S.CONTENT_ADDRESSABLE_STORE
-
 module type APPEND_ONLY_STORE = S.APPEND_ONLY_STORE
-
 module type ATOMIC_WRITE_STORE = S.ATOMIC_WRITE_STORE
-
 module type TREE = Tree.S
-
 module type S = Store.S
 
 type config = Conf.t
-
 type 'a diff = 'a Diff.t
 
 module type CONTENT_ADDRESSABLE_STORE_MAKER = S.CONTENT_ADDRESSABLE_STORE_MAKER
-
 module type APPEND_ONLY_STORE_MAKER = S.APPEND_ONLY_STORE_MAKER
-
 module type ATOMIC_WRITE_STORE_MAKER = S.ATOMIC_WRITE_STORE_MAKER
-
 module type S_MAKER = Store.MAKER
 
 module type KV =
@@ -328,9 +310,7 @@ module Private = struct
     include Node
 
     module type S = S.NODE
-
     module type GRAPH = S.NODE_GRAPH
-
     module type STORE = S.NODE_STORE
   end
 
@@ -338,9 +318,7 @@ module Private = struct
     include Commit
 
     module type S = S.COMMIT
-
     module type STORE = S.COMMIT_STORE
-
     module type HISTORY = S.COMMIT_HISTORY
   end
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -195,9 +195,7 @@ module Contents : sig
   (** [Store] creates a contents store. *)
   module Store (S : sig
     include CONTENT_ADDRESSABLE_STORE
-
     module Key : Hash.S with type t = key
-
     module Val : S with type t = value
   end) :
     STORE with type 'a t = 'a S.t and type key = S.key and type value = S.value
@@ -289,7 +287,6 @@ module Private : sig
            and type metadata = S.metadata
 
       val import : S.t -> t
-
       val export : t -> S.t
     end
 
@@ -302,7 +299,6 @@ module Private : sig
         (P : Path.S)
         (M : Metadata.S) (S : sig
           include CONTENT_ADDRESSABLE_STORE with type key = C.key
-
           module Key : Hash.S with type t = key
 
           module Val :
@@ -355,7 +351,6 @@ module Private : sig
       include S with type hash = S.hash
 
       val import : S.t -> t
-
       val export : t -> S.t
     end
 
@@ -366,9 +361,7 @@ module Private : sig
     module Store
         (N : Node.STORE) (S : sig
           include CONTENT_ADDRESSABLE_STORE with type key = N.key
-
           module Key : Hash.S with type t = key
-
           module Val : S with type t = value and type hash = key
         end) :
       STORE
@@ -439,15 +432,10 @@ module Private : sig
       type t
 
       val v : config -> t Lwt.t
-
       val close : t -> unit Lwt.t
-
       val contents_t : t -> [ `Read ] Contents.t
-
       val node_t : t -> [ `Read ] Node.t
-
       val commit_t : t -> [ `Read ] Commit.t
-
       val branch_t : t -> Branch.t
 
       val batch :
@@ -501,7 +489,6 @@ module Json_tree (Store : S with type contents = Contents.json) : sig
   include Contents.S with type t = Contents.json
 
   val to_concrete_tree : t -> Store.Tree.concrete
-
   val of_concrete_tree : Store.Tree.concrete -> t
 
   val get_tree : Store.tree -> Store.key -> t Lwt.t
@@ -612,7 +599,6 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
       open Astring
 
       let time = ref 0L
-
       let failure fmt = Fmt.kstrf failwith fmt
 
       (* A log entry *)
@@ -620,7 +606,6 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
         include Irmin.Type.S
 
         val v : string -> t
-
         val timestamp : t -> int64
       end = struct
         type t = { timestamp : int64; message : string } [@@deriving irmin]
@@ -657,15 +642,12 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
         include Irmin.Contents.S
 
         val add : t -> Entry.t -> t
-
         val empty : t
       end = struct
         type t = Entry.t list [@@deriving irmin]
 
         let empty = []
-
         let pp_entry = Irmin.Type.pp Entry.t
-
         let lines ppf l = List.iter (Fmt.pf ppf "%a\n" pp_entry) (List.rev l)
 
         let of_string str =
@@ -681,7 +663,6 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
           with Failure e -> Error (`Msg e)
 
         let t = Irmin.Type.like ~pp:lines ~of_string t
-
         let timestamp = function [] -> 0L | e :: _ -> Entry.timestamp e
 
         let newer_than timestamp file =
@@ -705,7 +686,6 @@ module Sync (S : S) : SYNC with type db = S.t and type commit = S.commit
           Irmin.Merge.ok (List.rev_append t3 old)
 
         let merge = Irmin.Merge.(option (v t merge))
-
         let add t e = e :: t
       end
     ]}

--- a/src/irmin/lock.ml
+++ b/src/irmin/lock.ml
@@ -18,13 +18,10 @@ let ( >>= ) = Lwt.bind
 
 module type S = sig
   type key
-
   type t
 
   val v : unit -> t
-
   val with_lock : t -> key -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-
   val stats : t -> int
 end
 
@@ -33,18 +30,15 @@ module Make (K : Type.S) = struct
     type t = K.t
 
     let hash = Hashtbl.hash
-
     let equal = Type.(unstage (equal K.t))
   end
 
   module KHashtbl = Hashtbl.Make (K)
 
   type key = K.t
-
   type t = { global : Lwt_mutex.t; locks : Lwt_mutex.t KHashtbl.t }
 
   let v () = { global = Lwt_mutex.create (); locks = KHashtbl.create 1024 }
-
   let stats t = KHashtbl.length t.locks
 
   let lock t key () =

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -53,7 +53,6 @@ module Make (H : Hashtbl.HashedType) = struct
           t.last <- on
 
     let node x = { value = x; prev = None; next = None }
-
     let create () = { first = None; last = None }
 
     let clear t =
@@ -71,7 +70,6 @@ module Make (H : Hashtbl.HashedType) = struct
   }
 
   let weight t = t.w
-
   let create cap = { cap; w = 0; ht = HT.create cap; q = Q.create () }
 
   let drop_lru t =

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -17,12 +17,8 @@ module Make (H : Hashtbl.HashedType) : sig
   type 'a t
 
   val create : int -> 'a t
-
   val add : 'a t -> H.t -> 'a -> unit
-
   val find : 'a t -> H.t -> 'a
-
   val mem : 'a t -> H.t -> bool
-
   val clear : 'a t -> unit
 end

--- a/src/irmin/merge.ml
+++ b/src/irmin/merge.ml
@@ -22,7 +22,6 @@ let src = Logs.Src.create "irmin.merge" ~doc:"Irmin merging"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 type conflict = [ `Conflict of string ]
-
 type 'a promise = unit -> ('a option, conflict) result Lwt.t
 
 let promise t : 'a promise = fun () -> Lwt.return (Ok (Some t))
@@ -38,11 +37,9 @@ let memo fn =
         Lwt.return x
 
 type 'a f = old:'a promise -> 'a -> 'a -> ('a, conflict) result Lwt.t
-
 type 'a t = 'a Type.t * 'a f
 
 let v t f = (t, f)
-
 let f (x : 'a t) = snd x
 
 let conflict fmt =
@@ -53,7 +50,6 @@ let conflict fmt =
     fmt
 
 let bind x f = x >>= function Error e -> Lwt.return (Error e) | Ok x -> f x
-
 let map f x = x >|= function Error _ as x -> x | Ok x -> Ok (f x)
 
 let map_promise f t () =
@@ -72,11 +68,8 @@ let ok x = Lwt.return (Ok x)
 
 module Infix = struct
   let ( >>=* ) = bind
-
   let ( >|=* ) x f = map f x
-
   let ( >>=? ) = bind_promise
-
   let ( >|=? ) x f = map_promise f x
 end
 
@@ -270,7 +263,6 @@ struct
   module M = Map.Make (K)
 
   let of_alist l = List.fold_left (fun map (k, v) -> M.add k v map) M.empty l
-
   let t = Type.map Type.(list (pair K.t int64)) of_alist M.bindings
 
   let merge ~old m1 m2 =
@@ -301,9 +293,7 @@ struct
   module S = Set.Make (K)
 
   let of_list l = List.fold_left (fun set elt -> S.add elt set) S.empty l
-
   let t = Type.(map @@ list K.t) of_list S.elements
-
   let pp = Type.pp t
 
   let merge ~old x y =
@@ -327,9 +317,7 @@ struct
   module M = Map.Make (K)
 
   let of_alist l = List.fold_left (fun map (k, v) -> M.add k v map) M.empty l
-
   let t x = Type.map Type.(list @@ pair K.t x) of_alist M.bindings
-
   let iter2 f t1 t2 = alist_iter2 K.compare f (M.bindings t1) (M.bindings t2)
 
   let iter2 f m1 m2 =
@@ -401,17 +389,11 @@ let like_lwt (type a b) da (t : b t) (a_to_b : a -> b Lwt.t)
   seq [ default da; (da, merge) ]
 
 let unit = default Type.unit
-
 let bool = default Type.bool
-
 let char = default Type.char
-
 let int32 = default Type.int32
-
 let int64 = default Type.int64
-
 let float = default Type.float
-
 let string = default Type.string
 
 type counter = int64

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -25,7 +25,6 @@ module No_metadata = struct
   type t = unit [@@deriving irmin]
 
   let default = ()
-
   let merge = Merge.v t (fun ~old:_ () () -> Merge.ok ())
 end
 
@@ -36,11 +35,8 @@ module Make
     (M : S.METADATA) =
 struct
   type hash = K.t [@@deriving irmin]
-
   type step = P.step [@@deriving irmin]
-
   type metadata = M.t [@@deriving irmin]
-
   type kind = [ `Node | `Contents of M.t ]
 
   let equal_metadata = Type.(unstage (equal M.t))
@@ -75,12 +71,10 @@ struct
     type t = P.step
 
     let compare_step = Type.(unstage (compare P.step_t))
-
     let compare (x : t) (y : t) = compare_step y x
   end)
 
   type value = [ `Contents of hash * metadata | `Node of hash ]
-
   type t = entry StepMap.t
 
   let v l =
@@ -97,7 +91,6 @@ struct
     with Not_found -> None
 
   let empty = StepMap.empty
-
   let is_empty e = list e = []
 
   let add t k v =
@@ -107,7 +100,6 @@ struct
       t
 
   let remove t k = StepMap.remove k t
-
   let default = M.default
 
   let value_t =
@@ -121,9 +113,7 @@ struct
     |> sealv
 
   let of_entries e = v (List.rev_map of_entry e)
-
   let entries e = List.rev_map (fun (_, e) -> e) (StepMap.bindings e)
-
   let t = Type.map Type.(list entry_t) of_entries entries
 end
 
@@ -132,7 +122,6 @@ module Store
     (P : S.PATH)
     (M : S.METADATA) (S : sig
       include S.CONTENT_ADDRESSABLE_STORE with type key = C.key
-
       module Key : S.HASH with type t = key
 
       module Val :
@@ -149,19 +138,13 @@ struct
   module Metadata = M
 
   type 'a t = 'a C.t * 'a S.t
-
   type key = S.key
-
   type value = S.value
 
   let mem (_, t) = S.mem t
-
   let find (_, t) = S.find t
-
   let clear (_, t) = S.clear t
-
   let add (_, t) = S.add t
-
   let unsafe_add (_, t) = S.unsafe_add t
 
   let all_contents t =
@@ -177,9 +160,7 @@ struct
       [] kvs
 
   let contents_t = C.Key.t
-
   let metadata_t = M.t
-
   let step_t = Path.step_t
 
   (* [Merge.alist] expects us to return an option. [C.merge] does
@@ -238,17 +219,11 @@ module Graph (S : S.NODE_STORE) = struct
   module Metadata = S.Metadata
 
   type step = Path.step [@@deriving irmin]
-
   type metadata = Metadata.t [@@deriving irmin]
-
   type contents = Contents.t [@@deriving irmin]
-
   type node = S.Key.t [@@deriving irmin]
-
   type path = Path.t [@@deriving irmin]
-
   type 'a t = 'a S.t
-
   type value = [ `Contents of contents * metadata | `Node of node ]
 
   let empty t = S.add t S.Val.empty
@@ -269,11 +244,8 @@ module Graph (S : S.NODE_STORE) = struct
       (S.Val.list t)
 
   let pp_key = Type.pp S.Key.t
-
   let pp_keys = Fmt.(Dump.list pp_key)
-
   let pp_path = Type.pp S.Path.t
-
   let equal_val = Type.(unstage (equal S.Val.t))
 
   let pred t = function
@@ -385,9 +357,7 @@ end
 module V1 (N : S.NODE with type step = string) = struct
   module K = struct
     let h = Type.string_of `Int64
-
     let to_bin_string = Type.(unstage (to_bin_string N.hash_t))
-
     let of_bin_string = Type.(unstage (of_bin_string N.hash_t))
 
     let size_of =
@@ -411,17 +381,12 @@ module V1 (N : S.NODE with type step = string) = struct
   end
 
   type step = N.step
-
   type hash = N.hash [@@deriving irmin]
-
   type metadata = N.metadata [@@deriving irmin]
-
   type value = N.value
-
   type t = { n : N.t; entries : (step * value) list }
 
   let import n = { n; entries = N.list n }
-
   let export t = t.n
 
   let v entries =
@@ -429,13 +394,9 @@ module V1 (N : S.NODE with type step = string) = struct
     { n; entries }
 
   let list t = t.entries
-
   let empty = { n = N.empty; entries = [] }
-
   let is_empty t = t.entries = []
-
   let default = N.default
-
   let find t k = N.find t.n k
 
   let add t k v =
@@ -447,9 +408,7 @@ module V1 (N : S.NODE with type step = string) = struct
     if t.n == n then t else { n; entries = N.list n }
 
   let v1_step = Type.string_of `Int64
-
   let step_to_bin_string = Type.(unstage (to_bin_string v1_step))
-
   let step_of_bin_string = Type.(unstage (of_bin_string v1_step))
 
   let step_t : step Type.t =

--- a/src/irmin/node.mli
+++ b/src/irmin/node.mli
@@ -31,7 +31,6 @@ module Store
     (P : S.PATH)
     (M : S.METADATA) (N : sig
       include S.CONTENT_ADDRESSABLE_STORE with type key = C.key
-
       module Key : S.HASH with type t = key
 
       module Val :
@@ -67,6 +66,5 @@ module V1 (N : S.NODE with type step = string) : sig
        and type metadata = N.metadata
 
   val import : N.t -> t
-
   val export : t -> N.t
 end

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -32,7 +32,6 @@ let list_partition_map f t =
 
 module type S = sig
   include Graph.Sig.I
-
   include Graph.Oper.S with type g := t
 
   module Topological : sig
@@ -40,7 +39,6 @@ module type S = sig
   end
 
   val vertex : t -> vertex list
-
   val edges : t -> (vertex * vertex) list
 
   val closure :
@@ -72,13 +70,11 @@ module type S = sig
     unit
 
   val min : t -> vertex list
-
   val max : t -> vertex list
 
   type dump = vertex list * (vertex * vertex) list
 
   val export : t -> dump
-
   val import : dump -> t
 
   module Dump : Type.S with type t = dump
@@ -100,9 +96,7 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
     [@@deriving irmin]
 
     let equal = Type.(unstage (equal t))
-
     let compare = Type.(unstage (compare t))
-
     let hash_branch = Type.(unstage (short_hash Branch.t))
 
     (* we are using cryptographic hashes here, so the first bytes
@@ -123,9 +117,7 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
     type t
 
     val create : int option -> t
-
     val add : t -> X.t -> int -> unit
-
     val mem : t -> X.t -> bool
   end = struct
     module Lru = Lru.Make (X)
@@ -138,7 +130,6 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
       | Some n -> L (Lru.create n)
 
     let add t k v = match t with L t -> Lru.add t k v | T t -> Tbl.add t k v
-
     let mem t k = match t with L t -> Lru.mem t k | T t -> Tbl.mem t k
   end
 
@@ -155,11 +146,8 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
   end
 
   let vertex g = G.fold_vertex (fun k set -> k :: set) g []
-
   let edges g = G.fold_edges (fun k1 k2 list -> (k1, k2) :: list) g []
-
   let pp_vertices = Fmt.Dump.list (Type.pp X.t)
-
   let pp_depth ppf d = if d <> max_int then Fmt.pf ppf "depth=%d,@ " d
 
   type action = Visit of (X.t * int) | Treat of X.t
@@ -258,16 +246,13 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
       g []
 
   let vertex_attributes = ref (fun _ -> [])
-
   let edge_attributes = ref (fun _ -> [])
-
   let graph_name = ref None
 
   module Dot = Graph.Graphviz.Dot (struct
     include G
 
     let edge_attributes k = !edge_attributes k
-
     let default_edge_attributes _ = []
 
     let vertex_name k =
@@ -279,9 +264,7 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
       | `Branch b -> str Branch.t b
 
     let vertex_attributes k = !vertex_attributes k
-
     let default_vertex_attributes _ = []
-
     let get_subgraph _ = None
 
     let graph_attributes _ =

--- a/src/irmin/path.ml
+++ b/src/irmin/path.ml
@@ -18,24 +18,18 @@ open Astring
 
 module String_list = struct
   type step = string [@@deriving irmin]
-
   type t = step list
 
   let empty = []
-
   let is_empty l = l = []
-
   let cons s t = s :: t
-
   let rcons t s = t @ [ s ]
-
   let decons = function [] -> None | h :: t -> Some (h, t)
 
   let rdecons l =
     match List.rev l with [] -> None | h :: t -> Some (List.rev t, h)
 
   let map l f = List.map f l
-
   let v x = x
 
   let pp ppf t =
@@ -49,6 +43,5 @@ module String_list = struct
     Fmt.string ppf (Buffer.contents buf)
 
   let of_string s = Ok (List.filter (( <> ) "") (String.cuts s ~sep:"/"))
-
   let t = Type.like ~pp ~of_string Type.(list step_t)
 end

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -84,7 +84,6 @@ end
 
 module type TYPED_HASH = sig
   type t
-
   type value
 
   val hash : value -> t
@@ -161,9 +160,7 @@ module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
   val v : Conf.t -> [ `Read ] t Lwt.t
-
   val close : 'a t -> unit Lwt.t
 end
 
@@ -201,9 +198,7 @@ module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
   include APPEND_ONLY_STORE with type key = K.t and type value = V.t
 
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
   val v : Conf.t -> [ `Read ] t Lwt.t
-
   val close : 'a t -> unit Lwt.t
 end
 
@@ -429,7 +424,6 @@ module type NODE_STORE = sig
 end
 
 type config = Conf.t
-
 type 'a diff = 'a Diff.t
 
 module type COMMIT = sig
@@ -760,13 +754,9 @@ end
 
 module type PRIVATE = sig
   module Hash : HASH
-
   module Contents : CONTENTS_STORE with type key = Hash.t
-
   module Node : NODE_STORE with type key = Hash.t
-
   module Commit : COMMIT_STORE with type key = Hash.t
-
   module Branch : BRANCH_STORE with type value = Hash.t
 
   module Slice :
@@ -779,15 +769,10 @@ module type PRIVATE = sig
     type t
 
     val v : Conf.t -> t Lwt.t
-
     val close : t -> unit Lwt.t
-
     val contents_t : t -> [ `Read ] Contents.t
-
     val node_t : t -> [ `Read ] Node.t
-
     val commit_t : t -> [ `Read ] Commit.t
-
     val branch_t : t -> Branch.t
 
     val batch :

--- a/src/irmin/slice.ml
+++ b/src/irmin/slice.ml
@@ -20,9 +20,7 @@ module Make
     (Commit : S.COMMIT_STORE) =
 struct
   type contents = Contents.Key.t * Contents.Val.t [@@deriving irmin]
-
   type node = Node.Key.t * Node.Val.t [@@deriving irmin]
-
   type commit = Commit.Key.t * Commit.Val.t [@@deriving irmin]
 
   type value = [ `Contents of contents | `Node of node | `Commit of commit ]

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -32,9 +32,7 @@ struct
   module H = Hash.Typed (K) (V)
 
   let hash = H.hash
-
   let pp_key = Type.pp K.t
-
   let equal_hash = Type.(unstage (equal K.t))
 
   let find t k =
@@ -62,9 +60,7 @@ module Make (P : S.PRIVATE) = struct
   module Hash = P.Hash
 
   type hash = Hash.t
-
   type lca_error = [ `Max_depth_reached | `Too_many_lcas ] [@@deriving irmin]
-
   type ff_error = [ `No_change | `Rejected | lca_error ]
 
   module Key = P.Node.Path
@@ -80,7 +76,6 @@ module Make (P : S.PRIVATE) = struct
     include P.Contents.Val
 
     let of_hash r h = P.Contents.find (P.Repo.contents_t r) h
-
     let hash c = P.Contents.Key.hash c
   end
 
@@ -88,7 +83,6 @@ module Make (P : S.PRIVATE) = struct
     include Tree.Make (P)
 
     let of_hash r h = import r h >|= Option.map of_node
-
     let shallow r h = import_no_check r h |> of_node
 
     let hash : t -> hash =
@@ -103,27 +97,17 @@ module Make (P : S.PRIVATE) = struct
     | `Node n -> Tree.export ~clear r x y n
 
   type node = Tree.node [@@deriving irmin]
-
   type contents = Contents.t [@@deriving irmin]
-
   type metadata = Metadata.t [@@deriving irmin]
-
   type tree = Tree.t
-
   type repo = P.Repo.t
 
   let equal_hash = Type.(unstage (equal Hash.t))
-
   let equal_contents = Type.(unstage (equal Contents.t))
-
   let equal_branch = Type.(unstage (equal Branch_store.Key.t))
-
   let pp_key = Type.pp Key.t
-
   let pp_hash = Type.pp Hash.t
-
   let pp_branch = Type.pp Branch_store.Key.t
-
   let pp_option = Type.pp (Type.option Type.int)
 
   module Commit = struct
@@ -146,17 +130,11 @@ module Make (P : S.PRIVATE) = struct
       P.Commit.add commit_t v >|= fun h -> { r; h; v }
 
     let node t = P.Commit.Val.node t.v
-
     let tree t = Tree.import_no_check t.r (node t) |> Tree.of_node
-
     let equal x y = equal_hash x.h y.h
-
     let hash t = t.h
-
     let info t = P.Commit.Val.info t.v
-
     let parents t = P.Commit.Val.parents t.v
-
     let pp_hash ppf t = Type.pp Hash.t ppf t.h
 
     let of_hash r h =
@@ -180,11 +158,8 @@ module Make (P : S.PRIVATE) = struct
   type commit = Commit.t
 
   let to_private_node = Tree.to_private_node
-
   let of_private_node = Tree.of_private_node
-
   let to_private_commit = Commit.to_private_commit
-
   let of_private_commit = Commit.of_private_commit
 
   type head_ref = [ `Branch of branch | `Head of commit option ref ]
@@ -194,7 +169,6 @@ module Make (P : S.PRIVATE) = struct
   module KGraph = Object_graph.Make (Hash) (Branch_store.Key)
 
   type slice = P.Slice.t [@@deriving irmin]
-
   type watch = unit -> unit Lwt.t
 
   let unwatch w = w ()
@@ -203,21 +177,13 @@ module Make (P : S.PRIVATE) = struct
     type t = repo
 
     let v = P.Repo.v
-
     let close = P.Repo.close
-
     let graph_t t = P.Repo.node_t t
-
     let history_t t = P.Repo.commit_t t
-
     let branch_t t = P.Repo.branch_t t
-
     let commit_t t = P.Repo.commit_t t
-
     let node_t t = P.Repo.node_t t
-
     let contents_t t = P.Repo.contents_t t
-
     let branches t = P.Branch.list (branch_t t)
 
     let heads repo =
@@ -345,9 +311,7 @@ module Make (P : S.PRIVATE) = struct
     [@@deriving irmin]
 
     let ignore_lwt _ = Lwt.return_unit
-
     let return_false _ = Lwt.return false
-
     let default_pred_contents _ _ = Lwt.return []
 
     let default_pred_node t k =
@@ -415,11 +379,8 @@ module Make (P : S.PRIVATE) = struct
   type step = Key.step [@@deriving irmin]
 
   let repo t = t.repo
-
   let branch_t t = Repo.branch_t t.repo
-
   let commit_t t = Repo.commit_t t.repo
-
   let history_t t = commit_t t
 
   let status t =
@@ -463,9 +424,7 @@ module Make (P : S.PRIVATE) = struct
     else err_invalid_branch id
 
   let master repo = of_branch repo Branch_store.Key.master
-
   let empty repo = of_ref repo (`Head (ref None))
-
   let of_commit c = of_ref c.Commit.r (`Head (ref (Some c)))
 
   let skip_key key =
@@ -587,7 +546,6 @@ module Make (P : S.PRIVATE) = struct
 
   module Head = struct
     let list = Repo.heads
-
     let find = head
 
     let get t =
@@ -721,7 +679,6 @@ module Make (P : S.PRIVATE) = struct
           t
 
   let write_error e : ('a, write_error) result Lwt.t = Lwt.return (Error e)
-
   let err_test v = write_error (`Test_was v)
 
   type snapshot = {
@@ -857,17 +814,11 @@ module Make (P : S.PRIVATE) = struct
     merge ?retries ?allow_empty ?parents ~info ~old t k v >>= fail "merge_exn"
 
   let mem t k = tree t >>= fun tree -> Tree.mem tree k
-
   let mem_tree t k = tree t >>= fun tree -> Tree.mem_tree tree k
-
   let find_all t k = tree t >>= fun tree -> Tree.find_all tree k
-
   let find t k = tree t >>= fun tree -> Tree.find tree k
-
   let get t k = tree t >>= fun tree -> Tree.get tree k
-
   let find_tree t k = tree t >>= fun tree -> Tree.find_tree tree k
-
   let get_tree t k = tree t >>= fun tree -> Tree.get_tree tree k
 
   let hash t k =
@@ -876,9 +827,7 @@ module Make (P : S.PRIVATE) = struct
     | Some tree -> Some (Tree.hash tree)
 
   let get_all t k = tree t >>= fun tree -> Tree.get_all tree k
-
   let list t k = tree t >>= fun tree -> Tree.list tree k
-
   let kind t k = tree t >>= fun tree -> Tree.kind tree k
 
   let with_tree ?(retries = 13) ?allow_empty ?parents
@@ -984,11 +933,8 @@ module Make (P : S.PRIVATE) = struct
     type t = commit
 
     let hash h = P.Commit.Key.short_hash h.Commit.h
-
     let compare_key = Type.(unstage (compare P.Commit.Key.t))
-
     let compare x y = compare_key x.Commit.h y.Commit.h
-
     let equal x y = equal_hash x.Commit.h y.Commit.h
   end)
 
@@ -1105,9 +1051,7 @@ module Make (P : S.PRIVATE) = struct
       | Some h -> Commit.of_hash t h
 
     let set t br h = P.Branch.set (P.Repo.branch_t t) br (Commit.hash h)
-
     let remove t = P.Branch.remove (P.Repo.branch_t t)
-
     let list = Repo.branches
 
     let watch t k ?init f =
@@ -1151,9 +1095,7 @@ module Make (P : S.PRIVATE) = struct
   end
 
   let tree_t = Tree.tree_t
-
   let commit_t = Commit.t
-
   let branch_t = Branch.t
 
   type kind = [ `Contents | `Node ] [@@deriving irmin]
@@ -1184,5 +1126,4 @@ end
 type S.remote += Store : (module Store_intf.S with type t = 'a) * 'a -> S.remote
 
 module type S = Store_intf.S
-
 module type MAKER = Store_intf.MAKER

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -868,7 +868,6 @@ module type S = sig
   (** {2 Converters to private types} *)
 
   val to_private_node : node -> Private.Node.value Tree.or_error Lwt.t
-
   val of_private_node : repo -> Private.Node.value -> node
 
   val to_private_commit : commit -> Private.Commit.value
@@ -911,7 +910,6 @@ module type MAKER = functor
 
 module type Store = sig
   module type S = S
-
   module type MAKER = MAKER
 
   type Sigs.remote += Store : (module S with type t = 'a) * 'a -> Sigs.remote
@@ -940,9 +938,7 @@ module type Store = sig
          and type value = V.t
 
     val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
     val v : Conf.t -> [ `Read ] t Lwt.t
-
     val close : 'a t -> unit Lwt.t
   end
 end

--- a/src/irmin/sync.ml
+++ b/src/irmin/sync.ml
@@ -22,9 +22,7 @@ module None (H : Type.S) (R : Type.S) = struct
   let v _ = Lwt.return_unit
 
   type endpoint = unit
-
   type commit = H.t
-
   type branch = R.t
 
   let fetch () ?depth:_ _ _br =

--- a/src/irmin/sync_ext.ml
+++ b/src/irmin/sync_ext.ml
@@ -18,7 +18,6 @@ open Lwt.Infix
 open S
 
 let invalid_argf fmt = Fmt.kstrf Lwt.fail_invalid_arg fmt
-
 let src = Logs.Src.create "irmin.sync" ~doc:"Irmin remote sync"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -29,7 +28,6 @@ module Make (S : Store.S) = struct
   module B = S.Private.Sync
 
   type db = S.t
-
   type commit = S.commit
 
   let conv dx dy =
@@ -78,7 +76,6 @@ module Make (S : Store.S) = struct
       [] l
 
   let pp_branch = Type.pp S.Branch.t
-
   let pp_hash = Type.pp S.Hash.t
 
   type status = [ `Empty | `Head of commit ]

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -25,7 +25,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 let option_of_result = function Ok x -> Some x | Error _ -> None
 
 type ('a, 'r) cont = ('a -> 'r) -> 'r
-
 type ('a, 'r) cont_lwt = ('a, 'r Lwt.t) cont
 
 (* assume l1 and l2 are key-sorted *)
@@ -107,7 +106,6 @@ module Make (P : S.PRIVATE) = struct
       type t = Path.step
 
       let t = Path.step_t
-
       let compare = Type.(unstage (compare Path.step_t))
     end
 
@@ -118,9 +116,7 @@ module Make (P : S.PRIVATE) = struct
   module Metadata = P.Node.Metadata
 
   type key = Path.t
-
   type hash = P.Hash.t
-
   type 'a or_error = ('a, [ `Dangling_hash of hash ]) result
 
   let get_ok : type a. a or_error -> a = function
@@ -129,20 +125,16 @@ module Make (P : S.PRIVATE) = struct
         Fmt.failwith "Encountered dangling hash %a" (Type.pp P.Hash.t) hash
 
   type step = Path.step
-
   type contents = P.Contents.value
-
   type repo = P.Repo.t
 
   let pp_hash = Type.pp P.Hash.t
-
   let pp_path = Type.pp Path.t
 
   module Hashes = Hashtbl.Make (struct
     type t = hash
 
     let hash = P.Hash.short_hash
-
     let equal = Type.(unstage (equal P.Hash.t))
   end)
 
@@ -153,27 +145,20 @@ module Make (P : S.PRIVATE) = struct
   let empty_marks () = Hashes.create 39
 
   type 'a force = [ `True | `False of key -> 'a -> 'a Lwt.t | `And_clear ]
-
   type uniq = [ `False | `True | `Marks of marks ]
-
   type 'a node_fn = key -> step list -> 'a -> 'a Lwt.t
 
   type depth = [ `Eq of int | `Le of int | `Lt of int | `Ge of int | `Gt of int ]
   [@@deriving irmin]
 
   let equal_contents = Type.(unstage (equal P.Contents.Val.t))
-
   let equal_metadata = Type.(unstage (equal Metadata.t))
-
   let equal_hash = Type.(unstage (equal P.Hash.t))
-
   let equal_node = Type.(unstage (equal P.Node.Val.t))
 
   module Contents = struct
     type v = Hash of repo * hash | Value of contents
-
     type info = { mutable hash : hash option; mutable value : contents option }
-
     type t = { mutable v : v; mutable info : info }
 
     let info_is_empty i = i.hash = None && i.value = None
@@ -209,9 +194,7 @@ module Make (P : S.PRIVATE) = struct
       | Value _, Some k -> t.v <- Hash (repo, k)
 
     let t = Type.map v of_v (fun t -> t.v)
-
     let of_value c = of_v (Value c)
-
     let of_hash repo k = of_v (Hash (repo, k))
 
     let cached_hash t =
@@ -379,7 +362,6 @@ module Make (P : S.PRIVATE) = struct
       | `Node t -> clear ~max_depth (depth + 1) t
 
     and clear_map ~max_depth depth = List.iter (clear_elt ~max_depth depth)
-
     and clear_maps ~max_depth depth = List.iter (clear_map ~max_depth depth)
 
     and clear_info ~max_depth ?v depth i =
@@ -424,11 +406,8 @@ module Make (P : S.PRIVATE) = struct
           | Some k -> t.v <- Hash (repo, k))
 
     let dump = Type.pp_json ~minify:false t
-
     let of_map m = of_v (Map m)
-
     let of_hash repo k = of_v (Hash (repo, k))
-
     let of_value ?added repo v = of_v (Value (repo, v, added))
 
     let empty = function
@@ -890,14 +869,12 @@ module Make (P : S.PRIVATE) = struct
   end
 
   type node = Node.t [@@deriving irmin]
-
   type metadata = Metadata.t
 
   type t = [ `Node of node | `Contents of P.Contents.Val.t * Metadata.t ]
   [@@deriving irmin { name = "tree_t" }]
 
   let of_private_node repo n = Node.of_value repo n
-
   let to_private_node = Node.to_value
 
   let dump ppf = function
@@ -927,9 +904,7 @@ module Make (P : S.PRIVATE) = struct
     | `Contents _ -> Lwt.return_false
 
   let of_node n = `Node n
-
   let of_contents ?(metadata = Metadata.default) c = `Contents (c, metadata)
-
   let v = function `Contents c -> `Contents c | `Node n -> `Node n
 
   let destruct : t -> [> `Node of node | `Contents of contents * metadata ] =
@@ -983,11 +958,8 @@ module Make (P : S.PRIVATE) = struct
   [@@deriving irmin]
 
   let empty_stats = { nodes = 0; leafs = 0; skips = 0; depth = 0; width = 0 }
-
   let incr_nodes s = { s with nodes = s.nodes + 1 }
-
   let incr_leafs s = { s with leafs = s.leafs + 1 }
-
   let incr_skips s = { s with skips = s.skips + 1 }
 
   let set_depth p s =
@@ -1021,9 +993,7 @@ module Make (P : S.PRIVATE) = struct
     | Some v -> Lwt.return v
 
   let get t k = get_all t k >|= fun (c, _) -> c
-
   let mem t k = find t k >|= function None -> false | _ -> true
-
   let mem_tree t k = find_tree t k >|= function None -> false | _ -> true
 
   let kind t path =
@@ -1160,7 +1130,6 @@ module Make (P : S.PRIVATE) = struct
     | false -> None
 
   let import_no_check repo k = Node.of_hash repo k
-
   let value_of_map t map = Node.value_of_map t map (fun x -> x)
 
   let export ?clear repo contents_t node_t n =
@@ -1474,9 +1443,7 @@ module Make (P : S.PRIVATE) = struct
     fold ~force ~pre ~post ~contents t empty_stats
 
   let counters () = cnt
-
   let dump_counters ppf () = dump_counters ppf cnt
-
   let reset_counters () = reset_counters cnt
 
   let inspect = function

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -17,15 +17,10 @@
 
 module type S = sig
   type key
-
   type step
-
   type metadata
-
   type contents
-
   type node
-
   type hash
 
   (** [Tree] provides immutable, in-memory partial mirror of the store, with
@@ -276,11 +271,8 @@ module type S = sig
   }
 
   val counters : unit -> counters
-
   val dump_counters : unit Fmt.t
-
   val reset_counters : unit -> unit
-
   val inspect : t -> [ `Contents | `Node of [ `Map | `Hash | `Value ] ]
 end
 
@@ -300,7 +292,6 @@ module type Tree = sig
          and type hash = P.Hash.t
 
     val import : P.Repo.t -> P.Node.key -> node option Lwt.t
-
     val import_no_check : P.Repo.t -> P.Node.key -> node
 
     val export :
@@ -312,17 +303,11 @@ module type Tree = sig
       P.Node.key Lwt.t
 
     val dump : t Fmt.t
-
     val equal : t -> t -> bool
-
     val node_t : node Type.t
-
     val tree_t : t Type.t
-
     val hash : t -> [ `Contents of hash * metadata | `Node of hash ]
-
     val of_private_node : P.Repo.t -> P.Node.value -> node
-
     val to_private_node : node -> P.Node.value or_error Lwt.t
   end
 end

--- a/src/irmin/watch.ml
+++ b/src/irmin/watch.ml
@@ -22,19 +22,13 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module type S = sig
   type key
-
   type value
-
   type watch
-
   type t
 
   val stats : t -> int * int
-
   val notify : t -> key -> value option -> unit Lwt.t
-
   val v : unit -> t
-
   val clear : t -> unit Lwt.t
 
   val watch_key :
@@ -74,9 +68,7 @@ let id () =
     !c
 
 let global = id ()
-
 let workers_r = ref 0
-
 let workers () = !workers_r
 
 let scheduler () =
@@ -117,9 +109,7 @@ end) (V : sig
 end) =
 struct
   type key = K.t
-
   type value = V.t
-
   type watch = int
 
   module KMap = Map.Make (struct
@@ -135,13 +125,10 @@ struct
   end)
 
   type key_handler = value Diff.t -> unit Lwt.t
-
   type all_handler = key -> value Diff.t -> unit Lwt.t
 
   let pp_value = Type.pp V.t
-
   let equal_opt_values = Type.(unstage (equal (option V.t)))
-
   let equal_keys = Type.(unstage (equal K.t))
 
   type t = {
@@ -232,7 +219,6 @@ struct
         Lwt.return_unit)
 
   let pp_option = Fmt.option ~none:(Fmt.any "<none>")
-
   let pp_key = Type.pp K.t
 
   let notify_all_unsafe t key value =

--- a/src/ppx_irmin/ppx_irmin.ml
+++ b/src/ppx_irmin/ppx_irmin.ml
@@ -16,7 +16,6 @@
 
 module Plugins = Ppx_repr_lib.Plugins.Make (struct
   let default_library = "Irmin.Type"
-
   let namespace = "irmin"
 end)
 

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -18,9 +18,7 @@
 open Lwt.Infix
 
 let () = Printexc.record_backtrace true
-
 let key_t : Test_chunk.Key.t Alcotest.testable = (module Test_chunk.Key)
-
 let value_t : Test_chunk.Value.t Alcotest.testable = (module Test_chunk.Value)
 
 let run f () =
@@ -29,7 +27,6 @@ let run f () =
   flush stdout
 
 let hash x = Test_chunk.Key.hash (fun l -> l x)
-
 let value_to_bin = Irmin.Type.(unstage (to_bin_string Test_chunk.Value.t))
 
 let test_add_read ?(stable = false) (module AO : Test_chunk.S) () =

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -22,7 +22,6 @@ module Key = struct
   include Irmin.Hash.SHA1
 
   let pp = Irmin.Type.pp t
-
   let equal = Irmin.Type.(unstage (equal t))
 end
 
@@ -30,7 +29,6 @@ module Value = struct
   include Irmin.Contents.String
 
   let pp = Fmt.string
-
   let equal = String.equal
 
   type hash = Key.t
@@ -47,7 +45,6 @@ module type S = sig
        and type value = Value.t
 
   val v : unit -> [ `Read ] t Lwt.t
-
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 end
 
@@ -64,7 +61,6 @@ module MemChunk = struct
   include Content_addressable (Key) (Value)
 
   let small_config = Irmin_chunk.config ~min_size:44 ~size:44 ()
-
   let v () = v small_config
 end
 

--- a/test/irmin-containers/blob_log.ml
+++ b/test/irmin-containers/blob_log.ml
@@ -20,9 +20,7 @@ open Lwt.Infix
 module B = Irmin_containers.Blob_log.Mem (Irmin.Contents.String)
 
 let path = [ "tmp"; "blob" ]
-
 let config () = B.Store.Repo.v (Irmin_mem.config ())
-
 let merge_into_exn = merge_into_exn (module B.Store)
 
 let test_empty_read _ () =

--- a/test/irmin-containers/counter.ml
+++ b/test/irmin-containers/counter.ml
@@ -20,9 +20,7 @@ open Lwt.Infix
 module C = Irmin_containers.Counter.Mem
 
 let path = [ "tmp"; "counter" ]
-
 let config () = C.Store.Repo.v (Irmin_mem.config ())
-
 let merge_into_exn = merge_into_exn (module C.Store)
 
 let test_inc _ () =

--- a/test/irmin-containers/linked_log.ml
+++ b/test/irmin-containers/linked_log.ml
@@ -27,9 +27,7 @@ end
 module L = Irmin_containers.Linked_log.Mem (CAS) (Irmin.Contents.String) ()
 
 let merge_into_exn = merge_into_exn (module L.Store)
-
 let path = [ "tmp"; "link" ]
-
 let config () = L.Store.Repo.v (Irmin_mem.config ())
 
 let test_empty_read _ () =

--- a/test/irmin-containers/lww_register.ml
+++ b/test/irmin-containers/lww_register.ml
@@ -27,9 +27,7 @@ end
 module L = Irmin_containers.Lww_register.Mem (In)
 
 let merge_into_exn = merge_into_exn (module L.Store)
-
 let path = [ "tmp"; "lww" ]
-
 let config () = L.Store.Repo.v (Irmin_mem.config ())
 
 let test_empty_read _ () =

--- a/test/irmin-fs/test_fs.ml
+++ b/test/irmin-fs/test_fs.ml
@@ -18,13 +18,9 @@ open Lwt.Infix
 module IO = Irmin_fs.IO_mem
 
 let test_db = Filename.concat "_build" "test-db"
-
 let init () = IO.clear () >|= fun () -> IO.set_listen_hook ()
-
 let config = Irmin_fs.config test_db
-
 let clean () = Lwt.return_unit
-
 let stats = None
 
 let store =

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -32,7 +32,6 @@ end
 
 module type G = sig
   include S
-
   module Git : Irmin_git.G
 end
 

--- a/test/irmin-git/test_git.mli
+++ b/test/irmin-git/test_git.mli
@@ -1,7 +1,5 @@
 val suite : Irmin_test.t
-
 val suite_generic : Irmin_test.t
-
 val test_db : string
 
 module type S = sig
@@ -12,10 +10,8 @@ end
 
 module type G = sig
   include S
-
   module Git : Irmin_git.G
 end
 
 val misc : (module G) -> unit Alcotest.test_case list
-
 val mem : (module G)

--- a/test/irmin-graphql/common.ml
+++ b/test/irmin-graphql/common.ml
@@ -2,11 +2,8 @@ open Lwt.Infix
 module Store = Irmin_mem.KV (Irmin.Contents.String)
 
 let ( / ) = Filename.concat
-
 let http_graphql_dir = "test-graphql"
-
 let socket = http_graphql_dir / "irmin.sock"
-
 let host = "irmin"
 
 let ctx =

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -19,19 +19,14 @@ let () = Random.self_init ()
 open Lwt.Infix
 
 let ( / ) = Filename.concat
-
 let test_http_dir = "test-http"
-
 let uri = Uri.of_string "http://irmin"
 
 type id = { name : string; id : int }
 
 let pp ppf t = Fmt.pf ppf "%s-%d" t.name t.id
-
 let socket t = test_http_dir / Fmt.strf "irmin-%a.sock" pp t
-
 let pid_file t = test_http_dir / Fmt.strf "irmin-test-%a.pid" pp t
-
 let tmp_file file = file ^ ".tmp"
 
 module Client (P : sig
@@ -100,7 +95,6 @@ let wait_for_the_server_to_start id =
   aux 1
 
 let servers = [ (`Quick, Test_mem.suite); (`Quick, Test_git.suite) ]
-
 let root c = Irmin.Private.Conf.(get c root)
 
 let mkdir d =

--- a/test/irmin-http/test_http.mli
+++ b/test/irmin-http/test_http.mli
@@ -1,7 +1,5 @@
 type test = Alcotest.speed_level * Irmin_test.t
 
 val servers : test list
-
 val suites : test list -> test list
-
 val with_server : test list -> (unit -> unit) -> unit

--- a/test/irmin-mem/bench.ml
+++ b/test/irmin-mem/bench.ml
@@ -20,5 +20,4 @@ module KV = Irmin_mem.KV (Irmin.Contents.String)
 module Bench = Irmin_bench.Make (KV)
 
 let size ~root:_ = 0
-
 let () = Bench.run ~config ~size

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -37,9 +37,7 @@ let clean () =
   clear repo >>= fun () -> S.Repo.close repo
 
 let init () = Lwt.return_unit
-
 let stats = None
-
 let lower_name = "lower"
 
 let suite =

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -11,7 +11,6 @@ let rm_dir () =
 
 module Conf = struct
   let entries = 32
-
   let stable_hash = 256
 end
 

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -6,12 +6,12 @@ module Commit = Irmin.Private.Commit.Make (Hash)
 
 module Conf = struct
   let entries = 32
-
   let stable_hash = 256
 end
 
 module Store = Irmin_pack.Checks.Make (struct
   module Hash = Hash
+
   module Store =
     Irmin_pack.Make_ext (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
       (Path)
@@ -23,6 +23,7 @@ end)
 
 module Store_layered = Irmin_pack_layered.Checks.Make (struct
   module Hash = Hash
+
   module Store =
     Irmin_pack_layered.Make_ext (Conf) (Irmin.Metadata.None)
       (Irmin.Contents.String)

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -2,9 +2,7 @@ open Lwt.Infix
 module Dict = Irmin_pack.Dict
 
 let ( let* ) x f = Lwt.bind x f
-
 let get = function Some x -> x | None -> Alcotest.fail "None"
-
 let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
 
 let rm_dir root =
@@ -15,16 +13,12 @@ let rm_dir root =
     ())
 
 let index_log_size = Some 1_000
-
 let () = Random.self_init ()
-
 let random_char () = char_of_int (Random.int 256)
-
 let random_string n = String.init n (fun _i -> random_char ())
 
 module Conf = struct
   let entries = 32
-
   let stable_hash = 256
 end
 
@@ -36,11 +30,8 @@ module S = struct
   module H = Irmin.Hash.Typed (Irmin.Hash.SHA1) (Irmin.Contents.String)
 
   let hash = H.hash
-
   let encode_pair = Irmin.Type.(unstage (encode_bin (pair H.t t)))
-
   let decode_pair = Irmin.Type.(unstage (decode_bin (pair H.t t)))
-
   let encode_bin ~dict:_ ~offset:_ x k = encode_pair (k, x)
 
   let decode_bin ~dict:_ ~hash:_ x off =

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -55,18 +55,13 @@ end) : sig
 end
 
 val ( let* ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
-
 val get : 'a option -> 'a
-
 val sha1 : string -> H.t
-
 val rm_dir : string -> unit
-
 val index_log_size : int option
 
 module Conf : sig
   val entries : int
-
   val stable_hash : int
 end
 

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -18,24 +18,21 @@ let index_log_size = Some 4
 
 module Conf = struct
   let entries = 32
-
   let stable_hash = 256
-
   let lower_root = "_lower"
-
   let upper0_root = "0"
-
   let copy_in_upper = true
-
   let with_lower = true
 end
 
 module Hash = Irmin.Hash.SHA1
+
 module Store =
   Irmin_pack_layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)
+
 module StoreSimple =
   Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -2,9 +2,7 @@ open Lwt.Infix
 open Common
 
 let ( let* ) x f = Lwt.bind x f
-
 let root = Filename.concat "_build" "test-instances"
-
 let src = Logs.Src.create "tests.instances" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -13,11 +11,11 @@ let index_log_size = Some 1_000
 
 module Conf = struct
   let entries = 32
-
   let stable_hash = 256
 end
 
 module Hash = Irmin.Hash.SHA1
+
 module S =
   Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -2,7 +2,6 @@ open Lwt.Infix
 open Common
 
 let ( let* ) x f = Lwt.bind x f
-
 let src = Logs.Src.create "tests.migration" ~doc:"Test migrations"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -57,7 +56,6 @@ end
 module Test
     (S : Migrate_store) (Config : sig
       val setup_test_env : unit -> unit
-
       val root_v1 : string
     end) =
 struct
@@ -152,6 +150,7 @@ module Config_store = struct
 end
 
 module Hash = Irmin.Hash.SHA1
+
 module Make () =
   Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
@@ -160,7 +159,6 @@ module Make () =
 
 module Test_store = struct
   module S = Make ()
-
   include Test (S) (Config_store)
 
   let uncached_instance_check_idempotent () =
@@ -185,7 +183,6 @@ end
 
 module Test_reconstruct = struct
   module S = Make ()
-
   include Test (S) (Config_store)
 
   let setup_test_env () =
@@ -272,6 +269,7 @@ module Make_layered =
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)
+
 module Test_layered_store = Test (Make_layered) (Config_layered_store)
 
 module Test_corrupted_stores = struct

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -19,7 +19,6 @@ open Common
 
 module Config = struct
   let entries = 2
-
   let stable_hash = 3
 end
 

--- a/test/irmin-pack/test_pack.mli
+++ b/test/irmin-pack/test_pack.mli
@@ -1,3 +1,2 @@
 val suite : Irmin_test.t
-
 val misc : (string * unit Alcotest.test_case list) list

--- a/test/irmin-unix/test_unix.ml
+++ b/test/irmin-unix/test_unix.ml
@@ -26,7 +26,6 @@ let stats =
 
 module FS = struct
   let test_db = Test_fs.test_db
-
   let config = Test_fs.config
 
   let store =

--- a/test/irmin-unix/test_unix.mli
+++ b/test/irmin-unix/test_unix.mli
@@ -1,8 +1,6 @@
 module Git : sig
   val misc : unit Alcotest.test_case list
-
   val store : (module Test_git.G)
-
   val suite : Irmin_test.t
 end
 

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1,3 +1,2 @@
 let suite = [ ("tree", Test_tree.suite); ("hash", Test_hash.suite) ]
-
 let () = Lwt_main.run (Alcotest_lwt.run "irmin" suite)

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -13,6 +13,7 @@ end
 module Store =
   Irmin_mem.Make (Metadata) (Contents.String) (Path.String_list) (Branch.String)
     (Hash.BLAKE2B)
+
 module Tree = Store.Tree
 
 type diffs = (string list * (Contents.String.t * Metadata.t) Diff.t) list
@@ -24,16 +25,12 @@ module Alcotest = struct
   include Alcotest
 
   let gtestable typ = testable (Type.pp_dump typ) Type.(unstage (equal typ))
-
   let gcheck typ = check (gtestable typ)
-
   let diffs = gtestable diffs_t
 end
 
 let ( >> ) f g x = g (f x)
-
 let ( let* ) = Lwt.bind
-
 let ( let+ ) x f = Lwt.map f x
 
 let get_ok = function


### PR DESCRIPTION
This brings the options in-line with the ones used in `index` and `repr`, and personally I think is an improvement overall – stock OCamlformat is a bit too keen to introduce empty lines in such a functor-heavy codebase.