### PR TITLE
Change Tree.t representation to use lazy contents values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Changed
+
+- Changed `Store.Tree.{of_hash, shallow}` to take kinded hashes, allowing the
+  creation of unforced contents values.
+
+- Changed `Tree.destruct` to return _lazy_ contents values, which may be forced
+  with `Tree.Contents.force`.
+
 ## 2.4.0 (2021-02-02)
 
 ### Fixed

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -29,6 +29,7 @@ depends: [
   "yojson"          {with-test}
   "cohttp-lwt-unix" {with-test}
   "alcotest"        {with-test & >= "1.2.3"}
+  "logs"            {with-test}
 ]
 
 

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -311,16 +311,9 @@ struct
                   >>= Lwt_list.map_s (fun (step, tree) ->
                           let absolute_key = Store.Key.rcons tree_key step in
                           match Store.Tree.destruct tree with
-                          | `Contents (c, m) -> (
-                              Store.Tree.Contents.force c >|= function
-                              | Ok c ->
-                                  Lazy.(
-                                    force contents_as_node (c, m, absolute_key))
-                              | Error (`Dangling_hash h) ->
-                                  Fmt.failwith
-                                    "Can't force dangling contents hash: %a"
-                                    (Irmin.Type.pp_dump Store.Hash.t)
-                                    h)
+                          | `Contents (c, m) ->
+                              let+ c = Store.Tree.Contents.force_exn c in
+                              Lazy.(force contents_as_node (c, m, absolute_key))
                           | _ ->
                               Lwt.return
                                 Lazy.(force tree_as_node (tree, absolute_key)))

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -133,7 +133,7 @@ module Make_helpers (S : S) = struct
 
   let r1 ~repo =
     let* kn2 = n2 ~repo in
-    S.Tree.of_hash repo kn2 >>= function
+    S.Tree.of_hash repo (`Node kn2) >>= function
     | None -> Alcotest.fail "r1"
     | Some tree ->
         S.Commit.v repo ~info:Irmin.Info.empty ~parents:[] (tree :> S.tree)
@@ -141,7 +141,7 @@ module Make_helpers (S : S) = struct
   let r2 ~repo =
     let* kn3 = n3 ~repo in
     let* kr1 = r1 ~repo in
-    S.Tree.of_hash repo kn3 >>= function
+    S.Tree.of_hash repo (`Node kn3) >>= function
     | None -> Alcotest.fail "r2"
     | Some t3 ->
         S.Commit.v repo ~info:Irmin.Info.empty ~parents:[ S.Commit.hash kr1 ]

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -33,7 +33,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
 
   let r1 ~repo =
     let* kn2 = n1 ~repo in
-    S.Tree.of_hash repo kn2 >>= function
+    S.Tree.of_hash repo (`Node kn2) >>= function
     | None -> Alcotest.fail "r1"
     | Some tree ->
         S.Commit.v repo ~info:(info "r1") ~parents:[] (tree :> S.tree)
