### PR TITLE
irmin: attach irmin-mem tests to irmin-test package

### DIFF
--- a/test/irmin-mem/dune
+++ b/test/irmin-mem/dune
@@ -10,7 +10,7 @@
 
 (rule
  (alias runtest)
- (package irmin)
+ (package irmin-test)
  (action
   (run ./test.exe -q --color=always)))
 


### PR DESCRIPTION
This is necessary to avoid a cycle between the `irmin` and `irmin-test` packages.