### PR TITLE
irmin-layered: New fancy stats for freeze

### DIFF
--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -1,10 +1,6 @@
 open! Import
 open Bench_common
 
-let reset_stats () =
-  reset_stats ();
-  Irmin_layers.Stats.reset_stats ()
-
 let () = Random.self_init ()
 
 type config = {
@@ -60,35 +56,15 @@ let checkout_and_commit config repo c nb =
 let total = ref 0
 
 let print_commit_stats config c i time =
-  let num_objects = Irmin_layers.Stats.get_adds () in
+  let num_objects = Irmin_layers.Stats.get_add_count () in
   total := !total + num_objects;
-  Irmin_layers.Stats.reset_adds ();
   if config.show_stats then
     Logs.app (fun l ->
         l "Commit %a %d in cycle completed in %f; objects created: %d"
           Store.Commit.pp_hash c i time num_objects)
 
-let print_stats config =
-  let t = Irmin_layers.Stats.get () in
-  let copied_objects =
-    List.map2 (fun x y -> x + y) t.copied_contents t.copied_commits
-    |> List.map2 (fun x y -> x + y) t.copied_nodes
-    |> List.map2 (fun x y -> x + y) t.copied_branches
-  in
-  if config.show_stats then (
-    Logs.app (fun l ->
-        l
-          "Irmin-layers stats: nb_freeze=%d copied_objects=%a \
-           waiting_freeze=%a completed_freeze=%a \
-           objects_added_in_upper_since_last_freeze=%d"
-          t.nb_freeze
-          Fmt.(Dump.list int)
-          copied_objects
-          Fmt.(Dump.list float)
-          t.waiting_freeze
-          Fmt.(Dump.list float)
-          t.completed_freeze !total);
-    total := 0)
+let print_stats () =
+  Logs.app (fun l -> l "%a%!" Irmin_layers.Stats.pp_latest ())
 
 let write_cycle config repo init_commit =
   let rec go c i =
@@ -126,7 +102,7 @@ let run_cycles config repo head =
     if i = config.ncycles then Lwt.return head
     else
       let* max = write_cycle config repo head in
-      print_stats config;
+      print_stats ();
       let min = consume_min () in
       add_min max;
       let* time, () =

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -64,7 +64,7 @@ let print_commit_stats config c i time =
           Store.Commit.pp_hash c i time num_objects)
 
 let print_stats () =
-  Logs.app (fun l -> l "%a%!" Irmin_layers.Stats.pp_latest ())
+  Logs.app (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
 
 let write_cycle config repo init_commit =
   let rec go c i =

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -63,8 +63,7 @@ let print_commit_stats config c i time =
         l "Commit %a %d in cycle completed in %f; objects created: %d"
           Store.Commit.pp_hash c i time num_objects)
 
