### PR TITLE
Reraise exception from the async thread

### DIFF
--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2091,6 +2091,8 @@ let layered_suite (speed, x) =
 
 let run name ?(slow = false) ~misc tl =
   Printexc.record_backtrace true;
+  (* Ensure that failures occuring in async lwt threads are raised. *)
+  (Lwt.async_exception_hook := fun exn -> raise exn);
   let tl1 = List.map suite tl in
   let tl1 = if slow then tl1 @ List.map slow_suite tl else tl1 in
   let tl2 = List.map layered_suite tl in


### PR DESCRIPTION
If I understand correctly, the default behaviour for `async_exception_hook` is to print a message on the stderr, which seems to be ignored by alcotest (unless we run it with the `--verbose` flag). This PR seems to behave a bit better, as alcotest correctly detects an error in the freeze thread and outputs the corresponding logs. 

It then also needs https://github.com/mirage/alcotest/issues/287 to work properly.

As a side node, it works because the `Repo.close` always waits  for the freeze thread to finish.