### PR TITLE
Draft: Prefix all pre hashes with a magic byte. BIS

### DIFF
--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -94,7 +94,7 @@ end = struct
 
   let merge = Irmin.Merge.(option (v t merge))
   let add t e = e :: t
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 (* Build an Irmin store containing log files. *)

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -94,6 +94,7 @@ end = struct
 
   let merge = Irmin.Merge.(option (v t merge))
   let add t e = e :: t
+  let pre_hash_prefix = "b"
 end
 
 (* Build an Irmin store containing log files. *)

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -110,6 +110,7 @@ module Chunk (K : Irmin.Hash.S) = struct
     Bytes.unsafe_to_string buf
 
   let t = Irmin.Type.(map string) of_string to_string
+  let pre_hash_prefix = "b"
 end
 
 module Content_addressable

--- a/src/irmin-containers/blob_log.ml
+++ b/src/irmin-containers/blob_log.ml
@@ -49,7 +49,7 @@ module Blob_log (T : Time.S) (V : Irmin.Type.S) :
     ok (List.rev_append l3 old)
 
   let merge = Irmin.Merge.(option (v t merge))
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module type S = sig

--- a/src/irmin-containers/blob_log.ml
+++ b/src/irmin-containers/blob_log.ml
@@ -49,6 +49,7 @@ module Blob_log (T : Time.S) (V : Irmin.Type.S) :
     ok (List.rev_append l3 old)
 
   let merge = Irmin.Merge.(option (v t merge))
+  let pre_hash_prefix = "b"
 end
 
 module type S = sig

--- a/src/irmin-containers/counter.ml
+++ b/src/irmin-containers/counter.ml
@@ -25,6 +25,7 @@ module Counter : Irmin.Contents.S with type t = int64 = struct
 
   let t = Irmin.Type.int64
   let merge = Irmin.Merge.(option counter)
+  let pre_hash_prefix = "b"
 end
 
 module type S = sig

--- a/src/irmin-containers/counter.ml
+++ b/src/irmin-containers/counter.ml
@@ -25,7 +25,7 @@ module Counter : Irmin.Contents.S with type t = int64 = struct
 
   let t = Irmin.Type.int64
   let merge = Irmin.Merge.(option counter)
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module type S = sig

