### PR TITLE
Define store handle permissions in a central location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
   - Added benchmarks for trees operations. (#1237, @icristescu, @Ngoguey42,
   @Craigfe)
 
+- **irmin**
+  - Added a `Perms` module containing helper types for using phantom-typed
+    capabilities as used by the store backends. (#1262, @CraigFe)
+
+  - Added an `Exported_for_stores` module containing miscellaneous helper types
+    for building backends. (#1262, @CraigFe)
+
 #### Changed
 
 ### 2.3.0 (2020-01-12)

--- a/src/irmin-fs/import.ml
+++ b/src/irmin-fs/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -79,7 +79,7 @@ struct
     IO.mkdir path >|= fun () -> { path }
 
   let close _ = Lwt.return_unit
-  let cast t = (t :> [ `Read | `Write ] t)
+  let cast t = (t :> read_write t)
   let batch t f = f (cast t)
 
   let file_of_key { path; _ } key =

--- a/src/irmin-http/import.ml
+++ b/src/irmin-http/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -233,7 +233,7 @@ module RO (Client : Cohttp_lwt.S.Client) (K : Irmin.Type.S) (V : Irmin.Type.S) :
         if Cohttp.Response.status r = `Not_found then Lwt.return_false
         else Lwt.return_true)
 
-  let cast t = (t :> [ `Read | `Write ] t)
+  let cast t = (t :> read_write t)
 
   let batch t f =
     (* TODO:cache the writes locally and send everything in one batch *)
@@ -491,9 +491,9 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
     module Repo = struct
       type t = {
         config : Irmin.config;
-        contents : [ `Read ] Contents.t;
-        node : [ `Read ] Node.t;
-        commit : [ `Read ] Commit.t;
+        contents : read Contents.t;
+        node : read Node.t;
+        commit : read Commit.t;
         branch : Branch.t;
       }
 

