### PR TITLE
Include Lwt syntax and infix operators in Exported_for_backends

### DIFF
--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -1,5 +1,4 @@
-let ( let* ) x f = Lwt.bind x f
-let ( let+ ) x f = Lwt.map f x
+open Irmin.Export_for_backends
 
 let reporter ?(prefix = "") () =
   let report src level ~over k msgf =

--- a/bench/irmin-pack/import.ml
+++ b/bench/irmin-pack/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -1,9 +1,5 @@
 open Bench_common
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) x f = Lwt.bind x f
-let ( let+ ) x f = Lwt.map f x
+open Irmin.Export_for_backends
 
 type key = string list [@@deriving yojson]
 type hash = string [@@deriving yojson]

--- a/src/irmin-chunk/import.ml
+++ b/src/irmin-chunk/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/src/irmin-containers/import.ml
+++ b/src/irmin-containers/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/src/irmin-fs/import.ml
+++ b/src/irmin-fs/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/src/irmin-git/import.ml
+++ b/src/irmin-git/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/src/irmin-graphql/import.ml
+++ b/src/irmin-graphql/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/src/irmin-http/import.ml
+++ b/src/irmin-http/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/src/irmin-layers/import.ml
+++ b/src/irmin-layers/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/src/irmin-pack/import.ml
+++ b/src/irmin-pack/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/src/irmin-pack/layered/checks.ml
+++ b/src/irmin-pack/layered/checks.ml
@@ -3,9 +3,6 @@ open Irmin_pack.Checks
 module I = Irmin_pack.Private.IO
 module IO = Irmin_pack.Private.IO.Unix
 
-let ( let+ ) x f = Lwt.map f x
-let ( let* ) = Lwt.bind
-
 module type S = sig
   include S
 

--- a/src/irmin-pack/layered/import.ml
+++ b/src/irmin-pack/layered/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/src/irmin-test/import.ml
+++ b/src/irmin-test/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -15,9 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
+open Irmin.Export_for_backends
 
 type t = {
   root : string;

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -17,7 +17,6 @@
 open! Import
 open Common
 
-let ( let* ) x f = Lwt.bind x f
 let src = Logs.Src.create "test" ~doc:"Irmin tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/irmin-unix/import.ml
+++ b/src/irmin-unix/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/src/irmin/export_for_backends.ml
+++ b/src/irmin/export_for_backends.ml
@@ -14,8 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type read = Perms.read
-type write = Perms.write
-type read_write = Perms.read_write
-
 module Store_properties = S.Store_properties
+include Import

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -14,16 +14,31 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** Extensions to the default namespace, opened throughout the Irmin codebase. *)
+(* Extensions to the default namespace, opened throughout the Irmin codebase. *)
+
+type read = Perms.read
+type write = Perms.write
+type read_write = Perms.read_write
+
+(** {2 Lwt syntax} *)
+
+let ( >>= ) = Lwt.Infix.( >>= )
+let ( >|= ) = Lwt.Infix.( >|= )
+let ( let* ) = ( >>= )
+let ( let+ ) = ( >|= )
+
+(** {2 Dependency extensions} *)
 
 module Option = struct
   include Option
+  (** @closed *)
 
   let of_result = function Ok x -> Some x | Error _ -> None
 end
 
 module Seq = struct
   include Seq
+  (** @closed *)
 
   let rec drop : type a. int -> a t -> a t =
    fun n l () ->
@@ -47,12 +62,3 @@ module Seq = struct
     in
     aux s
 end
-
-type read = Perms.read
-type write = Perms.write
-type read_write = Perms.read_write
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -580,4 +580,5 @@ module Of_private (P : Private.S) :
      and module Private = P
 
 module Export_for_backends = Export_for_backends
-(** Helper module containing useful top-level types for defining Irmin backends. *)
+(** Helper module containing useful top-level types for defining Irmin backends.
+    This module is relatively unstable. *)

--- a/src/irmin/mem/import.ml
+++ b/src/irmin/mem/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -15,10 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+open Irmin.Export_for_backends
+
 let () = Printexc.record_backtrace true
 let key_t : Test_chunk.Key.t Alcotest.testable = (module Test_chunk.Key)
 let value_t : Test_chunk.Value.t Alcotest.testable = (module Test_chunk.Value)

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -15,8 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let ( let* ) x f = Lwt.bind x f
-
+open Irmin.Export_for_backends
 module Hash = Irmin.Hash.SHA1
 
 module Key = struct

--- a/test/irmin-containers/import.ml
+++ b/test/irmin-containers/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -14,10 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+open Irmin.Export_for_backends
+
 let test_db = Filename.concat "_build" "test-db-git"
 
 let config =

--- a/test/irmin-graphql/import.ml
+++ b/test/irmin-graphql/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -14,11 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Irmin.Export_for_backends
+
 let () = Random.self_init ()
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
 let ( / ) = Filename.concat
 let test_http_dir = "test-http"
 let uri = Uri.of_string "http://irmin"

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let ( let* ) = Lwt.Infix.( >>= )
+open Irmin.Export_for_backends
 
 let store =
   Irmin_test.store (module Irmin_mem.Make) (module Irmin.Metadata.None)

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -1,11 +1,9 @@
-open Irmin.Perms
+open Irmin.Export_for_backends
 
 module Dict = Irmin_pack.Dict.Make (struct
   let io_version = `V2
 end)
 
-let ( let* ) x f = Lwt.bind x f
-let ( let+ ) x f = Lwt.map f x
 let get = function Some x -> x | None -> Alcotest.fail "None"
 let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
 

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -61,7 +61,6 @@ end) : sig
   val close : Index.t -> read Pack.t -> unit Lwt.t
 end
 
-val ( let* ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
 val get : 'a option -> 'a
 val sha1 : string -> H.t
 val rm_dir : string -> unit

--- a/test/irmin-pack/import.ml
+++ b/test/irmin-pack/import.ml
@@ -1,6 +1,1 @@
 include Irmin.Export_for_backends
-
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )

--- a/test/irmin-unix/import.ml
+++ b/test/irmin-unix/import.ml
@@ -1,4 +1,1 @@
-let ( >>= ) = Lwt.Infix.( >>= )
-let ( >|= ) = Lwt.Infix.( >|= )
-let ( let* ) = ( >>= )
-let ( let+ ) = ( >|= )
+include Irmin.Export_for_backends

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -1,4 +1,4 @@
-open Lwt.Infix
+open Irmin.Export_for_backends
 open Irmin
 
 module Metadata = struct
@@ -36,8 +36,6 @@ module Alcotest = struct
 end
 
 let ( >> ) f g x = g (f x)
-let ( let* ) = Lwt.bind
-let ( let+ ) x f = Lwt.map f x
 let c ?(info = Metadata.Default) blob = `Contents (blob, info)
 
 let invalid_tree () =


### PR DESCRIPTION
This avoids a bunch of boilerplate and sets up for using the `Stdlib` extensions in `import.ml` throughout the rest of the codebase.