-let print_stats () =
-  Logs.app (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
+let print_stats () = Logs.app (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
 
 let write_cycle config repo init_commit =
   let rec go c i =

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -76,11 +76,11 @@ let freeze_start_counter =
     !c - 1
 
 let freeze_profiles = ref []
-let latest = ref (fresh_freeze_profile ~-1 (Mtime_clock.now ()) "")
+let latest = ref (fresh_freeze_profile (-1) (Mtime_clock.now ()) "")
 
 let reset_stats () =
   freeze_profiles := [];
-  latest := fresh_freeze_profile ~-1 (Mtime_clock.now ()) ""
+  latest := fresh_freeze_profile (-1) (Mtime_clock.now ()) ""
 
 let freeze_start t0 current_section =
   (* Printf.eprintf "\n> freeze: start\n%!"; *)
@@ -146,7 +146,7 @@ let freeze_stop () =
   in
   freeze_profiles := shorter (!latest :: !freeze_profiles)
 
-let pp_latest ppf () =
+let pp_latest ppf =
   let v = !latest in
   let timeline =
     List.fold_right

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -35,6 +35,7 @@ type freeze_profile = {
   mutable commits : int;
   mutable branches : int;
   mutable adds : int;
+  mutable skip_tests : int;
   mutable skips : int;
   mutable copy_newies_loops : int;
   mutable yields : int;
@@ -59,6 +60,7 @@ let fresh_freeze_profile idx t0 current_section =
     branches = 0;
     adds = 0;
     skips = 0;
+    skip_tests = 0;
     copy_newies_loops = 0;
     yields = 0;
     outside_totlen = 0.;
@@ -105,7 +107,10 @@ let copy_nodes () = !latest.nodes <- succ !latest.nodes
 let copy_commits () = !latest.commits <- succ !latest.commits
 let copy_branches () = !latest.branches <- succ !latest.branches
 let add () = !latest.adds <- succ !latest.adds
-let skip () = !latest.skips <- succ !latest.skips
+
+let skip_test should_skip =
+  !latest.skip_tests <- succ !latest.skip_tests;
+  if should_skip then !latest.skips <- succ !latest.skips
 
 let copy_newies_loop () =
   !latest.copy_newies_loops <- succ !latest.copy_newies_loops
@@ -221,11 +226,11 @@ let pp_latest_when_any ppf v =
             Format.fprintf ppf " (max:%a)" Mtime.Span.pp_float_s max_len
         in
         if count = 1 then
-          Format.fprintf ppf "1 long %s in \"%s\" of %a" action_name section Mtime.Span.pp_float_s
-            totlen
+          Format.fprintf ppf "1 long %s in \"%s\" of %a" action_name section
+            Mtime.Span.pp_float_s totlen
         else
-          Format.fprintf ppf "%d long %ss in \"%s\" of ~%a%t" count action_name section
-            Mtime.Span.pp_float_s
+          Format.fprintf ppf "%d long %ss in \"%s\" of ~%a%t" count action_name
+            section Mtime.Span.pp_float_s
             (totlen /. float_of_int count)
             pp_if_max
       in
@@ -255,6 +260,7 @@ let pp_latest_when_any ppf v =
       ("copy_branches", v.branches);
       ("adds", v.adds);
       ("skips", v.skips);
+      ("skip_tests", v.skip_tests);
       ("yields", v.yields);
       ("copy_newies_loops", v.copy_newies_loops);
     ]

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -143,11 +143,16 @@ let skip_test should_skip =
 let copy_newies_loop () =
   !latest.copy_newies_loops <- succ !latest.copy_newies_loops
 
-let get_add_count () = !latest.current_counters.adds
-let get_copied_commits_count () = !latest.current_counters.commits
-let get_copied_branches_count () = !latest.current_counters.branches
-let get_copied_contents_count () = !latest.current_counters.contents
-let get_copied_nodes_count () = !latest.current_counters.nodes
+let fold_counters v f =
+  List.fold_left
+    (fun acc (_, _, _, c) -> acc + f c)
+    (f v.current_counters) v.rev_timeline
+
+let get_add_count () = fold_counters !latest (fun c -> c.adds)
+let get_copied_commits_count () = fold_counters !latest (fun c -> c.commits)
+let get_copied_branches_count () = fold_counters !latest (fun c -> c.branches)
+let get_copied_contents_count () = fold_counters !latest (fun c -> c.contents)
+let get_copied_nodes_count () = fold_counters !latest (fun c -> c.nodes)
 let get_freeze_count () = List.length !freeze_profiles
 
 let freeze_yield () =

--- a/src/irmin-layers/stats.ml
+++ b/src/irmin-layers/stats.ml
@@ -15,113 +15,187 @@
  *)
 open! Import
 
-type t = {
-  mutable nb_freeze : int;
-  mutable copied_contents : int list;
-  mutable copied_nodes : int list;
-  mutable copied_commits : int list;
-  mutable copied_branches : int list;
-  mutable waiting_freeze : float list;
-  mutable completed_freeze : float list;
-  mutable skips : int;
-}
+(* This file avoids [option] type and clean functionnal paradigms in order to
+   lower the cpu footprint *)
 
-type i = {
+(** Ensure lists are not growing indefinitely by dropping elements. *)
+let limit_length_list = 10
+
+type freeze_profile = {
+  mutable idx : int;
+  mutable t0 : Mtime.t;
+  mutable t1 : Mtime.t;
+  mutable current_section : string;
+  mutable rev_timeline : (string * Mtime.t * float) list;
   mutable contents : int;
   mutable nodes : int;
   mutable commits : int;
   mutable branches : int;
   mutable adds : int;
+  mutable skips : int;
+  mutable copy_newies_loops : int;
+  mutable yields : int;
+  mutable outside_totlen : float;
+  mutable inside_totlen : float;
+  mutable outside_maxlen : string * float;
+  mutable inside_maxlen : string * float;
 }
 
-let fresh_stats_t () =
+let fresh_freeze_profile idx t0 current_section =
   {
-    nb_freeze = 0;
-    copied_contents = [];
-    copied_nodes = [];
-    copied_commits = [];
-    copied_branches = [];
-    waiting_freeze = [];
-    completed_freeze = [];
+    idx;
+    t0;
+    t1 = t0;
+    current_section;
+    rev_timeline = [];
+    contents = 0;
+    nodes = 0;
+    commits = 0;
+    branches = 0;
+    adds = 0;
     skips = 0;
+    copy_newies_loops = 0;
+    yields = 0;
+    outside_totlen = 0.;
+    inside_totlen = 0.;
+    outside_maxlen = ("never", 0.);
+    inside_maxlen = ("never", 0.);
   }
 
-let fresh_stats_i () =
-  { contents = 0; nodes = 0; commits = 0; branches = 0; adds = 0 }
+let get_elapsed =
+  let c = ref (Mtime_clock.counter ()) in
+  fun ~reset ->
+    let elapsed = Mtime.Span.to_s (Mtime_clock.count !c) in
+    if reset then c := Mtime_clock.counter ();
+    elapsed
 
-let stats_t = fresh_stats_t ()
-let stats_i = fresh_stats_i ()
+let freeze_start_counter =
+  let c = ref 0 in
+  fun () ->
+    incr c;
+    !c - 1
 
-let reset_stats_i () =
-  stats_i.contents <- 0;
-  stats_i.nodes <- 0;
-  stats_i.commits <- 0;
-  stats_i.branches <- 0
+let freeze_profiles = ref []
+let latest = ref (fresh_freeze_profile ~-1 (Mtime_clock.now ()) "")
 
 let reset_stats () =
-  stats_t.nb_freeze <- 0;
-  stats_t.copied_contents <- [];
-  stats_t.copied_nodes <- [];
-  stats_t.copied_commits <- [];
-  stats_t.copied_branches <- [];
-  stats_t.skips <- 0;
-  reset_stats_i ()
+  freeze_profiles := [];
+  latest := fresh_freeze_profile ~-1 (Mtime_clock.now ()) ""
 
-let get () =
-  {
-    nb_freeze = stats_t.nb_freeze;
-    copied_contents = stats_i.contents :: stats_t.copied_contents;
-    copied_nodes = stats_i.nodes :: stats_t.copied_nodes;
-    copied_commits = stats_i.commits :: stats_t.copied_commits;
-    copied_branches = stats_i.branches :: stats_t.copied_branches;
-    waiting_freeze = stats_t.waiting_freeze;
-    completed_freeze = stats_t.completed_freeze;
-    skips = stats_t.skips;
-  }
+let freeze_start t0 current_section =
+  (* Printf.eprintf "\n> freeze: start\n%!"; *)
+  let (_ : float) = get_elapsed ~reset:true in
+  latest := fresh_freeze_profile (freeze_start_counter ()) t0 current_section
 
-(** Ensure lists are not growing indefinitely by dropping elements. *)
-let limit_length_list = 10
+let freeze_section ev_name' =
+  let ev_name = !latest.current_section in
+  let now = Mtime_clock.now () in
+  let now_inside = get_elapsed ~reset:false +. !latest.inside_totlen in
+  (* Format.printf "\n> freeze: end of \"%s\", entering \"%s\"\n%!" ev_name
+   *   ev_name'; *)
+  !latest.current_section <- ev_name';
+  !latest.rev_timeline <- (ev_name, now, now_inside) :: !latest.rev_timeline
 
-let drop_last_elements n =
+let copy_contents () = !latest.contents <- succ !latest.contents
+let copy_nodes () = !latest.nodes <- succ !latest.nodes
+let copy_commits () = !latest.commits <- succ !latest.commits
+let copy_branches () = !latest.branches <- succ !latest.branches
+let add () = !latest.adds <- succ !latest.adds
+let skip () = !latest.skips <- succ !latest.skips
+
+let copy_newies_loop () =
+  !latest.copy_newies_loops <- succ !latest.copy_newies_loops
+
+let get_add_count () = !latest.adds
+let get_copied_commits_count () = !latest.commits
+let get_copied_branches_count () = !latest.branches
+let get_copied_contents_count () = !latest.contents
+let get_copied_nodes_count () = !latest.nodes
+let get_freeze_count () = List.length !freeze_profiles
+
+let freeze_yield () =
+  !latest.yields <- !latest.yields + 1;
+  let d1 = get_elapsed ~reset:true in
+  let d0 = !latest.inside_totlen in
+  !latest.inside_totlen <- d0 +. d1;
+  let _, d0 = !latest.inside_maxlen in
+  if d1 > d0 then !latest.inside_maxlen <- (!latest.current_section, d1)
+
+let freeze_yield_end () =
+  let d1 = get_elapsed ~reset:true in
+  let d0 = !latest.outside_totlen in
+  !latest.outside_totlen <- d0 +. d1;
+  let _, d0 = !latest.outside_maxlen in
+  if d1 > d0 then !latest.outside_maxlen <- (!latest.current_section, d1)
+
+let freeze_stop () =
+  freeze_yield ();
+  !latest.yields <- !latest.yields - 1;
+  !latest.t1 <- Mtime_clock.now ();
+  !latest.rev_timeline <-
+    (!latest.current_section, Mtime_clock.now (), !latest.inside_totlen)
+    :: !latest.rev_timeline;
+  (* Printf.eprintf "\n> freeze: end of \"%s\" (end)\n%!" !latest.current_section; *)
   let shorter ls =
     List.fold_left
-      (fun (acc, i) x -> if i < n then (x :: acc, i + 1) else (acc, i + 1))
+      (fun (acc, i) x ->
+        if i < limit_length_list then (x :: acc, i + 1) else (acc, i + 1))
       ([], 0) ls
     |> fst
     |> List.rev
   in
-  stats_t.copied_contents <- shorter stats_t.copied_contents;
-  stats_t.copied_nodes <- shorter stats_t.copied_nodes;
-  stats_t.copied_commits <- shorter stats_t.copied_commits;
-  stats_t.copied_branches <- shorter stats_t.copied_branches;
-  stats_t.completed_freeze <- shorter stats_t.completed_freeze;
-  stats_t.waiting_freeze <- shorter stats_t.waiting_freeze
+  freeze_profiles := shorter (!latest :: !freeze_profiles)
 
-let freeze () =
-  stats_t.nb_freeze <- succ stats_t.nb_freeze;
-  stats_t.skips <- 0;
-  if stats_t.nb_freeze <> 1 then (
-    stats_t.copied_contents <- stats_i.contents :: stats_t.copied_contents;
-    stats_t.copied_nodes <- stats_i.nodes :: stats_t.copied_nodes;
-    stats_t.copied_commits <- stats_i.commits :: stats_t.copied_commits;
-    stats_t.copied_branches <- stats_i.branches :: stats_t.copied_branches;
-    reset_stats_i ());
-  if List.length stats_t.completed_freeze >= limit_length_list then
-    drop_last_elements (limit_length_list / 2)
+let pp_latest ppf () =
+  let v = !latest in
+  let timeline =
+    List.fold_right
+      (fun (s, t1, t1_block) (acc, t0, t0_block) ->
+        let acc = (s, Mtime.span t0 t1, t1_block -. t0_block) :: acc in
+        (acc, t1, t1_block))
+      v.rev_timeline ([], v.t0, 0.)
+    |> (fun (l, _, _) -> l)
+    |> List.rev
+  in
 
-let copy_contents () = stats_i.contents <- succ stats_i.contents
-let copy_nodes () = stats_i.nodes <- succ stats_i.nodes
-let copy_commits () = stats_i.commits <- succ stats_i.commits
-let copy_branches () = stats_i.branches <- succ stats_i.branches
-let skip () = stats_t.skips <- succ stats_t.skips
-let add () = stats_i.adds <- succ stats_i.adds
-let get_adds () = stats_i.adds
-let reset_adds () = stats_i.adds <- 0
-
-let with_timer (operation : [ `Freeze | `Waiting ]) f =
-  let timer = Mtime_clock.counter () in
-  f () >|= fun () ->
-  let span = Mtime.Span.to_us (Mtime_clock.count timer) in
-  match operation with
-  | `Freeze -> stats_t.completed_freeze <- span :: stats_t.completed_freeze
-  | `Waiting -> stats_t.waiting_freeze <- span :: stats_t.waiting_freeze
+  let totlen = Mtime.span v.t0 v.t1 in
+  let frac_out, frac_in =
+    let totlen = Mtime.Span.to_s totlen in
+    if totlen = 0. then (0., 0.)
+    else (v.outside_totlen /. totlen, v.inside_totlen /. totlen)
+  in
+  let pp_timeline_section ppf (name, span, span_block) =
+    let totlen = Mtime.Span.to_s totlen in
+    let span = Mtime.Span.to_s span in
+    let pp = Mtime.Span.pp_float_s in
+    let pp' ppf v = Format.fprintf ppf "%.0f%%" (v *. 100.) in
+    Format.fprintf ppf
+      "@\n    %20s took %a (%a of total) and blocked %a (%a of total)." name pp
+      span pp' (span /. totlen) pp span_block pp'
+      (span_block /. v.inside_totlen)
+  in
+  Format.fprintf ppf
+    "freeze %d blocked %a (%.0f%%), and yielded %a (%.0f%%). Total %a.@\n\
+    \  Event counts: %a@\n\
+    \  Longest block %a (during \"%s\"). Longest yield %a (during \"%s\"). \
+     %.3f yield per sec.@\n\
+    \  Timeline: %a@\n"
+    v.idx Mtime.Span.pp_float_s v.inside_totlen (frac_in *. 100.)
+    Mtime.Span.pp_float_s v.outside_totlen (frac_out *. 100.) Mtime.Span.pp
+    totlen
+    Fmt.(list ~sep:(any ", ") (pair ~sep:(any ":") string int))
+    [
+      ("copy_contents", v.contents);
+      ("copy_nodes", v.nodes);
+      ("copy_commits", v.commits);
+      ("copy_branches", v.branches);
+      ("adds", v.adds);
+      ("skips", v.skips);
+      ("yields", v.yields);
+      ("copy_newies_loops", v.copy_newies_loops);
+    ]
+    Mtime.Span.pp_float_s (snd v.inside_maxlen) (fst v.inside_maxlen)
+    Mtime.Span.pp_float_s (snd v.outside_maxlen) (fst v.outside_maxlen)
+    (float_of_int v.yields /. Mtime.Span.to_s totlen)
+    Fmt.(list ~sep:(any "") pp_timeline_section)
+    timeline

--- a/src/irmin-layers/stats.mli
+++ b/src/irmin-layers/stats.mli
@@ -14,65 +14,62 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type t = {
-  mutable nb_freeze : int;
-  mutable copied_contents : int list;
-  mutable copied_nodes : int list;
-  mutable copied_commits : int list;
-  mutable copied_branches : int list;
-  mutable waiting_freeze : float list;
-  mutable completed_freeze : float list;
-  mutable skips : int;
-}
-(** The type for stats for a store S.
+(** {2 Profiling of Freeze}
 
-    - [nb_freeze] is the number of calls to [S.freeze];
-    - [copied_contents] is the number of contents copied per freeze;
-    - [copied_nodes] is the number of nodes copied per freeze;
-    - [copied_commits] is the number of commits copied per freeze;
-    - [copied_branches] is the number of branches copied per freeze;
-    - [waiting_freeze] are the times the freeze threads waited to start, for the
-      last 10 freezes at most;
-    - [completed_freeze] are the times the freeze threads took to complete, for
-      the last 10 freezes at most;
-    - [skips] the number of skips during the graph traversals called by the
-      freeze, where the same object can be skipped several times;
+    {3 Control Flow of the Freeze Thread}
 
-    Note that stats assume that there always is an ongoing freeze. If its not
-    the case, you should discard the last 0.*)
+    Most of the functions here should be called from under a single mutex lock. *)
 
-val reset_stats : unit -> unit
-val get : unit -> t
+val freeze_start : Mtime.t -> string -> unit
+(** Signals the start of a new freeze given the time at which the freeze process
+    started and the name given to the initial code section. *)
+
+val freeze_section : string -> unit
+(** Signals that the freeze is entering a specific section of the code. *)
+
+val freeze_stop : unit -> unit
+(** Signals the end of an ongoing freeze freeze. *)
+
+val freeze_yield : unit -> unit
+(** Signals that the freeze is cooperatively yielding to other threads. *)
+
+val freeze_yield_end : unit -> unit
+(** Signals that the freeze is given back the control. *)
+
+(** {3 Incrementations of Counters} *)
 
 val copy_contents : unit -> unit
-(** Increments t.copied_contents for the current freeze *)
+(** Increments the number of copied contents for the current freeze. *)
 
 val copy_nodes : unit -> unit
-(** Increments t.copied_nodes for the current freeze *)
+(** Increments the number of copied nodes for the current freeze. *)
 
 val copy_commits : unit -> unit
-(** Increments t.copied_commits for the current freeze *)
+(** Increments the number of copied commits for the current freeze. *)
 
 val copy_branches : unit -> unit
-(** Increments t.copied_branches for the current freeze *)
-
-val freeze : unit -> unit
-(** Signals the start of a new freeze, and increments t.nb_freeze *)
+(** Increments the number of copied branches for the current freeze. *)
 
 val add : unit -> unit
-(** Increment the number of objects added, do not call this for objects copied
-    during a freeze. *)
-
-val get_adds : unit -> int
-(** Get the number of objects added, not including the copied objects during a
-    freeze. *)
-
-val reset_adds : unit -> unit
-(** Reset the number of objects added. *)
-
-val with_timer : [ `Freeze | `Waiting ] -> (unit -> unit Lwt.t) -> unit Lwt.t
-(** Either the duration of a freeze thread waiting on the freeze lock to start;
-    or the duration of a freeze thread to complete a freeze. *)
+(** Increment the number of objects added by main thread. *)
 
 val skip : unit -> unit
-(** Increment the number of skips during a graph traversal. *)
+(** Increment the number of skips during a graph traversal for the current
+    freeze. *)
+
+val copy_newies_loop : unit -> unit
+(** Increment the number of iterations of newies copy. *)
+
+(** {3 Observation} *)
+
+val get_add_count : unit -> int
+val get_copied_commits_count : unit -> int
+val get_copied_branches_count : unit -> int
+val get_copied_contents_count : unit -> int
+val get_copied_nodes_count : unit -> int
+val get_freeze_count : unit -> int
+val pp_latest : Format.formatter -> unit -> unit
+
+(** {3 Misc.} *)
+
+val reset_stats : unit -> unit

--- a/src/irmin-layers/stats.mli
+++ b/src/irmin-layers/stats.mli
@@ -68,7 +68,7 @@ val get_copied_branches_count : unit -> int
 val get_copied_contents_count : unit -> int
 val get_copied_nodes_count : unit -> int
 val get_freeze_count : unit -> int
-val pp_latest : Format.formatter -> unit -> unit
+val pp_latest : Format.formatter -> unit
 
 (** {3 Misc.} *)
 

--- a/src/irmin-layers/stats.mli
+++ b/src/irmin-layers/stats.mli
@@ -53,9 +53,9 @@ val copy_branches : unit -> unit
 val add : unit -> unit
 (** Increment the number of objects added by main thread. *)
 
-val skip : unit -> unit
-(** Increment the number of skips during a graph traversal for the current
-    freeze. *)
+val skip_test : bool -> unit
+(** Increment the number time we wondered if an entry was present at the
+    destination during a graph traversal for the current freeze. *)
 
 val copy_newies_loop : unit -> unit
 (** Increment the number of iterations of newies copy. *)

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -559,11 +559,9 @@ struct
         ~mem_commit_upper:(mem_commit_next t) t.X.Repo.branch
 
     let skip_with_stats ~skip h =
-      skip h >|= function
-      | true ->
-          Irmin_layers.Stats.skip ();
-          true
-      | false -> false
+      skip h >|= fun should_skip ->
+      Irmin_layers.Stats.skip_test should_skip;
+      should_skip
 
     let no_skip _ = Lwt.return false
 

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -359,7 +359,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
     run x test
 
   let log_stats () =
-    Logs.debug (fun l -> l "%a%!" Irmin_layers.Stats.pp_latest ())
+    Logs.debug (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
 
   let test_squash x () =
     let check_val = check T.(option S.contents_t) in

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -358,8 +358,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
     in
     run x test
 
-  let log_stats () =
-    Logs.debug (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
+  let log_stats () = Logs.debug (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
 
   let test_squash x () =
     let check_val = check T.(option S.contents_t) in

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -358,17 +358,8 @@ module Make_Layered (S : LAYERED_STORE) = struct
     in
     run x test
 
-  let log_stats (s : Irmin_layers.Stats.t) =
-    let concat_list ls =
-      List.fold_left (fun acc x -> string_of_int x ^ ";" ^ acc) "" ls
-    in
-    Log.debug (fun l ->
-        l "contents = %s nodes = %s, commits = %s, branches = %s freezes =%d"
-          (concat_list s.copied_contents)
-          (concat_list s.copied_nodes)
-          (concat_list s.copied_commits)
-          (concat_list s.copied_branches)
-          s.nb_freeze)
+  let log_stats () =
+    Logs.debug (fun l -> l "%a%!" Irmin_layers.Stats.pp_latest ())
 
   let test_squash x () =
     let check_val = check T.(option S.contents_t) in
@@ -385,10 +376,12 @@ module Make_Layered (S : LAYERED_STORE) = struct
       let* tree3 = S.Tree.add tree [ "x"; "z" ] v1 in
       S.set_tree_exn t ~info:(infof "update") [ "u" ] tree3 >>= fun () ->
       let* c3 = S.Head.get t in
-      let s = Irmin_layers.Stats.get () in
-      log_stats s;
-      Alcotest.(check int) "zero freeze" s.nb_freeze 0;
-      Alcotest.(check (list int)) "zero commit" s.copied_commits [ 0 ];
+      log_stats ();
+      let () =
+        let open Irmin_layers.Stats in
+        Alcotest.(check int) "zero freeze" (get_freeze_count ()) 0;
+        Alcotest.(check int) "zero commit" (get_copied_commits_count ()) 0
+      in
       S.freeze repo ~squash:true >>= fun () ->
       let* tree = S.tree t in
       S.set_tree_exn t ~info:(infof "update") [] tree >>= fun () ->
@@ -430,10 +423,12 @@ module Make_Layered (S : LAYERED_STORE) = struct
         else Lwt.return_unit
       in
       S.PrivateLayer.wait_for_freeze repo >>= fun () ->
-      let s = Irmin_layers.Stats.get () in
-      log_stats s;
-      Alcotest.(check int) "one freeze" s.nb_freeze 1;
-      Alcotest.(check (list int)) "one commit" s.copied_commits [ 1 ];
+      log_stats ();
+      let () =
+        let open Irmin_layers.Stats in
+        Alcotest.(check int) "one freeze" (get_freeze_count ()) 1;
+        Alcotest.(check int) "one commit" (get_copied_commits_count ()) 1
+      in
       P.Repo.close repo
     in
     run x test
@@ -508,13 +503,16 @@ module Make_Layered (S : LAYERED_STORE) = struct
         fail_with_some (S.Branch.find repo "foo")
           "should not find branch foo in dst"
       in
-      let s = Irmin_layers.Stats.get () in
-      log_stats s;
-      Alcotest.(check int) "one freeze" s.nb_freeze 1;
-      Alcotest.(check (list int)) "one commit" s.copied_commits [ 1 ];
-      Alcotest.(check (list int)) "one branch" s.copied_branches [ 1 ];
-      Alcotest.(check (list int)) "one content" s.copied_contents [ 1 ];
-      Alcotest.(check (list int)) "several nodes" s.copied_nodes [ 3 ];
+      log_stats ();
+      let () =
+        let open Irmin_layers.Stats in
+        Alcotest.(check int) "one freeze" (get_freeze_count ()) 1;
+        Alcotest.(check int) "one commit" (get_copied_commits_count ()) 1;
+        Alcotest.(check int) "one commit" (get_copied_commits_count ()) 1;
+        Alcotest.(check int) "one branch" (get_copied_branches_count ()) 1;
+        Alcotest.(check int) "one content" (get_copied_contents_count ()) 1;
+        Alcotest.(check int) "several nodes" (get_copied_nodes_count ()) 3
+      in
       P.Repo.close repo
     in
     run x test;


### PR DESCRIPTION
```
freeze 0 blocked 40.672s (35%), and yielded 1min15s (65%). Total 1min56s.
  Event counts: copy_contents:208847, copy_nodes:1465555, copy_commits:13315, copy_branches:0, adds:1312338, skips:2369230, yields:13316, copy_newies_loops:1
  Longest block 3.454s (during "copy newies (loop)"). Longest yield 1min15s (during "copy to lower"). 114.231 yield per sec.
  Timeline:
    wait for freeze lock took 1.27us (0% of total) and blocked 0.873us (0% of total).
                    misc took 471us (0% of total) and blocked 471us (0% of total).
           copy to lower took 1min20s (69% of total) and blocked 4.661s (11% of total).
      copy to next upper took 0.299us (0% of total) and blocked 0.291us (0% of total).
           copy branches took 3.791us (0% of total) and blocked 3.792us (0% of total).
             flush lower took 131us (0% of total) and blocked 131us (0% of total).
      copy newies (loop) took 36.114s (31% of total) and blocked 35.999s (89% of total).
     wait for batch lock took 1.765us (0% of total) and blocked 0.671us (0% of total).
      copy newies (last) took 65.661us (0% of total) and blocked 65.646us (0% of total).
                    misc took 11.78ms (0% of total) and blocked 11.821ms (0% of total).
                finalize took 358us (0% of total) and blocked 317us (0% of total).

```