--- a/src/irmin-http/irmin_http_server.ml
+++ b/src/irmin-http/irmin_http_server.ml
@@ -81,7 +81,7 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
   module Content_addressable (S : sig
     include Irmin.CONTENT_ADDRESSABLE_STORE
 
-    val batch : P.Repo.t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
+    val batch : P.Repo.t -> (read_write t -> 'a Lwt.t) -> 'a Lwt.t
   end)
   (K : Irmin.Type.S with type t = S.key)
   (V : Irmin.Type.S with type t = S.value) =

--- a/src/irmin-http/s.ml
+++ b/src/irmin-http/s.ml
@@ -66,7 +66,7 @@ end
 
 module type READ_ONLY_STORE = sig
   type ctx
-  type 'a t = { uri : Uri.t; item : string; items : string; ctx : ctx option }
+  type -'a t = { uri : Uri.t; item : string; items : string; ctx : ctx option }
   type key
   type value
 
@@ -88,7 +88,7 @@ module type READ_ONLY_STORE = sig
 end
 
 module type APPEND_ONLY_STORE = sig
-  type 'a t
+  type -'a t
   type key
   type value
   type ctx

--- a/src/irmin-http/s.ml
+++ b/src/irmin-http/s.ml
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Irmin.Perms
 module T = Irmin.Type
 
 module type HELPER = sig

--- a/src/irmin-layers/import.ml
+++ b/src/irmin-layers/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -95,9 +95,9 @@ struct
     module Repo = struct
       type t = {
         config : Irmin.Private.Conf.t;
-        contents : [ `Read ] Contents.t;
-        nodes : [ `Read ] Node.t;
-        commits : [ `Read ] Commit.t;
+        contents : read Contents.t;
+        nodes : read Node.t;
+        commits : read Commit.t;
         branch : Branch.t;
       }
 

--- a/src/irmin-layers/layered_store.ml
+++ b/src/irmin-layers/layered_store.ml
@@ -14,16 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
+open Store_properties
+
 let src = Logs.Src.create "irmin.layers" ~doc:"Irmin layered store"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module type CA = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
-
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-  val v : Irmin.Private.Conf.t -> [ `Read ] t Lwt.t
-  val close : 'a t -> unit Lwt.t
+  include BATCH with type 'a t := 'a t
+  include OF_CONFIG with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
 end
 
 module Content_addressable

--- a/src/irmin-layers/layered_store.mli
+++ b/src/irmin-layers/layered_store.mli
@@ -14,12 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
+open Store_properties
+
 module type CA = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
-
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-  val v : Irmin.Private.Conf.t -> [ `Read ] t Lwt.t
-  val close : 'a t -> unit Lwt.t
+  include BATCH with type 'a t := 'a t
+  include OF_CONFIG with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
 end
 
 module Content_addressable

--- a/src/irmin-mem/import.ml
+++ b/src/irmin-mem/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin-mem/irmin_mem.ml
+++ b/src/irmin-mem/irmin_mem.ml
@@ -43,7 +43,7 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
     Log.debug (fun f -> f "close");
     Lwt.return_unit
 
-  let cast t = (t :> [ `Read | `Write ] t)
+  let cast t = (t :> read_write t)
   let batch t f = f (cast t)
   let pp_key = Irmin.Type.pp K.t
 

--- a/src/irmin-pack/IO.mli
+++ b/src/irmin-pack/IO.mli
@@ -15,3 +15,4 @@
  *)
 
 include IO_intf.IO
+(** @inline *)

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -143,9 +143,9 @@ struct
     module Repo = struct
       type t = {
         config : Irmin.Private.Conf.t;
-        contents : [ `Read ] Contents.CA.t;
-        node : [ `Read ] Node.CA.t;
-        commit : [ `Read ] Commit.CA.t;
+        contents : read Contents.CA.t;
+        node : read Node.CA.t;
+        commit : read Commit.CA.t;
         branch : Branch.t;
         index : Index.t;
       }

--- a/src/irmin-pack/import.ml
+++ b/src/irmin-pack/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -14,6 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
+open Store_properties
+
 module type Val_intf = sig
   include Irmin.Private.Node.S
 
@@ -38,14 +41,13 @@ module type S = sig
     ?lru_size:int ->
     index:index ->
     string ->
-    [ `Read ] t Lwt.t
+    read t Lwt.t
 
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
+  include BATCH with type 'a t := 'a t
   module Key : Irmin.Hash.S with type t = key
   module Val : Val_intf with type t = value and type hash = key
   include S.CHECKABLE with type 'a t := 'a t and type key := key
-  include S.CLOSEABLE with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
 
   val sync : ?on_generation_change:(unit -> unit) -> 'a t -> unit
   val clear_caches : 'a t -> unit
@@ -84,12 +86,10 @@ end
 
 module type S_EXT = sig
   include Irmin.CONTENT_ADDRESSABLE_STORE
-
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-
+  include BATCH with type 'a t := 'a t
   module Key : Irmin.Hash.S with type t = key
   include S.CHECKABLE with type 'a t := 'a t and type key := key
-  include S.CLOSEABLE with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
 
   val clear_caches : 'a t -> unit
   val hash : value -> key

--- a/src/irmin-pack/layered/IO_layers.ml
+++ b/src/irmin-pack/layered/IO_layers.ml
@@ -15,6 +15,7 @@
  *)
 
 open! Import
+open Store_properties
 
 let src = Logs.Src.create "irmin.layers.io" ~doc:"IO for irmin-layers"
 
@@ -25,7 +26,7 @@ module type S = sig
 
   val v : string -> t Lwt.t
 
-  include S.CLOSEABLE with type _ t := t
+  include CLOSEABLE with type _ t := t
 
   val read_flip : t -> bool Lwt.t
   val write_flip : bool -> t -> unit Lwt.t

--- a/src/irmin-pack/layered/IO_layers.mli
+++ b/src/irmin-pack/layered/IO_layers.mli
@@ -14,12 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
+open Store_properties
+
 module type S = sig
   type t
 
   val v : string -> t Lwt.t
 
-  include S.CLOSEABLE with type _ t := t
+  include CLOSEABLE with type _ t := t
 
   val read_flip : t -> bool Lwt.t
   val write_flip : bool -> t -> unit Lwt.t
@@ -32,7 +35,7 @@ module Lock : sig
 
   val v : string -> t Lwt.t
 
-  include S.CLOSEABLE with type _ t := t
+  include CLOSEABLE with type _ t := t
 
   val unlink : string -> unit Lwt.t
   val test : string -> bool

--- a/src/irmin-pack/layered/import.ml
+++ b/src/irmin-pack/layered/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -107,12 +107,12 @@ struct
   let flush ?index t = P.flush ?index t
 
   type 'a layer_type =
-    | Upper : [ `Read ] U.t layer_type
-    | Lower : [ `Read ] L.t layer_type
+    | Upper : read U.t layer_type
+    | Lower : read L.t layer_type
 
   let copy_from_lower ~dst t = P.copy_from_lower t "Node" ~dst
 
-  let copy : type l. l layer_type * l -> [ `Read ] t -> key -> unit =
+  let copy : type l. l layer_type * l -> read t -> key -> unit =
    fun (layer, dst) t ->
     match layer with
     | Lower -> P.copy (Lower, dst) t "Node"

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -1,3 +1,4 @@
+open! Import
 module Sigs = S
 module Inode = Irmin_pack.Private.Inode
 module Pack = Irmin_pack.Pack
@@ -8,25 +9,25 @@ module type S = sig
   module L : Pack.S
 
   val v :
-    [ `Read ] U.t ->
-    [ `Read ] U.t ->
-    [ `Read ] L.t option ->
+    read U.t ->
+    read U.t ->
+    read L.t option ->
     flip:bool ->
     freeze_in_progress:(unit -> bool) ->
-    [ `Read ] t
+    read t
 
-  val layer_id : [ `Read ] t -> key -> Irmin_layers.Layer_id.t Lwt.t
+  val layer_id : read t -> key -> Irmin_layers.Layer_id.t Lwt.t
 
   type 'a layer_type =
-    | Upper : [ `Read ] U.t layer_type
-    | Lower : [ `Read ] L.t layer_type
+    | Upper : read U.t layer_type
+    | Lower : read L.t layer_type
 
-  val copy : 'l layer_type * 'l -> [ `Read ] t -> key -> unit
+  val copy : 'l layer_type * 'l -> read t -> key -> unit
   val mem_lower : 'a t -> key -> bool Lwt.t
-  val mem_next : [> `Read ] t -> key -> bool Lwt.t
-  val next_upper : 'a t -> [ `Read ] U.t
-  val current_upper : 'a t -> [ `Read ] U.t
-  val lower : 'a t -> [ `Read ] L.t
+  val mem_next : [> read ] t -> key -> bool Lwt.t
+  val next_upper : 'a t -> read U.t
+  val current_upper : 'a t -> read U.t
+  val lower : 'a t -> read L.t
 
   include S.LAYERED_GENERAL with type 'a t := 'a t
 
@@ -47,7 +48,7 @@ module type S = sig
     (unit, S.integrity_error) result
 
   val flush : ?index:bool -> 'a t -> unit
-  val copy_from_lower : dst:'a U.t -> [ `Read ] t -> key -> unit Lwt.t
+  val copy_from_lower : dst:'a U.t -> read t -> key -> unit Lwt.t
   val consume_newies : 'a t -> key list
 
   val check :

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
 module Checks = Checks
 
 let config = Config.v
@@ -171,17 +172,17 @@ struct
 
     module Repo = struct
       type upper_layer = {
-        contents : [ `Read ] Contents.CA.U.t;
-        node : [ `Read ] Node.CA.U.t;
-        commit : [ `Read ] Commit.CA.U.t;
+        contents : read Contents.CA.U.t;
+        node : read Node.CA.U.t;
+        commit : read Commit.CA.U.t;
         branch : Branch.U.t;
         index : Index.t;
       }
 
       type lower_layer = {
-        lcontents : [ `Read ] Contents.CA.L.t;
-        lnode : [ `Read ] Node.CA.L.t;
-        lcommit : [ `Read ] Commit.CA.L.t;
+        lcontents : read Contents.CA.L.t;
+        lnode : read Node.CA.L.t;
+        lcommit : read Commit.CA.L.t;
         lbranch : Branch.L.t;
         lindex : Index.t;
       }
@@ -198,10 +199,10 @@ struct
         blocking_copy_size : int;
         with_lower : bool;
         copy_in_upper : bool;
-        contents : [ `Read ] Contents.CA.t;
-        node : [ `Read ] Node.CA.t;
+        contents : read Contents.CA.t;
+        node : read Node.CA.t;
         branch : Branch.t;
-        commit : [ `Read ] Commit.CA.t;
+        commit : read Commit.CA.t;
         lower_index : Index.t option;
         uppers_index : Index.t * Index.t;
         mutable flip : bool;
@@ -220,19 +221,19 @@ struct
         module Contents = struct
           include Contents.CA
 
-          type t = [ `Read ] Contents.CA.t
+          type t = read Contents.CA.t
         end
 
         module Nodes = struct
           include Node.CA
 
-          type t = [ `Read ] Node.CA.t
+          type t = read Node.CA.t
         end
 
         module Commits = struct
           include Commit.CA
 
-          type t = [ `Read ] Commit.CA.t
+          type t = read Commit.CA.t
         end
 
         type 'a store_fn = {

--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -76,9 +76,9 @@ struct
   type value = U.value
 
   type 'a t = {
-    lower : [ `Read ] L.t option;
+    lower : read L.t option;
     mutable flip : bool;
-    uppers : [ `Read ] U.t * [ `Read ] U.t;
+    uppers : read U.t * read U.t;
     freeze_in_progress : unit -> bool;
     mutable newies : key list;
   }
@@ -184,7 +184,7 @@ struct
     U.flush ~index_merge:true next;
     match t.lower with None -> () | Some x -> L.flush ~index_merge:true x
 
-  let cast t = (t :> [ `Read | `Write ] t)
+  let cast t = (t :> read_write t)
 
   let batch t f =
     f (cast t) >|= fun r ->
@@ -289,8 +289,8 @@ struct
   module CopyLower = Copy (H) (U) (L)
 
   type 'a layer_type =
-    | Upper : [ `Read ] U.t layer_type
-    | Lower : [ `Read ] L.t layer_type
+    | Upper : read U.t layer_type
+    | Lower : read L.t layer_type
 
   let copy_to_lower t ~dst str k =
     CopyLower.copy ~src:(current_upper t) ~dst str k
@@ -301,7 +301,7 @@ struct
   let check t ?none ?some k =
     CopyUpper.check ~src:(current_upper t) ?none ?some k
 
-  let copy : type l. l layer_type * l -> [ `Read ] t -> string -> key -> unit =
+  let copy : type l. l layer_type * l -> read t -> string -> key -> unit =
    fun (ltype, dst) ->
     match ltype with Lower -> copy_to_lower ~dst | Upper -> copy_to_next ~dst
 

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -1,3 +1,5 @@
+open! Import
+open Store_properties
 include Irmin_pack.Private.Sigs
 
 module type STORE = sig
@@ -63,23 +65,23 @@ module type LAYERED_PACK = sig
   module L : S
 
   val v :
-    [ `Read ] U.t ->
-    [ `Read ] U.t ->
-    [ `Read ] L.t option ->
+    read U.t ->
+    read U.t ->
+    read L.t option ->
     flip:bool ->
     freeze_in_progress:(unit -> bool) ->
-    [ `Read ] t
+    read t
 
-  val layer_id : [ `Read ] t -> key -> Irmin_layers.Layer_id.t Lwt.t
+  val layer_id : read t -> key -> Irmin_layers.Layer_id.t Lwt.t
 
   type 'a layer_type =
-    | Upper : [ `Read ] U.t layer_type
-    | Lower : [ `Read ] L.t layer_type
+    | Upper : read U.t layer_type
+    | Lower : read L.t layer_type
 
-  val copy : 'l layer_type * 'l -> [ `Read ] t -> string -> key -> unit
+  val copy : 'l layer_type * 'l -> read t -> string -> key -> unit
 
   val copy_from_lower :
-    [ `Read ] t ->
+    read t ->
     dst:'a U.t ->
     ?aux:(value -> unit Lwt.t) ->
     string ->
@@ -87,10 +89,10 @@ module type LAYERED_PACK = sig
     unit Lwt.t
 
   val mem_lower : 'a t -> key -> bool Lwt.t
-  val mem_next : [> `Read ] t -> key -> bool Lwt.t
-  val current_upper : 'a t -> [ `Read ] U.t
-  val next_upper : 'a t -> [ `Read ] U.t
-  val lower : 'a t -> [ `Read ] L.t
+  val mem_next : [> read ] t -> key -> bool Lwt.t
+  val current_upper : 'a t -> read U.t
+  val next_upper : 'a t -> read U.t
+  val lower : 'a t -> read L.t
   val clear_previous_upper : ?keep_generation:unit -> 'a t -> unit Lwt.t
 
   val sync :

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -227,7 +227,7 @@ struct
       let v = unsafe_find ~check_integrity:true t k in
       Lwt.return v
 
-    let cast t = (t :> [ `Read | `Write ] t)
+    let cast t = (t :> read_write t)
 
     let integrity_check ~offset ~length k t =
       try

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -16,12 +16,6 @@
 
 type integrity_error = [ `Wrong_hash | `Absent_value ]
 
-module type CLOSEABLE = sig
-  type 'a t
-
-  val close : _ t -> unit Lwt.t
-end
-
 module type CHECKABLE = sig
   type 'a t
   type key

--- a/src/irmin/branch_intf.ml
+++ b/src/irmin/branch_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 open S
 
 module type S = sig

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -15,6 +15,7 @@
  *)
 
 open S
