### PR TITLE
irmin-pack: expose internal inode trees

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 - **irmin-bench**
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)
+- **irmin-pack**
+  - Expose internal inode trees (#1273, @mattiasdrp, @samoht)
 
 ### Changed
 


### PR DESCRIPTION
New attempt to serialise and deserialise inodes this time using Irmin.Type

As an example, the current version will transform the following inode (use `json-pretty-print-buffer` in emacs to display it in a human readable way):

```json
{"hash":"46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864","stable":true,"v":{"Tree":{"depth":0,"length":3,"entries":[null,{"some":{"hash":"3b35271ed01c21d2ffd305eeae99a518c3e979c9","target":{"hash":"3b35271ed01c21d2ffd305eeae99a518c3e979c9","stable":false,"v":{"Tree":{"depth":1,"length":3,"entries":[{"some":{"hash":"1ea663b1d5da857985ae54e6306a9c5203eb57e2","target":{"hash":"1ea663b1d5da857985ae54e6306a9c5203eb57e2","stable":false,"v":{"Tree":{"depth":2,"length":3,"entries":[{"some":{"hash":"4c908006bc050c8ceea78934223332f573ec4eb5","target":{"hash":"4c908006bc050c8ceea78934223332f573ec4eb5","stable":false,"v":{"Values":[["x",{"contents":"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"}],["y",{"contents":"62cdb7020ff920e5aa642c3d4066950dd1f01f4d"}]]}}}},{"some":{"hash":"94342a88b46624f23ceb3a4e574ecf8048882647","target":{"hash":"94342a88b46624f23ceb3a4e574ecf8048882647","stable":false,"v":{"Values":[["z",{"contents":"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"}]]}}}}]}}}}},null]}}}}}]}}}
```
in

```json
{"hash":"46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864","bindings":[["x",{"contents":"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"}],["y",{"contents":"62cdb7020ff920e5aa642c3d4066950dd1f01f4d"}],["z",{"contents":"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"}]],"v":{"Tree":[0,[null,{"some":{"Tree":[1,[{"some":{"Tree":[2,[{"some":{"Values":[["x",{"contents":"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"}],["y",{"contents":"62cdb7020ff920e5aa642c3d4066950dd1f01f4d"}]]}},{"some":{"Values":[["z",{"contents":"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"}]]}}]]}},null]]}}]]}}
```

For deserialising, only the list of bindings is used so this can't be used right now to check if an inode is always constructed the same way. If necessary, I can add a function that checks if a constructed inode from bindings has the same structure as the one saved during serialisation.