### PR TITLE
More features in bench/tree.exe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+#### Fixed
+
+#### Added
+
+#### Changed
+- **irmin-bench**
+  - New features in benchmarks for tree operations (#1269, @Ngoguey42)
+
+#### Removed
+
 ## 2.4.0 (2021-02-02)
 
 ### Fixed
@@ -21,7 +33,7 @@
 
   - Added new operations `Tree.update` and `Tree.update_tree` for efficient
     read-and-set on trees. (#1274, @CraigFe)
-    
+
 - **irmin-pack**:
   - Added `integrity-check-inodes` command to `irmin-fsck` for checking the
     integrity of inodes. (#1253, @icristescu, @Ngoguey42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,14 @@
-# Unreleased
+## Unreleased
 
-#### Fixed
+### Fixed
 
-#### Added
+### Added
 
-#### Changed
+### Changed
 - **irmin-bench**
   - New features in benchmarks for tree operations (#1269, @Ngoguey42)
 
-#### Removed
+### Removed
 
 ## 2.4.0 (2021-02-02)
 

--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -29,6 +29,21 @@ let random_string n = String.init n (fun _i -> random_char ())
 let random_blob () = random_string 10
 let random_key () = random_string 5
 
+let default_results_dir =
+  let ( / ) = Filename.concat in
+  Unix.getcwd () / "_results" / Uuidm.to_string (Uuidm.v `V4)
+
+let prepare_results_dir path =
+  let rec mkdir_p path =
+    if Sys.file_exists path then ()
+    else
+      let path' = Filename.dirname path in
+      if path' = path then failwith "Failed to prepare result dir";
+      mkdir_p path';
+      Unix.mkdir path 0o755
+  in
+  mkdir_p path
+
 let with_timer f =
   let t0 = Sys.time () in
   let+ a = f () in

--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -35,6 +35,19 @@ let with_timer f =
   let t1 = Sys.time () -. t0 in
   (t1, a)
 
+let with_progress_bar ~message ~n ~unit ~sampling_interval =
+  let bar =
+    let w =
+      if n = 0 then 1
+      else float_of_int n |> log10 |> floor |> int_of_float |> succ
+    in
+    let pp fmt i = Format.fprintf fmt "%*Ld/%*d %s" w i w n unit in
+    let pp f = f ~width:(w + 1 + w + 1 + String.length unit) pp in
+    Progress_unix.counter ~mode:`ASCII ~width:79 ~total:(Int64.of_int n)
+      ~sampling_interval ~message ~pp ()
+  in
+  Progress_unix.with_reporters bar
+
 module Conf = struct
   let entries = 32
   let stable_hash = 256

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -1,3 +1,5 @@
+val default_results_dir : string
+val prepare_results_dir : string -> unit
 val reporter : ?prefix:string -> unit -> Logs.reporter
 val reset_stats : unit -> unit
 val with_timer : (unit -> 'a Lwt.t) -> (float * 'a) Lwt.t

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -1,6 +1,15 @@
 val reporter : ?prefix:string -> unit -> Logs.reporter
 val reset_stats : unit -> unit
 val with_timer : (unit -> 'a Lwt.t) -> (float * 'a) Lwt.t
+
+val with_progress_bar :
+  message:string ->
+  n:int ->
+  unit:string ->
+  sampling_interval:int ->
+  ((int64 -> unit) -> 'a) ->
+  'a
+
 val info : unit -> Irmin.Info.t
 val random_blob : unit -> string
 

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -12,7 +12,7 @@
 (library
  (name bench_common)
  (modules bench_common)
- (libraries irmin-pack unix))
+ (libraries irmin-pack unix progress progress.unix))
 
 ;; Require the above executables to compile during tests
 
@@ -29,4 +29,4 @@
   (pps ppx_deriving_yojson ppx_repr))
  (libraries irmin-pack irmin-pack.layered irmin-test.bench irmin-layers lwt
    unix cmdliner logs yojson ppx_deriving_yojson memtrace repr ppx_repr
-   bench_common))
+   bench_common mtime mtime.clock.os bentov))

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -12,7 +12,7 @@
 (library
  (name bench_common)
  (modules bench_common)
- (libraries irmin-pack unix progress progress.unix))
+ (libraries irmin-pack unix progress progress.unix uuidm))
 
 ;; Require the above executables to compile during tests
 

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -114,11 +114,6 @@ struct
 
       The histograms are computed using https://github.com/barko/bentov.
 
-      [Bentov] does exactly what's needed here, i.e. compute dynamic histograms
-      without any a-priori informations on the timings distribution being
-      available while keeping a constant memory space and a marginal cpu
-      footprint.
-
       [Bentov] does exactly the right thing here, i.e. computing dynamic
       histograms without the need for a priori information on the distributions,
       while maintaining a constant memory space and a marginal CPU footprint.

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -302,7 +302,6 @@ type config = {
   nchain_trees : int;
   width : int;
   nlarge_trees : int;
-  operations_file : string;
   root : string;
   flatten : bool;
   inode_config : [ `Entries_32 | `Entries_2 ];
@@ -565,13 +564,12 @@ let get_suite suite_filter =
       | _, _, _ -> false)
     suite
 
