### PR TITLE
Tree.remove scaling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 - **irmin-bench**
   - New features in benchmarks for tree operations (#1269, @Ngoguey42)
 
+- **irmin**
+  - `Store.Tree.remove` is now much faster when operating on large directories.
+     The commits following removals are also much faster. (#1289, @Ngoguey42)
+
 ### Removed
 
 ## 2.4.0 (2021-02-02)

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -39,6 +39,13 @@ module Seq = struct
         match l () with Nil -> acc | Cons (x, l') -> aux (x :: acc) (n - 1) l'
     in
     fun n s -> List.rev (aux [] n s)
+
+  let exists : type a. (a -> bool) -> a Seq.t -> bool =
+   fun f s ->
+    let rec aux s =
+      match s () with Seq.Nil -> false | Seq.Cons (v, s) -> f v || aux s
+    in
+    aux s
 end
 
 type read = Perms.read

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -323,6 +323,19 @@ module Make (P : Private.S) = struct
       | Value of repo * value * updatemap option
 
     and t = { mutable v : v; mutable info : info }
+    (** [t.v] has 3 possible states:
+
+        - A [Map], only after a [Tree.of_concrete] operation.
+        - A [Value], only after an add, a remove, temporarily during an export
+          or at the end of a merge.
+        - It is otherwise a [Hash].
+
+        [t.info.map] is only populated during a call to [Node.to_map] which only
+        happens during a call to one of those traversal functions:
+
+        - Traversal: [Node.list], [Node.bindings], [Node.fold]
+        - Conversion: [Tree.to_concrete]
+        - Misc: [Node.merge], [Tree.diff_node] *)
 
     let elt_t (t : t Type.t) : elt Type.t =
       let open Type in

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -330,12 +330,7 @@ module Make (P : Private.S) = struct
           or at the end of a merge.
         - It is otherwise a [Hash].
 
-        [t.info.map] is only populated during a call to [Node.to_map] which only
-        happens during a call to one of those traversal functions:
-
-        - Traversal: [Node.list], [Node.bindings], [Node.fold]
-        - Conversion: [Tree.to_concrete]
-        - Misc: [Node.merge], [Tree.diff_node] *)
+        [t.info.map] is only populated during a call to [Node.to_map]. *)
 
     let elt_t (t : t Type.t) : elt Type.t =
       let open Type in
@@ -366,12 +361,7 @@ module Make (P : Private.S) = struct
       |> sealv
 
     let updatemap_t (elt : elt Type.t) : updatemap Type.t =
-      let open Type in
-      let to_map x =
-        List.fold_left (fun acc (k, v) -> StepMap.add k v acc) StepMap.empty x
-      in
-      let of_map m = StepMap.fold (fun k v acc -> (k, v) :: acc) m [] in
-      map (list (pair Path.step_t (update_t elt))) to_map of_map
+      map_t (update_t elt) to_map of_map
 
     let v_t (m : map Type.t) (um : updatemap Type.t) : v Type.t =
       let open Type in
@@ -680,13 +670,7 @@ module Make (P : Private.S) = struct
             let entries = P.Node.Val.list v in
             if List.length entries > remove_count then false
             else
-              let any_kept =
-                (* Would converting to [Set] and use [subset : t -> t -> bool]
-                   be quicker? *)
-                List.exists (fun (step, _) -> not (StepMap.mem step um)) entries
-              in
-              let res = not any_kept in
-              res)
+              List.for_all (fun (step, _) -> StepMap.mem step um) entries)
 
     let is_empty t =
       match cached_map t with

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -337,7 +337,8 @@ module Make (P : Private.S) = struct
       |~ case1 "Contents-x" (pair Contents.t Metadata.t) (fun x -> `Contents x)
       |> sealv
 
-    let map_t (elt : elt Type.t) : map Type.t =
+    let stepmap_t : 'a. 'a Type.t -> 'a StepMap.t Type.t =
+     fun elt ->
       let open Type in
       let to_map x =
         List.fold_left (fun acc (k, v) -> StepMap.add k v acc) StepMap.empty x
@@ -353,10 +354,9 @@ module Make (P : Private.S) = struct
       |~ case0 "remove" Remove
       |> sealv
 
-    let updatemap_t (elt : elt Type.t) : updatemap Type.t =
-      map_t (update_t elt) to_map of_map
-
-    let v_t (m : map Type.t) (um : updatemap Type.t) : v Type.t =
+    let v_t (elt : elt Type.t) : v Type.t =
+      let m = stepmap_t elt in
+      let um = stepmap_t (update_t elt) in
       let open Type in
       variant "Node.node" (fun map hash value -> function
         | Map m -> map m
@@ -387,7 +387,7 @@ module Make (P : Private.S) = struct
     let _, t =
       Type.mu2 (fun _ y ->
           let elt = elt_t y in
-          let v = v_t (map_t elt) (updatemap_t elt) in
+          let v = v_t elt in
           let t = t v in
           (v, t))
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -28,6 +28,11 @@ type ('a, 'r) cont_lwt = ('a, 'r Lwt.t) cont
 
 let ok x = Lwt.return (Ok x)
 
+let rec list_is_longer_than : type a. a list -> int -> bool =
+ fun l len ->
+  if len < 0 then true
+  else match l with [] -> false | _ :: tl -> list_is_longer_than tl (len - 1)
+
 (* assume l1 and l2 are key-sorted *)
 let alist_iter2 compare_k f l1 l2 =
   let rec aux l1 l2 =
@@ -665,7 +670,7 @@ module Make (P : Private.S) = struct
                no alternative. *)
             cnt.node_val_list <- cnt.node_val_list + 1;
             let entries = P.Node.Val.list v in
-            if List.length entries > remove_count then false
+            if list_is_longer_than entries remove_count then false
             else List.for_all (fun (step, _) -> StepMap.mem step um) entries)
 
     let is_empty t =

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -18,6 +18,13 @@
 open! Import
 include Tree_intf
 
+let seq_exists : ('a -> bool) -> 'a Seq.t -> bool =
+ fun f s ->
+  let rec aux s =
+    match s () with Seq.Nil -> false | Seq.Cons (v, s) -> f v || aux s
+  in
+  aux s
+
 let src = Logs.Src.create "irmin.tree" ~doc:"Persistent lazy trees for Irmin"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -111,6 +118,9 @@ module Make (P : Private.S) = struct
     end
 
     include Map.Make (X)
+
+    let stdlib_merge = merge
+
     include Merge.Map (X)
   end
 
@@ -294,6 +304,10 @@ module Make (P : Private.S) = struct
 
     type elt = [ `Node of t | `Contents of Contents.t * Metadata.t ]
 
+    and update = Add of elt | Remove
+
+    and updatemap = update StepMap.t
+
     and map = elt StepMap.t
 
     and info = {
@@ -306,11 +320,11 @@ module Make (P : Private.S) = struct
     and v =
       | Map of map
       | Hash of repo * hash
-      | Value of repo * value * map option
+      | Value of repo * value * updatemap option
 
     and t = { mutable v : v; mutable info : info }
 
-    let elt_t t : elt Type.t =
+    let elt_t (t : t Type.t) : elt Type.t =
       let open Type in
       variant "Node.value" (fun node contents contents_m -> function
         | `Node x -> node x
@@ -330,7 +344,23 @@ module Make (P : Private.S) = struct
       let of_map m = StepMap.fold (fun k v acc -> (k, v) :: acc) m [] in
       map (list (pair Path.step_t elt)) to_map of_map
 
-    let v_t (m : map Type.t) : v Type.t =
+    let update_t (elt : elt Type.t) : update Type.t =
+      let open Type in
+      variant "Node.update" (fun add remove -> function
+        | Add elt -> add elt | Remove -> remove)
+      |~ case1 "add" elt (fun elt -> Add elt)
+      |~ case0 "remove" Remove
+      |> sealv
+
+    let updatemap_t (elt : elt Type.t) : updatemap Type.t =
+      let open Type in
+      let to_map x =
+        List.fold_left (fun acc (k, v) -> StepMap.add k v acc) StepMap.empty x
+      in
+      let of_map m = StepMap.fold (fun k v acc -> (k, v) :: acc) m [] in
+      map (list (pair Path.step_t (update_t elt))) to_map of_map
+
+    let v_t (m : map Type.t) (um : updatemap Type.t) : v Type.t =
       let open Type in
       variant "Node.node" (fun map hash value -> function
         | Map m -> map m
@@ -338,7 +368,7 @@ module Make (P : Private.S) = struct
         | Value (_, v, m) -> value (v, m))
       |~ case1 "map" m (fun m -> Map m)
       |~ case1 "hash" P.Hash.t (fun _ -> assert false)
-      |~ case1 "value" (pair P.Node.Val.t (option m)) (fun _ -> assert false)
+      |~ case1 "value" (pair P.Node.Val.t (option um)) (fun _ -> assert false)
       |> sealv
 
     let info_is_empty i =
@@ -361,7 +391,7 @@ module Make (P : Private.S) = struct
     let _, t =
       Type.mu2 (fun _ y ->
           let elt = elt_t y in
-          let v = v_t (map_t elt) in
+          let v = v_t (map_t elt) (updatemap_t elt) in
           let t = t v in
           (v, t))
 
@@ -376,9 +406,13 @@ module Make (P : Private.S) = struct
     and clear_maps ~max_depth depth = List.iter (clear_map ~max_depth depth)
 
     and clear_info ~max_depth ?v depth i =
-      let added =
+      let updates =
         match v with
-        | Some (Value (_, _, Some m)) -> StepMap.bindings m
+        | Some (Value (_, _, Some um)) ->
+            StepMap.bindings um
+            |> List.filter_map (function
+                 | _, Remove -> None
+                 | k, Add v -> Some (k, v))
         | _ -> []
       in
       let map =
@@ -394,7 +428,7 @@ module Make (P : Private.S) = struct
         i.map <- None;
         i.hash <- None;
         i.findv_cache <- None);
