### PR TITLE
irmin-pack: Inode detect non roots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,17 @@
     message. For Irmin users, it should not change anything (#1301, @dinosaure,
     @CraigFe)
 
+### Added
+- **irmin-pack**
+  - It is no longer possible to modify an `inode` that doesn't point to the root
+    of a directory. (#1292, @Ngoguey42)
+
+### Changed
+
+- **irmin-pack**
+  - When configuring a store, is it no longer possible to set `entries` to a
+    value larger than `stable_hash`. (#1292, @Ngoguey42)
+
 ## 2.5.0 (2021-02-16)
 
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,7 @@
-## 2.5.1 (2021-02-19)
-
-- **irmin-git**
-  - Use the last version of git 3.3.0. It fixes a bug about trailing LF on
-    message. For Irmin users, it should not change anything (#1301, @dinosaure,
-    @CraigFe)
+## Unreleased
 
 ### Added
+
 - **irmin-pack**
   - It is no longer possible to modify an `inode` that doesn't point to the root
     of a directory. (#1292, @Ngoguey42)
@@ -15,6 +11,13 @@
 - **irmin-pack**
   - When configuring a store, is it no longer possible to set `entries` to a
     value larger than `stable_hash`. (#1292, @Ngoguey42)
+
+## 2.5.1 (2021-02-19)
+
+- **irmin-git**
+  - Use the last version of git 3.3.0. It fixes a bug about trailing LF on
+    message. For Irmin users, it should not change anything (#1301, @dinosaure,
+    @CraigFe)
 
 ## 2.5.0 (2021-02-16)
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -314,13 +314,13 @@ struct
       recursion depth. An inode with [depth = 0] corresponds to the root of a
       directory, its hash is the hash of the directory.
 
-      A [Val.t] pointes to the topmost [Val_impl.t] of an inode tree. In most
+      A [Val.t] points to the topmost [Val_impl.t] of an inode tree. In most
       scenarios, that topmost inode has [depth = 0], but it is also legal for
       the topmost inode to be an intermediate inode, i.e. with [depth > 0].
 
       The only way for an inode tree to have an intermediate inode as root, is
       to fetch it from the backend by calling [Make_ext.find], using the hash
-      that inode.
+     of that inode.
 
       Write-only operations on trees starting by an intermediate inode are
       forbiden. *)

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -651,9 +651,11 @@ struct
       match find_value ~depth:0 layout t s with
       | Some v' when equal_value v v' -> stabilize layout t
       | Some _ ->
-          add ~depth:0 layout ~copy ~replace:true t s v (stabilize layout)
+          add ~depth:0 layout ~copy ~replace:true t s v Fun.id
+          |> stabilize layout
       | None ->
-          add ~depth:0 layout ~copy ~replace:false t s v (stabilize layout)
+          add ~depth:0 layout ~copy ~replace:false t s v Fun.id
+          |> stabilize layout
 
     let rec remove layout ~depth t s k =
       match t.v with
@@ -692,7 +694,7 @@ struct
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
       match find_value layout ~depth:0 t s with
       | None -> stabilize layout t
-      | Some _ -> remove layout ~depth:0 t s (stabilize layout)
+      | Some _ -> remove layout ~depth:0 t s Fun.id |> stabilize layout
 
     let v l =
       let len = List.length l in

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -494,19 +494,20 @@ struct
       | Tree { depth; _ } when depth = 0 -> true
       | Tree _ -> false
       | Values _ ->
-          (* Those 3 facts imply [t is stable => t is root]:
+          (* When [t] is of tag [Values], then [t] is root iff [t] is stable. It
+             is implied by the following.
+
+             When [t] is stable, then [t] is a root, because:
               - Only 2 functions produce stable inodes: [stabilize] and [empty].
               - Only the roots are output of [stabilize].
               - An empty map can only be located at the root.
 
-             Those 3 facts imply [(t is Values /\ t is root) => t is stable]:
+             When [t] is a root of tag [Value], then [t] is stable, because:
              - All the roots are output of [stabilize].
              - When an unstable inode enters [stabilize], it becomes stable if
                it has at most [Conf.stable_hash] leaves.
              - A [Value] has at most [Conf.stable_hash] leaves because
-               [Conf.entries <= Conf.stable_hash] is enforced somewhere.
-
-             Then [t is Values => (t is root = t is stable)].
+               [Conf.entries <= Conf.stable_hash] is enforced.
           *)
           t.stable
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -310,20 +310,20 @@ struct
 
       {3 Topmost Inode Ancestor}
 
-      [Val_impl.t] is a recursive type. The [depth] interer is a witness of the
-      recursion depth. An inode with [depth = 0] corresponds to the root of a
-      directory, its hash is the hash of the directory.
+      [Val_impl.t] is a recursive type, it is labelled with a [depth] integer
+      that indicates the recursion depth. An inode with [depth = 0] corresponds
+      to the root of a directory, its hash is the hash of the directory.
 
       A [Val.t] points to the topmost [Val_impl.t] of an inode tree. In most
       scenarios, that topmost inode has [depth = 0], but it is also legal for
       the topmost inode to be an intermediate inode, i.e. with [depth > 0].
 
-      The only way for an inode tree to have an intermediate inode as root, is
-      to fetch it from the backend by calling [Make_ext.find], using the hash
-     of that inode.
+      The only way for an inode tree to have an intermediate inode as root is to
+      fetch it from the backend by calling [Make_ext.find], using the hash of
+      that inode.
 
-      Write-only operations on trees starting by an intermediate inode are
-      forbiden. *)
+      Write-only operations are not permitted when the root is an intermediate
+      inode. *)
   module Val_impl = struct
     open T
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -491,8 +491,7 @@ struct
 
     let is_root t =
       match t.v with
-      | Tree { depth; _ } when depth = 0 -> true
-      | Tree _ -> false
+      | Tree { depth; _ } -> depth = 0
       | Values _ ->
           (* When [t] is of tag [Values], then [t] is root iff [t] is stable. It
              is implied by the following.

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -5,8 +5,7 @@
  (libraries alcotest fmt common index irmin irmin-test irmin-pack
    irmin-pack.layered logs lwt lwt.unix fpath)
  (preprocess
-  (pps ppx_irmin))
-)
+  (pps ppx_irmin)))
 
 (executable
  (name test)

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -3,7 +3,10 @@
  (modules test_pack multiple_instances test_existing_stores layered
    test_inode import)
  (libraries alcotest fmt common index irmin irmin-test irmin-pack
-   irmin-pack.layered logs lwt lwt.unix fpath))
+   irmin-pack.layered logs lwt lwt.unix fpath)
+ (preprocess
+  (pps ppx_irmin))
+)
 
 (executable
  (name test)


### PR DESCRIPTION
Resolves https://github.com/mirage/irmin/issues/1266.

irmin-pack: adapt inode.ml to acknowledge root inodes that are not directory roots

- [Conf.entries <= Conf.stable_hash] is now an invariant.
- Can now detect and raise when an inodes that isn't the root of directory attempts a write-only operation.
- Add Val_impl.is_root.