+open! Import
 
 module type S = sig
   (** {1 Commit values} *)
@@ -51,7 +52,7 @@ module type STORE = sig
 
   include CONTENT_ADDRESSABLE_STORE
 
-  val merge : [ `Read | `Write ] t -> info:Info.f -> key option Merge.t
+  val merge : [> read_write ] t -> info:Info.f -> key option Merge.t
   (** [merge] is the 3-way merge function for commit keys. *)
 
   (** [Key] provides base functions for commit keys. *)
@@ -80,25 +81,25 @@ module type HISTORY = sig
   (** The type for commit objects. *)
 
   val v :
-    [> `Write ] t ->
+    [> write ] t ->
     node:node ->
     parents:commit list ->
     info:Info.t ->
     (commit * v) Lwt.t
   (** Create a new commit. *)
 
-  val parents : [> `Read ] t -> commit -> commit list Lwt.t
+  val parents : [> read ] t -> commit -> commit list Lwt.t
   (** Get the commit parents.
 
       Commits form a append-only, fully functional, partial-order
       data-structure: every commit carries the list of its immediate
       predecessors. *)
 
-  val merge : [ `Read | `Write ] t -> info:Info.f -> commit Merge.t
+  val merge : [> read_write ] t -> info:Info.f -> commit Merge.t
   (** [merge t] is the 3-way merge function for commit. *)
 
   val lcas :
