### PR TITLE
WIP: Add an irmin-pack.mem package

### DIFF
--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -172,7 +172,7 @@ struct
           Format.fprintf ppf "[%2d,%.3e]" bin.count bin.center
         in
         Format.fprintf ppf "%a:[%a]" (Repr.pp stat_entry_t) which
-          Ppf.(list ~sep:(any ",") pp_bar)
+          Fmt.(list ~sep:(any ",") pp_bar)
           (Bentov.bins histo)
       else
         Format.fprintf ppf "%d %a %.3f sec (%.1f%%)" n (Repr.pp stat_entry_t)

--- a/src/irmin-pack/closeable.mli
+++ b/src/irmin-pack/closeable.mli
@@ -13,7 +13,10 @@
 (** Augments primitive store modules with close semantics *)
 
 module Content_addressable (CA : Pack.S) :
-  Pack.S
+  Pack.S with type key = CA.key and type value = CA.value
+
+module Content_addressable_indexed (CA : Pack.INDEXED_S) :
+  Pack.INDEXED_S
     with type key = CA.key
      and type value = CA.value
      and type index = CA.index

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -88,14 +88,14 @@ struct
           let magic _ = magic
         end)
 
-        include Closeable.Content_addressable (CA_Pack)
+        include Closeable.Content_addressable_indexed (CA_Pack)
       end
 
       include Irmin.Contents.Store (CA)
     end
 
     module Node = struct
-      module CA = Inode.Make (Config) (H) (Pack) (Node)
+      module CA = Inode.Make_indexed_store (Config) (H) (Pack) (Node)
       include Irmin.Private.Node.Store (Contents) (P) (M) (CA)
     end
 
@@ -124,7 +124,7 @@ struct
           let magic _ = magic
         end)
 
-        include Closeable.Content_addressable (CA_Pack)
+        include Closeable.Content_addressable_indexed (CA_Pack)
       end
 
       include Irmin.Private.Commit.Store (Node) (CA)

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -113,7 +113,7 @@ struct
           let magic _ = magic
         end)
 
-        module CA = Closeable.Content_addressable (CA_Pack)
+        module CA = Closeable.Content_addressable_indexed (CA_Pack)
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
       end
 
@@ -151,7 +151,7 @@ struct
           let magic _ = magic
         end)
 
-        module CA = Closeable.Content_addressable (CA_Pack)
+        module CA = Closeable.Content_addressable_indexed (CA_Pack)
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
       end
 

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -4,9 +4,9 @@ module Inode = Irmin_pack.Private.Inode
 module Pack = Irmin_pack.Pack
 
 module type S = sig
-  include Inode.S
-  module U : Pack.S
-  module L : Pack.S
+  include Inode.INDEXED_S
+  module U : Pack.INDEXED_S
+  module L : Pack.INDEXED_S
 
   val v :
     read U.t ->

--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -34,8 +34,8 @@ let stats = function
 
 module Copy
     (Key : Irmin.Hash.S)
-    (SRC : Pack.S with type key = Key.t)
-    (DST : Pack.S with type key = SRC.key and type value = SRC.value) =
+    (SRC : Pack.INDEXED_S with type key = Key.t)
+    (DST : Pack.INDEXED_S with type key = SRC.key and type value = SRC.value) =
 struct
   let ignore_lwt _ = Lwt.return_unit
 
@@ -65,8 +65,8 @@ let pp_next_upper ppf t = pp_layer_id ppf (if t then `Upper0 else `Upper1)
 module Content_addressable
     (H : Irmin.Hash.S)
     (Index : Private.Pack_index.S)
