### PR TITLE
Print inodes

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -316,6 +316,8 @@ struct
     let length t =
       match t.v with Values vs -> StepMap.cardinal vs | Inodes vs -> vs.length
 
+    let stable t = t.stable
+
     let get_tree ~find t =
       match t.tree with
       | Some t -> t
@@ -734,7 +736,11 @@ struct
       in
       Irmin.Type.map I.t ~pre_hash (fun v -> { find = niet; v }) (fun t -> t.v)
 
-    let hash t = I.hash t.v
+    module Private = struct
+      let hash t = I.hash t.v
+      let stable t = I.stable t.v
+      let length t = I.length t.v
+    end
   end
 end
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -722,6 +722,8 @@ struct
           pre_hash_node (Node.v vs)
       in
       Irmin.Type.map I.t ~pre_hash (fun v -> { find = niet; v }) (fun t -> t.v)
+
+    let hash t = I.hash t.v
   end
 end
 

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -14,6 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module type Val_intf = sig
+  include Irmin.Private.Node.S
+
+  val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+
+  module Private : sig
+    val hash : t -> hash
+    val stable : t -> bool
+    val length : t -> int
+  end
+end
+
 module type S = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
 
@@ -30,14 +42,7 @@ module type S = sig
   val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
 
   module Key : Irmin.Hash.S with type t = key
-
-  module Val : sig
-    include Irmin.Private.Node.S with type t = value and type hash = key
-
-    val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
-    val hash : t -> hash
-  end
-
+  module Val : Val_intf with type t = value and type hash = key
   include S.CHECKABLE with type 'a t := 'a t and type key := key
   include S.CLOSEABLE with type 'a t := 'a t
 
@@ -72,10 +77,7 @@ module type INTER = sig
     type nonrec hash = hash
     type t = { find : hash -> Val_impl.t option; v : Val_impl.t }
 
-    include Irmin.Private.Node.S with type hash := hash and type t := t
-
-    val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
-    val hash : t -> hash
+    include Val_intf with type hash := hash and type t := t
   end
 end
 

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -23,6 +23,7 @@ module type Val_intf = sig
     val hash : t -> hash
     val stable : t -> bool
     val length : t -> int
+    val pp : ?nomore : bool -> t -> unit
   end
 end
 

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -35,6 +35,7 @@ module type S = sig
     include Irmin.Private.Node.S with type t = value and type hash = key
 
     val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+    val hash : t -> hash
   end
 
   include S.CHECKABLE with type 'a t := 'a t and type key := key
@@ -74,6 +75,7 @@ module type INTER = sig
     include Irmin.Private.Node.S with type hash := hash and type t := t
 
     val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+    val hash : t -> hash
   end
 end
 

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -90,3 +90,4 @@ module Private = struct
 end
 
 module Config = Config
+module Inode = Inode

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -18,6 +18,7 @@ module Pack = Pack
 module Dict = Pack_dict
 module Index = Pack_index
 module Config = Config
+module Inode = Inode
 
 val config :
   ?fresh:bool ->

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -126,6 +126,11 @@ module Alcotest = struct
               "Fail %s: expected function to raise %s, but it raised %s \
                instead."
               msg (Printexc.to_string exn) (Printexc.to_string e))
+
+  let testable_repr t =
+    Alcotest.testable (Irmin.Type.pp t) Irmin.Type.(unstage (equal t))
+
+  let check_repr t = Alcotest.check (testable_repr t)
 end
 
 module Filename = struct

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -18,6 +18,7 @@ module Alcotest : sig
   include module type of Alcotest
 
   val check_raises_lwt : string -> exn -> (unit -> _ Lwt.t) -> unit Lwt.t
+  val check_repr : 'a Irmin.Type.t -> string -> 'a -> 'a -> unit
 end
 
 module Index : Irmin_pack.Index.S with type key = H.t
@@ -27,6 +28,11 @@ module Pack :
     with type key = H.t
      and type value = string
      and type index = Index.t