-    [> `Read ] t ->
+    [> read ] t ->
     ?max_depth:int ->
     ?n:int ->
     commit ->
@@ -109,7 +110,7 @@ module type HISTORY = sig
       commits. *)
 
   val lca :
-    [ `Read | `Write ] t ->
+    [> read_write ] t ->
     info:Info.f ->
     ?max_depth:int ->
     ?n:int ->
@@ -123,7 +124,7 @@ module type HISTORY = sig
       the function returns the same error. *)
 
   val three_way_merge :
-    [ `Read | `Write ] t ->
+    [> read_write ] t ->
     info:Info.f ->
     ?max_depth:int ->
     ?n:int ->
@@ -133,12 +134,12 @@ module type HISTORY = sig
   (** Compute the {!lcas} of the two commit and 3-way merge the result. *)
 
   val closure :
-    [> `Read ] t -> min:commit list -> max:commit list -> commit list Lwt.t
+    [> read ] t -> min:commit list -> max:commit list -> commit list Lwt.t
   (** Same as {{!NODE_GRAPH.closure} NODE_GRAPH.closure} but for the history
       graph. *)
 
   val iter :
-    [> `Read ] t ->
+    [> read ] t ->
     min:node list ->
     max:node list ->
     ?commit:(commit -> unit Lwt.t) ->

--- a/src/irmin/contents_intf.ml
+++ b/src/irmin/contents_intf.ml
@@ -1,3 +1,4 @@
+open! Import
 open S
 
 module type S = sig
@@ -17,7 +18,7 @@ end
 module type STORE = sig
   include CONTENT_ADDRESSABLE_STORE
 
-  val merge : [ `Read | `Write ] t -> key option Merge.t
+  val merge : [> read_write ] t -> key option Merge.t
   (** [merge t] lifts the merge functions defined on contents values to contents
       key. The merge function will: {e (i)} read the values associated with the
       given keys, {e (ii)} use the merge function defined on values and

--- a/src/irmin/contents_intf.ml
+++ b/src/irmin/contents_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 open! Import
 open S
 

--- a/src/irmin/export_for_backends.ml
+++ b/src/irmin/export_for_backends.ml
@@ -1,0 +1,5 @@
+type read = Perms.read
+type write = Perms.write
+type read_write = Perms.read_write
+
+module Store_properties = S.Store_properties

--- a/src/irmin/export_for_backends.ml
+++ b/src/irmin/export_for_backends.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 type read = Perms.read
 type write = Perms.write
 type read_write = Perms.read_write

--- a/src/irmin/hash_intf.ml
+++ b/src/irmin/hash_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module type S = sig
   (** Signature for digest hashes, inspired by Digestif. *)
 

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -1,3 +1,7 @@
+type read = Perms.read
+type write = Perms.write
+type read_write = Perms.read_write
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 type read = Perms.read
 type write = Perms.write
 type read_write = Perms.read_write

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -289,6 +289,7 @@ module Private = struct
   module Commit = Commit
   module Slice = Slice
   module Sync = Sync
+  module Sigs = S
 
   module type S = Private.S
 

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -317,3 +317,4 @@ module Metadata = struct
 end
 
 module Json_tree = Store.Json_tree
+module Export_for_backends = Export_for_backends

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -25,6 +25,7 @@ module Info = Info
 module Dot = Dot.Make
 module Hash = Hash
 module Path = Path
+module Perms = Perms
 
 exception Closed
 
@@ -208,9 +209,9 @@ struct
     module Repo = struct
       type t = {
         config : Conf.t;
-        contents : [ `Read ] Contents.t;
-        nodes : [ `Read ] Node.t;
-        commits : [ `Read ] Commit.t;
+        contents : read Contents.t;
+        nodes : read Node.t;
+        commits : read Commit.t;
         branch : Branch.t;
       }
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -157,6 +157,7 @@ module Private : sig
   module Commit = Commit
   module Slice = Slice
   module Sync = Sync
