### PR TITLE
Add paginated lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - **irmin-git**
   - Update `irmin` to the last version of `ocaml-git` (#1065)
     It fixes an issue on serialization/deserialization of big tree object
-    (see #1001) 
+    (see #1001)
 
 - **irmin-pack***
   - Fix a major bug in the LRU which was never used (#1035, @samoht)
@@ -23,7 +23,7 @@
     (#1174, @Ngoguey42, @samoht and @CraigFe )
 
   - Fix `Tree.kind`. Empty path on a tree used to return a None instead of a
-	`` `Node``. (#1218, @Ngoguey42)
+    `` `Node``. (#1218, @Ngoguey42)
 
 - **ppx_irmin**
   - Fix a bug causing certain type derivations to be incorrect due to unsound
@@ -45,8 +45,8 @@
     (#1146, @gs0510)
 
 - **irmin**
-  - Added `Tree.{Contents,Node}` modules exposing operations over lazy tree
-    contents and nodes respectively. (#1022, @CraigFe)
+  - Added `Tree.Contents` module exposing operations over lazy tree contents.
+    (#1022 #1241, @CraigFe @samoht)
 
   - Added `Type.Unboxed.{encode_bin,decode_bin,size_of}` to work with unboxed
     values (#1030, @samoht)
@@ -141,6 +141,11 @@
 
   - Make `Tree.fold` more expressive and ensure it uses a bounded memory
     (#1169, @samoht)
+
+  - Changed `list` and `Tree.list` to take optional `offset` and `length`
+    arguments to help with pagination. Also return direct pointers to the
+    subtrees to speed up subsequent accesses (#1241, @samoht, @zshipko,
+    @CraigFe, @Ngoguey42 and @icristescu)
 
 - **irmin-pack**:
   - `sync` has to be called by the read-only instance to synchronise with the

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -308,17 +308,12 @@ struct
                 ~args:[]
                 ~resolve:(fun _ (tree, tree_key) ->
                   Store.Tree.list tree Store.Key.empty
-                  >>= Lwt_list.map_p (fun (step, kind) ->
-                          let relative_key = Store.Key.v [ step ] in
+                  >|= List.map (fun (step, tree) ->
                           let absolute_key = Store.Key.rcons tree_key step in
-                          match kind with
-                          | `Contents ->
-                              Store.Tree.get_all tree relative_key
-                              >|= fun (c, m) ->
+                          match Store.Tree.destruct tree with
+                          | `Contents (c, m) ->
                               Lazy.(force contents_as_node (c, m, absolute_key))
-                          | `Node ->
-                              Store.Tree.get_tree tree relative_key >|= fun t ->
-                              Lazy.(force tree_as_node (t, absolute_key)))
+                          | _ -> Lazy.(force tree_as_node (tree, absolute_key)))
                   >>= fun r -> Lwt.return (Ok r));
             ]))
 

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -136,7 +136,10 @@ module KV_RO (G : Git.S) = struct
       let l =
         List.map
           (fun (s, k) ->
-            (s, match k with `Contents -> `Value | `Node -> `Dictionary))
+            ( s,
+              match S.Tree.destruct k with
+              | `Contents _ -> `Value
+              | `Node _ -> `Dictionary ))
           l
       in
       Ok l

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -194,9 +194,9 @@ let list =
              S.list t (key S.Key.t path) >>= fun paths ->
              let pp_step = Irmin.Type.pp S.Key.step_t in
              let pp ppf (s, k) =
-               match k with
-               | `Contents -> Fmt.pf ppf "FILE %a" pp_step s
-               | `Node -> Fmt.pf ppf "DIR  %a" pp_step s
+               match S.Tree.destruct k with
+               | `Contents _ -> Fmt.pf ppf "FILE %a" pp_step s
+               | `Node _ -> Fmt.pf ppf "DIR  %a" pp_step s
              in
              List.iter (print "%a" pp) paths;
              Lwt.return_unit )
@@ -225,11 +225,11 @@ let tree =
                    Lwt_list.iter_p
                      (fun (s, c) ->
                        let k = S.Key.rcons k s in
-                       match c with
-                       | `Node ->
+                       match S.Tree.destruct c with
+                       | `Node _ ->
                            todo := k :: !todo;
                            Lwt.return_unit
-                       | `Contents ->
+                       | `Contents _ ->
                            S.get t k >|= fun v -> all := (k, v) :: !all)
                      childs
                    >>= walk

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -254,8 +254,9 @@ module type NODE = sig
   val v : (step * value) list -> t
   (** [create l] is a new node. *)
 
-  val list : t -> (step * value) list
-  (** [list t] is the contents of [t]. *)
+  val list : ?offset:int -> ?length:int -> t -> (step * value) list
+  (** [list t] is the contents of [t]. [offset] and [length] are used to
+      paginate results.*)
 
   val empty : t
   (** [empty] is the empty node. *)

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -372,7 +372,7 @@ module type S = sig
   val kind : t -> key -> [ `Contents | `Node ] option Lwt.t
   (** [kind] is {!Tree.kind} applied to [t]'s root tree. *)
 
-  val list : t -> key -> (step * [ `Contents | `Node ]) list Lwt.t
+  val list : t -> key -> (step * tree) list Lwt.t
   (** [list t] is {!Tree.list} applied to [t]'s root tree. *)
 
   val mem : t -> key -> bool Lwt.t

--- a/test/irmin-pack/cli/stat.t/run.t
+++ b/test/irmin-pack/cli/stat.t/run.t
@@ -83,4 +83,4 @@ Running stat on a layered store after a first freeze
 Running check on a layered store that is not self contained
 
   $ PACK_LAYERED=true ../irmin_fsck.exe check ../data/layered_pack_upper
-  Error -- Upper layer is not self contained for heads ff696e4f06f0b156e542c77d8b35a8419158b00c22168154a4b004684e36dbe8cd3e30de3b9e2c7e2d1acd07bed152bd65a79c349e4aacccdb379ea621e9be40: 2 phantom objects detected
+  Error -- Upper layer is not self contained for heads 6a88b83f76c48b1b20a0d421c73de6e0e0e42553d44a40fccc07af074f304e0d9f10a7b5ab47b61205da0f2f599d2ebb1bf27452c05b926b0c7ef8f867778130: 2 phantom objects detected


### PR DESCRIPTION
This PR adds paginated lists. 

The element order of `list` is not specified anymore (as the paginated lists will fold over the underlying structure) but it is guaranteed to be stable. 