-      clear_maps ~max_depth depth [ map; added; findv ]
+      clear_maps ~max_depth depth [ map; updates; findv ]
 
     and clear ~max_depth depth t = clear_info ~v:t.v ~max_depth depth t.info
 
@@ -419,7 +453,7 @@ module Make (P : Private.S) = struct
     let dump = Type.pp_json ~minify:false t
     let of_map m = of_v (Map m)
     let of_hash repo k = of_v (Hash (repo, k))
-    let of_value ?added repo v = of_v (Value (repo, v, added))
+    let of_value ?updates repo v = of_v (Value (repo, v, updates))
 
     let empty = function
       | { v = Hash (repo, _) | Value (repo, _, _); _ } ->
@@ -478,7 +512,7 @@ module Make (P : Private.S) = struct
               match t.v with
               | Hash (_, h) -> k h
               | Value (_, v, None) -> a_of_value v
-              | Value (_, v, Some a) -> value_of_adds t v a a_of_value
+              | Value (_, v, Some um) -> value_of_updates t v um a_of_value
               | Map m -> value_of_map t m a_of_value))
 
     and value_of_map : type r. t -> map -> (value, r) cont =
@@ -509,17 +543,18 @@ module Make (P : Private.S) = struct
       | `Contents (c, m) -> k (`Contents (Contents.hash c, m))
       | `Node n -> hash n (fun h -> k (`Node h))
 