+  module Sigs = S
 
   module type S = Private.S
   (** The complete collection of private implementations. *)
@@ -471,17 +472,14 @@ module Dot (S : S) : Dot.S with type db = S.t
 module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
   include APPEND_ONLY_STORE with type key = K.t and type value = V.t
 
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-  (** [batch t f] applies the writes in [f] in a separate batch. The exact
-      guarantees depends on the backends. *)
+  include Private.Sigs.BATCH with type 'a t := 'a t
+  (** @inline *)
 
-  val v : config -> [ `Read ] t Lwt.t
-  (** [v config] is a function returning fresh store handles, with the
-      configuration [config], which is provided by the backend. *)
+  include Private.Sigs.OF_CONFIG with type 'a t := 'a t
+  (** @inline *)
 
-  val close : 'a t -> unit Lwt.t
-  (** [close t] frees up all the resources associated to [t]. Any operations run
-      on a closed store will raise {!Closed}. *)
+  include Private.Sigs.CLOSEABLE with type 'a t := 'a t
+  (** @inline *)
 end
 
 (** [CONTENT_ADDRESSABLE_STOREMAKER] is the signature exposed by
@@ -493,17 +491,14 @@ module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   -> sig
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
 
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-  (** [batch t f] applies the writes in [f] in a separate batch. The exact
-      guarantees depends on the backends. *)
+  include Private.Sigs.BATCH with type 'a t := 'a t
+  (** @inline *)
 
-  val v : config -> [ `Read ] t Lwt.t
-  (** [v config] is a function returning fresh store handles, with the
-      configuration [config], which is provided by the backend. *)
+  include Private.Sigs.OF_CONFIG with type 'a t := 'a t
+  (** @inline *)
 
-  val close : 'a t -> unit Lwt.t
-  (** [close t] frees up all the resources associated to [t]. Any operations run
-      on a closed store will raise {!Closed}. *)
+  include Private.Sigs.CLOSEABLE with type 'a t := 'a t
+  (** @inline *)
 end
 
 module Content_addressable
@@ -516,17 +511,14 @@ module Content_addressable
        and type key = K.t
        and type value = V.t
 
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-  (** [batch t f] applies the writes in [f] in a separate batch. The exact
-      guarantees depends on the backends. *)
+  include Private.Sigs.BATCH with type 'a t := 'a t
+  (** @inline *)
 
-  val v : config -> [ `Read ] t Lwt.t
-  (** [v config] is a function returning fresh store handles, with the
-      configuration [config], which is provided by the backend. *)
+  include Private.Sigs.OF_CONFIG with type 'a t := 'a t
+  (** @inline *)
 
-  val close : 'a t -> unit Lwt.t
-  (** [close t] frees up all the resources associated to [t]. Any operations run
-      on a closed store will raise {!Closed}. *)
+  include Private.Sigs.CLOSEABLE with type 'a t := 'a t
+  (** @inline *)
 end
 
 (** [ATOMIC_WRITE_STORE_MAKER] is the signature exposed by atomic-write store
@@ -535,9 +527,8 @@ end
 module type ATOMIC_WRITE_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
   include ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
 
-  val v : config -> t Lwt.t
-  (** [v config] is a function returning fresh store handles, with the
-      configuration [config], which is provided by the backend. *)
+  include Private.Sigs.OF_CONFIG with type _ t := t
+  (** @inline *)
 end
 
 (** Simple store creator. Use the same type of all of the internal keys and

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -471,14 +471,15 @@ module Dot (S : S) : Dot.S with type db = S.t
     values. *)
 module type APPEND_ONLY_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
   include APPEND_ONLY_STORE with type key = K.t and type value = V.t
+  open Private.Sigs.Store_properties
 
-  include Private.Sigs.BATCH with type 'a t := 'a t
+  include BATCH with type 'a t := 'a t
   (** @inline *)
 
-  include Private.Sigs.OF_CONFIG with type 'a t := 'a t
+  include OF_CONFIG with type 'a t := 'a t
   (** @inline *)
 
-  include Private.Sigs.CLOSEABLE with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
   (** @inline *)
 end
 
@@ -490,14 +491,15 @@ module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   (V : Type.S)
   -> sig
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
+  open Private.Sigs.Store_properties
 
-  include Private.Sigs.BATCH with type 'a t := 'a t
+  include BATCH with type 'a t := 'a t
   (** @inline *)
 
-  include Private.Sigs.OF_CONFIG with type 'a t := 'a t
+  include OF_CONFIG with type 'a t := 'a t
   (** @inline *)
 
-  include Private.Sigs.CLOSEABLE with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
   (** @inline *)
 end
 
@@ -511,13 +513,15 @@ module Content_addressable
        and type key = K.t
        and type value = V.t
 
-  include Private.Sigs.BATCH with type 'a t := 'a t
+  open Private.Sigs.Store_properties
+
+  include BATCH with type 'a t := 'a t
   (** @inline *)
 
-  include Private.Sigs.OF_CONFIG with type 'a t := 'a t
+  include OF_CONFIG with type 'a t := 'a t
   (** @inline *)
 
-  include Private.Sigs.CLOSEABLE with type 'a t := 'a t
+  include CLOSEABLE with type 'a t := 'a t
   (** @inline *)
 end
 
@@ -526,8 +530,9 @@ end
     values.*)
 module type ATOMIC_WRITE_STORE_MAKER = functor (K : Type.S) (V : Type.S) -> sig
   include ATOMIC_WRITE_STORE with type key = K.t and type value = V.t
+  open Private.Sigs.Store_properties
 
-  include Private.Sigs.OF_CONFIG with type _ t := t
+  include OF_CONFIG with type _ t := t
   (** @inline *)
 end
 
@@ -573,3 +578,6 @@ module Of_private (P : Private.S) :
      and type repo = P.Repo.t
      and type slice = P.Slice.t
      and module Private = P
+
+module Export_for_backends = Export_for_backends
+(** Helper module containing useful top-level types for defining Irmin backends. *)

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -54,6 +54,8 @@ module Diff = Diff
 type 'a diff = 'a Diff.t
 (** The type for representing differences betwen values. *)
 
+module Perms = Perms
+
 (** {1 Low-level Stores} *)
 
 (** An Irmin store is automatically built from a number of lower-level stores,

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -15,6 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
 open S
 
 module type S = sig
@@ -90,7 +91,7 @@ module type STORE = sig
   module Path : Path.S
   (** [Path] provides base functions on node paths. *)
 
-  val merge : [ `Read | `Write ] t -> key option Merge.t
+  val merge : [> read_write ] t -> key option Merge.t
   (** [merge] is the 3-way merge function for nodes keys. *)
 
   (** [Key] provides base functions for node keys. *)
@@ -135,28 +136,27 @@ module type GRAPH = sig
   type value = [ `Node of node | `Contents of contents * metadata ]
   (** The type for store values. *)
 
-  val empty : [> `Write ] t -> node Lwt.t
+  val empty : [> write ] t -> node Lwt.t
   (** The empty node. *)
 
