### PR TITLE
irmin: move list_is_longer_than to List extension

### DIFF
--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -22,6 +22,16 @@ module Option = struct
   let of_result = function Ok x -> Some x | Error _ -> None
 end
 
+module List = struct
+  include List
+  (** @closed *)
+
+  let rec is_longer_than : type a. int -> a list -> bool =
+   fun len l ->
+    if len < 0 then true
+    else match l with [] -> false | _ :: tl -> is_longer_than (len - 1) tl
+end
+
 module Seq = struct
   include Seq
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -28,11 +28,6 @@ type ('a, 'r) cont_lwt = ('a, 'r Lwt.t) cont
 
 let ok x = Lwt.return (Ok x)
 
-let rec list_is_longer_than : type a. a list -> int -> bool =
- fun l len ->
-  if len < 0 then true
-  else match l with [] -> false | _ :: tl -> list_is_longer_than tl (len - 1)
-
 (* assume l1 and l2 are key-sorted *)
 let alist_iter2 compare_k f l1 l2 =
   let rec aux l1 l2 =
@@ -670,7 +665,7 @@ module Make (P : Private.S) = struct
                no alternative. *)
             cnt.node_val_list <- cnt.node_val_list + 1;
             let entries = P.Node.Val.list v in
-            if list_is_longer_than entries remove_count then false
+            if List.is_longer_than remove_count entries then false
             else List.for_all (fun (step, _) -> StepMap.mem step um) entries)
 
     let is_empty t =


### PR DESCRIPTION
Tiny fixup for consistency; we should probably use `import.ml` for all such extensions in future.