### PR TITLE
irmin-pack: retain compatibility with V1 IO

### DIFF
--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -41,6 +41,10 @@ end
 
 type version = Version.t
 
+module type VERSION = sig
+  val io_version : version
+end
+
 let pp_version = Version.pp
 
 exception Invalid_version of { expected : version; found : version }

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -48,6 +48,11 @@ module type S = sig
   val exists : string -> bool
   val size : t -> int
 
+  val truncate : t -> unit
+  (** Sets the length of the underlying IO to be 0, without actually purging the
+      associated data. Not supported for stores beyond [`V1], which should use
+      {!clear} instead. *)
+
   val migrate :
     progress:(int64 -> unit) ->
     t ->

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -22,6 +22,10 @@ exception Invalid_version of { expected : version; found : version }
 
 type path := string
 
+module type VERSION = sig
+  val io_version : version
+end
+
 module type S = sig
   type t
 

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -21,10 +21,11 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let current_version = `V2
 let ( -- ) = Int64.sub
 
-module Make (IO : IO.S) : S = struct
+module Make (IO_version : IO.VERSION) (IO : IO.S) : S = struct
+  let current_version = IO_version.io_version
+
   type t = {
     capacity : int;
     cache : (string, int) Hashtbl.t;

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -103,9 +103,12 @@ module Make (IO_version : IO.VERSION) (IO : IO.S) : S = struct
     v
 
   let clear t =
-    IO.clear t.io;
-    Hashtbl.clear t.cache;
-    Hashtbl.clear t.index
+    match current_version with
+    | `V1 -> IO.truncate t.io
+    | `V2 ->
+        IO.clear t.io;
+        Hashtbl.clear t.cache;
+        Hashtbl.clear t.index
 
   let v ?(fresh = true) ?(readonly = false) ?(capacity = 100_000) file =
     let io = IO.v ~fresh ~version:(Some current_version) ~readonly file in

--- a/src/irmin-pack/dict_intf.ml
+++ b/src/irmin-pack/dict_intf.ml
@@ -33,5 +33,5 @@ end
 module type Dict = sig
   module type S = S
 
-  module Make (IO : IO.S) : S
+  module Make (_ : IO.VERSION) (_ : IO.S) : S
 end

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -16,14 +16,12 @@
 
 open Lwt.Infix
 module Pack_config = Config
-module Dict = Pack_dict
 module Index = Pack_index
 
 let src = Logs.Src.create "irmin.pack" ~doc:"irmin-pack backend"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let current_version = `V1
 let pp_version = IO.pp_version
 
 exception Unsupported_version = Store.Unsupported_version
@@ -40,11 +38,8 @@ let () =
 module I = IO
 module IO = IO.Unix
 
-module IO_version = struct
-  let io_version = current_version
-end
-
 module Make
+    (IO_version : I.VERSION)
     (Config : Config.S)
     (M : Irmin.Metadata.S)
     (C : Irmin.Contents.S)
@@ -59,6 +54,9 @@ module Make
 struct
   module Index = Pack_index.Make (H)
   module Pack = Pack.File (Index) (H) (IO_version)
+  module Dict = Pack_dict.Make (IO_version)
+
+  let current_version = IO_version.io_version
 
   module X = struct
     module Hash = H

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -54,7 +54,12 @@ module Make
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
-  module Pack = Pack.File (Index) (H)
+
+  module Pack =
+    Pack.File (Index) (H)
+      (struct
+        let io_version = current_version
+      end)
 
   module X = struct
     module Hash = H

--- a/src/irmin-pack/ext.mli
+++ b/src/irmin-pack/ext.mli
@@ -15,13 +15,13 @@
  *)
 
 module Pack_config = Config
-module Dict = Pack_dict
 module Index = Pack_index
 
 exception RO_Not_Allowed
 exception Unsupported_version of IO.version
 
 module Make
+    (_ : IO.VERSION)
     (Config : Config.S)
     (Metadata : Irmin.Metadata.S)
     (Contents : Irmin.Contents.S)

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -94,7 +94,11 @@ end
 
 module KV (Config : Config.S) : Irmin.KV_MAKER
 
-module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) : sig
+module Atomic_write
+    (K : Irmin.Type.S)
+    (V : Irmin.Hash.S) (C : sig
+      val io_version : IO.version
+    end) : sig
   include Irmin.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
   val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -43,6 +43,7 @@ exception RO_Not_Allowed
 exception Unsupported_version of IO.version
 
 module Make_ext
+    (_ : IO.VERSION)
     (Config : Config.S)
     (Metadata : Irmin.Metadata.S)
     (Contents : Irmin.Contents.S)
@@ -70,13 +71,14 @@ module Make_ext
   val reconstruct_index : ?output:string -> Irmin.config -> unit
 end
 
-module Make
-    (Config : Config.S)
-    (M : Irmin.Metadata.S)
-    (C : Irmin.Contents.S)
-    (P : Irmin.Path.S)
-    (B : Irmin.Branch.S)
-    (H : Irmin.Hash.S) : sig
+module type MAKER = functor
+  (Config : Config.S)
+  (M : Irmin.Metadata.S)
+  (C : Irmin.Contents.S)
+  (P : Irmin.Path.S)
+  (B : Irmin.Branch.S)
+  (H : Irmin.Hash.S)
+  -> sig
   include
     Irmin.S
       with type key = P.t
@@ -92,13 +94,11 @@ module Make
   val reconstruct_index : ?output:string -> Irmin.config -> unit
 end
 
+module Make : MAKER
+module Make_V2 : MAKER
 module KV (Config : Config.S) : Irmin.KV_MAKER
 
-module Atomic_write
-    (K : Irmin.Type.S)
-    (V : Irmin.Hash.S) (C : sig
-      val io_version : IO.version
-    end) : sig
+module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) (_ : IO.VERSION) : sig
   include Irmin.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
   val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -63,7 +63,12 @@ module Make_ext
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
-  module Pack = Pack.File (Index) (H)
+
+  module Pack =
+    Pack.File (Index) (H)
+      (struct
+        let io_version = current_version
+      end)
 
   type store_handle =
     | Commit_t : H.t -> store_handle

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -28,6 +28,11 @@ open Irmin_pack
 open Private
 
 let current_version = `V2
+
+module IO_version = struct
+  let io_version = current_version
+end
+
 let pp_version = IO.pp_version
 let ( -- ) = Int64.sub
 
@@ -63,12 +68,7 @@ module Make_ext
     (Commit : Irmin.Private.Commit.S with type hash = H.t) =
 struct
   module Index = Pack_index.Make (H)
-
-  module Pack =
-    Pack.File (Index) (H)
-      (struct
-        let io_version = current_version
-      end)
+  module Pack = Pack.File (Index) (H) (IO_version)
 
   type store_handle =
     | Commit_t : H.t -> store_handle
@@ -161,7 +161,7 @@ struct
     module Branch = struct
       module Key = B
       module Val = H
-      module AW = Atomic_write (Key) (Val)
+      module AW = Atomic_write (Key) (Val) (IO_version)
       module Closeable_AW = Closeable.Atomic_write (AW)
       include Layered_store.Atomic_write (Key) (Closeable_AW) (Closeable_AW)
     end

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -54,8 +54,11 @@ struct
 
   let clear ?keep_generation t =
     Index.clear t.index;
-    IO.clear ?keep_generation t.block;
-    Dict.clear t.dict
+    match current_version with
+    | `V1 -> IO.truncate t.block
+    | `V2 ->
+        IO.clear ?keep_generation t.block;
+        Dict.clear t.dict
 
   let valid t =
     if t.open_instances <> 0 then (

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -33,18 +33,17 @@ end)
 
 module File
     (Index : Pack_index.S)
-    (K : Irmin.Hash.S with type t = Index.key) (C : sig
-      val io_version : IO.version
-    end) =
+    (K : Irmin.Hash.S with type t = Index.key)
+    (IO_version : IO.VERSION) =
 struct
   module IO_cache = IO.Cache
   module IO = IO.Unix
   module Tbl = Table (K)
-  module Dict = Pack_dict
+  module Dict = Pack_dict.Make (IO_version)
 
   type index = Index.t
 
-  let current_version = C.io_version
+  let current_version = IO_version.io_version
 
   type 'a t = {
     mutable block : IO.t;

--- a/src/irmin-pack/pack_dict.ml
+++ b/src/irmin-pack/pack_dict.ml
@@ -10,14 +10,22 @@
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
-include Dict.Make (IO.Unix)
+module type S = sig
+  include Dict.S
 
-(* Add IO caching around Dict.v *)
-let IO.Cache.{ v } =
-  let v_no_cache ~fresh ~readonly = v ~fresh ~readonly in
-  IO.Cache.memoize ~clear ~valid
-    ~v:(fun capacity -> v_no_cache ~capacity)
-    Layout.dict
+  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
+end
 
-let v ?fresh ?readonly ?(capacity = 100_000) root =
-  v capacity ?fresh ?readonly root
+module Make (Io_version : IO.VERSION) = struct
+  include Dict.Make (Io_version) (IO.Unix)
+
+  (* Add IO caching around Dict.v *)
+  let IO.Cache.{ v } =
+    let v_no_cache ~fresh ~readonly = v ~fresh ~readonly in
+    IO.Cache.memoize ~clear ~valid
+      ~v:(fun capacity -> v_no_cache ~capacity)
+      Layout.dict
+
+  let v ?fresh ?readonly ?(capacity = 100_000) root =
+    v capacity ?fresh ?readonly root
+end

--- a/src/irmin-pack/pack_dict.mli
+++ b/src/irmin-pack/pack_dict.mli
@@ -10,6 +10,10 @@
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
-include Dict.S
+module type S = sig
+  include Dict.S
 
-val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
+  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
+end
+
+module Make (_ : IO.VERSION) : S

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -104,7 +104,6 @@ module type Pack = sig
 
   module File
       (Index : Pack_index.S)
-      (K : Irmin.Hash.S with type t = Index.key) (C : sig
-        val io_version : IO.version
-      end) : MAKER with type key = K.t and type index = Index.t
+      (K : Irmin.Hash.S with type t = Index.key)
+      (_ : IO.VERSION) : MAKER with type key = K.t and type index = Index.t
 end

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -102,6 +102,9 @@ module type Pack = sig
   module type S = S
   module type MAKER = MAKER
 
-  module File (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
-    MAKER with type key = K.t and type index = Index.t
+  module File
+      (Index : Pack_index.S)
+      (K : Irmin.Hash.S with type t = Index.key) (C : sig
+        val io_version : IO.version
+      end) : MAKER with type key = K.t and type index = Index.t
 end

--- a/src/irmin-pack/store.ml
+++ b/src/irmin-pack/store.ml
@@ -151,9 +151,12 @@ struct
 
   let unsafe_clear ?keep_generation t =
     Lwt.async (fun () -> W.clear t.w);
-    IO.clear ?keep_generation t.block;
-    Tbl.clear t.cache;
-    Tbl.clear t.index
+    match current_version with
+    | `V1 -> IO.truncate t.block
+    | `V2 ->
+        IO.clear ?keep_generation t.block;
+        Tbl.clear t.cache;
+        Tbl.clear t.index
 
   let clear t =
     Log.debug (fun l -> l "[branches] clear");

--- a/src/irmin-pack/store.ml
+++ b/src/irmin-pack/store.ml
@@ -26,11 +26,10 @@ let pp_version = IO.pp_version
 
 module Atomic_write
     (K : Irmin.Type.S)
-    (V : Irmin.Hash.S) (C : sig
-      val io_version : IO.version
-    end) =
+    (V : Irmin.Hash.S)
+    (IO_version : IO.VERSION) =
 struct
-  let current_version = C.io_version
+  let current_version = IO_version.io_version
 
   module Tbl = Table (K)
   module W = Irmin.Private.Watch.Make (K) (V)

--- a/src/irmin-pack/store_intf.ml
+++ b/src/irmin-pack/store_intf.ml
@@ -39,11 +39,8 @@ end
 module type Store = sig
   module type S = S
 
-  module Atomic_write
-      (K : Irmin.Type.S)
-      (V : Irmin.Hash.S) (C : sig
-        val io_version : IO.version
-      end) : S.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
+  module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) (_ : IO.VERSION) :
+    S.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
   val migrate : Irmin.config -> unit
 

--- a/src/irmin-pack/store_intf.ml
+++ b/src/irmin-pack/store_intf.ml
@@ -39,8 +39,11 @@ end
 module type Store = sig
   module type S = S
 
-  module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) :
-    S.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
+  module Atomic_write
+      (K : Irmin.Type.S)
+      (V : Irmin.Hash.S) (C : sig
+        val io_version : IO.version
+      end) : S.ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
   val migrate : Irmin.config -> unit
 

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -13,7 +13,13 @@ module Store = Irmin_pack.Checks.Make (struct
   module Hash = Hash
 
   module Store =
-    Irmin_pack.Make_ext (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+    Irmin_pack.Make_ext
+      (struct
+        let io_version = `V1
+      end)
+      (Conf)
+      (Irmin.Metadata.None)
+      (Irmin.Contents.String)
       (Path)
       (Irmin.Branch.String)
       (Hash)

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -1,5 +1,8 @@
 open Lwt.Infix
-module Dict = Irmin_pack.Dict
+
+module Dict = Irmin_pack.Dict.Make (struct
+  let io_version = `V2
+end)
 
 let ( let* ) x f = Lwt.bind x f
 let get = function Some x -> x | None -> Alcotest.fail "None"

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -42,7 +42,13 @@ end
 module H = Irmin.Hash.SHA1
 module I = Index
 module Index = Irmin_pack.Index.Make (H)
-module P = Irmin_pack.Pack.File (Index) (H)
+
+module P =
+  Irmin_pack.Pack.File (Index) (H)
+    (struct
+      let io_version = `V2
+    end)
+
 module Pack = P.Make (S)
 module Branch = Irmin_pack.Atomic_write (Irmin.Branch.String) (H)
 

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -1,4 +1,4 @@
-module Dict = Irmin_pack.Dict
+module Dict : Irmin_pack.Dict.S
 module H = Irmin.Hash.SHA1
 module I = Index
 

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -34,7 +34,7 @@ module Store =
     (Hash)
 
 module StoreSimple =
-  Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Make_V2 (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -16,11 +16,26 @@ end
 
 module Hash = Irmin.Hash.SHA1
 
-module S =
-  Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
-    (Irmin.Path.String_list)
-    (Irmin.Branch.String)
-    (Hash)
+module S = struct
+  module P = Irmin.Path.String_list
+  module M = Irmin.Metadata.None
+  module XNode = Irmin.Private.Node.Make (Hash) (P) (M)
+  module XCommit = Irmin.Private.Commit.Make (Hash)
+
+  include
+    Irmin_pack.Make_ext
+      (struct
+        let io_version = `V2
+      end)
+      (Conf)
+      (M)
+      (Irmin.Contents.String)
+      (P)
+      (Irmin.Branch.String)
+      (Hash)
+      (XNode)
+      (XCommit)
+end
 
 let config ?(readonly = false) ?(fresh = true) root =
   Irmin_pack.config ~readonly ?index_log_size ~fresh root

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -152,7 +152,7 @@ end
 module Hash = Irmin.Hash.SHA1
 
 module Make () =
-  Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack.Make_V2 (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -544,6 +544,9 @@ end
 module Branch = struct
   module Branch =
     Irmin_pack.Atomic_write (Irmin.Branch.String) (Irmin.Hash.SHA1)
+      (struct
+        let io_version = `V1
+      end)
 
   let pp_hash = Irmin.Type.pp Irmin.Hash.SHA1.t
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -24,11 +24,34 @@ end
 
 let test_dir = Filename.concat "_build" "test-db-pack"
 
+module Irmin_pack_maker
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) =
+struct
+  module XNode = Irmin.Private.Node.Make (H) (P) (M)
+  module XCommit = Irmin.Private.Commit.Make (H)
+
+  include
+    Irmin_pack.Make_ext
+      (struct
+        let io_version = `V2
+      end)
+      (Config)
+      (M)
+      (C)
+      (P)
+      (B)
+      (H)
+      (XNode)
+      (XCommit)
+end
+
 let suite =
   let store =
-    Irmin_test.store
-      (module Irmin_pack.Make (Config))
-      (module Irmin.Metadata.None)
+    Irmin_test.store (module Irmin_pack_maker) (module Irmin.Metadata.None)
   in
   let layered_store =
     Irmin_test.layered_store
@@ -545,7 +568,7 @@ module Branch = struct
   module Branch =
     Irmin_pack.Atomic_write (Irmin.Branch.String) (Irmin.Hash.SHA1)
       (struct
-        let io_version = `V1
+        let io_version = `V2
       end)
 
   let pp_hash = Irmin.Type.pp Irmin.Hash.SHA1.t


### PR DESCRIPTION
During the 2.2.0 → 2.3.0 transition, we added a generation number header to the Pack file in order to support a `clear` operation needed by `irmin-layers`.

At the time, we broke compatibility with pre-2.3.0 stores and provided an automatic migration. However, since the next release of Tezos will not use the layered stores – at least by default – it's helpful to have access to V1-era pack files so as to not force an unnecessary migration on Tezos users. This PR does this in the simplest way I could imagine: having the `Pack.File` functor take an IO version to use, which is set to `V1` in `irmin-pack` and `V2` in `irmin-pack.layered`.