+
+module P :
+  Irmin_pack.Pack.MAKER
+    with type key = H.t
+     and type index = Irmin_pack.Index.Make(H).t
 
 (** Helper constructors for fresh pre-initialised dictionaries and packs *)
 module Make_context (Config : sig

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -1,6 +1,7 @@
 (library
  (name test_pack)
- (modules test_pack multiple_instances test_existing_stores layered)
+ (modules test_pack multiple_instances test_existing_stores layered
+   test_inode)
  (libraries alcotest fmt common index irmin irmin-test irmin-pack
    irmin-pack.layered logs lwt lwt.unix fpath))
 

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -133,8 +133,11 @@ let test_remove_inodes () =
     Inode.Val.v [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
   in
   check_hardcoded_hash "hash v1" "9e455b571805ec9d3404d9ac86009757382db687" v1;
+  Private.pp v1;
   let v2 = Inode.Val.remove v1 "x" in
+  Private.pp v2;
   let v3 = Inode.Val.v [ ("y", normal bar); ("z", normal foo) ] in
+  Private.pp ~nomore:true v3;
   check_values "node y+z obtained two ways" v2 v3;
   check_hardcoded_hash "hash v2" "75d043f00ef5368e667eaf768f89a35addf73fb9" v2;
   let v4 =

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -1,0 +1,147 @@
+open Lwt.Infix
+open Common
+
+let root = Filename.concat "_build" "test-inode"
+let src = Logs.Src.create "tests.instances" ~doc:"Tests"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Conf = struct
+  let entries = 2
+  let stable_hash = 3
+end
+
+let log_size = 1000
+
+module Path = Irmin.Path.String_list
+module Metadata = Irmin.Metadata.None
+module Node = Irmin.Private.Node.Make (H) (Path) (Metadata)
+module Index = Irmin_pack.Index.Make (H)
+module Inode = Irmin_pack.Inode.Make (Conf) (H) (P) (Node)
+
+module Context = struct
+  type t = {
+    index : Index.t;
+    store : [ `Read ] Inode.t;
+    clone : readonly:bool -> [ `Read ] Inode.t Lwt.t;
+  }
+
+  let get_store ?(lru_size = 0) () =
+    rm_dir root;
+    let index = Index.v ~log_size ~fresh:true root in
+    Inode.v ~fresh:true ~lru_size ~index root >|= fun store ->
+    let clone ~readonly =
+      Inode.v ~lru_size ~fresh:false ~readonly ~index root
+    in
+
+    { index; store; clone }
+
+  let close t =
+    Index.close t.index;
+    Inode.close t.store
+end
+
+module H_contents =
+  Irmin.Hash.Typed
+    (H)
+    (struct
+      type t = string
+
+      let t = Irmin.Type.string
+    end)
+
+let normal x = `Contents (x, Metadata.default)
+let foo = H_contents.hash "foo"
+let bar = H_contents.hash "bar"
+let check_hash = Alcotest.check_repr Inode.Val.hash_t
+let check_values = Alcotest.check_repr Inode.Val.t
+
+let check_node msg v t =
+  let h = Inode.Val.hash v in
+  Inode.batch t.Context.store (fun i -> Inode.add i v) >|= fun h' ->
+  check_hash msg h h'
+
+(** Test add values from an empty node. *)
+let test_add_values () =
+  rm_dir root;
+  Context.get_store () >>= fun t ->
+  check_node "hash empty node" Inode.Val.empty t >>= fun () ->
+  let v1 = Inode.Val.add Inode.Val.empty "x" (normal foo) in
+  let v2 = Inode.Val.add v1 "y" (normal bar) in
+  check_node "node x y" v1 t >>= fun () ->
+  let v3 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
+  check_values "add x+y vs v x+y" v2 v3;
+  Context.close t
+
+(** Test add to inodes. *)
+let test_add_inodes () =
+  rm_dir root;
+  Context.get_store () >>= fun t ->
+  let v1 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
+  let v2 = Inode.Val.add v1 "z" (normal foo) in
+  let v3 =
+    Inode.Val.v [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
+  in
+  check_values "add x+y+z vs v x+z+y" v2 v3;
+  let v4 = Inode.Val.add v2 "a" (normal foo) in
+  let v5 =
+    Inode.Val.v
+      [
+        ("x", normal foo);
+        ("z", normal foo);
+        ("a", normal foo);
+        ("y", normal bar);
+      ]
+  in
+  check_values "add x+y+z+a vs v x+z+a+y" v4 v5;
+  Context.close t
+
+(** Test remove values on an empty node. *)
+let test_remove_values () =
+  rm_dir root;
+  Context.get_store () >>= fun t ->
+  let v1 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
+  let v2 = Inode.Val.remove v1 "y" in
+  let v3 = Inode.Val.v [ ("x", normal foo) ] in
+  check_values "node x obtained two ways" v2 v3;
+  let v4 = Inode.Val.remove v2 "x" in
+  check_node "remove results in an empty node" Inode.Val.empty t >>= fun () ->
+  let v5 = Inode.Val.remove v4 "x" in
+  check_values "remove on an already empty node" v4 v5;
+  Alcotest.(check bool) "v5 is empty" (Inode.Val.is_empty v5) true;
+  Context.close t
+
+(** Test remove and add values to go from stable to unstable inodes. *)
+let test_remove_inodes () =
+  rm_dir root;
+  Context.get_store () >>= fun t ->
+  let v1 =
+    Inode.Val.v [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
+  in
+  let v2 = Inode.Val.remove v1 "x" in
+  let v3 = Inode.Val.v [ ("y", normal bar); ("z", normal foo) ] in
+  check_values "node y+z obtained two ways" v2 v3;
+  let v4 =
+    Inode.Val.v
+      [
+        ("x", normal foo);
+        ("z", normal foo);
+        ("a", normal foo);
+        ("y", normal bar);
+      ]
+  in
+  let v5 = Inode.Val.remove v4 "a" in
+  check_values "node x+y+z obtained two ways" v1 v5;
+  Context.close t
+
+let tests =
+  [
+    Alcotest.test_case "add values" `Quick (fun () ->
+        Lwt_main.run (test_add_values ()));
+    Alcotest.test_case "add values to inodes" `Quick (fun () ->
+        Lwt_main.run (test_add_inodes ()));
+    Alcotest.test_case "remove values" `Quick (fun () ->
+        Lwt_main.run (test_remove_values ()));
+    Alcotest.test_case "remove inodes" `Quick (fun () ->
+        Lwt_main.run (test_remove_inodes ()));
+  ]

--- a/test/irmin-pack/test_inode.mli
+++ b/test/irmin-pack/test_inode.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -659,4 +659,5 @@ let misc =
     ("instances", Multiple_instances.tests);
     ("existing stores", Test_existing_stores.tests);
     ("layers", Layered.tests);
+    ("inodes", Test_inode.tests);
   ]


### PR DESCRIPTION
Pretty-print inodes to display them in tests and see immediately where they differ (if they differ) and other informations

Since hashes take a lot of brain-parsing time for nothing a Hashtbl is created and each hash is replaced by an unique identifier. The Hashtbl can be displayed by calling the `pp` function with `~nomore:true` and a dummy inode (not a huge fan but couldn't find a better way to do it in the meantime)