### PR TITLE
Add fuzzing test that Store.Tree.shallow preserves Store.Tree.hash

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,21 @@
+kind: pipeline
+type: docker
+name: amd
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: ocaml/opam:debian-10-ocaml-4.12-afl
+  commands:
+  - sudo apt-get update && sudo apt-get -y install afl
+  - sudo chown -R opam .
+  - git -C /home/opam/opam-repository pull origin && opam update
+  - opam pin add --no-action irmin.dev ./
+  - opam pin add --no-action irmin-fuzz.dev ./
+  - opam pin add --no-action ppx_irmin.dev ./
+  - opam depext --update irmin-fuzz
+  - opam install -y --with-test irmin-fuzz
+  - opam exec -- dune build @runfuzz --no-buffer

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,10 @@
     (#1377, @samoht)
   - Moved `Irmin_pack.Store.Atomic_write` into its own module (#1378, @samoht)
 
+- **irmin-fuzz** (_new_)
+  - Added a package to contain fuzz tests of Irmin and related packages.
+    (#1291, @smelc)
+
 ## 2.5.1 (2021-02-19)
 
 - **irmin-git**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
 
   - Fix stack overflow exception when working with wide trees (#1313, @zshipko)
 
+  - Added `Store.Tree.kinded_hash`, which takes a tree and returns both its hash
+    and the corresponding metadata. (#1291, @CraigFe)
+
 - **irmin-chunk**
   - use the pre_hash function to compute entry keys instead of
     their raw binary representation (#1308, @samoht)

--- a/fuzz/irmin/dune
+++ b/fuzz/irmin/dune
@@ -1,0 +1,16 @@
+(executable
+ (name tree)
+ (preprocess
+  (pps ppx_irmin))
+ (libraries lwt lwt.unix irmin irmin.mem crowbar))
+
+(rule
+ (alias runtest)
+ (deps tree.exe)
+ (action (progn)))
+
+(rule
+ (alias runfuzz)
+ (package irmin)
+ (action
+  (run %{exe:fuzz.exe})))

--- a/fuzz/irmin/dune
+++ b/fuzz/irmin/dune
@@ -6,11 +6,14 @@
 
 (rule
  (alias runtest)
+ (package irmin-fuzz)
  (deps tree.exe)
- (action (progn)))
+ (action progn))
 
 (rule
  (alias runfuzz)
- (package irmin)
+ (deps
+  (source_tree ./input))
  (action
-  (run %{exe:fuzz.exe})))
+  (run timeout --preserve-status 1h bun -v --input=input --output=output --
+    ./%{exe:tree.exe})))

--- a/fuzz/irmin/dune
+++ b/fuzz/irmin/dune
@@ -15,5 +15,5 @@
  (deps
   (source_tree ./input))
  (action
-  (run timeout --preserve-status 1h bun -v --input=input --output=output --
+  (run timeout --preserve-status 50m bun -v --input=input --output=output --
     ./%{exe:tree.exe})))

--- a/fuzz/irmin/input/seed
+++ b/fuzz/irmin/input/seed
@@ -1,0 +1,1 @@
+bactrian

--- a/fuzz/irmin/tree.ml
+++ b/fuzz/irmin/tree.ml
@@ -1,6 +1,6 @@
 include Irmin.Export_for_backends
 open Irmin
-module Store = Irmin_mem.KV (Contents.String)
+module Store = Irmin_mem.KV.Make (Contents.String)
 
 module Generators : sig
   val irmin_tree : Store.tree Crowbar.gen

--- a/fuzz/irmin/tree.ml
+++ b/fuzz/irmin/tree.ml
@@ -36,13 +36,8 @@ end
 let create_repo () = Lwt_main.run (Irmin_mem.config () |> Store.Repo.v)
 
 module Tree_hash = struct
-  let is_contents tree =
-    match Store.Tree.destruct tree with `Contents _ -> true | `Node _ -> false
-
   let make_tree_shallow repo tree =
-    let hash = Store.Tree.hash tree in
-    let data = if is_contents tree then `Contents (hash, ()) else `Node hash in
-    Store.Tree.shallow repo data
+    Store.Tree.shallow repo (Store.Tree.kinded_hash tree)
 
   (** Returns [Some] if [tree] could be made partially shallow, [None]
       otherwise. At the top-level, you want to receive [Some]; but internally

--- a/fuzz/irmin/tree.ml
+++ b/fuzz/irmin/tree.ml
@@ -1,8 +1,6 @@
 open Lwt.Infix
 open Irmin
 
-(* Run this test with: dune build @test/irmin/runtest_fuzz *)
-
 module Store =
   Irmin_mem.Make (Metadata.None) (Contents.String) (Path.String_list)
     (Branch.String)

--- a/fuzz/irmin/tree.mli
+++ b/fuzz/irmin/tree.mli
@@ -1,0 +1,1 @@
+(* Intentionally empty *)

--- a/irmin-fuzz.opam
+++ b/irmin-fuzz.opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:   "craig@tarides.com"
+authors:      ["The Irmin authors"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune"    {>= "2.7.0"}
+  "irmin"   {= version}
+  "lwt"     {>= "2.4.7" & with-test}
+  "bun"     {with-test}
+  "crowbar" {with-test}
+]
+
+synopsis: """
+Fuzz tests for the Irmin packages
+"""
+description: """
+Fuzz tests for the Irmin packages.
+"""

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -29,6 +29,7 @@ depends: [
   "ocaml-syntax-shims"
   "cmdliner"
   "metrics" {>= "0.2.0"}
+  "crowbar"
 ]
 
 synopsis: "Irmin test suite"

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -61,6 +61,18 @@ module List = struct
       | h :: t, l -> (aux [@tailcall]) (h :: acc) t l
     in
     aux [] [] l
+
+  (** [combine_drop l1 l2] zips the elements of [l1] and [l2] into pairs,
+      discarding any trailing elements of the longest input. *)
+  let combine_drop : type a b. a list -> b list -> (a * b) list =
+    let rec aux acc l1 l2 =
+      match (l1, l2) with
+      | [], _ -> []
+      | _, [] -> []
+      | x1 :: rest1, x2 :: rest2 ->
+          (aux [@tailcall]) ((x1, x2) :: acc) rest1 rest2
+    in
+    fun l1 l2 -> rev (aux [] l1 l2)
 end
 
 module Seq = struct

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -54,6 +54,7 @@ module Make (P : Private.S) = struct
 
     let of_hash r h = import r h
     let shallow r h = import_no_check r h
+    let kinded_hash = hash
 
     let hash : t -> hash =
      fun tr -> match hash tr with `Node h -> h | `Contents (h, _) -> h

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -363,6 +363,9 @@ module type S = sig
         reference (either {!contents} or {!node}). In the [contents] case, the
         hash is paired with corresponding {!metadata}. *)
 
+    val kinded_hash : tree -> kinded_hash
+    (** Like {!hash}, but also returns the corresponding metadata. *)
+
     val of_hash : Repo.t -> kinded_hash -> tree option Lwt.t
     (** [of_hash r h] is the the tree object in [r] having [h] as hash, or
         [None] is no such tree object exists. *)

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -1,10 +1,6 @@
 (tests
- (names test fuzz)
+ (names test)
  (package irmin)
  (preprocess
   (pps ppx_irmin))
- (libraries irmin irmin.mem alcotest alcotest-lwt lwt hex logs logs.fmt crowbar))
-
-(rule
- (alias runtest_fuzz)
- (action (run %{exe:fuzz.exe})))
+ (libraries irmin irmin.mem alcotest alcotest-lwt lwt hex logs logs.fmt))

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -1,6 +1,10 @@
-(test
- (name test)
+(tests
+ (names test fuzz)
  (package irmin)
  (preprocess
   (pps ppx_irmin))
- (libraries irmin irmin.mem alcotest alcotest-lwt lwt hex logs logs.fmt))
+ (libraries irmin irmin.mem alcotest alcotest-lwt lwt hex logs logs.fmt crowbar))
+
+(rule
+ (alias runtest_fuzz)
+ (action (run %{exe:fuzz.exe})))

--- a/test/irmin/fuzz.ml
+++ b/test/irmin/fuzz.ml
@@ -1,0 +1,147 @@
+open Lwt.Infix
+open Irmin
+
+(* Run this test with: dune build @test/irmin/runtest_fuzz *)
+
+module Store =
+  Irmin_mem.Make (Metadata.None) (Contents.String) (Path.String_list)
+    (Branch.String)
+    (Hash.BLAKE2B)
+
+(* Combine [l1] and [l2], dropping elements of the longer one *)
+let rec combine_drop l1 l2 =
+  match (l1, l2) with
+  | [], _ -> []
+  | _, [] -> []
+  | x1 :: rest1, x2 :: rest2 -> (x1, x2) :: combine_drop rest1 rest2
+
+module Generators = struct
+  let string_gen =
+    let open Crowbar in
+    (* Data that is easier to read than random bytes *)
+    let strs = [ "a"; "b"; "c"; "d"; "e"; "f"; "g"; "h" ] in
+    List.map const strs |> choose
+
+  module StringSet = Set.Make (String)
+
+  let remove_doublons l =
+    l |> StringSet.of_list |> StringSet.to_seq |> List.of_seq
+
+  let concrete_tree_gen =
+    let open Crowbar in
+    fix (fun g ->
+        let dir =
+          map [ list string_gen; list g ] (fun strs subs ->
+              (* To have well-formed trees: *)
+              let strs = remove_doublons strs in
+              `Tree (combine_drop strs subs))
+        in
+        choose
+          [ map [ string_gen ] (fun str -> `Contents (str, ())); dir; dir; dir ])
+
+  let irmin_tree_gen =
+    let open Crowbar in
+    map [ concrete_tree_gen ] Store.Tree.of_concrete
+end
+
+let create_repo () = Lwt_main.run (Irmin_mem.config () |> Store.Repo.v)
+
+module TreeHash = struct
+  let is_contents tree =
+    match Store.Tree.destruct tree with `Contents _ -> true | `Node _ -> false
+
+  let make_tree_shallow repo tree =
+    let hash = Store.Tree.hash tree in
+    let data = if is_contents tree then `Contents (hash, ()) else `Node hash in
+    Store.Tree.shallow repo data
+
+  (** Returns [Some] if [tree] could be made partially shallow, [None]
+      otherwise. At the top-level, you want to receive [Some]; but internally
+      this function handles [None] by keeping some tree non-shallow: that's the
+      point, you don't want an entirely shallow tree.
+
+      [randoms] is used as an oracle to make choices. It should not be empty. *)
+  let rec make_partially_shallow repo tree randoms =
+    match randoms with
+    | [] -> Lwt.return_some tree (* do not make shallow *)
+    | i :: _ -> (
+        if i mod 4 = 0 then
+          (* make entirely shallow *)
+          Lwt.return_some @@ make_tree_shallow repo tree
+        else
+          match Store.Tree.destruct tree with
+          | `Contents _ ->
+              (* maybe make shallow *)
+              if i mod 2 = 0 then Lwt.return_none
+              else Lwt.return_some @@ make_tree_shallow repo tree
+          | `Node _ ->
+              (* make partially shallow *)
+              let rec enlarge len l =
+                (* Using [l] as a generator, return a list of length >= len *)
+                assert (l <> []);
+                if List.length l < len then enlarge len (l @ l) else l
+              in
+              Store.Tree.list tree [] >>= fun dir ->
+              let dir_len = List.length dir in
+              (* We use [randoms] to shallow differently the siblings within [dir]
+                 and we pass a tail of [randoms] in recursive calls, to have
+                 variance in subtrees. *)
+              let dir' = combine_drop dir (enlarge dir_len randoms) in
+              assert (List.length dir' = dir_len);
+              Lwt_list.fold_left_s
+                (fun (shallowed, acc) ((k, subtree), i) ->
+                  (* random oracle to decide whether to make complety shallow
+                     (b holds) or partially shallow (b doesn't hold: recurse) *)
+                  let b = i mod 2 = 0 in
+                  (if b then make_tree_shallow repo subtree |> Lwt.return_some
+                  else
+                    let sub_randoms =
+                      match randoms with
+                      | [] -> assert false
+                      | [ x ] -> [ x ]
+                      | _ :: rest -> rest
+                    in
+                    make_partially_shallow repo subtree sub_randoms)
+                  >>= fun subtree_opt ->
+                  let shallowed', subtree' =
+                    match subtree_opt with
+                    | None -> (shallowed, subtree) (* no change *)
+                    | Some subtree' ->
+                        (* subtree' is partially shallow *)
+                        (true, subtree')
+                  in
+                  Store.Tree.add_tree acc [ k ] subtree' >>= fun acc ->
+                  Lwt.return (shallowed', acc))
+                (false, Store.Tree.empty) dir'
+              >>= fun (shallowed, tree') ->
+              if shallowed then Lwt.return_some tree' else Lwt.return_none)
+
+  (** Test that subtituting subtrees by their [Store.Tree.shallow] version
+      doesn't change the tree's top-level hash. *)
+  let test_hash_stability repo tree is =
+    make_partially_shallow repo tree is >>= fun tree_opt ->
+    match tree_opt with
+    | None -> Crowbar.bad_test ()
+    | Some tree' ->
+        let hash_to_string = Irmin.Type.to_string Store.Hash.t in
+        let hash_eq = Irmin.Type.(unstage (equal Store.Hash.t)) in
+        let hash = Store.Tree.hash tree in
+        let hash' = Store.Tree.hash tree' in
+        let err_opt =
+          if hash_eq hash hash' then None
+          else
+            Some
+              (Printf.sprintf "Hash mismatch: %s <> %s\n" (hash_to_string hash)
+                 (hash_to_string hash'))
+        in
+        (match err_opt with None -> () | Some err -> Crowbar.fail err);
+        Lwt.return_unit
+
+  let test_hash_stability r t is = test_hash_stability r t is |> Lwt_main.run
+end
+
+let () =
+  Crowbar.add_test
+    ~name:"Store.Tree.hash t = Store.Tree.hash (make_partially_shallow t)"
+    [ Generators.irmin_tree_gen; Crowbar.(list1 int) ]
+    (TreeHash.test_hash_stability @@ create_repo ())


### PR DESCRIPTION
For that, we generate random irmin trees, which we make randomly partially shallow and compare the obtained hashs on the pristine tree and the partially shallow one.

This is the test that made me find https://github.com/mirage/irmin/issues/1284.

I went for the simplest integration opam/dune-wise. Please change it as you see fit.

If such fuzzing tests are interesting to you, there are some others that I authored on Tezos that would make more sense being in Irmin directly; which I could port in another MR.