-  val v : [> `Write ] t -> (step * value) list -> node Lwt.t
+  val v : [> write ] t -> (step * value) list -> node Lwt.t
   (** [v t n] is a new node containing [n]. *)
 
-  val list : [> `Read ] t -> node -> (step * value) list Lwt.t
+  val list : [> read ] t -> node -> (step * value) list Lwt.t
   (** [list t n] is the contents of the node [n]. *)
 
-  val find : [> `Read ] t -> node -> path -> value option Lwt.t
+  val find : [> read ] t -> node -> path -> value option Lwt.t
   (** [find t n p] is the contents of the path [p] starting form [n]. *)
 
-  val add : [ `Read | `Write ] t -> node -> path -> value -> node Lwt.t
+  val add : [> read_write ] t -> node -> path -> value -> node Lwt.t
   (** [add t n p v] is the node [x] such that [find t x p] is [Some v] and it
       behaves the same [n] for other operations. *)
 
-  val remove : [ `Read | `Write ] t -> node -> path -> node Lwt.t
+  val remove : [> read_write ] t -> node -> path -> node Lwt.t
   (** [remove t n path] is the node [x] such that [find t x] is [None] and it
       behhaves then same as [n] for other operations. *)
 
-  val closure :
-    [> `Read ] t -> min:node list -> max:node list -> node list Lwt.t
+  val closure : [> read ] t -> min:node list -> max:node list -> node list Lwt.t
   (** [closure t min max] is the unordered list of nodes [n] reachable from a
       node of [max] along a path which: (i) either contains no [min] or (ii) it
       ends with a [min].
@@ -164,7 +164,7 @@ module type GRAPH = sig
       {b Note:} Both [min] and [max] are subsets of [n]. *)
 
   val iter :
-    [> `Read ] t ->
+    [> read ] t ->
     min:node list ->
     max:node list ->
     ?node:(node -> unit Lwt.t) ->

--- a/src/irmin/object_graph_intf.ml
+++ b/src/irmin/object_graph_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module type S = sig
   include Graph.Sig.I
   (** Directed graph *)

--- a/src/irmin/path_intf.ml
+++ b/src/irmin/path_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module type S = sig
   (** {1 Path} *)
 

--- a/src/irmin/perms.ml
+++ b/src/irmin/perms.ml
@@ -1,0 +1,15 @@
+module Read = struct
+  type t = [ `Read ]
+end
+
+module Write = struct
+  type t = [ `Write ]
+end
+
+module Read_write = struct
+  type t = [ Read.t | Write.t ]
+end
+
+type read = Read.t
+type write = Write.t
+type read_write = Read_write.t

--- a/src/irmin/perms.ml
+++ b/src/irmin/perms.ml
@@ -1,3 +1,32 @@
+(** Types representing {i permissions} ['perms] for performing operations on a
+    certain type ['perms t].
+
+    They are intended to be used as phantom parameters of the types that they
+    control access to. As an example, consider the following type of references
+    with permissions:
+
+    {[
+      module Ref : sig
+        type (+'a, -'perms) t
+
+        val create : 'a -> ('a, read_write) t
+        val get : ('a, [> read ]) t -> 'a
+        val set : ('a, [> write ]) t -> 'a -> unit
+      end
+    ]}
+
+    This type allows references to be created with arbitrary read-write access.
+    One can then create weaker views onto the reference – with access to fewer
+    operations – by upcasting:
+
+    {[
+      let read_only t = (t :> (_, read) Ref.t)
+      let write_only t = (t :> (_, write) Ref.t)
+    ]}
+
+    Note that the ['perms] phantom type parameter should be contravariant: it's
+    safe to discard permissions, but not to gain new ones. *)
+
 module Read = struct
   type t = [ `Read ]
 end
@@ -11,5 +40,10 @@ module Read_write = struct
 end
 
 type read = Read.t
+(** The type parameter of a handle with [read] permissions. *)
+
 type write = Write.t
+(** The type parameter of a handle with [write] permissions. *)
+
 type read_write = Read_write.t
+(** The type parameter of a handle with both {!read} and {!write} permissions. *)

