### PR TITLE
Remove ppx_irmin runtime dependency

### DIFF
--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -2,6 +2,6 @@
  (name irmin)
  (public_name irmin)
  (libraries astring bheap digestif fmt jsonm logs lwt ocamlgraph uri uutf
-   repr ppx_irmin)
+   repr)
  (preprocess
   (pps ppx_irmin -- --lib "Type")))


### PR DESCRIPTION
Adding `ppx_irmin` to the `libraries` field break cross-compilation as it's introduced as a _runtime_ dependency. 
The solution is to simply remove it, as it's already inferred from the `preprocess` field.