### PR TITLE
Implement Tree.update and Tree.update_tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@
   - Added an `Exported_for_stores` module containing miscellaneous helper types
     for building backends. (#1262, @CraigFe)
 
+  - Added new operations `Tree.update` and `Tree.update_tree` for efficient
+    read-and-set on trees. (#1274, @CraigFe)
+    
 - **irmin-pack**:
   - Added `integrity-check-inodes` command to `irmin-fsck` for checking the
     integrity of inodes. (#1253, @icristescu, @Ngoguey42)

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -216,7 +216,7 @@ let line msg =
 let ( / ) = Filename.concat
 
 let testable t =
-  Alcotest.testable (Irmin.Type.pp t) Irmin.Type.(unstage (equal t))
+  Alcotest.testable (Irmin.Type.pp_dump t) Irmin.Type.(unstage (equal t))
 
 let check t = Alcotest.check (testable t)
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1110,14 +1110,10 @@ module Make (P : Private.S) = struct
            sensitivity to ordering of subtree operations: updating in a subtree
            and adding the subtree are not necessarily commutative. *)
         | None -> Lwt.return empty_tree
-        | Some (`Node _ as t) -> Lwt.return t
-        | Some (`Contents c' as t) ->
-            let t =
-              match root_tree with
-              | `Contents c when contents_equal c c' -> root_tree
-              | _ -> t
-            in
-            Lwt.return t)
+        | Some new_root -> (
+            match maybe_equal root_tree new_root with
+            | True -> Lwt.return root_tree
+            | Maybe | False -> Lwt.return new_root))
     | Some (path, file) -> (
         let rec aux : type r. key -> node -> (node updated, r) cont_lwt =
          fun path parent_node k ->

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1483,7 +1483,9 @@ module Make (P : Private.S) = struct
       | `Node n ->
           let* m = Node.to_map n in
           let bindings = m |> get_ok |> StepMap.bindings in
-          (node [@tailcall]) [] bindings (fun n -> k (`Tree n))
+          (node [@tailcall]) [] bindings (fun n ->
+              let n = List.sort (fun (s, _) (s', _) -> compare_step s s') n in
+              k (`Tree n))
     and contents : type r. Contents.t * metadata -> (concrete, r) cont_lwt =
      fun (c, m) k ->
       let* c = Contents.to_value c >|= get_ok in

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1190,6 +1190,168 @@ module Make (P : Private.S) = struct
         | None -> Lwt.return t
         | Some n -> Lwt.return (`Node n))
 
+  (** During recursive updates, we keep track of whether or not we've made a
+      modification in order to avoid unnecessary allocations of identical tree
+      objects. *)
+  type 'a updated = Changed of 'a | Unchanged
+
+  let update_tree root_tree path f =
+    Log.debug (fun l -> l "Tree.update_tree %a" pp_path path);
+    let empty_node = empty_node root_tree in
+    let* empty_tree =
+      is_empty root_tree >|= function
+      | true -> root_tree
+      | false -> `Node empty_node
+    in
+    match Path.rdecons path with
+    | None -> (
+        match f (Some root_tree) with
+        (* Here we consider "deleting" a root contents value or node to
+           consist of changing it to an empty node. Note that this
+           introduces sensitivity to ordering of subtree operations:
+           updating in a subtree and adding the subtree are not
+           commutative. *)
+        | None -> Lwt.return empty_tree
+        | Some (`Node n as t) -> (
+            Node.is_empty n >|= get_ok >|= function
+            | true -> empty_tree
+            | false -> t)
+        | Some (`Contents c' as t) ->
+            let t =
+              match root_tree with
+              | `Contents c when contents_equal c c' -> root_tree
+              | _ -> t
+            in
+            Lwt.return t)
+    | Some (path, file) -> (
+        let rec aux : type r. key -> node -> (node updated, r) cont_lwt =
+         fun path n k ->
+          let changed n = k (Changed n) in
+          match Path.decons path with
+          | None -> (
+              let* old_binding = Node.findv n file in
+              let new_binding = f old_binding in
+              match (old_binding, new_binding) with
+              | None, None -> k Unchanged
+              | None, Some (`Contents _ as t) -> Node.add n file t >>= changed
+              | None, Some (`Node n as t) -> (
+                  (* Prune empty directories *)
+                  Node.is_empty n >|= get_ok
+                  >>= function
+                  | true -> k Unchanged
+                  | false -> Node.add n file t >>= changed)
+              | Some _, Some (`Node n as t) -> (
+                  (* Prune empty directories *)
+                  Node.is_empty n >|= get_ok
+                  >>= function
+                  | true -> Node.remove n file >>= changed
+                  | false -> Node.add n file t >>= changed)
+              | Some _, None -> Node.remove n file >>= changed
+              | Some (`Contents c), Some (`Contents c' as t) ->
+                  if contents_equal c c' then k Unchanged
+                  else Node.add n file t >>= changed
+              | Some (`Node _), Some (`Contents _ as t) ->
+                  Node.add n file t >>= changed)
+          | Some (h, p) -> (
+              let* old_binding = Node.findv n h in
+              let to_recurse =
+                match old_binding with
+                | Some (`Node child) -> child
+                | None | Some (`Contents _) -> empty_node
+              in
+              (aux [@tailcall]) p to_recurse @@ function
+              | Unchanged -> k Unchanged
+              | Changed child -> (
+                  (* Prune empty directories *)
+                  Node.is_empty child >|= get_ok
+                  >>= function
+                  | true -> Node.remove n h >>= changed
+                  | false -> Node.add n h (`Node child) >>= changed))
+        in
+        let top_node =
+          match root_tree with `Node n -> n | `Contents _ -> empty_node
+        in
+        aux path top_node @@ function
+        | Unchanged ->
+            Lwt.return root_tree
+            (* TODO: None on empty_node should return empty_node *)
+        | Changed node -> Lwt.return (`Node node))
+
+  let update root_tree path ?(metadata = Metadata.default) f =
+    Log.debug (fun l -> l "Tree.update %a" pp_path path);
+    let empty_node = empty_node root_tree in
+    match Path.rdecons path with
+    | None -> (
+        let old_root =
+          match root_tree with `Contents c -> Some (fst c) | `Node _ -> None
+        in
+        match f old_root with
+        | None -> (
+            (* Here we consider "deleting" a root contents value or node to
+               consist of changing it to an empty node. Note that this
+               introduces sensitivity to ordering of subtree operations:
+               updating in a subtree and adding the subtree are not
+               commutative. *)
+            is_empty root_tree
+            >|= function
+            | true -> root_tree
+            | false -> `Node empty_node)
+        | Some c' ->
+            let c' = (c', metadata) in
+            let t =
+              match root_tree with
+              | `Contents c when contents_equal c c' -> root_tree
+              | _ -> `Contents c'
+            in
+            Lwt.return t)
+    | Some (path, file) -> (
+        let rec aux : type r. key -> node -> (node updated, r) cont_lwt =
+         fun path n k ->
+          let changed n = k (Changed n) in
+          match Path.decons path with
+          | None -> (
+              let* old_binding = Node.findv n file in
+              let old_contents =
+                match old_binding with
+                | Some (`Contents old) -> Some (fst old)
+                | Some (`Node _) | None -> None
+              in
+              let new_contents = f old_contents in
+              match (old_binding, new_contents) with
+              | None, None -> k Unchanged
+              | Some _, None -> Node.remove n file >>= changed
+              | Some (`Contents c), Some c' ->
+                  let c' = (c', metadata) in
+                  if contents_equal c c' then k Unchanged
+                  else Node.add n file (`Contents c') >>= changed
+              | (None | Some (`Node _)), Some c' ->
+                  let new_binding = `Contents (c', metadata) in
+                  Node.add n file new_binding >>= changed)
+          | Some (h, p) -> (
+              let* old_binding = Node.findv n h in
+              let to_recurse =
+                match old_binding with
+                | Some (`Node child) -> child
+                | None | Some (`Contents _) -> empty_node
+              in
+              (aux [@tailcall]) p to_recurse @@ function
+              | Unchanged -> k Unchanged
+              | Changed child -> (
+                  (* Prune empty directories *)
+                  Node.is_empty child >|= get_ok
+                  >>= function
+                  | true -> Node.remove n h >>= changed
+                  | false -> Node.add n h (`Node child) >>= changed))
+        in
+        let top_node =
+          match root_tree with `Node n -> n | `Contents _ -> empty_node
+        in
+        aux path top_node @@ function
+        | Unchanged ->
+            Lwt.return root_tree
+            (* TODO: None on empty_node should return empty_node *)
+        | Changed node -> Lwt.return (`Node node))
+
   let import repo k =
     cnt.node_mem <- cnt.node_mem + 1;
     P.Node.mem (P.Repo.node_t repo) k >|= function

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -117,6 +117,15 @@ module type S = sig
   (** [add t k c] is the tree where the key [k] is bound to the contents [c] but
       is similar to [t] for other bindings. *)
 
+  val update :
+    t ->
+    key ->
+    ?metadata:metadata ->
+    (contents option -> contents option) ->
+    t Lwt.t
+  (** [update t k f] is the tree [t'] that is the same as [t] for all keys
+      except [k], and whose binding for [k] is determined by [f (find t k)]. *)
+
   val remove : t -> key -> t Lwt.t
   (** [remove t k] is the tree where [k] bindings has been removed but is
       similar to [t] for other bindings. *)
@@ -137,6 +146,10 @@ module type S = sig
   val add_tree : t -> key -> t -> t Lwt.t
   (** [add_tree t k v] is the tree where the key [k] is bound to the tree [v]
       but is similar to [t] for other bindings *)
+
+  val update_tree : t -> key -> (t option -> t option) -> t Lwt.t
+  (** [update t k f] is the tree [t'] that is the same as [t] for all keys
+      except [k], and whose subtree at [k] is determined by [f (find_tree t k)]. *)
 
   val merge : t Merge.t
   (** [merge] is the 3-way merge function for trees. *)

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -124,7 +124,10 @@ module type S = sig
     (contents option -> contents option) ->
     t Lwt.t
   (** [update t k f] is the tree [t'] that is the same as [t] for all keys
-      except [k], and whose binding for [k] is determined by [f (find t k)]. *)
+      except [k], and whose binding for [k] is determined by [f (find t k)].
+
+      If [k] refers to an internal node of [t], [f] is called with [None] to
+      determine the value with which to replace it. *)
 
   val remove : t -> key -> t Lwt.t
   (** [remove t k] is the tree where [k] bindings has been removed but is

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -148,8 +148,9 @@ module type S = sig
       but is similar to [t] for other bindings *)
 
   val update_tree : t -> key -> (t option -> t option) -> t Lwt.t
-  (** [update t k f] is the tree [t'] that is the same as [t] for all keys
-      except [k], and whose subtree at [k] is determined by [f (find_tree t k)]. *)
+  (** [update_tree t k f] is the tree [t'] that is the same as [t] for all
+      subtrees except under [k], and whose subtree at [k] is determined by
+      [f (find_tree t k)]. *)
 
   val merge : t Merge.t
   (** [merge] is the 3-way merge function for trees. *)

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -3,4 +3,4 @@
  (package irmin)
  (preprocess
   (pps ppx_irmin))
- (libraries irmin irmin-mem alcotest alcotest-lwt lwt hex))
+ (libraries irmin irmin-mem alcotest alcotest-lwt lwt hex logs logs.fmt))

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -1,2 +1,6 @@
 let suite = [ ("tree", Test_tree.suite); ("hash", Test_hash.suite) ]
-let () = Lwt_main.run (Alcotest_lwt.run "irmin" suite)
+
+let () =
+  Logs.set_level (Some Debug);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Lwt_main.run (Alcotest_lwt.run "irmin" suite)

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -263,6 +263,18 @@ let test_update _ () =
   in
 
   let* () =
+    let+ abc1' =
+      Tree.update_tree abc1 [ "a"; "b" ] (function
+        | Some t -> Some t
+        | None -> None)
+    in
+    Alcotest.(check bool)
+      "Replacing a subtree node with a physically-equal one preserves physical \
+       equality"
+      true (abc1 == abc1')
+  in
+
+  let* () =
     Alcotest.check_tree_lwt
       "Changing the metadata of an existing contents value updates the tree."
       ~expected:(abc ~info:Metadata.Left "1")

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -361,17 +361,6 @@ let test_update _ () =
       (t == t')
   in
 
-  let* () =
-    let+ abc1' =
-      Tree.update_tree abc1 [ "a"; "b"; "d" ] (function
-        | None -> Some Tree.empty
-        | Some _ -> assert false)
-    in
-    Alcotest.assert_
-      "Adding an empty tree at an empty location preserves physical equality"
-      (abc1 == abc1')
-  in
-
   Lwt.return_unit
 
 (* Correct stats for a completely lazy tree *)

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -156,6 +156,129 @@ let test_remove _ () =
 
   Lwt.return_unit
 
+(* Build a function that requires a given input, always returns a given output,
+   and can be called at most once. *)
+let transform_once : type a b. a Type.t -> a -> b -> a -> b =
+ fun typ ->
+  let equal = Type.(unstage (equal typ)) in
+  let pp = Type.pp_dump typ in
+  fun source target ->
+    let called = ref false in
+    fun x ->
+      if !called then Alcotest.failf "Transformation called more than once";
+      called := true;
+      if equal source x then target
+      else Alcotest.failf "Expected %a but got %a" pp source pp x
+
+let test_update _ () =
+  let unrelated_binding = ("a_unrelated", c "<>") in
+  let abc ?info v =
+    `Tree
+      [ ("a", `Tree [ ("b", `Tree [ ("c", c ?info v) ]) ]); unrelated_binding ]
+  in
+  let abc1 = Tree.of_concrete (abc "1") in
+  let ( --> ) = transform_once [%typ: string option] in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Changing the value of a root contents node results in a new contents \
+       node."
+      ~expected:(c "2")
+      (Tree.update (Tree.of_concrete (c "1")) [] (Some "1" --> Some "2"))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Removing a root contents node results in an empty root node."
+      ~expected:(`Tree [])
+      (Tree.update (Tree.of_concrete (c "1")) [] (Some "1" --> None))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Updating a root node to a contents value removes all bindings and sets \
+       the correct metadata."
+      ~expected:(c ~info:Metadata.Right "2")
+      (Tree.update ~metadata:Metadata.Right abc1 [] (None --> Some "2"))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Updating at an existing contents path changes the contents value \
+       appropriately."
+      ~expected:(abc "2")
+      (Tree.update abc1 [ "a"; "b"; "c" ] (Some "1" --> Some "2"))
+  in
+
+  let* () =
+    let+ abc1' = Tree.update abc1 [ "a"; "b"; "c" ] (Some "1" --> Some "1") in
+    Alcotest.(check bool)
+      "Performing a no-op change to tree contents preserves physical equality"
+      true (abc1 == abc1')
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Changing the metadata of an existing contents value updates the tree."
+      ~expected:(abc ~info:Metadata.Left "1")
+      (Tree.update ~metadata:Metadata.Left abc1 [ "a"; "b"; "c" ]
+         (Some "1" --> Some "1"))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Removing a siblingless contents value causes newly-empty directories to \
+       be pruned."
+      ~expected:(`Tree [ unrelated_binding ])
+      (Tree.update abc1 [ "a"; "b"; "c" ] (Some "1" --> None))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Updating at a non-existent contents path adds a new directory entry."
+      ~expected:
+        (`Tree
+          [
+            ("a", `Tree [ ("b", `Tree [ ("c", c "1"); ("c'", c "new_value") ]) ]);
+            unrelated_binding;
+          ])
+      (Tree.update abc1 [ "a"; "b"; "c'" ] (None --> Some "new_value"))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Updating at an existing node path replaces the subtree with the given \
+       element."
+      ~expected:
+        (`Tree [ ("a", `Tree [ ("b", c "new_value") ]); unrelated_binding ])
+      (Tree.update abc1 [ "a"; "b" ] (None --> Some "new_value"))
+  in
+
+  let* () =
+    Alcotest.check_tree_lwt
+      "Updating at a path in an empty tree creates the necessary intermediate \
+       nodes with the new contents."
+      ~expected:(`Tree [ ("a", `Tree [ ("b", `Tree [ ("c", c "1") ]) ]) ])
+      (Tree.update Tree.empty [ "a"; "b"; "c" ] (None --> Some "1"))
+  in
+
+  let* () =
+    let+ abc1' = Tree.update abc1 [ "a"; "b"; "c"; "d"; "e" ] (None --> None) in
+    Alcotest.(check bool)
+      "Removing at a non-existent path in a non-empty tree preserves physical \
+       equality."
+      true (abc1 == abc1')
+  in
+
+  let* () =
+    let t = Tree.empty in
+    let+ t' = Tree.update t [] (None --> None) in
+    Alcotest.(check bool)
+      "Removing from an empty tree preserves physical equality" true (t == t')
+  in
+
+  Lwt.return_unit
+
 (* Correct stats for a completely lazy tree *)
 let lazy_stats = Tree.{ nodes = 0; leafs = 0; skips = 1; depth = 0; width = 0 }
 
@@ -274,6 +397,7 @@ let suite =
     Alcotest_lwt.test_case "paginated bindings" `Quick test_paginated_bindings;
     Alcotest_lwt.test_case "diff" `Quick test_diff;
     Alcotest_lwt.test_case "remove" `Quick test_remove;
+    Alcotest_lwt.test_case "update" `Quick test_update;
     Alcotest_lwt.test_case "clear" `Quick test_clear;
     Alcotest_lwt.test_case "fold" `Quick test_fold_force;
     Alcotest_lwt.test_case "kind of empty path" `Quick test_kind_empty_path;

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -248,6 +248,16 @@ let test_update _ () =
   in
 
   let* () =
+    (* Replacing a root node with a dangling hash does not raise an
+       exception. *)
+    let* invalid_tree = invalid_tree () in
+    Tree.update_tree abc1 [] (function
+      | Some _ -> Some invalid_tree
+      | None -> assert false)
+    >|= ignore
+  in
+
+  let* () =
     Alcotest.check_tree_lwt
       "Updating at an existing contents path changes the contents value \
        appropriately."


### PR DESCRIPTION
Resolves https://github.com/mirage/irmin/issues/1270.

`Tree.update_tree` is quite complicated, with many edge cases that I've tried to test as much as is practical. Fortunately, the functions `Tree.add`, `Tree.add_tree`, `Tree.remove` and `Tree.update` can all be implemented in terms of it with little to no performance cost, which I've done here.