-    and value_of_adds : type r. t -> value -> _ -> (value, r) cont =
-     fun t v added k ->
-      let added = StepMap.bindings added in
+    and value_of_updates : type r. t -> value -> _ -> (value, r) cont =
+     fun t v updates k ->
+      let updates = StepMap.bindings updates in
       let rec aux acc = function
         | [] ->
             t.info.value <- Some acc;
             k acc
-        | (k, e) :: rest ->
+        | (k, Add e) :: rest ->
             value_of_elt e (fun e -> aux (P.Node.Val.add acc k e) rest)
+        | (k, Remove) :: rest -> aux (P.Node.Val.remove acc k) rest
       in
-      aux v added
+      aux v updates
 
     let hash k = hash k (fun x -> x)
 
@@ -540,7 +575,7 @@ module Make (P : Private.S) = struct
       | None -> (
           match t.v with
           | Value (_, v, None) -> ok v
-          | Value (_, v, Some m) -> value_of_adds t v m ok
+          | Value (_, v, Some um) -> value_of_updates t v um ok
           | Map m -> value_of_map t m ok
           | Hash (repo, h) -> value_of_hash t repo h)
 
@@ -548,12 +583,20 @@ module Make (P : Private.S) = struct
       match cached_map t with
       | Some m -> Lwt.return (Ok m)
       | None -> (
-          let of_value repo v added =
+          let of_value repo v updates =
             let m = map_of_value repo v in
             let m =
-              match added with
+              match updates with
               | None -> m
-              | Some added -> StepMap.union (fun _ _ a -> Some a) m added
+              | Some updates ->
+                  StepMap.stdlib_merge
+                    (fun _ left right ->
+                      match (left, right) with
+                      | None, None -> assert false
+                      | (Some _ as v), None -> v
+                      | _, Some (Add v) -> Some v
+                      | _, Some Remove -> None)
+                    m updates
             in
             t.info.map <- Some m;
             m
@@ -606,12 +649,40 @@ module Make (P : Private.S) = struct
             | Some x, Some y -> if equal_node x y then True else False
             | _ -> Maybe)
 
