### PR TITLE
irmin-fsck: Add number of objects in stats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
     of a directory. (#1292, @Ngoguey42)
   - When configuring a store, is it no longer possible to set `entries` to a
     value larger than `stable_hash`. (#1292, @Ngoguey42)
+  - Added number of objects to the output of `stat-pack` command in
+    `irmin-fsck`. (#1311, @icristescu)
 
 ## 2.5.1 (2021-02-19)
 

--- a/src/irmin-pack/checks_intf.ml
+++ b/src/irmin-pack/checks_intf.ml
@@ -34,8 +34,12 @@ module type S = sig
     type files = { pack : io option; branch : io option; dict : io option }
     [@@deriving irmin]
 
+    type objects = { nb_commits : int; nb_nodes : int; nb_contents : int }
+    [@@deriving irmin]
+
     val v : root:string -> version:IO.version -> files
     val detect_version : root:string -> IO.version
+    val traverse_index : root:string -> int -> objects
   end
 
   module Reconstruct_index :

--- a/test/irmin-pack/cli/stat.t/run.t
+++ b/test/irmin-pack/cli/stat.t/run.t
@@ -2,10 +2,14 @@ Running stat on a layered store after a first freeze
   $ PACK_LAYERED=true ../irmin_fsck.exe stat ../data/layered_pack_upper
   >> Getting statistics for store: `../data/layered_pack_upper'
   
+  	0k contents / 0k nodes / 0k commits	0k contents / 0k nodes / 0k commits
+  	0k contents / 0k nodes / 0k commits	0k contents / 0k nodes / 0k commits
+  	0k contents / 0k nodes / 0k commits	0k contents / 0k nodes / 0k commits
   {
     "hash_size": {
       "Bytes": 64
     },
+    "log_size": 500000,
     "files": {
       "flip": "Upper0",
       "lower": {
@@ -85,6 +89,23 @@ Running stat on a layered store after a first freeze
           "generation": 0,
           "version": "V2"
         }
+      }
+    },
+    "objects": {
+      "lower": {
+        "nb_commits": 1,
+        "nb_nodes": 3,
+        "nb_contents": 1
+      },
+      "upper1": {
+        "nb_commits": 0,
+        "nb_nodes": 0,
+        "nb_contents": 0
+      },
+      "upper0": {
+        "nb_commits": 1,
+        "nb_nodes": 3,
+        "nb_contents": 1
       }
     }
   }


### PR DESCRIPTION
The command `./tezos-node storage stat-pack --data-dir ../tezos_docs/store/` now returns also the number of objects in the store. It takes `63s` for a `42GB` store. 