@@ -42,7 +42,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
     let* kn2 = n1 ~repo in
     let* kn3 = with_node repo (fun t -> Graph.v t [ ("a", `Node kn2) ]) in
     let* kr1 = r1 ~repo in
-    S.Tree.of_hash repo kn3 >>= function
+    S.Tree.of_hash repo (`Node kn3) >>= function
     | None -> Alcotest.fail "r2"
     | Some t3 ->
         S.Commit.v repo ~info:(info "r2") ~parents:[ S.Commit.hash kr1 ]

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1032,7 +1032,7 @@ module Make (S : S) = struct
       Alcotest.(check int) "val-list:3" 0 (S.Tree.counters ()).node_val_list;
 
       (* Test caching (makesure that no tree is lying in scope) *)
-      let v0 = S.Tree.shallow repo (P.Contents.Key.hash "foo-x") in
+      let v0 = S.Tree.shallow repo (`Node (P.Contents.Key.hash "foo-x")) in
       S.Tree.reset_counters ();
       let foo = "foo-x" in
       let* v0 = S.Tree.add v0 [ "foo" ] foo in
@@ -1043,7 +1043,7 @@ module Make (S : S) = struct
       let _ = S.Tree.hash v0 in
       let* _v0 = S.Tree.add v0 [ "foo" ] foo in
       let _k = S.Tree.hash v0 in
-      let v0 = S.Tree.shallow repo (P.Contents.Key.hash "bar-x") in
+      let v0 = S.Tree.shallow repo (`Node (P.Contents.Key.hash "bar-x")) in
       let xxx = "xxx" in
       let yyy = "yyy" in
       let zzz = "zzz" in
@@ -1898,8 +1898,8 @@ module Make (S : S) = struct
     let test repo =
       let foo_k = S.Private.Contents.Key.hash "foo" in
       let bar_k = S.Private.Contents.Key.hash "bar" in
-      let tree_1 = S.Tree.shallow repo foo_k in
-      let tree_2 = S.Tree.shallow repo bar_k in
+      let tree_1 = S.Tree.shallow repo (`Node foo_k) in
+      let tree_2 = S.Tree.shallow repo (`Node bar_k) in
       let node_3 =
         S.Private.Node.Val.v
           [

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -93,12 +93,9 @@ module Make (P : Private.S) = struct
 
   let save_tree ?(clear = true) r x y (tr : Tree.t) =
     match Tree.destruct tr with
-    | `Contents (c, _) -> (
-        Tree.Contents.force c >>= function
-        | Ok c -> save_contents x c
-        | Error (`Dangling_hash h) ->
-            Fmt.failwith "Can't save tree with danging contents hash: %a"
-              (Type.pp_dump Hash.t) h)
+    | `Contents (c, _) ->
+        let* c = Tree.Contents.force_exn c in
+        save_contents x c
     | `Node n -> Tree.export ~clear r x y n
 
   type node = Tree.node [@@deriving irmin]

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -359,11 +359,16 @@ module type S = sig
     val hash : tree -> hash
     (** [hash r c] it [c]'s hash in the repository [r]. *)
 
-    val of_hash : Repo.t -> hash -> tree option Lwt.t
+    type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]
+    (** Hashes in the Irmin store are tagged with the type of the value they
+        reference (either {!contents} or {!node}). In the [contents] case, the
+        hash is paired with corresponding {!metadata}. *)
+
+    val of_hash : Repo.t -> kinded_hash -> tree option Lwt.t
     (** [of_hash r h] is the the tree object in [r] having [h] as hash, or
         [None] is no such tree object exists. *)
 
-    val shallow : Repo.t -> hash -> tree
+    val shallow : Repo.t -> kinded_hash -> tree
     (** [shallow r h] is the shallow tree object with the hash [h]. No check is
         performed to verify if [h] actually exists in [r]. *)
   end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1463,7 +1463,7 @@ module Make (P : Private.S) = struct
     let rec tree : type r. t -> (concrete, r) cont_lwt =
      fun t k ->
       match t with
-      | `Contents (c, m) -> contents (c, m) k
+      | `Contents c -> contents c k
       | `Node n ->
           let* m = Node.to_map n in
           let bindings = m |> get_ok |> StepMap.bindings in

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -986,11 +986,7 @@ module Make (P : Private.S) = struct
   let fold ?(force = `And_clear) ?(uniq = `False) ?(pre = id) ?(post = id)
       ?depth ?(contents = id) ?(node = id) (t : t) acc =
     match t with
-    | `Contents (c, _) -> (
-        (* TODO: respect {!force} here? *)
-        Contents.to_value c >>= function
-        | Error (`Dangling_hash _) -> assert false
-        | Ok v -> contents Path.empty v acc)
+    | `Contents (c, _) -> Contents.fold ~force ~path:Path.empty contents c acc
     | `Node n ->
         Node.fold ~force ~uniq ~pre ~post ~path:Path.empty ?depth ~contents
           ~node n acc

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -259,6 +259,12 @@ module Make (P : Private.S) = struct
 
     let force = to_value
 
+    let force_exn t =
+      force t >|= function
+      | Ok v -> v
+      | Error (`Dangling_hash h) ->
+          Fmt.failwith "Can't force dangling contents hash: %a" pp_hash h
+
     let equal (x : t) (y : t) =
       x == y
       ||

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -172,9 +172,9 @@ module type S = sig
 
   type 'a force = [ `True | `False of key -> 'a -> 'a Lwt.t | `And_clear ]
   (** The type for {!fold}'s [force] parameter. [`True] forces the fold to read
-      the objects of the lazy nodes. [`False f] is applying [f] on every lazy
-      node instead. [`And_clear] is like [`True] but also eagerly empty the Tree
-      caches when traversing sub-nodes. *)
+      the objects of the lazy nodes and contents. [`False f] is applying [f] on
+      every lazy node and content value instead. [`And_clear] is like [`True]
+      but also eagerly empties the Tree caches when traversing sub-nodes. *)
 
   type uniq = [ `False | `True | `Marks of marks ]
   (** The type for {!fold}'s [uniq] parameters. [`False] folds over all the

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -84,6 +84,10 @@ module type S = sig
     (** [force t] forces evaluation of the lazy content value [t], or returns an
         error if no such value exists in the underlying repository. *)
 
+    val force_exn : t -> contents Lwt.t
+    (** Equivalent to {!force}, but raises an exception if the lazy content
+        value is not present in the underlying repository. *)
+
     val clear : t -> unit
     (** [clear t] clears [t]'s cache. *)
   end

--- a/test/irmin-graphql/dune
+++ b/test/irmin-graphql/dune
@@ -2,7 +2,7 @@
  (name test)
  (modules test common import)
  (libraries alcotest alcotest-lwt yojson irmin irmin-graphql irmin.mem
-   cohttp-lwt-unix))
+   cohttp-lwt-unix logs.fmt logs))
 
 (rule
  (alias runtest)

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -108,6 +108,8 @@ let suite ~set_tree =
 
 let () =
   Random.self_init ();
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.set_level (Some Debug);
   let main =
     let* { event_loop; set_tree } = spawn_graphql_server () in
     Lwt.pick [ event_loop; Alcotest_lwt.run "irmin-graphql" (suite ~set_tree) ]

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -460,6 +460,26 @@ let test_fold_force _ () =
 
   Lwt.return_unit
 
+let test_shallow _ () =
+  let* () =
+    let compute_hash ~subtree =
+      Tree.(add_tree empty) [ "key" ] subtree >|= Tree.hash
+    in
+    let leaf = Tree.of_concrete (c "0") in
+    let* shallow_leaf =
+      let+ repo = Store.Repo.v (Irmin_mem.config ()) in
+      Tree.shallow repo (Tree.hash leaf)
+    in
+    let* hash = compute_hash ~subtree:leaf in
+    let+ hash_shallow = compute_hash ~subtree:shallow_leaf in
+    Alcotest.(gcheck Store.Hash.t)
+      "Hashing a shallow contents value is equivalent to hashing the \
+       non-shallow contents"
+      hash hash_shallow
+  in
+
+  Lwt.return_unit
+
 let test_kind_empty_path _ () =
   let cont = c "c" |> Tree.of_concrete in
   let tree = `Tree [ ("k", c "c") ] |> Tree.of_concrete in
@@ -485,5 +505,6 @@ let suite =
     Alcotest_lwt.test_case "update" `Quick test_update;
     Alcotest_lwt.test_case "clear" `Quick test_clear;
     Alcotest_lwt.test_case "fold" `Quick test_fold_force;
+    Alcotest_lwt.test_case "shallow" `Quick test_shallow;
     Alcotest_lwt.test_case "kind of empty path" `Quick test_kind_empty_path;
   ]

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -43,7 +43,7 @@ let c ?(info = Metadata.Default) blob = `Contents (blob, info)
 let invalid_tree () =
   let+ repo = Store.Repo.v (Irmin_mem.config ()) in
   let hash = Store.Hash.hash (fun f -> f "") in
-  Tree.shallow repo hash
+  Tree.shallow repo (`Node hash)
 
 let test_bindings _ () =
   let tree =
