### PR TITLE
Add test for wide nodes

### DIFF
--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1332,6 +1332,72 @@ module Make (S : S) = struct
     in
     run x test
 
+  let test_wide_nodes x () =
+    let test repo =
+      let size = 500_000 in
+      let c0 = S.Tree.empty in
+      let rec wide_node i c =
+        if i >= size then Lwt.return c
+        else
+          S.Tree.add c [ "foo"; string_of_int i ] (string_of_int i) >>= fun c ->
+          wide_node (i + 1) c
+      in
+      wide_node 0 c0 >>= fun c ->
+      S.Tree.list c [ "foo" ] >>= fun ls ->
+      Alcotest.(check int) "list wide dir" size (List.length ls);
+      S.Tree.fold ~force:`True c ~uniq:`False
+        ~contents:(fun k _ i ->
+          Alcotest.(check int) "contents at [foo; i]" (List.length k) 2;
+          Lwt.return (i + 1))
+        ~node:(fun k _ i ->
+          if not (List.length k = 0 || List.length k = 1) then
+            Alcotest.failf "nodes should be at [] and [foo], got %a"
+              (Irmin.Type.pp S.key_t) k;
+          Lwt.return i)
+        0
+      >>= fun nb_contents ->
+      Alcotest.(check int) "nb of contents folded over" size nb_contents;
+      S.Tree.remove c [ "foo"; "499999" ] >>= fun c1 ->
+      S.Tree.add c0 [] "499999" >>= fun c2 ->
+      S.Tree.add_tree c1 [ "foo"; "499999" ] c2 >>= fun c' ->
+      let h' = S.Tree.hash c' in
+      let h = S.Tree.hash c in
+      check S.Hash.t "same tree" h h';
+      S.Tree.get_tree c [ "foo" ] >>= fun c1 ->
+      (match S.Tree.destruct c1 with
+      | `Contents _ -> Alcotest.fail "got `Contents, expected `Node"
+      | `Node node -> (
+          S.to_private_node node >>= function
+          | Ok v -> (
+              let ls = P.Node.Val.list v in
+              Alcotest.(check int) "list wide node" size (List.length ls);
+              let k = normal (P.Contents.Key.hash "bar") in
+              let v1 = P.Node.Val.add v "x" k in
+              let h' = H_node.hash v1 in
+              with_node repo (fun n -> P.Node.add n v1) >>= fun h ->
+              check H_node.t "wide node + x: hash(v) = add(v)" h h';
+              let v2 = P.Node.Val.add v "x" k in
+              check P.Node.Val.t "add x" v1 v2;
+              let v0 = P.Node.Val.remove v1 "x" in
+              check P.Node.Val.t "remove x" v v0;
+              let v3 = P.Node.Val.remove v "1" in
+              let h' = H_node.hash v3 in
+              with_node repo (fun n -> P.Node.add n v3) >|= fun h ->
+              check H_node.t "wide node - 1 : hash(v) = add(v)" h h';
+              (match P.Node.Val.find v "499999" with
+              | None -> Alcotest.fail "value 499999 not found"
+              | Some x ->
+                  let x' = normal (P.Contents.Key.hash "499999") in
+                  check P.Node.Val.value_t "find 499999" x x');
+              match P.Node.Val.find v "500000" with
+              | None -> ()
+              | Some _ -> Alcotest.fail "value 500000 should not be found")
+          | Error (`Dangling_hash _) ->
+              Alcotest.fail "unexpected dangling hash in wide node"))
+      >>= fun () -> P.Repo.close repo
+    in
+    run x test
+
   module Sync = Irmin.Sync (S)
 
   let test_sync x () =
@@ -1861,6 +1927,7 @@ let suite (speed, x) =
       ("Shallow objects", speed, T.test_shallow_objects x);
       ("Closure with disconnected commits", speed, T.test_closure x);
       ("Clear", speed, T.test_clear x);
+      ("Wide nodes", `Slow, T.test_wide_nodes x);
     ]
     @ List.map (fun (n, test) -> ("Graph." ^ n, speed, test x)) T_graph.tests
     @ List.map (fun (n, test) -> ("Watch." ^ n, speed, test x)) T_watch.tests )


### PR DESCRIPTION
As suggested in https://github.com/mirage/irmin/pull/1241#discussion_r555676980. A bit late for https://github.com/mirage/irmin/pull/1241, but could be useful for future inode/tree refactoring. 

However, it takes around 4 minutes to run for irmin-pack, so I marked it `Slow`. (I tried smaller nodes, but they don't trigger stack overflow for incorrect usage of `List.map`.)