--- a/src/irmin/perms.ml
+++ b/src/irmin/perms.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 (** Types representing {i permissions} ['perms] for performing operations on a
     certain type ['perms t].
 

--- a/src/irmin/private.ml
+++ b/src/irmin/private.ml
@@ -1,5 +1,5 @@
 open! Import
-open S
+open S.Store_properties
 
 module type S = sig
   module Hash : Hash.S

--- a/src/irmin/private.ml
+++ b/src/irmin/private.ml
@@ -1,3 +1,6 @@
+open! Import
+open S
+
 module type S = sig
   module Hash : Hash.S
   (** Internal hashes. *)
@@ -25,18 +28,22 @@ module type S = sig
   module Repo : sig
     type t
 
-    val v : Conf.t -> t Lwt.t
-    val close : t -> unit Lwt.t
-    val contents_t : t -> [ `Read ] Contents.t
-    val node_t : t -> [ `Read ] Node.t
-    val commit_t : t -> [ `Read ] Commit.t
+    include OF_CONFIG with type _ t := t
+    (** @inline *)
+
+    include CLOSEABLE with type _ t := t
+    (** @inline *)
+
+    val contents_t : t -> read Contents.t
+    val node_t : t -> read Node.t
+    val commit_t : t -> read Commit.t
     val branch_t : t -> Branch.t
 
     val batch :
       t ->
-      ([ `Read | `Write ] Contents.t ->
-      [ `Read | `Write ] Node.t ->
-      [ `Read | `Write ] Commit.t ->
+      (read_write Contents.t ->
+      read_write Node.t ->
+      read_write Commit.t ->
       'a Lwt.t) ->
       'a Lwt.t
   end

--- a/src/irmin/private.ml
+++ b/src/irmin/private.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 open! Import
 open S.Store_properties
 

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -62,7 +62,7 @@ module type CONTENT_ADDRESSABLE_STORE = sig
       new values. Keys are derived from the values raw contents and hence are
       deterministic. *)
 
-  type 'a t
+  type -'a t
   (** The type for content-addressable backend stores. The ['a] phantom type
       carries information about the store mutability. *)
 
@@ -107,7 +107,7 @@ module type APPEND_ONLY_STORE = sig
       Append-onlye stores are store where it is possible to read and add new
       values. *)
 
-  type 'a t
+  type -'a t
   (** The type for append-only backend stores. The ['a] phantom type carries
       information about the store mutability. *)
 

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -16,6 +16,8 @@
 
 (** Irmin signatures *)
 
+open! Import
+
 module type CONTENT_ADDRESSABLE_STORE = sig
   (** {1 Content-addressable stores}
 
@@ -33,18 +35,18 @@ module type CONTENT_ADDRESSABLE_STORE = sig
   type value
   (** The type for raw values. *)
 
-  val mem : [> `Read ] t -> key -> bool Lwt.t
+  val mem : [> read ] t -> key -> bool Lwt.t
   (** [mem t k] is true iff [k] is present in [t]. *)
 
-  val find : [> `Read ] t -> key -> value option Lwt.t
+  val find : [> read ] t -> key -> value option Lwt.t
   (** [find t k] is [Some v] if [k] is associated to [v] in [t] and [None] is
       [k] is not present in [t]. *)
 
-  val add : [> `Write ] t -> value -> key Lwt.t
+  val add : [> write ] t -> value -> key Lwt.t
   (** Write the contents of a value to the store. It's the responsibility of the
       content-addressable store to generate a consistent key. *)
 
-  val unsafe_add : [> `Write ] t -> key -> value -> unit Lwt.t
+  val unsafe_add : [> write ] t -> key -> value -> unit Lwt.t
   (** Same as {!add} but allows to specify the key directly. The backend might
       choose to discared that key and/or can be corrupt if the key scheme is not
       consistent. *)
@@ -80,14 +82,14 @@ module type APPEND_ONLY_STORE = sig
   type value
   (** The type for raw values. *)
 
-  val mem : [> `Read ] t -> key -> bool Lwt.t
+  val mem : [> read ] t -> key -> bool Lwt.t
   (** [mem t k] is true iff [k] is present in [t]. *)
 
-  val find : [> `Read ] t -> key -> value option Lwt.t
+  val find : [> read ] t -> key -> value option Lwt.t
   (** [find t k] is [Some v] if [k] is associated to [v] in [t] and [None] is
       [k] is not present in [t]. *)
 
-  val add : [> `Write ] t -> key -> value -> unit Lwt.t
+  val add : [> write ] t -> key -> value -> unit Lwt.t
   (** Write the contents of a value to the store. *)
 
   val clear : 'a t -> unit Lwt.t

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -16,6 +16,7 @@
 
 open! Import
 module Sigs = S
+open Sigs.Store_properties
 
 module type S = sig
   (** {1 Irmin stores}
@@ -89,9 +90,8 @@ module type S = sig
     val v : S.config -> t Lwt.t
     (** [v config] connects to a repository in a backend-specific manner. *)
 
-    val close : t -> unit Lwt.t
-    (** [close t] frees up all resources associated with [t]. Any operations run
-        on a closed repository will raise {!Closed}. *)
+    include CLOSEABLE with type _ t := t
+    (** @inline *)
 
     val heads : t -> commit list Lwt.t
     (** [heads] is {!Head.list}. *)
@@ -965,8 +965,8 @@ module type Store = sig
          and type key = K.t
          and type value = V.t
 
-    include Sigs.BATCH with type 'a t := 'a t
-    include Sigs.OF_CONFIG with type 'a t := 'a t
-    include Sigs.CLOSEABLE with type 'a t := 'a t
+    include BATCH with type 'a t := 'a t
+    include OF_CONFIG with type 'a t := 'a t
+    include CLOSEABLE with type 'a t := 'a t
   end
 end

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -965,8 +965,8 @@ module type Store = sig
          and type key = K.t
          and type value = V.t
 
-    val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
-    val v : Conf.t -> [ `Read ] t Lwt.t
-    val close : 'a t -> unit Lwt.t
+    include Sigs.BATCH with type 'a t := 'a t
+    include Sigs.OF_CONFIG with type 'a t := 'a t
+    include Sigs.CLOSEABLE with type 'a t := 'a t
   end
 end

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
 module Sigs = S
 
 module type S = sig
@@ -878,14 +879,14 @@ module type S = sig
   (** [of_private_commit r c] is the commit associated with the private commit
       object [c]. *)
 
-  val save_contents : [> `Write ] Private.Contents.t -> contents -> hash Lwt.t
+  val save_contents : [> write ] Private.Contents.t -> contents -> hash Lwt.t
   (** Save a content into the database *)
 
   val save_tree :
     ?clear:bool ->
     repo ->
-    [> `Write ] Private.Contents.t ->
-    [ `Read | `Write ] Private.Node.t ->
+    [> write ] Private.Contents.t ->
+    [> read_write ] Private.Node.t ->
     tree ->
     hash Lwt.t
   (** Save a tree into the database. Does not do any reads. If [clear] is set

--- a/src/irmin/sync_ext_intf.ml
+++ b/src/irmin/sync_ext_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 open S
 
 module type SYNC_STORE = sig

--- a/src/irmin/sync_intf.ml
+++ b/src/irmin/sync_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2013-2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module type S = sig
   (** {1 Remote synchronization} *)
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -279,8 +279,8 @@ module type Tree = sig
     val export :
       ?clear:bool ->
       P.Repo.t ->
-      [> `Write ] P.Contents.t ->
-      [ `Read | `Write ] P.Node.t ->
+      [> write ] P.Contents.t ->
+      [> read_write ] P.Node.t ->
       node ->
       P.Node.key Lwt.t
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -15,6 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
+
 module type S = sig
   type key
   type step

--- a/src/irmin/watch_intf.ml
+++ b/src/irmin/watch_intf.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2017 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module type S = sig
   (** {1 Watch Helpers} *)
 

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -45,8 +45,11 @@ module type S = sig
       with type key = Key.t
        and type value = Value.t
 
-  val v : unit -> [ `Read ] t Lwt.t
-  val batch : [ `Read ] t -> ([ `Read | `Write ] t -> 'a Lwt.t) -> 'a Lwt.t
+  open Irmin.Export_for_backends
+
+  val v : unit -> read t Lwt.t
+
+  include Store_properties.BATCH with type 'a t := 'a t
 end
 
 module Append_only = Irmin_mem.Append_only

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -1,3 +1,5 @@
+open Irmin.Perms
+
 module Dict = Irmin_pack.Dict.Make (struct
   let io_version = `V2
 end)
@@ -79,9 +81,9 @@ struct
 
   type t = {
     index : Index.t;
-    pack : [ `Read ] Pack.t;
-    clone_pack : readonly:bool -> [ `Read ] Pack.t Lwt.t;
-    clone_index_pack : readonly:bool -> (Index.t * [ `Read ] Pack.t) Lwt.t;
+    pack : read Pack.t;
+    clone_pack : readonly:bool -> read Pack.t Lwt.t;
+    clone_index_pack : readonly:bool -> (Index.t * read Pack.t) Lwt.t;
   }
 
   let log_size = 10_000_000

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -1,3 +1,4 @@
+open Irmin.Perms
 module Dict : Irmin_pack.Dict.S
 module H = Irmin.Hash.SHA1
 module I = Index
@@ -48,16 +49,16 @@ end) : sig
 
   type t = {
     index : Index.t;
-    pack : [ `Read ] Pack.t;
-    clone_pack : readonly:bool -> [ `Read ] Pack.t Lwt.t;
-    clone_index_pack : readonly:bool -> (Index.t * [ `Read ] Pack.t) Lwt.t;
+    pack : read Pack.t;
+    clone_pack : readonly:bool -> read Pack.t Lwt.t;
+    clone_index_pack : readonly:bool -> (Index.t * read Pack.t) Lwt.t;
   }
 
   val get_pack : ?lru_size:int -> unit -> t Lwt.t
   (** Fresh, empty index and pack. [clone_pack] opens a clone of the pack at the
       same location, [clone_index_pack] opens a clone of the index and the pack. *)
 
-  val close : Index.t -> [ `Read ] Pack.t -> unit Lwt.t
+  val close : Index.t -> read Pack.t -> unit Lwt.t
 end
 
 val ( let* ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t

--- a/test/irmin-pack/import.ml
+++ b/test/irmin-pack/import.ml
@@ -1,3 +1,5 @@
+include Irmin.Export_for_backends
+
 let ( >>= ) = Lwt.Infix.( >>= )
 let ( >|= ) = Lwt.Infix.( >|= )
 let ( let* ) = ( >>= )

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -23,8 +23,8 @@ module Private = Inode.Val.Private
 module Context = struct
   type t = {
     index : Index.t;
-    store : [ `Read ] Inode.t;
-    clone : readonly:bool -> [ `Read ] Inode.t Lwt.t;
+    store : read Inode.t;
+    clone : readonly:bool -> read Inode.t Lwt.t;
   }
 
   let get_store ?(lru_size = 0) () =


### PR DESCRIPTION
This is the first of several refactors on the route to https://github.com/mirage/irmin/issues/1240. 

- exports various common `Store.S` extensions as module types for use by the backends.

- extracts all usages of `` `Read `` or `` `Write `` to be pulled from a central `Irmin.Perms` module, allowing them to (in future) be properly documented and used by `Irmin.Conf.t`.

Depends on https://github.com/mirage/irmin/pull/1261 to avoid merge conflicts.