### PR TITLE
Node.length to rescue Tree.is_empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### Added
 
+- **irmin**
+  - The signature of an irmin nodes in `Make_ext` and `Of_private` now requires
+    a `length` function. (#1315, @Ngoguey42)
 - **irmin-bench**
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -262,6 +262,7 @@ struct
 
       let remove t step = G.Value.Tree.remove ~name:(of_step step) t
       let is_empty = G.Value.Tree.is_empty
+      let length t = G.Value.Tree.length t |> Int64.to_int
 
       let add t name value =
         let name = of_step name in

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -114,6 +114,7 @@ struct
 
   let empty = StepMap.empty
   let is_empty e = StepMap.is_empty e
+  let length e = StepMap.cardinal e
 
   let add t k v =
     let e = to_entry (k, v) in
@@ -427,6 +428,7 @@ module V1 (N : S with type step = string) = struct
 
   let empty = { n = N.empty; entries = [] }
   let is_empty t = t.entries = []
+  let length e = N.length e.n
   let default = N.default
   let find t k = N.find t.n k
 

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -50,6 +50,9 @@ module type S = sig
   val is_empty : t -> bool
   (** [is_empty t] is true iff [t] is {!empty}. *)
 
+  val length : t -> int
+  (** [length t] is the number of entries in [t]. *)
+
   val find : t -> step -> value option
   (** [find t s] is the value associated with [s] in [t].
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -660,13 +660,13 @@ module Make (P : Private.S) = struct
         else
           let remove_count = StepMap.cardinal um in
           if (not val_is_empty) && remove_count = 0 then false
+          else if P.Node.Val.length v > remove_count then false
           else (
             (* Starting from this point the function is expensive, but there is
                no alternative. *)
             cnt.node_val_list <- cnt.node_val_list + 1;
             let entries = P.Node.Val.list v in
-            if List.is_longer_than remove_count entries then false
-            else List.for_all (fun (step, _) -> StepMap.mem step um) entries)
+            List.for_all (fun (step, _) -> StepMap.mem step um) entries)
 
     let is_empty t =
       match cached_map t with


### PR DESCRIPTION
Alternative to #1257 in order to finish improving the performances of `Tree.remove`.
