### PR TITLE
irmin-bench: bench/tree.exe supports layered store

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,15 @@
 
 ### Added
 
-- **irmin-pack**
-  - It is no longer possible to modify an `inode` that doesn't point to the root
-    of a directory. (#1292, @Ngoguey42)
+- **irmin-bench**
+  - Benchmarks for tree operations now support layered stores
+    (#1293, @Ngoguey42)
 
 ### Changed
 
 - **irmin-pack**
+  - It is no longer possible to modify an `inode` that doesn't point to the root
+    of a directory. (#1292, @Ngoguey42)
   - When configuring a store, is it no longer possible to set `entries` to a
     value larger than `stable_hash`. (#1292, @Ngoguey42)
 

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -16,9 +16,38 @@ type op =
   | Copy of key * key
 [@@deriving yojson]
 
+type config = {
+  ncommits : int;
+  ncommits_trace : int;
+  depth : int;
+  nchain_trees : int;
+  width : int;
+  nlarge_trees : int;
+  root : string;
+  flatten : bool;
+  inode_config : [ `Entries_32 | `Entries_2 ];
+  store_type : [ `Pack | `Pack_layered ];
+  freeze_commit : int;
+  commit_data_file : string;
+  results_dir : string;
+}
+
+module type STORE = sig
+  include Irmin.S with type key = string list and type contents = string
+
+  type on_commit := int -> Hash.t -> unit Lwt.t
+  type pp := Format.formatter -> unit -> unit
+
+  val create_repo : int -> config -> (Repo.t * on_commit * pp) Lwt.t
+end
+
 let pp_inode_config ppf = function
   | `Entries_2 -> Format.fprintf ppf "[2, 5]"
   | `Entries_32 -> Format.fprintf ppf "[32, 256]"
+
+let pp_store_type ppf = function
+  | `Pack -> Format.fprintf ppf "[pack store]"
+  | `Pack_layered -> Format.fprintf ppf "[pack-layered store]"
 
 module Parse_trace = struct
   let is_hex_char = function
@@ -102,9 +131,7 @@ module Parse_trace = struct
     (commits, n)
 end
 
-module Generate_trees_from_trace
-    (Store : Irmin.S with type contents = string and type key = string list) =
-struct
+module Generate_trees_from_trace (Store : STORE) = struct
   type t = { mutable tree : Store.tree }
 
   type stat_entry =
@@ -150,7 +177,7 @@ struct
     let+ concrete = Store.Tree.to_concrete tree in
     aux concrete
 
-  let pp_stats ppf (as_json, flatten, inode_config) =
+  let pp_stats ppf (as_json, flatten, inode_config, store_type) =
     let mean histo =
       if Bentov.total_count histo > 0 then Bentov.mean histo else 0.
     in
@@ -180,11 +207,12 @@ struct
     in
     if as_json then
       Fmt.pf ppf
-        "{\"revision\":\"%s\", \"flatten\":%d, \"inode_config\":\"%a\", @\n\
+        "{\"revision\":\"%s\", \"flatten\":%d, \"inode_config\":\"%a\", \
+         \"store_type\":\"%a\", @\n\
          \"points\":{%a}}"
         "missing"
         (if flatten then 1 else 0)
-        pp_inode_config inode_config
+        pp_inode_config inode_config pp_store_type store_type
         Fmt.(list ~sep:(any ",@\n") pp_stat)
         op_tags
     else Fmt.pf ppf "%a" Fmt.(list ~sep:(any "@\n") pp_stat) op_tags
@@ -278,35 +306,23 @@ struct
             |> with_monitoring `Commit)
       (0, prev_commit) operations
 
-  let add_commits repo commits () =
-    with_progress_bar ~message:"Replaying trace" ~n:(Array.length commits)
-      ~unit:"commits" ~sampling_interval:50
+  let add_commits repo commits on_commit () =
+    let n = Array.length commits in
+    with_progress_bar ~message:"Replaying trace" ~n ~unit:"commits"
+      ~sampling_interval:50
     @@ fun prog ->
     let t = { tree = Store.Tree.empty } in
     let rec array_iter_lwt prev_commit i =
-      if i >= Array.length commits then Lwt.return_unit
+      if i >= n then Lwt.return_unit
       else
         let operations = commits.(i) in
         let* _, prev_commit = add_operations t repo prev_commit operations i in
+        let* () = on_commit i (Option.get prev_commit) in
         prog Int64.one;
         array_iter_lwt prev_commit (i + 1)
     in
     array_iter_lwt None 0
 end
-
-type config = {
-  ncommits : int;
-  ncommits_trace : int;
-  depth : int;
-  nchain_trees : int;
-  width : int;
-  nlarge_trees : int;
-  root : string;
-  flatten : bool;
-  inode_config : [ `Entries_32 | `Entries_2 ];
-  commit_data_file : string;
-  results_dir : string;
-}
 
 module Benchmark = struct
   type result = { time : float; size : int }
@@ -323,17 +339,7 @@ end
 
 module Hash = Irmin.Hash.SHA1
 
-module Bench_suite (Conf : sig
-  val entries : int
-  val stable_hash : int
-end) =
-struct
-  module Store =
-    Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
-      (Irmin.Path.String_list)
-      (Irmin.Branch.String)
-      (Hash)
-
+module Bench_suite (Store : STORE) = struct
   let init_commit repo =
     Store.Commit.v repo ~info:(info ()) ~parents:[] Store.Tree.empty
 
@@ -348,7 +354,7 @@ struct
         let* tree = f tree in
         Store.Commit.v repo ~info:(info ()) ~parents:[ prev_commit ] tree
 
-  let add_commits ~message repo ncommits f () =
+  let add_commits ~message repo ncommits on_commit f () =
     with_progress_bar ~message ~n:ncommits ~unit:"commits" ~sampling_interval:1
     @@ fun prog ->
     let* c = init_commit repo in
@@ -356,6 +362,7 @@ struct
       if i >= ncommits then Lwt.return c
       else
         let* c' = checkout_and_commit repo (Store.Commit.hash c) f in
+        let* () = on_commit i (Store.Commit.hash c') in
         prog Int64.one;
         aux c' (i + 1)
     in
@@ -364,39 +371,43 @@ struct
 
   let run_large config =
     reset_stats ();
-    let conf = Irmin_pack.config ~readonly:false ~fresh:true config.root in
-    let* repo = Store.Repo.v conf in
+    let* repo, on_commit, repo_pp = Store.create_repo config.ncommits config in
     let* result =
       Trees.add_large_trees config.width config.nlarge_trees
       |> add_commits ~message:"Playing large mode" repo config.ncommits
+           on_commit
       |> Benchmark.run config
     in
     let+ () = Store.Repo.close repo in
     fun ppf ->
       Format.fprintf ppf
-        "Large trees mode on inode config %a: %d commits, each consisting of \
-         %d large trees of %d entries\n\
+        "Large trees mode on inode config %a, %a: %d commits, each consisting \
+         of %d large trees of %d entries\n\
+         %a@\n\
          %a"
-        pp_inode_config config.inode_config config.ncommits config.nlarge_trees
-        config.width Benchmark.pp_results result
+        pp_inode_config config.inode_config pp_store_type config.store_type
+        config.ncommits config.nlarge_trees config.width repo_pp ()
+        Benchmark.pp_results result
 
   let run_chains config =
     reset_stats ();
-    let conf = Irmin_pack.config ~readonly:false ~fresh:true config.root in
-    let* repo = Store.Repo.v conf in
+    let* repo, on_commit, repo_pp = Store.create_repo config.ncommits config in
     let* result =
       Trees.add_chain_trees config.depth config.nchain_trees
       |> add_commits ~message:"Playing chain mode" repo config.ncommits
+           on_commit
       |> Benchmark.run config
     in
     let+ () = Store.Repo.close repo in
     fun ppf ->
       Format.fprintf ppf
-        "Chain trees mode on inode config %a: %d commits, each consisting of \
-         %d chains of depth %d\n\
+        "Chain trees mode on inode config %a, %a: %d commits, each consisting \
+         of %d chains of depth %d\n\
+         %a@\n\
          %a"
-        pp_inode_config config.inode_config config.ncommits config.nchain_trees
-        config.depth Benchmark.pp_results result
+        pp_inode_config config.inode_config pp_store_type config.store_type
+        config.ncommits config.nchain_trees config.depth repo_pp ()
+        Benchmark.pp_results result
 
   let run_read_trace config =
     reset_stats ();
@@ -405,43 +416,112 @@ struct
         config.commit_data_file
     in
     let config = { config with ncommits_trace = n } in
-    let conf = Irmin_pack.config ~readonly:false ~fresh:true config.root in
-    let* repo = Store.Repo.v conf in
+    let* repo, on_commit, repo_pp = Store.create_repo n config in
     let* result =
-      Trees_trace.add_commits repo commits |> Benchmark.run config
+      Trees_trace.add_commits repo commits on_commit |> Benchmark.run config
     in
     let+ () = Store.Repo.close repo in
+
     prepare_results_dir config.results_dir;
-    let json_channel =
+    let json_path =
       let ( / ) = Filename.concat in
-      config.results_dir / "boostrap_trace.json" |> open_out
+      config.results_dir / "boostrap_trace_timings.json"
     in
+    let json_channel = open_out json_path in
     Format.fprintf
       (Format.formatter_of_out_channel json_channel)
       "%a%!" Trees_trace.pp_stats
-      (true, config.flatten, config.inode_config);
+      (true, config.flatten, config.inode_config, config.store_type);
     close_out json_channel;
 
     fun ppf ->
       Format.fprintf ppf
-        "Tezos_log mode on inode config %a: %d commits @\n%a@\n%a"
-        pp_inode_config config.inode_config config.ncommits_trace
-        Trees_trace.pp_stats
-        (false, config.flatten, config.inode_config)
-        Benchmark.pp_results result
+        "Tezos_log mode on inode config %a, %a. @\n\
+         %a@\n\
+         Results: @\n\
+         %a@\n\
+         Stats saved to %s@\n\
+         %a"
+        pp_inode_config config.inode_config pp_store_type config.store_type
+        repo_pp () Trees_trace.pp_stats
+        (false, config.flatten, config.inode_config, config.store_type)
+        json_path Benchmark.pp_results result
 end
 
-module Bench_inodes_32 = Bench_suite (Conf)
+module Make_store_layered (Conf : sig
+  val entries : int
+  val stable_hash : int
+end) =
+struct
+  module Store =
+    Irmin_pack_layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+      (Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Hash)
 
-module Bench_inodes_2 = Bench_suite (struct
+  let create_repo ncommits config =
+    let conf = Irmin_pack.config ~readonly:false ~fresh:true config.root in
+    let* repo = Store.Repo.v conf in
+    let on_commit i commit_hash =
+      let* () =
+        if i = config.freeze_commit then
+          let* c = Store.Commit.of_hash repo commit_hash in
+          let c = Option.get c in
+          Store.freeze repo ~max:[ c ] ~min_upper:[ c ]
+        else Lwt.return_unit
+      in
+      let* () =
+        if i = ncommits - 1 then Store.PrivateLayer.wait_for_freeze repo
+        else Lwt.return_unit
+      in
+      Lwt.pause ()
+      (* Lwt_unix.sleep 0.001 *)
+      (* Lwt_unix.sleep 0.00001 *)
+      (* Lwt_unix.sleep 0.0000001 *)
+    in
+    let pp ppf () =
+      if Irmin_layers.Stats.get_freeze_count () = 0 then
+        Format.fprintf ppf "no freeze"
+      else Format.fprintf ppf "%t" Irmin_layers.Stats.pp_latest
+    in
+    Lwt.return (repo, on_commit, pp)
+
+  include Store
+end
+
+module Make_store_pack (Conf : sig
+  val entries : int
+  val stable_hash : int
+end) =
+struct
+  module Store =
+    Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+      (Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Hash)
+
+  let create_repo _ config =
+    let conf = Irmin_pack.config ~readonly:false ~fresh:true config.root in
+    let* repo = Store.Repo.v conf in
+    let on_commit _ _ = Lwt.return_unit in
+    let pp _ () = () in
+    Lwt.return (repo, on_commit, pp)
+
+  include Store
+end
+
+module Conf2 = struct
   let entries = 2
   let stable_hash = 5
-end)
+end
 
-type mode_elt = [ `Read_trace | `Chains | `Large ]
+module Bench_inodes_32 = Bench_suite (Make_store_pack (Conf))
+module Bench_inodes_2 = Bench_suite (Make_store_pack (Conf2))
+module Bench_inodes_32_layered = Bench_suite (Make_store_layered (Conf))
+module Bench_inodes_2_layered = Bench_suite (Make_store_layered (Conf2))
 
 type suite_elt = {
-  mode : mode_elt;
+  mode : [ `Read_trace | `Chains | `Large ];
   speed : [ `Quick | `Slow | `Custom ];
   run : config -> (Format.formatter -> unit) Lwt.t;
 }
@@ -459,6 +539,7 @@ let suite : suite_elt list =
               ncommits_trace = 10000;
               flatten = false;
               inode_config = `Entries_32;
+              store_type = `Pack;
             });
     };
     {
@@ -472,6 +553,7 @@ let suite : suite_elt list =
               ncommits_trace = 13315;
               flatten = false;
               inode_config = `Entries_32;
+              store_type = `Pack;
             });
     };
     {
@@ -486,6 +568,7 @@ let suite : suite_elt list =
               depth = 1000;
               nchain_trees = 1;
               inode_config = `Entries_32;
+              store_type = `Pack;
             });
     };
     {
@@ -500,6 +583,7 @@ let suite : suite_elt list =
               depth = 1000;
               nchain_trees = 1;
               inode_config = `Entries_2;
+              store_type = `Pack;
             });
     };
     {
@@ -514,6 +598,7 @@ let suite : suite_elt list =
               width = 1_000_000;
               nlarge_trees = 1;
               inode_config = `Entries_32;
+              store_type = `Pack;
             });
     };
     {
@@ -528,6 +613,7 @@ let suite : suite_elt list =
               width = 1_000_000;
               nlarge_trees = 1;
               inode_config = `Entries_2;
+              store_type = `Pack;
             });
     };
     {
@@ -535,27 +621,39 @@ let suite : suite_elt list =
       speed = `Custom;
       run =
         (fun config ->
-          match config.inode_config with
-          | `Entries_2 -> Bench_inodes_2.run_read_trace config
-          | `Entries_32 -> Bench_inodes_32.run_read_trace config);
+          match (config.inode_config, config.store_type) with
+          | `Entries_2, `Pack -> Bench_inodes_2.run_read_trace config
+          | `Entries_32, `Pack -> Bench_inodes_32.run_read_trace config
+          | `Entries_2, `Pack_layered ->
+              Bench_inodes_2_layered.run_read_trace config
+          | `Entries_32, `Pack_layered ->
+              Bench_inodes_32_layered.run_read_trace config);
     };
     {
       mode = `Chains;
       speed = `Custom;
       run =
         (fun config ->
-          match config.inode_config with
-          | `Entries_2 -> Bench_inodes_2.run_chains config
-          | `Entries_32 -> Bench_inodes_32.run_chains config);
+          match (config.inode_config, config.store_type) with
+          | `Entries_2, `Pack -> Bench_inodes_2.run_chains config
+          | `Entries_32, `Pack -> Bench_inodes_32.run_chains config
+          | `Entries_2, `Pack_layered ->
+              Bench_inodes_2_layered.run_chains config
+          | `Entries_32, `Pack_layered ->
+              Bench_inodes_32_layered.run_chains config);
     };
     {
       mode = `Large;
       speed = `Custom;
       run =
         (fun config ->
-          match config.inode_config with
-          | `Entries_2 -> Bench_inodes_2.run_large config
-          | `Entries_32 -> Bench_inodes_32.run_large config);
+          match (config.inode_config, config.store_type) with
+          | `Entries_2, `Pack -> Bench_inodes_2.run_read_trace config
+          | `Entries_32, `Pack -> Bench_inodes_32.run_read_trace config
+          | `Entries_2, `Pack_layered ->
+              Bench_inodes_2_layered.run_read_trace config
+          | `Entries_32, `Pack_layered ->
+              Bench_inodes_32_layered.run_read_trace config);
     };
   ]
 
@@ -578,8 +676,9 @@ let get_suite suite_filter =
           false)
     suite
 
-let main ncommits ncommits_trace suite_filter inode_config flatten depth width
-    nchain_trees nlarge_trees commit_data_file results_dir =
+let main ncommits ncommits_trace suite_filter inode_config store_type
+    freeze_commit flatten depth width nchain_trees nlarge_trees commit_data_file
+    results_dir =
   let config =
     {
       ncommits;
@@ -592,6 +691,8 @@ let main ncommits ncommits_trace suite_filter inode_config flatten depth width
       nlarge_trees;
       commit_data_file;
       inode_config;
+      store_type;
+      freeze_commit;
       results_dir;
     }
   in
@@ -622,6 +723,19 @@ let inode_config =
   let mode = [ ("2", `Entries_2); ("32", `Entries_32) ] in
   let doc = Arg.info ~doc:(Arg.doc_alts_enum mode) [ "inode-config" ] in
   Arg.(value @@ opt (Arg.enum mode) `Entries_32 doc)
