### PR TITLE
irmin: Add Store.Tree.length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,8 @@
 ### Added
 
 - **irmin**
-  - The signature of an irmin nodes in `Make_ext` and `Of_private` now requires
-    a `length` function. (#1315, @Ngoguey42)
+   - Add `Store.Private.Node.Val.length`. (#1315, @Ngoguey42)
+   - Add `Store.Tree.length`. (#1316, @Ngoguey42)
 - **irmin-bench**
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -99,6 +99,9 @@ module type S = sig
   (** [find_all t k] is [Some (b, m)] if [k] is associated to the contents [b]
       and metadata [m] in [t] and [None] if [k] is not present in [t]. *)
 
+  val length : node -> int Lwt.t
+  (** [find n] is the number of entries in [n]. *)
+
   val find : t -> key -> contents option Lwt.t
   (** [find] is similar to {!find_all} but it discards metadata. *)
 


### PR DESCRIPTION
I need a `Tree.length` to record the size of the largest directory in `bench/irmin-pack/tree.exe`.

2 alternative signatures:
- `val length_exn : node -> int Lwt.t`
- `val length : node -> int or_error Lwt.t`