### PR TITLE
Remove non-existent bench target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,10 @@ all:
 test:
 	dune runtest
 
-bench-pack:
-	dune exec ./test/irmin-pack/bench.exe
-
 bench-layers:
 	dune exec -- ./bench/irmin-pack/layers.exe -n 2005 -b 2 -j
 
-bench: bench-pack bench-layers
+bench: bench-layers
 
 fuzz:
 	dune build @fuzz --no-buffer

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 	dune runtest
 
 bench-layers:
-	dune exec -- ./bench/irmin-pack/layers.exe -n 2005 -b 2 -j
+	@dune exec -- ./bench/irmin-pack/layers.exe -n 2005 -b 2 -j
 
 bench: bench-layers
 

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -146,6 +146,7 @@ let get_json_str total_time time_per_commit commits_per_sec =
     `Assoc
       [
         ( "results",
+          (* Pipeline format expects a list of results.*)
           `List
             (List.map
                (fun result ->


### PR DESCRIPTION
Removing this target for now as it will get the layers benchmarks in the pipeline, working on getting the `tree` benchmarks in in the meantime.