+    let is_updatemap_empty v um =
+      let any_add =
+        StepMap.to_seq um
+        |> seq_exists (function _, Remove -> false | _, Add _ -> true)
+      in
+      if any_add then false
+      else
+        let val_is_empty = P.Node.Val.is_empty v in
+        if val_is_empty then true
+        else
+          let remove_count = StepMap.cardinal um in
+          if (not val_is_empty) && remove_count = 0 then false
+          else (
+            (* This is expensive from this point but there is no alternative *)
+            cnt.node_val_list <- cnt.node_val_list + 1;
+            let entries = P.Node.Val.list v in
+            if List.length entries > remove_count then false
+            else
+              let any_kept =
+                (* Would converting to [Set] and use [subset : t -> t -> bool]
+                   be quicker? *)
+                List.exists (fun (step, _) -> not (StepMap.mem step um)) entries
+              in
+              let res = not any_kept in
+              res)
+
     let is_empty t =
       match cached_map t with
       | Some m -> Lwt.return (Ok (StepMap.is_empty m))
       | None -> (
           match t.v with
-          | Value (_, _, Some _) -> Lwt.return (Ok false)
+          | Value (_, v, Some um) ->
+              let res = is_updatemap_empty v um in
+              Lwt.return_ok res
           | _ -> (
               to_value t >|= function
               | Error _ as e -> e
@@ -642,9 +713,10 @@ module Make (P : Private.S) = struct
         match t.v with
         | Map m -> Lwt.return (of_map m)
         | Value (repo, v, None) -> Lwt.return (of_value repo v)
-        | Value (repo, v, Some m) -> (
-            match of_map m with
-            | Some _ as v -> Lwt.return v
+        | Value (repo, v, Some um) -> (
+            match StepMap.find_opt step um with
+            | Some (Add v) -> Lwt.return (Some v)
+            | Some Remove -> Lwt.return None
             | None -> Lwt.return (of_value repo v))
         | Hash (repo, h) -> (
             match cached_value t with
@@ -812,14 +884,14 @@ module Make (P : Private.S) = struct
         let m' = StepMap.add step v m in
         if m == m' then t else of_map m'
       in
-      let of_value repo n added =
-        let added' = StepMap.add step v added in
-        if added == added' then t else of_value repo n ~added:added'
+      let of_value repo n updates =
+        let updates' = StepMap.add step (Add v) updates in
+        if updates == updates' then t else of_value repo n ~updates:updates'
       in
       match t.v with
       | Map m -> Lwt.return (of_map m)
       | Value (repo, n, None) -> Lwt.return (of_value repo n StepMap.empty)
-      | Value (repo, n, Some m) -> Lwt.return (of_value repo n m)
+      | Value (repo, n, Some um) -> Lwt.return (of_value repo n um)
       | Hash (repo, h) -> (
           match (cached_value t, cached_map t) with
           | Some v, _ -> Lwt.return (of_value repo v StepMap.empty)
@@ -1220,53 +1292,63 @@ module Make (P : Private.S) = struct
                     (* might happen if the node has already been added
                        (while the thread was block on P.Node.mem *)
                     k ()
-                | Map children | Value (_, _, Some children) ->
-                    (* 1. convert partial values to total values *)
-                    let* () =
-                      match n.v with
-                      | Value (_, _, Some _) -> (
-                          Node.to_value n >|= function
-                          | Error (`Dangling_hash _) -> ()
-                          | Ok v -> n.v <- Value (repo, v, None))
-                      | _ -> Lwt.return_unit
+                | Map children ->
+                    let l = StepMap.bindings children |> List.map snd in
+                    add_steps_to_todo l n k
+                | Value (_, _, Some children) ->
+                    let l =
+                      StepMap.bindings children
+                      |> List.filter_map (function
+                           | _, Node.Remove -> None
+                           | _, Node.Add v -> Some v)
                     in
-                    (* 2. push the current node job on the stack. *)
-                    let () =
-                      match (n.v, Node.cached_value n) with
-                      | _, Some v -> Stack.push (add_node n v) todo
-                      | Map x, None -> Stack.push (add_node_map n x) todo
-                      | _ -> assert false
-                    in
-                    let contents = ref [] in
-                    let nodes = ref [] in
-                    StepMap.iter
-                      (fun _ -> function
-                        | `Contents c -> contents := c :: !contents
-                        | `Node n -> nodes := n :: !nodes)
-                      children;
+                    add_steps_to_todo l n k)))
+    and add_steps_to_todo : type a. _ -> _ -> (unit -> a Lwt.t) -> a Lwt.t =
+     fun l n k ->
+      (* 1. convert partial values to total values *)
+      let* () =
+        match n.Node.v with
+        | Value (_, _, Some _) -> (
+            Node.to_value n >|= function
+            | Error (`Dangling_hash _) -> ()
+            | Ok v -> n.v <- Value (repo, v, None))
+        | _ -> Lwt.return_unit
+      in
+      (* 2. push the current node job on the stack. *)
+      let () =
+        match (n.v, Node.cached_value n) with
+        | _, Some v -> Stack.push (add_node n v) todo
+        | Map x, None -> Stack.push (add_node_map n x) todo
+        | _ -> assert false
+      in
+      let contents = ref [] in
+      let nodes = ref [] in
+      List.iter
+        (function
+          | `Contents c -> contents := c :: !contents
+          | `Node n -> nodes := n :: !nodes)
+        l;
 
-                    (* 2. push the contents job on the stack. *)
-                    List.iter
-                      (fun (c, _) ->
-                        let h = Contents.hash c in
-                        if Hashes.mem seen h then ()
-                        else (
-                          Hashes.add seen h ();
-                          match c.Contents.v with
-                          | Contents.Hash _ -> ()
-                          | Contents.Value x ->
-                              Stack.push (add_contents c x) todo))
-                      !contents;
+      (* 2. push the contents job on the stack. *)
+      List.iter
+        (fun (c, _) ->
+          let h = Contents.hash c in
+          if Hashes.mem seen h then ()
+          else (
+            Hashes.add seen h ();
+            match c.Contents.v with
+            | Contents.Hash _ -> ()
+            | Contents.Value x -> Stack.push (add_contents c x) todo))
+        !contents;
 
-                    (* 3. push the children jobs on the stack. *)
-                    List.iter
-                      (fun n ->
-                        Stack.push
-                          (fun () -> (add_to_todo [@tailcall]) n Lwt.return)
-                          todo)
-                      !nodes;
-                    k ())))
+      (* 3. push the children jobs on the stack. *)
+      List.iter
+        (fun n ->
+          Stack.push (fun () -> (add_to_todo [@tailcall]) n Lwt.return) todo)
+        !nodes;
+      k ()
     in
+
     let rec loop () =
       let task = try Some (Stack.pop todo) with Stack.Empty -> None in
       match task with None -> Lwt.return_unit | Some t -> t () >>= loop


### PR DESCRIPTION
Resolves #1272

# New perfs

Commit it now ~14 times quicker, it is repaired.

Remove is now only ~3 times quicker because of the poor implementation of `Tree.Node.is_empty`. 

### Master - flatten
```
dune exec -- ./bench/irmin-pack/tree.exe --mode trace --inode-config 32 --flatten  ~/boostrap_trace.json
Replaying trace  13300/13315 commits  09:16  [##########################.]  99%
Tezos_log mode on inode config [32, 256]: 13315 commits
895827 "Add" 2.376 sec (0.4%)
54196 "Remove" 204.781 sec (37.1%)
2950152 "Find" 12.638 sec (2.3%)
669692 "Mem" 2.185 sec (0.4%)
439329 "Mem_tree" 0.528 sec (0.1%)
13314 "Checkout" 0.029 sec (0.0%)
59 "Copy" 0.000 sec (0.0%)
13315 "Commit" 329.685 sec (59.7%)
Total time: 551.869637
Size on disk: 114 M
```
![13k_flatten_master](https://user-images.githubusercontent.com/9285880/107519151-3276e180-6bb0-11eb-8fc9-7112f8eec9a6.png)

### This PR - flatten
```
dune exec -- ./bench/irmin-pack/tree.exe --mode trace --inode-config 32 --flatten  ~/boostrap_trace.json
Replaying trace  13300/13315 commits  02:45  [##########################.]  99%
Tezos_log mode on inode config [32, 256]: 13315 commits
895827 "Add" 1.966 sec (1.9%)
54196 "Remove" 67.908 sec (66.5%)
2950152 "Find" 7.454 sec (7.3%)
669692 "Mem" 1.158 sec (1.1%)
439329 "Mem_tree" 0.375 sec (0.4%)
13314 "Checkout" 0.022 sec (0.0%)
59 "Copy" 0.000 sec (0.0%)
13315 "Commit" 23.207 sec (22.7%)
Total time: 104.945730
Size on disk: 114 M
```
![13k_flatten_rmscale](https://user-images.githubusercontent.com/9285880/107519146-30ad1e00-6bb0-11eb-9f40-6316e60bb335.png)