-let main ncommits ncommits_trace operations_file suite_filter inode_config
-    flatten depth width nchain_trees nlarge_trees commit_data_file =
+let main ncommits ncommits_trace suite_filter inode_config flatten depth width
+    nchain_trees nlarge_trees commit_data_file =
   let config =
     {
       ncommits;
       ncommits_trace;
-      operations_file;
       root = "test-bench";
       flatten;
       depth;
@@ -655,17 +653,13 @@ let nlarge_trees =
   in
   Arg.(value @@ opt int 1 doc)
 
-let operations_file =
-  let doc =
-    Arg.info ~doc:"Compressed file containing the tree operations."
-      [ "f"; "file" ]
-  in
-  Arg.(value @@ opt string "bench/irmin-pack/tezos_log.tar.gz" doc)
-
 let commit_data_file =
   let doc =
     Arg.info ~docv:"PATH"
-      ~doc:"Path to the JSON-encoded commit data to use for the benchmark run."
+      ~doc:
+        "Path to the JSON-encoded commit data to use for the benchmark run. \
+         This json can be found in a tarball at\n\
+         https://github.com/icristescu/dataset"
       []
   in
   Arg.(required @@ pos 0 (some string) None doc)
@@ -675,7 +669,6 @@ let main_term =
     const main
     $ ncommits
     $ ncommits_trace
-    $ operations_file
     $ mode
     $ inode_config
     $ flatten

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -53,7 +53,15 @@ module Parse_trace = struct
       hashes to a single step.
 
       The paths in tezos:
-      https://www.dailambda.jp/blog/2020-05-11-plebeia/#tezos-path *)
+      https://www.dailambda.jp/blog/2020-05-11-plebeia/#tezos-path
+
+      A chopped hash has this form:
+
+      {v ([0-9a-f]{2}/){5}[0-9a-f]{30} v}
+
+      and is flattened to that form:
+
+      {v [0-9a-f]{40} v} *)
   let flatten_key = flatten_key_suffix
 
   let flatten_op = function
@@ -114,9 +122,9 @@ struct
 
       The histograms are computed using https://github.com/barko/bentov.
 
-      [Bentov] computes dynamic
-      histograms without the need for a priori information on the distributions,
-      while maintaining a constant memory space and a marginal CPU footprint.
+      [Bentov] computes dynamic histograms without the need for a priori
+      information on the distributions, while maintaining a constant memory
+      space and a marginal CPU footprint.
 
       The implementation of that library is pretty straightforward, but not
       perfect; it doesn't scale well with the number of bins. I chose 32

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -419,7 +419,7 @@ struct
     in
     Format.fprintf
       (Format.formatter_of_out_channel json_channel)
-      "%a" Trees_trace.pp_stats
+      "%a%!" Trees_trace.pp_stats
       (true, config.flatten, config.inode_config);
     close_out json_channel;
 
@@ -573,7 +573,7 @@ let get_suite suite_filter =
       | `Custom_trace, `Custom, `Read_trace -> true
       | `Custom_chains, `Custom, `Chains -> true
       | `Custom_large, `Custom, `Large -> true
-      | _, _, _ -> false)
+      | (`Slow | `Quick | `Custom_trace | `Custom_chains | `Custom_large), _, _ -> false)
     suite
 
 let main ncommits ncommits_trace suite_filter inode_config flatten depth width
@@ -671,7 +671,7 @@ let commit_data_file =
     Arg.info ~docv:"PATH"
       ~doc:
         "Path to the JSON-encoded commit data to use for the benchmark run. \
-         This json can be found in a tarball at\n\
+         An example of this data is available at\n\
          https://github.com/icristescu/dataset"
       []
   in

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -114,7 +114,7 @@ struct
 
       The histograms are computed using https://github.com/barko/bentov.
 
-      [Bentov] does exactly the right thing here, i.e. computing dynamic
+      [Bentov] computes dynamic
       histograms without the need for a priori information on the distributions,
       while maintaining a constant memory space and a marginal CPU footprint.
 
@@ -123,7 +123,7 @@ struct
       randomly.
 
       The computed histogram depends on the order of the operations, some
-      maginal unsabilities are to be expected. *)
+      marginal unsabilities are to be expected. *)
   let histo_per_op =
     op_tags
     |> List.map (fun which -> (which, Bentov.create 32))

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -27,6 +27,10 @@ depends: [
   "ppx_repr"
   "re"           {>= "1.9.0"}
   "fmt"
+  "bentov"
+  "uuidm"
+  "progress"
+  "mtime"
 ]
 
 synopsis: "Irmin benchmarking suite"


### PR DESCRIPTION
Diff 1: `--quick` is now `--mode quick`, and `--mode` gives more choices.
Diff 2: The configurations for the `quick` and `slow` modes are now hard coded and can't be changed from the CLI. The other modes can be configured from the CLI.
Diff 3: Add `--flatten` for trace mode to collapse the 6 step-long hashes to single steps. 
Diff 4: Add a progress bar using https://github.com/CraigFe/progress
Diff 5: Trace mode now tracks the time spent by the 8 unitary operation, using mtime and https://github.com/barko/bentov (more info in tree.ml).

I also have a python script to plot the histograms
![tree_normal](https://user-images.githubusercontent.com/9285880/106889315-1ffc3400-66e8-11eb-94a0-2f95ece6f3ad.png)
![tree_flatten](https://user-images.githubusercontent.com/9285880/106889333-27bbd880-66e8-11eb-84dc-b4c7c95e249e.png)


