### PR TITLE
A git commit expects a string option now

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- **irmin-git**
+  - Use the last version of git 3.3.0. It fixes a bug about trailing LF on
+    message. For irmin user, it should not change anything (#1301, @dinosaure, @CraigFe)
+
 ## 2.5.0 (2021-02-16)
 
 ### Changed

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.0.0"}
+  "git"        {>= "3.3.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -20,9 +20,9 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-cohttp-mirage" {>= "3.0.0"}
+  "git-cohttp-mirage" {>= "3.3.0"}
   "fmt"
-  "git"               {>= "3.0.0"}
+  "git"               {>= "3.3.0"}
   "lwt"
   "mirage-clock"
   "uri"

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -40,8 +40,8 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.0.0"}
-  "git-cohttp-unix" {>= "3.0.0"}
+  "git"             {>= "3.3.0"}
+  "git-cohttp-unix" {>= "3.3.0"}
   "lwt"
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -391,11 +391,7 @@ struct
         let parents = G.Value.Commit.parents g in
         let author = G.Value.Commit.author g in
         let message = G.Value.Commit.message g in
-        let message =
-          if String.length message > 0 && message.[0] = '\n' then
-            String.sub message 1 (String.length message - 1)
-          else message
-        in
+        let message = Option.value ~default:"" message in
         let info = info_of_git author message in
         (info, node, parents)
 
@@ -408,9 +404,9 @@ struct
           Git.User.{ name; email; date = (date, None) }
         in
         let message = Irmin.Info.message info in
-        let message = if message = "" then "" else "\n" ^ message in
         G.Value.Commit.make (* FIXME: should be v *) ~tree ~parents ~author
-          ~committer:author message
+          ~committer:author
+          (if message = "" then None else Some message)
 
       let v ~info ~node ~parents = to_git info node parents
       let xnode g = G.Value.Commit.tree g
@@ -419,7 +415,7 @@ struct
 
       let info g =
         let author = G.Value.Commit.author g in
-        let message = G.Value.Commit.message g in
+        let message = Option.value ~default:"" (G.Value.Commit.message g) in
         info_of_git author message
 
       module C = Irmin.Private.Commit.Make (H)


### PR DESCRIPTION
`ocaml-git` updates the interfaces to fix #917 at the `ocaml-git` level. That mostly means that the hack into `irmin` to produce well formed commit is not needed anymore. 