-    (U : Pack.S with type index = Index.t and type key = H.t)
-    (L : Pack.S
+    (U : Pack.INDEXED_S with type index = Index.t and type key = H.t)
+    (L : Pack.INDEXED_S
            with type index = U.index
             and type key = U.key
             and type value = U.value) =
@@ -325,7 +325,7 @@ end
 module Pack_Maker
     (H : Irmin.Hash.S)
     (Index : Private.Pack_index.S)
-    (P : Pack.MAKER with type key = H.t and type index = Index.t) =
+    (P : Pack.INDEXED_MAKER with type key = H.t and type index = Index.t) =
 struct
   type index = P.index
   type key = P.key

--- a/src/irmin-pack/layered/layered_store.mli
+++ b/src/irmin-pack/layered/layered_store.mli
@@ -19,8 +19,8 @@ val pp_current_upper : bool Fmt.t
 module Content_addressable
     (H : Irmin.Hash.S)
     (Index : Irmin_pack.Private.Pack_index.S)
-    (U : Irmin_pack.Pack.S with type index = Index.t and type key = H.t)
-    (L : Irmin_pack.Pack.S
+    (U : Irmin_pack.Pack.INDEXED_S with type index = Index.t and type key = H.t)
+    (L : Irmin_pack.Pack.INDEXED_S
            with type index = U.index
             and type key = U.key
             and type value = U.value) :
@@ -43,5 +43,7 @@ module Atomic_write
 module Pack_Maker
     (H : Irmin.Hash.S)
     (Index : Irmin_pack.Private.Pack_index.S)
-    (P : Irmin_pack.Pack.MAKER with type key = H.t and type index = Index.t) :
+    (P : Irmin_pack.Pack.INDEXED_MAKER
+           with type key = H.t
+            and type index = Index.t) :
   S.LAYERED_PACK_MAKER with type key = P.key and type index = P.index

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -60,9 +60,9 @@ end
 
 module type LAYERED_PACK = sig
   open Irmin_pack.Pack
-  include S
-  module U : S with type value = value
-  module L : S
+  include INDEXED_S
+  module U : INDEXED_S with type value = value
+  module L : INDEXED_S
 
   val v :
     read U.t ->

--- a/src/irmin-pack/mem/dune
+++ b/src/irmin-pack/mem/dune
@@ -1,0 +1,6 @@
+(library
+ (public_name irmin-pack.mem)
+ (name irmin_pack_mem)
+ (libraries irmin-pack)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-pack/mem/import.ml
+++ b/src/irmin-pack/mem/import.ml
@@ -1,0 +1,6 @@
+include Irmin.Export_for_backends
+
+let ( >>= ) = Lwt.Infix.( >>= )
+let ( >|= ) = Lwt.Infix.( >|= )
+let ( let* ) = ( >>= )
+let ( let+ ) = ( >|= )

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -1,0 +1,241 @@
+(*
+ * Copyright (c) 2013-2020 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+
+let src = Logs.Src.create "irmin.pack" ~doc:"irmin-pack backend"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+module I = Irmin_pack.Private.IO
+
+let pp_version = Irmin_pack.Private.IO.pp_version
+
+exception Unsupported_version = Irmin_pack.Store.Unsupported_version
+
+module Make
+    (IO_version : Irmin_pack.VERSION)
+    (Config : Irmin_pack.Config.S)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S)
+    (Node : Irmin.Private.Node.S
+              with type metadata = M.t
+               and type hash = H.t
+               and type step = P.step)
+    (Commit : Irmin.Private.Commit.S with type hash = H.t) =
+struct
+  module Pack = Pack_mem.File (H) (IO_version)
+  module Dict = Irmin_pack.Dict.Make (IO_version)
+
+  let current_version = IO_version.io_version
+
+  module X = struct
+    module Hash = H
+
+    type 'a value = { hash : H.t; magic : char; v : 'a } [@@deriving irmin]
+
+    module Contents = struct
+      module CA = struct
+        module Key = H
+        module Val = C
+
+        module CA_Pack = Pack.Make (struct
+          include Val
+          module H = Irmin.Hash.Typed (H) (Val)
+
+          let hash = H.hash
+          let magic = 'B'
+          let value = value_t Val.t
+          let encode_value = Irmin.Type.(unstage (encode_bin value))
+          let decode_value = Irmin.Type.(unstage (decode_bin value))
+
+          let encode_bin ~dict:_ ~offset:_ v hash =
+            encode_value { magic; hash; v }
+
+          let decode_bin ~dict:_ ~hash:_ s off =
+            let _, t = decode_value s off in
+            t.v
+
+          let magic _ = magic
+        end)
+
+        include Irmin_pack.Private.Closeable.Content_addressable (CA_Pack)
+      end
+
+      include Irmin.Contents.Store (CA)
+    end
+
+    module Node = struct
+      module CA = Irmin_pack.Private.Inode.Make (Config) (H) (Pack) (Node)
+      include Irmin.Private.Node.Store (Contents) (P) (M) (CA)
+    end
+
+    module Commit = struct
+      module CA = struct
+        module Key = H
+        module Val = Commit
+
+        module CA_Pack = Pack.Make (struct
+          include Val
+          module H = Irmin.Hash.Typed (H) (Val)
+
+          let hash = H.hash
+          let value = value_t Val.t
+          let magic = 'C'
+          let encode_value = Irmin.Type.(unstage (encode_bin value))
+          let decode_value = Irmin.Type.(unstage (decode_bin value))
+
+          let encode_bin ~dict:_ ~offset:_ v hash =
+            encode_value { magic; hash; v }
+
+          let decode_bin ~dict:_ ~hash:_ s off =
+            let _, v = decode_value s off in
+            v.v
+
+          let magic _ = magic
+        end)
+
+        include Irmin_pack.Private.Closeable.Content_addressable (CA_Pack)
+      end
+
+      include Irmin.Private.Commit.Store (Node) (CA)
+    end
+
+    module Branch = struct
+      module Key = B
+      module Val = H
+      module AW = Irmin_pack.Store.Atomic_write (Key) (Val) (IO_version)
+      include Irmin_pack.Private.Closeable.Atomic_write (AW)
+    end
+
+    module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
+    module Sync = Irmin.Private.Sync.None (H) (B)
+
+    module Repo = struct
+      type t = {
+        config : Irmin.Private.Conf.t;
+        contents : read Contents.CA.t;
+        node : read Node.CA.t;
+        commit : read Commit.CA.t;
+        branch : Branch.t;
+      }
+
+      let contents_t t : 'a Contents.t = t.contents
+      let node_t t : 'a Node.t = (contents_t t, t.node)
+      let commit_t t : 'a Commit.t = (node_t t, t.commit)
+      let branch_t t = t.branch
+
+      let batch t f =
+        Commit.CA.batch t.commit (fun commit ->
+            Node.CA.batch t.node (fun node ->
+                Contents.CA.batch t.contents (fun contents ->
+                    let contents : 'a Contents.t = contents in
+                    let node : 'a Node.t = (contents, node) in
+                    let commit : 'a Commit.t = (node, commit) in
+                    f contents node commit)))
+
+      let unsafe_v config =
+        let root = Irmin_pack.Config.root config in
+        let fresh = Irmin_pack.Config.fresh config in
+        let readonly = Irmin_pack.Config.readonly config in
+        let* contents = Contents.CA.v ~fresh ~readonly root in
+        let* node = Node.CA.v ~fresh ~readonly root in
+        let* commit = Commit.CA.v ~fresh ~readonly root in
+        let+ branch = Branch.v ~fresh ~readonly root in
+        { contents; node; commit; branch; config }
+
+      let close t =
+        Contents.CA.close (contents_t t) >>= fun () ->
+        Node.CA.close (snd (node_t t)) >>= fun () ->
+        Commit.CA.close (snd (commit_t t)) >>= fun () -> Branch.close t.branch
+
+      let v config =
+        Lwt.catch
+          (fun () -> unsafe_v config)
+          (function
+            | I.Invalid_version { expected; found }
+              when expected = current_version ->
+                Log.err (fun m ->
+                    m "[%s] Attempted to open store of unsupported version %a"
+                      (Irmin_pack.Config.root config)
+                      pp_version found);
+                Lwt.fail (Unsupported_version found)
+            | e -> Lwt.fail e)
+
+      (** Stores share instances in memory, one sync is enough. However each
+          store has its own lru and all have to be cleared. *)
+      let sync t =
+        let on_generation_change () =
+          Node.CA.clear_caches (snd (node_t t));
+          Commit.CA.clear_caches (snd (commit_t t))
+        in
+        Contents.CA.sync ~on_generation_change (contents_t t)
+
+      (** Stores share instances so one clear is enough. *)
+      let clear t = Contents.CA.clear (contents_t t)
+
+      let flush t =
+        Contents.CA.flush (contents_t t);
+        Branch.flush t.branch
+    end
+  end
+
+  include Irmin.Of_private (X)
+
+  let integrity_check_inodes ?heads t =
+    Log.debug (fun l -> l "Check integrity for inodes");
+    let bar, (_, progress_nodes, progress_commits) =
+      Irmin_pack.Private.Utils.Progress.increment ()
+    in
+    let errors = ref [] in
+    let nodes = X.Repo.node_t t |> snd in
+    let node k =
+      progress_nodes ();
+      X.Node.CA.integrity_check_inodes nodes k >|= function
+      | Ok () -> ()
+      | Error msg -> errors := msg :: !errors
+    in
+    let commit _ =
+      progress_commits ();
+      Lwt.return_unit
+    in
+    let* heads =
+      match heads with None -> Repo.heads t | Some m -> Lwt.return m
+    in
+    let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
+    let+ () =
+      Repo.iter ~cache_size:1_000_000 ~min:[] ~max:hashes ~node ~commit t
+    in
+    Irmin_pack.Private.Utils.Progress.finalise bar;
+    let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
+    if !errors = [] then
+      Fmt.kstrf (fun x -> Ok (`Msg x)) "Ok for heads %a" pp_commits heads
+    else
+      Fmt.kstrf
+        (fun x -> Error (`Msg x))
+        "Inconsistent inodes found for heads %a: %a" pp_commits heads
+        Fmt.(list ~sep:comma string)
+        !errors
+
+  let sync = X.Repo.sync
+  let clear = X.Repo.clear
+  let migrate = Irmin_pack.Store.migrate
+  let flush = X.Repo.flush
+end
+
+module Pack = Pack_mem

--- a/src/irmin-pack/mem/pack_mem.ml
+++ b/src/irmin-pack/mem/pack_mem.ml
@@ -1,0 +1,227 @@
+(*
+  * Copyright (c) 2013-2019 Thomas Gazagnaire <thomas@gazagnaire.org>
+  *
+  * Permission to use, copy, modify, and distribute this software for any
+  * purpose with or without fee is hereby granted, provided that the above
+  * copyright notice and this permission notice appear in all copies.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  *)
+
+let src = Logs.Src.create "irmin.pack.mem" ~doc:"irmin-pack backend"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+open Lwt.Infix
+
+let current_version = `V2
+
+module IO_cache = Irmin_pack.Private.IO.Cache
+module IO = Irmin_pack.Private.IO.Unix
+
+module File (K : Irmin.Hash.S) (IO_version : Irmin_pack.VERSION) :
+  Irmin_pack.Pack.MAKER with type key = K.t = struct
+  type key = K.t
+  type 'a t = { mutable block : IO.t; mutable open_instances : int }
+
+  let clear ?keep_generation t = IO.clear ?keep_generation t.block
+  let flush t = IO.flush t.block
+  let offset t = IO.offset t.block
+  let generation t = IO.generation t.block
+
+  let valid t =
+    if t.open_instances <> 0 then (
+      t.open_instances <- t.open_instances + 1;
+      true)
+    else false
+
+  let unsafe_v ~fresh ~readonly file =
+    let block = IO.v ~version:(Some current_version) ~fresh ~readonly file in
+    { block; open_instances = 1 }
+
+  let IO_cache.{ v } =
+    IO_cache.memoize ~clear ~valid
+      ~v:(fun () -> unsafe_v)
+      Irmin_pack.Layout.pack
+
+  let close t =
+    t.open_instances <- t.open_instances - 1;
+    if t.open_instances = 0 then (
+      if not (IO.readonly t.block) then IO.flush t.block;
+      IO.close t.block)
+
+  module Make (V : Irmin_pack.Pack.ELT with type hash := K.t) :
+    Irmin_pack.Pack.S with type key = K.t and type value = V.t = struct
+    module KMap = Hashtbl.Make (struct
+      type t = K.t
+
+      let hash = Hashtbl.hash
+      let equal = Irmin.Type.(unstage (equal K.t))
+    end)
+
+    type key = K.t
+
+    let equal_key = Irmin.Type.(unstage (equal K.t))
+
+    type value = V.t
+
+    type nonrec 'a t = {
+      t : value KMap.t;
+      root : string;
+      pack : 'a t;
+      readonly : bool;
+      mutable open_instances : int;
+    }
+
+    let _decode_value = Irmin.Type.(unstage (decode_bin V.t))
+    let encode_key = Irmin.Type.(unstage (encode_bin K.t))
+    let encode_value = Irmin.Type.(unstage (encode_bin V.t))
+    let encode_magic = Irmin.Type.(unstage (encode_bin char))
+    let pp_key = Irmin.Type.pp K.t
+
+    let sync ?on_generation_change:_ t =
+      let former_generation = IO.generation t.pack.block in
+      let generation = IO.force_generation t.pack.block in
+      if former_generation <> generation then (
+        Log.debug (fun l -> l "[%s] generation changed, refill buffers" t.root);
+        KMap.clear t.t;
+        IO.close t.pack.block;
+        let block =
+          IO.v ~fresh:false ~version:(Some current_version) ~readonly:true
+            (IO.name t.pack.block)
+        in
+        t.pack.block <- block)
+
+    let _refill t =
+      let former_offset = IO.offset t.pack.block in
+      let offset = IO.force_offset t.pack.block in
+      Log.debug (fun l -> l "former = %Ld now = %Ld" former_offset offset);
+      (former_offset, offset, t.pack.block)
+
+    let roots = Hashtbl.create 10
+
+    let unsafe_clear ?keep_generation t =
+      Log.debug (fun f -> f "[%s] clear" t.root);
+      KMap.clear t.t;
+      clear ?keep_generation t.pack
+
+    let clear t =
+      unsafe_clear t;
+      Lwt.return_unit
+
+    let clear_keep_generation t =
+      unsafe_clear ~keep_generation:() t;
+      Lwt.return_unit
+
+    let valid t =
+      if t.open_instances <> 0 then (
+        t.open_instances <- t.open_instances + 1;
+        true)
+      else false
+
+    let unsafe_v_no_cache ~fresh ~readonly root =
+      Log.debug (fun l -> l "[%s] v fresh =%b readonly =%b" root fresh readonly);
+      let pack = v () ~fresh ~readonly root in
+      { t = KMap.create 0; root; pack; readonly; open_instances = 1 }
+
+    let unsafe_v ?(fresh = false) ?(readonly = false) root =
+      try
+        let t = Hashtbl.find roots (root, readonly) in
+        if valid t then (
+          if fresh then unsafe_clear t;
+          t)
+        else (
+          Hashtbl.remove roots (root, readonly);
+          raise Not_found)
+      with Not_found ->
+        let t = unsafe_v_no_cache ~fresh ~readonly root in
+        if fresh then unsafe_clear t;
+        Hashtbl.add roots (root, readonly) t;
+        t
+
+    let v ?fresh ?readonly root =
+      let t = unsafe_v ?fresh ?readonly root in
+      Lwt.return t
+
+    let flush ?index:_ ?index_merge:_ t = flush t.pack
+
+    let unsafe_close t =
+      t.open_instances <- t.open_instances - 1;
+      if t.open_instances = 0 then (
+        Log.debug (fun f -> f "[%s] close" t.root);
+        KMap.clear t.t;
+        close t.pack)
+
+    let close t =
+      unsafe_close t;
+      Lwt.return_unit
+
+    let offset t = offset t.pack
+    let generation t = generation t.pack
+    let cast t = (t :> [ `Read | `Write ] t)
+
+    let batch t f =
+      f (cast t) >>= fun r ->
+      flush t;
+      Lwt.return r
+
+    let check_key k v =
+      let k' = V.hash v in
+      if equal_key k k' then Ok () else Error (k, k')
+
+    let find t k =
+      try
+        let v = KMap.find t.t k in
+        check_key k v |> Result.map (fun () -> Some v)
+      with Not_found -> Ok None
+
+    let unsafe_find ~check_integrity:_ t k =
+      Log.debug (fun f -> f "[%s] unsafe find %a" t.root pp_key k);
+      find t k |> function
+      | Ok r -> r
+      | Error (k, k') ->
+          Fmt.invalid_arg "corrupted value: got %a, expecting %a" pp_key k'
+            pp_key k
+
+    let find t k =
+      Log.debug (fun f -> f "[%s] find %a" t.root pp_key k);
+      find t k |> function
+      | Ok r -> Lwt.return r
+      | Error (k, k') ->
+          Fmt.kstrf Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
+            pp_key k' pp_key k
+
+    let unsafe_mem t k =
+      Log.debug (fun f -> f "[%s] mem %a" t.root pp_key k);
+      KMap.mem t.t k
+
+    let mem t k =
+      let b = unsafe_mem t k in
+      Lwt.return b
+
+    let unsafe_append ~ensure_unique:_ ~overcommit:_ t k v =
+      Log.debug (fun f -> f "[%s] add -> %a" t.root pp_key k);
+      KMap.add t.t k v;
+      encode_key k (IO.append t.pack.block);
+      encode_magic (V.magic v) (IO.append t.pack.block);
+      encode_value v (IO.append t.pack.block)
+
+    let unsafe_add t k v =
+      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
+      Lwt.return_unit
+
+    let add t v =
+      let k = V.hash v in
+      unsafe_add t k v >|= fun () -> k
+
+    let _add_in_mem t k v = KMap.add t.t k v
+    let version _ = current_version
+    let clear_caches t = KMap.clear t.t
+    let integrity_check ~offset:_ ~length:_ _k _t = Ok ()
+  end
+end

--- a/src/irmin-pack/mem/pack_mem.mli
+++ b/src/irmin-pack/mem/pack_mem.mli
@@ -1,0 +1,18 @@
+(*
+  * Copyright (c) 2013-2019 Thomas Gazagnaire <thomas@gazagnaire.org>
+  *
+  * Permission to use, copy, modify, and distribute this software for any
+  * purpose with or without fee is hereby granted, provided that the above
+  * copyright notice and this permission notice appear in all copies.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  *)
+
+module File (K : Irmin.Hash.S) (_ : Irmin_pack.VERSION) :
+  Irmin_pack.Pack.MAKER with type key = K.t

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -25,13 +25,13 @@ end
 module Index : Irmin_pack.Index.S with type key = H.t
 
 module Pack :
-  Irmin_pack.Pack.S
+  Irmin_pack.Pack.INDEXED_S
     with type key = H.t
      and type value = string
      and type index = Index.t
 
 module P :
-  Irmin_pack.Pack.MAKER
+  Irmin_pack.Pack.INDEXED_MAKER
     with type key = H.t
      and type index = Irmin_pack.Index.Make(H).t
 

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -3,7 +3,7 @@
  (modules test_pack multiple_instances test_existing_stores layered
    test_inode import)
  (libraries alcotest fmt common index irmin irmin-test irmin-pack
-   irmin-pack.layered logs lwt lwt.unix fpath))
+   irmin-pack.layered irmin-pack.mem logs lwt lwt.unix fpath))
 
 (executable
  (name test)

--- a/test/irmin-pack/test.ml
+++ b/test/irmin-pack/test.ml
@@ -17,4 +17,4 @@
 let () =
   Irmin_test.Store.run "irmin-pack"
     ~misc:(Test_pack.misc @ [ ("utils", Test_utils.tests) ])
-    [ (`Quick, Test_pack.suite) ]
+    [ (`Quick, Test_pack.suite); (`Quick, Test_pack.suite_mem) ]

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -106,6 +106,71 @@ let suite =
     layered_store = Some layered_store;
   }
 