--- a/src/irmin-containers/linked_log.ml
+++ b/src/irmin-containers/linked_log.ml
@@ -28,6 +28,8 @@ module Store_item (T : Time.S) (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
   module L = Log_item (T) (K) (V)
 
   type t = Value of L.t | Merge of L.t list [@@deriving irmin]
+
+  let pre_hash_prefix = "?"
 end
 
 module Linked_log
@@ -84,6 +86,7 @@ struct
     Store.add store (S.Merge (sort @@ lv1 @ lv2)) >>= ok
 
   let merge = Irmin.Merge.(option (v t merge))
+  let pre_hash_prefix = "??"
 end
 
 module type S = sig

--- a/src/irmin-containers/lww_register.ml
+++ b/src/irmin-containers/lww_register.ml
@@ -35,7 +35,7 @@ module LWW (T : Time.S) (V : Irmin.Type.S) :
     if compare v1 v2 > 0 then ok v1 else ok v2
 
   let merge = Irmin.Merge.(option (v t merge))
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module type S = sig

--- a/src/irmin-containers/lww_register.ml
+++ b/src/irmin-containers/lww_register.ml
@@ -35,6 +35,7 @@ module LWW (T : Time.S) (V : Irmin.Type.S) :
     if compare v1 v2 > 0 then ok v1 else ok v2
 
   let merge = Irmin.Merge.(option (v t merge))
+  let pre_hash_prefix = "b"
 end
 
 module type S = sig

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -346,6 +346,8 @@ struct
 
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
+
+      let pre_hash_prefix = "n"
     end
 
     include Content_addressable (struct
@@ -445,6 +447,8 @@ struct
 
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c
+
+      let pre_hash_prefix = "c"
     end
 
     module Key = H
@@ -1056,6 +1060,7 @@ module Content_addressable (G : Git.S) (V : Irmin.Type.S) = struct
     include V
 
     let merge = Irmin.Merge.default Irmin.Type.(option V.t)
+    let pre_hash_prefix = "b"
   end
 
   module M = Make_ext (G) (No_sync (G)) (V) (Irmin.Path.String_list) (Reference)

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -197,6 +197,7 @@ struct
 
       let size_of = Irmin.Type.stage (fun _ -> None)
       let t = Irmin.Type.like ~bin:(encode_bin, decode_bin, size_of) t
+      let pre_hash_prefix = ""
     end
 
     module Key = H
@@ -347,7 +348,7 @@ struct
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
 
-      let pre_hash_prefix = "n"
+      let pre_hash_prefix = ""
     end
 
     include Content_addressable (struct
@@ -448,7 +449,7 @@ struct
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c
 
-      let pre_hash_prefix = "c"
+      let pre_hash_prefix = ""
     end
 
     module Key = H
@@ -1060,7 +1061,7 @@ module Content_addressable (G : Git.S) (V : Irmin.Type.S) = struct
     include V
 
     let merge = Irmin.Merge.default Irmin.Type.(option V.t)
-    let pre_hash_prefix = "b"
+    let pre_hash_prefix = ""
   end
 
   module M = Make_ext (G) (No_sync (G)) (V) (Irmin.Path.String_list) (Reference)

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -113,6 +113,7 @@ struct
           type t = v
 
           let t = v_t
+          let pre_hash_prefix = Node.pre_hash_prefix
         end)
 
     type t = { hash : H.t Lazy.t; stable : bool; v : v }
@@ -952,6 +953,7 @@ struct
         (fun x -> apply x { f = (fun layout v -> I.to_bin layout v) })
 
     let hash t = apply t { f = (fun _ v -> I.hash v) }
+    let pre_hash_prefix = Node.pre_hash_prefix
 
     let save ~add ~mem t =
       let f layout v =

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -37,6 +37,8 @@ module Make (K : Type.S) = struct
   let v ~info ~node ~parents =
     let parents = List.fast_sort compare_hash parents in
     { node; parents; info }
+
+  let pre_hash_prefix = "c"
 end
 
 module Store
@@ -530,4 +532,6 @@ module V1 (C : S) = struct
     |+ field "parents" (list ~len:`Int64 K.t) parents
     |+ field "info" info_t info
     |> sealr
+
+  let pre_hash_prefix = ""
 end

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -38,7 +38,7 @@ module Make (K : Type.S) = struct
     let parents = List.fast_sort compare_hash parents in
     { node; parents; info }
 
-  let pre_hash_prefix = "c"
+  let pre_hash_prefix = "C"
 end
 
 module Store

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -45,6 +45,8 @@ module type S = sig
 
   val hash_t : hash Type.t
   (** [hash_t] is the value type for {!hash}. *)
+
+  val pre_hash_prefix : string
 end
 
 module type STORE = sig

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -163,6 +163,7 @@ module Json_value = struct
 
   let merge_json = Merge.(v t merge_value)
   let merge = Merge.(option merge_json)
+  let pre_hash_prefix = "b"
 end
 
 module Json = struct
@@ -188,12 +189,15 @@ module Json = struct
 
   let merge =
     Merge.(option (alist Type.string Json_value.t (fun _ -> Json_value.merge)))
+
+  let pre_hash_prefix = "b"
 end
 
 module String = struct
   type t = string [@@deriving irmin]
 
   let merge = Merge.idempotent Type.(option string)
+  let pre_hash_prefix = "b"
 end
 
 module Store (S : sig
@@ -234,5 +238,6 @@ module V1 = struct
     let encode_bin = Type.encode_bin t
     let pre_hash = Type.pre_hash t
     let t = Type.like t ~bin:(encode_bin, decode_bin, size_of) ~pre_hash
+    let pre_hash_prefix = ""
   end
 end

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -163,7 +163,7 @@ module Json_value = struct
 
   let merge_json = Merge.(v t merge_value)
   let merge = Merge.(option merge_json)
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module Json = struct
@@ -190,14 +190,14 @@ module Json = struct
   let merge =
     Merge.(option (alist Type.string Json_value.t (fun _ -> Json_value.merge)))
 
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module String = struct
   type t = string [@@deriving irmin]
 
   let merge = Merge.idempotent Type.(option string)
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module Store (S : sig

--- a/src/irmin/contents_intf.ml
+++ b/src/irmin/contents_intf.ml
@@ -29,6 +29,8 @@ module type S = sig
       mean that the key does not exists for either the least-common ancestor or
       one of the two merging points. The merge function returns [None] when the
       key's value should be deleted. *)
+
+  val pre_hash_prefix : string
 end
 
 module type STORE = sig

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -58,13 +58,19 @@ module SHA512 = Make (Digestif.SHA512)
 module BLAKE2B = Make (Digestif.BLAKE2B)
 module BLAKE2S = Make (Digestif.BLAKE2S)
 
-module Typed (K : S) (V : Type.S) = struct
+module Typed (K : S) (V : VALUE) = struct
   include K
 
   type value = V.t
 
   let pre_hash = Type.unstage (Type.pre_hash V.t)
-  let hash v = K.hash (pre_hash v)
+
+  let hash v =
+    let f g =
+      g V.pre_hash_prefix;
+      (pre_hash v) g
+    in
+    K.hash f
 end
 
 module V1 (K : S) : S with type t = K.t = struct

--- a/src/irmin/hash_intf.ml
+++ b/src/irmin/hash_intf.ml
@@ -36,6 +36,12 @@ module type S = sig
   (** [t] is the value type for {!t}. *)
 end
 
+module type VALUE = sig
+  include Type.S
+
+  val pre_hash_prefix : string
+end
+
 module type TYPED = sig
   type t
   type value
@@ -59,6 +65,8 @@ end
 module type Hash = sig
   module type S = S
   (** Signature for hash values. *)
+
+  module type VALUE = VALUE
 
   module type TYPED = TYPED
   (** Signature for typed hashes, where [hash] directly takes a value as
@@ -88,6 +96,6 @@ module type Hash = sig
   module V1 (H : S) : S with type t = H.t
 
   (** Typed hashes. *)
-  module Typed (K : S) (V : Type.S) :
+  module Typed (K : S) (V : VALUE) :
     TYPED with type t = K.t and type value = V.t
 end

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -33,7 +33,7 @@ module CA_check_closed (CA : S.CONTENT_ADDRESSABLE_STORE_MAKER) :
   S.CONTENT_ADDRESSABLE_STORE_MAKER =
 functor
   (K : Hash.S)
-  (V : Type.S)
+  (V : Hash.VALUE)
   ->
   struct
     module S = CA (K) (V)

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -488,7 +488,7 @@ end
     [V] is the implementation of values. *)
 module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   (K : Hash.S)
-  (V : Type.S)
+  (V : Hash.VALUE)
   -> sig
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
   open Private.Sigs.Store_properties
@@ -506,7 +506,7 @@ end
 module Content_addressable
     (S : APPEND_ONLY_STORE_MAKER)
     (K : Hash.S)
-    (V : Type.S) : sig
+    (V : Hash.VALUE) : sig
   include
     CONTENT_ADDRESSABLE_STORE
       with type 'a t = 'a S(K)(V).t

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -137,7 +137,7 @@ struct
   let of_entries e = v (List.rev_map of_entry e)
   let entries e = List.rev_map (fun (_, e) -> e) (StepMap.bindings e)
   let t = Type.map Type.(list entry_t) of_entries entries
-  let pre_hash_prefix = "n"
+  let pre_hash_prefix = "N"
 end
 
 module Store

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -137,6 +137,7 @@ struct
   let of_entries e = v (List.rev_map of_entry e)
   let entries e = List.rev_map (fun (_, e) -> e) (StepMap.bindings e)
   let t = Type.map Type.(list entry_t) of_entries entries
+  let pre_hash_prefix = "n"
 end
 
 module Store
@@ -472,4 +473,6 @@ module V1 (N : S with type step = string) = struct
 
   let t : t Type.t =
     Type.map Type.(list ~len:`Int64 (pair step_t value_t)) v list
+
+  let pre_hash_prefix = ""
 end

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -83,6 +83,8 @@ module type S = sig
 
   val value_t : value Type.t
   (** [value_t] is the value type for {!value}. *)
+
+  val pre_hash_prefix : string
 end
 
 module type STORE = sig

--- a/src/irmin/s.ml
+++ b/src/irmin/s.ml
@@ -93,7 +93,7 @@ end
 
 module type CONTENT_ADDRESSABLE_STORE_MAKER = functor
   (K : Hash.S)
-  (V : Type.S)
+  (V : Hash.VALUE)
   -> sig
   include CONTENT_ADDRESSABLE_STORE with type key = K.t and type value = V.t
   include BATCH with type 'a t := 'a t

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -25,7 +25,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Content_addressable
     (AO : S.APPEND_ONLY_STORE_MAKER)
     (K : Hash.S)
-    (V : Type.S) =
+    (V : Hash.VALUE) =
 struct
   include AO (K) (V)
   open Lwt.Infix

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -963,7 +963,7 @@ module type Store = sig
   module Content_addressable
       (X : Sigs.APPEND_ONLY_STORE_MAKER)
       (K : Hash.S)
-      (V : Type.S) : sig
+      (V : Hash.VALUE) : sig
     include
       Sigs.CONTENT_ADDRESSABLE_STORE
         with type 'a t = 'a X(K)(V).t

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -28,7 +28,7 @@ let run f () =
 
 let hash x =
   Test_chunk.Key.hash (fun l ->
-      l "b";
+      l "B";
       l x)
 
 let value_to_bin = Irmin.Type.(unstage (to_bin_string Test_chunk.Value.t))

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -26,7 +26,11 @@ let run f () =
   flush stderr;
   flush stdout
 
-let hash x = Test_chunk.Key.hash (fun l -> l x)
+let hash x =
+  Test_chunk.Key.hash (fun l ->
+      l "b";
+      l x)
+
 let value_to_bin = Irmin.Type.(unstage (to_bin_string Test_chunk.Value.t))
 
 let test_add_read ?(stable = false) (module AO : Test_chunk.S) () =

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -37,6 +37,7 @@ module X = struct
   type t = X of (int * int) | Y of string list [@@deriving irmin]
 
   let merge = Irmin.Merge.idempotent [%typ: t option]
+  let pre_hash_prefix = "b"
 end
 
 module type X =

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -37,7 +37,7 @@ module X = struct
   type t = X of (int * int) | Y of string list [@@deriving irmin]
 
   let merge = Irmin.Merge.idempotent [%typ: t option]
-  let pre_hash_prefix = "b"
+  let pre_hash_prefix = "B"
 end
 
 module type X =

--- a/test/irmin-pack/cli/stat.t/run.t
+++ b/test/irmin-pack/cli/stat.t/run.t
@@ -92,4 +92,4 @@ Running stat on a layered store after a first freeze
 Running check on a layered store that is not self contained
 
   $ PACK_LAYERED=true ../irmin_fsck.exe check ../data/layered_pack_upper
-  Error -- Upper layer is not self contained for heads 6a88b83f76c48b1b20a0d421c73de6e0e0e42553d44a40fccc07af074f304e0d9f10a7b5ab47b61205da0f2f599d2ebb1bf27452c05b926b0c7ef8f867778130: 2 phantom objects detected
+  Error -- Upper layer is not self contained for heads 174ab7219d81baf9317ff892fa9c767e4f1487759b5748dbefb940802f2bde381a1f9129c3632b3265205b7e105b39eaeded3e25e21c6b053ce8ccb44cd887f0: 2 phantom objects detected

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -5,7 +5,6 @@ module Dict = Irmin_pack.Dict.Make (struct
 end)
 
 let get = function Some x -> x | None -> Alcotest.fail "None"
-let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
 
 let rm_dir root =
   if Sys.file_exists root then (
@@ -42,6 +41,8 @@ module S = struct
     let _, (_, v) = decode_pair x off in
     v
 end
+
+let sha1 x = S.H.hash x
 
 module H = Irmin.Hash.SHA1
 module I = Index

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -54,7 +54,7 @@ module H_contents =
       type t = string
 
       let t = Irmin.Type.string
-      let pre_hash_prefix = "b"
+      let pre_hash_prefix = "B"
     end)
 
 let normal x = `Contents (x, Metadata.default)
@@ -195,12 +195,10 @@ let check_node msg v t =
   let+ h' = Inode.batch t.Context.store (fun i -> Inode.add i v) in
   check_hash msg h h'
 
-let _check_hardcoded_hash msg h v =
+let check_hardcoded_hash msg h v =
   h |> Irmin.Type.of_string Inode.Val.hash_t |> function
   | Error (`Msg str) -> Alcotest.failf "hash of string failed: %s" str
   | Ok hash -> check_hash msg hash (Inter.Val.hash v)
-
-let check_hardcoded_hash _ _ _ = ()
 
 (** Test add values from an empty node. *)
 let test_add_values () =
@@ -210,7 +208,7 @@ let test_add_values () =
   let v1 = Inode.Val.add Inode.Val.empty "x" (normal foo) in
   let v2 = Inode.Val.add v1 "y" (normal bar) in
   check_node "node x+y" v2 t >>= fun () ->
-  check_hardcoded_hash "hash v2" "d4b55db5d2d806283766354f0d7597d332156f74" v2;
+  check_hardcoded_hash "hash v2" "c7f712f1be10dc0aedf53e63f077f878bf0eb183" v2;
   let v3 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
   check_values "add x+y vs v x+y" v2 v3;
   Context.close t
@@ -232,7 +230,7 @@ let test_add_inodes () =
     Inode.Val.v [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
   in
   check_values "add x+y+z vs v x+z+y" v2 v3;
-  check_hardcoded_hash "hash v3" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v3;
+  check_hardcoded_hash "hash v3" "bce58c3d82f74526c3efe2860bba20083f7812d5" v3;
   integrity_check v1;
   integrity_check v2;
   let v4 = Inode.Val.add v2 "a" (normal foo) in
@@ -246,7 +244,7 @@ let test_add_inodes () =
       ]
   in
   check_values "add x+y+z+a vs v x+z+a+y" v4 v5;
-  check_hardcoded_hash "hash v4" "c330c08571d088141dfc82f644bffcfcf6696539" v4;
+  check_hardcoded_hash "hash v4" "7dcb6593af20158e8e2a5ef4b15003b8f63e0fa6" v4;
   integrity_check v4 ~stable:false;
   Context.close t
 
@@ -258,12 +256,12 @@ let test_remove_values () =
   let v2 = Inode.Val.remove v1 "y" in
   let v3 = Inode.Val.v [ ("x", normal foo) ] in
   check_values "node x obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "a1996f4309ea31cc7ba2d4c81012885aa0e08789" v2;
+  check_hardcoded_hash "hash v2" "e1168f832d223676aca295dcc047eaae9473dd40" v2;
   let v4 = Inode.Val.remove v2 "x" in
   check_node "remove results in an empty node" Inode.Val.empty t >>= fun () ->
   let v5 = Inode.Val.remove v4 "x" in
   check_values "remove on an already empty node" v4 v5;
-  check_hardcoded_hash "hash v4" "5ba93c9db0cff93f52b521d7420e43f6eda2784f" v4;
+  check_hardcoded_hash "hash v4" "e42e8bb820d4f7550a0f04619f4e15fdc56943b9" v4;
   Alcotest.(check bool) "v5 is empty" (Inode.Val.is_empty v5) true;
   Context.close t
 
@@ -274,11 +272,11 @@ let test_remove_inodes () =
   let v1 =
     Inode.Val.v [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
   in
-  check_hardcoded_hash "hash v1" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v1;
+  check_hardcoded_hash "hash v1" "bce58c3d82f74526c3efe2860bba20083f7812d5" v1;
   let v2 = Inode.Val.remove v1 "x" in
   let v3 = Inode.Val.v [ ("y", normal bar); ("z", normal foo) ] in
   check_values "node y+z obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "ea22a2936eed53978bde62f0185cee9d8bbf9489" v2;
+  check_hardcoded_hash "hash v2" "13667c467db76311bef78d77dee178fb9f3df6ff" v2;
   let v4 =
     Inode.Val.v
       [

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -54,6 +54,7 @@ module H_contents =
       type t = string
 
       let t = Irmin.Type.string
+      let pre_hash_prefix = "b"
     end)
 
 let normal x = `Contents (x, Metadata.default)
@@ -194,10 +195,12 @@ let check_node msg v t =
   let+ h' = Inode.batch t.Context.store (fun i -> Inode.add i v) in
   check_hash msg h h'
 
-let check_hardcoded_hash msg h v =
+let _check_hardcoded_hash msg h v =
   h |> Irmin.Type.of_string Inode.Val.hash_t |> function
   | Error (`Msg str) -> Alcotest.failf "hash of string failed: %s" str
   | Ok hash -> check_hash msg hash (Inter.Val.hash v)
+
+let check_hardcoded_hash _ _ _ = ()
 
 (** Test add values from an empty node. *)
 let test_add_values () =

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -667,7 +667,7 @@ let misc =
     ("pack-files", Pack.tests);
     ("branch-files", Branch.tests);
     ("instances", Multiple_instances.tests);
-    ("existing stores", Test_existing_stores.tests);
+    (* ("existing stores", Test_existing_stores.tests); *)
     ("layers", Layered.tests);
     ("inodes", Test_inode.tests);
   ]

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -667,7 +667,7 @@ let misc =
     ("pack-files", Pack.tests);
     ("branch-files", Branch.tests);
     ("instances", Multiple_instances.tests);
-    (* ("existing stores", Test_existing_stores.tests); *)
+    ("existing stores", Test_existing_stores.tests);
     ("layers", Layered.tests);
     ("inodes", Test_inode.tests);
   ]


### PR DESCRIPTION
As I had no idea how to improve #1305 following @samoht legitimate comment, this is another approach. 

Since all hashes in irmin are produced by `Hash.Typed`, I modified it to require a `pre_hash_prefix`. We now just have to grep all the `pre_hash_prefix` occurences in the code to see that they are all different.

Interrogations I have:
- [x] The computed hashes seem different from #1305. 
- [x]  `irmin-git` tests failing?, i'm not sure why.
- [X] `irmin-chunk` tests are broken too, I don't know how to fix that.
- [x] Hashes hardcoded into the tests need to be updated
- [ ] Tests agains existing pack stores don't work anymore
- [ ] Which prefixes to use where I used `"??"`