@@ -398,7 +398,7 @@ let test_fold_force _ () =
   let* invalid_tree =
     let+ repo = Store.Repo.v (Irmin_mem.config ()) in
     let hash = Store.Hash.hash (fun f -> f "") in
-    Tree.shallow repo hash
+    Tree.shallow repo (`Node hash)
   in
 
   (* Ensure that [fold] doesn't force a lazy tree when [~force:(`False f)],
@@ -468,7 +468,7 @@ let test_shallow _ () =
     let leaf = Tree.of_concrete (c "0") in
     let* shallow_leaf =
       let+ repo = Store.Repo.v (Irmin_mem.config ()) in
-      Tree.shallow repo (Tree.hash leaf)
+      Tree.shallow repo (`Contents (Tree.hash leaf, Metadata.default))
     in
     let* hash = compute_hash ~subtree:leaf in
     let+ hash_shallow = compute_hash ~subtree:shallow_leaf in


### PR DESCRIPTION
This changes the type of trees to support lazy contents values:

```diff
- type t = Node of lazy_node | Contents of blob * metadata
+ type t = Node of lazy_node | Contents of lazy_contents
```

This means that contents are (internally) handled symmetrically to nodes: as unforced pointers to values in the underlying stores wherever possible. The user-facing changes are: 

- `Tree.destruct` returns unforced contents pointers that can be dereferenced with `Tree.Contents.force`.
- `Tree.of_hash` and `Tree.shallow` now take _kinded_ hashes with appropriate metadata.

This is motivated by https://github.com/mirage/irmin/issues/1284, which stems from the fact that we don't currently support "shallow" tree leaves. With this change, it's easy to extend `Tree.shallow` to support this, and I've added @smelc's now-working test case from that issue here. (Thanks!)

Fixes https://github.com/mirage/irmin/issues/1284.