### PR TITLE
ppx_irmin: remove unnecessary dependencies

### DIFF
--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -14,8 +14,6 @@ build: [
 
 depends: [
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.08.0"}
-  "ppxlib" {>= "0.12.0" & < "0.18.0"}
   "ppx_repr" {>= "0.2.0"}
   "irmin" {with-test & post & = version}
 ]

--- a/src/ppx_irmin/dune
+++ b/src/ppx_irmin/dune
@@ -2,4 +2,4 @@
  (public_name ppx_irmin)
  (modules ppx_irmin)
  (kind ppx_deriver)
- (libraries ppx_repr.lib ppxlib))
+ (libraries ppx_repr.lib))


### PR DESCRIPTION
These are a hold over from before the extraction of `ppx_repr`, and are no longer accurate thanks to https://github.com/mirage/repr/pull/35.