+module Irmin_pack_mem_maker
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) =
+struct
+  module XNode = Irmin.Private.Node.Make (H) (P) (M)
+  module XCommit = Irmin.Private.Commit.Make (H)
+
+  include
+    Irmin_pack_mem.Make
+      (struct
+        let io_version = `V2
+      end)
+      (Config)
+      (M)
+      (C)
+      (P)
+      (B)
+      (H)
+      (XNode)
+      (XCommit)
+end
+
+let suite_mem =
+  let store =
+    Irmin_test.store (module Irmin_pack_mem_maker) (module Irmin.Metadata.None)
+  in
+  let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_dir in
+  let init () =
+    if Sys.file_exists test_dir then (
+      let cmd = Printf.sprintf "rm -rf %s" test_dir in
+      Fmt.epr "exec: %s\n%!" cmd;
+      let _ = Sys.command cmd in
+      ());
+    Lwt.return_unit
+  in
+  let clean () =
+    let (module S : Irmin_test.S) = store in
+    let module P = S.Private in
+    let clear repo =
+      Lwt.join
+        [
+          P.Commit.clear (P.Repo.commit_t repo);
+          P.Node.clear (P.Repo.node_t repo);
+          P.Contents.clear (P.Repo.contents_t repo);
+          P.Branch.clear (P.Repo.branch_t repo);
+        ]
+    in
+    let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_dir in
+    S.Repo.v config >>= fun repo ->
+    clear repo >>= fun () -> S.Repo.close repo
+  in
+  let stats = None in
+  {
+    Irmin_test.name = "PACK MEM";
+    init;
+    clean;
+    config;
+    store;
+    stats;
+    layered_store = None;
+  }
+
 module Context = Make_context (struct
   let root = test_dir
 end)

--- a/test/irmin-pack/test_pack.mli
+++ b/test/irmin-pack/test_pack.mli
@@ -1,2 +1,3 @@
 val suite : Irmin_test.t
 val misc : (string * unit Alcotest.test_case list) list
+val suite_mem : Irmin_test.t


### PR DESCRIPTION
I’m exploring two routes: 
 - reuse the irmin-pack Make functors, by passing Pack as argument; this has the down side that pack_mem will depend on an index that it won’t use. It’s the first commit and mostly extracted from PR https://github.com/mirage/irmin/pull/1099;
 - add a dedicated Make functor in irmin_pack_mem, this way the pack_mem does not depend on index. The downside is that there is a lot of code duplication between the Make functors of irmin_pack, irmin_pack_mem (and irmin_pack_layers).  It’s the second commit (very much still a wip). I prefer this route, so I’ll keep exploring it.   

Also pack_mem keeps everything in a hashtable but also writes to disk, to support the readonly instances. But we can simplify this if we don’t want the support for readonly. 