+
+let store_type =
+  let mode = [ ("pack", `Pack); ("pack-layered", `Pack_layered) ] in
+  let doc = Arg.info ~doc:(Arg.doc_alts_enum mode) [ "store-type" ] in
+  Arg.(value @@ opt (Arg.enum mode) `Pack doc)
+
+let freeze_commit =
+  let doc =
+    Arg.info
+      ~doc:"Index of the commit after which to start the layered store freeze."
+      [ "freeze-commit" ]
+  in
+  Arg.(value @@ opt int 1664 doc)
 
 let flatten =
   let doc =
@@ -693,6 +807,8 @@ let main_term =
     $ ncommits_trace
     $ mode
     $ inode_config
+    $ store_type
+    $ freeze_commit
     $ flatten
     $ depth
     $ width


### PR DESCRIPTION
# (bonus) A series of tests using `bench/tree.exe`
TLDR ; Freeze is extremely sensible to cooperative yields

Test setup: 
- `dune exec -- ./bench/irmin-pack/tree.exe --mode trace --inode-config 32 ~/boostrap_trace.json`.
- Using a layered store.
- 13315 commits total.
- By default, one freeze launched after commit 1664.
- By default, main thread doesn't yield control.
- By default, freeze thread yields control every time it hits a commit.
- After the 13315 commits, we wait for the freeze to end, if still ongoing.

### Variation: Vanilla
As soon as freeze calls Lwt.pause (from `copy to lower`), it is never resumed until the end of the main thread.

Lots of newies.
```
freeze 0 blocked 40.672s (35%), and yielded 1min15s (65%). Total 1min56s.
  Event counts: copy_contents:208847, copy_nodes:1465555, copy_commits:13315, copy_branches:0, adds:1312338, skips:2369230, yields:13316, copy_newies_loops:1
  Longest block 3.454s (during "copy newies (loop)"). Longest yield 1min15s (during "copy to lower"). 114.231 yield per sec.
  Timeline:
    wait for freeze lock took 1.27us (0% of total) and blocked 0.873us (0% of total).
                    misc took 471us (0% of total) and blocked 471us (0% of total).
           copy to lower took 1min20s (69% of total) and blocked 4.661s (11% of total).
      copy to next upper took 0.299us (0% of total) and blocked 0.291us (0% of total).
           copy branches took 3.791us (0% of total) and blocked 3.792us (0% of total).
             flush lower took 131us (0% of total) and blocked 131us (0% of total).
      copy newies (loop) took 36.114s (31% of total) and blocked 35.999s (89% of total).
     wait for batch lock took 1.765us (0% of total) and blocked 0.671us (0% of total).
      copy newies (last) took 65.661us (0% of total) and blocked 65.646us (0% of total).
                    misc took 11.78ms (0% of total) and blocked 11.821ms (0% of total).
                finalize took 358us (0% of total) and blocked 317us (0% of total).
Tezos_log mode on inode config [32, 256]. Results:
895827 "Add" 3.117 sec (4.0%)
54196 "Remove" 1.487 sec (1.9%)
2950152 "Find" 16.010 sec (20.8%)
669692 "Mem" 2.855 sec (3.7%)
439329 "Mem_tree" 0.547 sec (0.7%)
13314 "Checkout" 0.046 sec (0.1%)
59 "Copy" 0.001 sec (0.0%)
13315 "Commit" 52.918 sec (68.7%)
Stats saved to /Users/nico/r/irmin/_results/ad6ffb0c-c7a0-448c-a5e4-67046c2fc0f9/boostrap_trace_timings.json
Total time: 115.013495
```

### Variation: Call `Lwt.pause` after each commit in main thread.
The freeze thread quickly reaches `copy newies (loop)` but it keeps looping in there because the main thread pushes a lot of data.

Lots of newies.
```
freeze 0 blocked 37.963s (32%), and yielded 1min19s (68%). Total 1min57s.
  Event counts: copy_contents:208847, copy_nodes:1465555, copy_commits:13315, copy_branches:0, adds:1312338, skips:2613798, yields:13316, copy_newies_loops:8
  Longest block 2.613s (during "copy newies (loop)"). Longest yield 387ms (during "copy to lower"). 113.432 yield per sec.
  Timeline:
    wait for freeze lock took 0.878us (0% of total) and blocked 0.402us (0% of total).
                    misc took 592us (0% of total) and blocked 592us (0% of total).
           copy to lower took 10.9s (9% of total) and blocked 3.177s (8% of total).
      copy to next upper took 0.411us (0% of total) and blocked 0.397us (0% of total).
           copy branches took 3.991us (0% of total) and blocked 3.992us (0% of total).
             flush lower took 89.446us (0% of total) and blocked 89.86us (0% of total).
      copy newies (loop) took 1min46s (91% of total) and blocked 34.774s (92% of total).
     wait for batch lock took 1.024us (0% of total) and blocked 0.232us (0% of total).
      copy newies (last) took 11.247us (0% of total) and blocked 11.266us (0% of total).
                    misc took 11.696ms (0% of total) and blocked 11.697ms (0% of total).
                finalize took 221us (0% of total) and blocked 220us (0% of total).
Tezos_log mode on inode config [32, 256]. Results:
895827 "Add" 3.318 sec (4.1%)
54196 "Remove" 1.512 sec (1.9%)
2950152 "Find" 15.725 sec (19.6%)
669692 "Mem" 2.458 sec (3.1%)
439329 "Mem_tree" 0.659 sec (0.8%)
13314 "Checkout" 0.047 sec (0.1%)
59 "Copy" 0.000 sec (0.0%)
13315 "Commit" 56.636 sec (70.5%)
Stats saved to /Users/nico/r/irmin/_results/19aa3158-5f9f-41ac-a0fb-80ffbbe46e4e/boostrap_trace_timings.json
Total time: 121.971133
```

### Variation: Call `Lwt_unix.sleep 0.000_000_1` after each commit in main thread.
The freeze thread quickly reaches `copy newies (loop)` but this time it manages to catch up on the main thread after 11 `copy newies` loops.
```
freeze 0 blocked 7.897s (49%), and yielded 8.268s (51%). Total 16.165s.
  Event counts: copy_contents:90383, copy_nodes:514234, copy_commits:3328, copy_branches:0, adds:123077, skips:414837, yields:3329, copy_newies_loops:11
  Longest block 2.262s (during "copy newies (loop)"). Longest yield 352ms (during "copy to lower"). 205.937 yield per sec.
  Timeline:
    wait for freeze lock took 2.27us (0% of total) and blocked 0.45us (0% of total).
                    misc took 357us (0% of total) and blocked 358us (0% of total).
           copy to lower took 6.282s (39% of total) and blocked 3.106s (39% of total).
      copy to next upper took 14.687us (0% of total) and blocked 14.664us (0% of total).
           copy branches took 5.732us (0% of total) and blocked 5.743us (0% of total).
             flush lower took 112us (0% of total) and blocked 112us (0% of total).
      copy newies (loop) took 9.839s (61% of total) and blocked 4.747s (60% of total).
     wait for batch lock took 113us (0% of total) and blocked 112us (0% of total).
      copy newies (last) took 98.457us (0% of total) and blocked 98.444us (0% of total).
                    misc took 25.598ms (0% of total) and blocked 25.598ms (0% of total).
                finalize took 17.579ms (0% of total) and blocked 17.578ms (0% of total).
Tezos_log mode on inode config [32, 256]
895827 "Add" 2.939 sec (4.0%)
54196 "Remove" 1.267 sec (1.7%)
2950152 "Find" 12.640 sec (17.3%)
669692 "Mem" 2.024 sec (2.8%)
439329 "Mem_tree" 0.549 sec (0.8%)
13314 "Checkout" 0.047 sec (0.1%)
59 "Copy" 0.000 sec (0.0%)
13315 "Commit" 53.749 sec (73.4%)
Stats saved to /Users/nico/r/irmin/_results/f35faa99-8c11-4341-a8f6-ac7fa3ad7e62/boostrap_trace_timings.json
Total time: 86.667993
```

### Variation: Call `Lwt_unix.sleep 0.001` after each commit in main thread.
Same, only quicker.
```
freeze 0 blocked 5.968s (65%), and yielded 3.223s (35%). Total 9.192s.
  Event counts: copy_contents:83749, copy_nodes:458641, copy_commits:2444, copy_branches:0, adds:54489, skips:212156, yields:2445, copy_newies_loops:7
  Longest block 2.008s (during "copy newies (loop)"). Longest yield 374ms (during "copy to lower"). 266.004 yield per sec.
  Timeline:
    wait for freeze lock took 1.441us (0% of total) and blocked 0.647us (0% of total).
                    misc took 1.028ms (0% of total) and blocked 1.029ms (0% of total).
           copy to lower took 4.941s (54% of total) and blocked 2.913s (49% of total).
      copy to next upper took 0.37us (0% of total) and blocked 0.279us (0% of total).
           copy branches took 3.505us (0% of total) and blocked 3.506us (0% of total).
             flush lower took 120us (0% of total) and blocked 121us (0% of total).
      copy newies (loop) took 4.228s (46% of total) and blocked 3.032s (51% of total).
     wait for batch lock took 0.554us (0% of total) and blocked 0.265us (0% of total).
      copy newies (last) took 56.936us (0% of total) and blocked 56.938us (0% of total).
                    misc took 20.754ms (0% of total) and blocked 20.754ms (0% of total).
                finalize took 226us (0% of total) and blocked 225us (0% of total).
Tezos_log mode on inode config [32, 256]. Results: ######################] 100%
895827 "Add" 3.477 sec (4.1%)
54196 "Remove" 1.595 sec (1.9%)
2950152 "Find" 18.222 sec (21.7%)
669692 "Mem" 3.064 sec (3.6%)
439329 "Mem_tree" 0.627 sec (0.7%)
13314 "Checkout" 0.126 sec (0.2%)
59 "Copy" 0.001 sec (0.0%)
13315 "Commit" 56.881 sec (67.7%)
Stats saved to /Users/nico/r/irmin/_results/c1256bf4-10ef-40ab-8dd0-220e5c48f2ac/boostrap_trace_timings.json
Total time: 93.481594
```

### Variation: Call `Lwt.pause` after each commit in main thread and remove `Lwt.pause` from freeze thread
The freeze thread totally blocks the main thread
```
freeze 0 blocked 3.092s (100%), and yielded 309us (0%). Total 3.092s.
  Event counts: copy_contents:39355, copy_nodes:220133, copy_commits:1665, copy_branches:0, adds:58, skips:81013, yields:1666, copy_newies_loops:0
  Longest block 2.208s (during "copy to lower"). Longest yield 157us (during "copy to lower"). 538.733 yield per sec.
  Timeline:
    wait for freeze lock took 0.841us (0% of total) and blocked 0.42us (0% of total).
                    misc took 508us (0% of total) and blocked 508us (0% of total).
           copy to lower took 3.058s (99% of total) and blocked 3.057s (99% of total).
      copy to next upper took 0.339us (0% of total) and blocked 0.306us (0% of total).
           copy branches took 4.266us (0% of total) and blocked 4.269us (0% of total).
             flush lower took 150us (0% of total) and blocked 150us (0% of total).
      copy newies (loop) took 1.346us (0% of total) and blocked 1.295us (0% of total).
     wait for batch lock took 0.859us (0% of total) and blocked 0.211us (0% of total).
      copy newies (last) took 60.058us (0% of total) and blocked 60.064us (0% of total).
                    misc took 27.486ms (1% of total) and blocked 27.487ms (1% of total).
                finalize took 6.389ms (0% of total) and blocked 6.388ms (0% of total).
Tezos_log mode on inode config [32, 256]
895827 "Add" 3.087 sec (3.8%)
54196 "Remove" 1.661 sec (2.0%)
2950152 "Find" 20.873 sec (25.7%)
669692 "Mem" 2.462 sec (3.0%)
439329 "Mem_tree" 0.588 sec (0.7%)
13314 "Checkout" 0.050 sec (0.1%)
59 "Copy" 0.001 sec (0.0%)
13315 "Commit" 52.512 sec (64.6%)
Stats saved to /Users/nico/r/irmin/_results/a247c732-f596-41cf-93ab-0c2ada9bd96a/boostrap_trace_timings.json
Total time: 85.884298
```