### PR TITLE
irmin-layers: Rework freeze API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,12 @@
     value larger than `stable_hash`. (#1292, @Ngoguey42)
   - Added number of objects to the output of `stat-pack` command in
     `irmin-fsck`. (#1311, @icristescu)
+- **irmin-layers**
+  - Remove `copy_in_upper` from the repo configuration. The default is now to
+    copy. (#1322, @Ngoguey42)
+  - Simplify the API of `freeze`. It is now possible to specify two distinct
+    commit closures for the copy to lower and the copy to next upper.
+    (#1322, @Ngoguey42)
 
 ## 2.5.1 (2021-02-19)
 

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -29,8 +29,7 @@ let configure_store root merge_throttle freeze_throttle =
     Irmin_pack.config ~readonly:false ~fresh:true ~freeze_throttle
       ~merge_throttle root
   in
-  Irmin_pack_layered.config ~conf ~with_lower:false ~blocking_copy_size:1000
-    ~copy_in_upper:true ()
+  Irmin_pack_layered.config ~conf ~with_lower:false ~blocking_copy_size:1000 ()
 
 let init config =
   FSHelper.rm_dir config.root;
@@ -80,7 +79,7 @@ let write_cycle config repo init_commit =
 
 let freeze ~min_upper ~max config repo =
   if config.no_freeze then Lwt.return_unit
-  else Store.freeze ~max ~min_upper repo
+  else Store.freeze ~max_lower:max ~min_upper repo
 
 let min_uppers = Queue.create ()
 let add_min c = Queue.add c min_uppers

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -133,7 +133,7 @@ struct
 
   include Irmin.Of_private (X)
 
-  let freeze ?min:_ ?max:_ ?squash:_ ?copy_in_upper:_ ?min_upper:_ ?recovery:_
+  let freeze ?min_lower:_ ?max_lower:_ ?min_upper:_ ?max_upper:_ ?recovery:_
       _repo =
     Lwt.fail_with "not implemented"
 
@@ -158,8 +158,8 @@ struct
 
     let wait_for_freeze _ = Lwt.fail_with "not implemented"
 
-    let freeze' ?min:_ ?max:_ ?squash:_ ?copy_in_upper:_ ?min_upper:_
-        ?recovery:_ ?hook:_ _repo =
+    let freeze' ?min_lower:_ ?max_lower:_ ?min_upper:_ ?max_upper:_ ?recovery:_
+        ?hook:_ _repo =
       Lwt.fail_with "not implemented"
 
     let upper_in_use = upper_in_use

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -34,16 +34,17 @@ module type S = sig
 
       Let [o] be the set of objects reachable from the [max_lower] commits and
       bounded by the [min_lower] commits. During the freeze, all objects in [o]
-      are copied to the lower layer, if there is one. [min_lower] defaults to
-      the empty list (i.e. the copy is unbounded) and [max_lower] defaults to
-      the head commits of the repo. When [max_lower] is the empty list, nothing
+      are copied to the lower layer, if there is one. [max_lower] defaults to
+      the head commits of the repo and [min_lower] defaults to the empty list
+      (i.e. the copy is unbounded). When [max_lower] is the empty list, nothing
       is copied.
 
       Let [o'] be the set of objects reachable from the [max_upper] commits and
       bounded by the [min_upper] commits. When the freeze is over, the new upper
-      layer will only contain the objects of [o']. [min_upper] defaults to the
-      empty list and [max_upper] defaults to [max_lower]. When [max_upper] is
-      the empty list, nothing is copied.
+      layer will only contain the objects of [o']. [max_upper] defaults to
+      [max_lower] and [min_upper] defaults to [max_upper] (i.e. only the max
+      commits are copied). When [max_upper] is the empty list, nothing is
+      copied.
 
       If [recovery] is true then the function will first try to recover from a
       previously interrupted freeze. See {!needs_recovery}.

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -20,31 +20,30 @@ module type S = sig
   include Irmin.S
 
   val freeze :
-    ?min:commit list ->
-    ?max:commit list ->
-    ?squash:bool ->
-    ?copy_in_upper:bool ->
+    ?min_lower:commit list ->
+    ?max_lower:commit list ->
     ?min_upper:commit list ->
+    ?max_upper:commit list ->
     ?recovery:bool ->
     repo ->
     unit Lwt.t
-  (** [freeze ?min ?max ?squash ?copy_in_upper ?min_upper ?recovery t] launches
+  (** [freeze ?min_lower ?max_lower ?min_upper ?max_upper ?recovery t] launches
       an asynchronous freezing operation on the repo [t] to reduce the size of
       the upper layer and discard unnecessary branches of objects (i.e. commits,
       nodes and contents).
 
-      Let [o] be the set of objects reachable from the [max] commits and bounded
-      by the [min] commits. During the freeze, all objects in [o] are copied to
-      the lower layer, if there is one. Setting [squash] to [true] is equivalent
-      to setting [min] to [max]. [min] defaults to the empty list and [max]
-      defaults to the head commits of the repo.
+      Let [o] be the set of objects reachable from the [max_lower] commits and
+      bounded by the [min_lower] commits. During the freeze, all objects in [o]
+      are copied to the lower layer, if there is one. [min_lower] defaults to
+      the empty list (i.e. the copy is unbounded) and [max_lower] defaults to
+      the head commits of the repo. When [max_lower] is the empty list, nothing
+      is copied.
 
-      Let [o'] be the set of objects reachable from the [max] commits and
-      bounded by the [min_upper] commits. When the freeze is over, if
-      [copy_in_upper] is true, then the new upper layer will only contain the
-      objects of [o'], otherwise the new upper layer will be empty. [min_upper]
-      defaults to the empty list and [copy_in_upper] defaults to the repo's
-      configuration.
+      Let [o'] be the set of objects reachable from the [max_upper] commits and
+      bounded by the [min_upper] commits. When the freeze is over, the new upper
+      layer will only contain the objects of [o']. [min_upper] defaults to the
+      empty list and [max_upper] defaults to [max_lower]. When [max_upper] is
+      the empty list, nothing is copied.
 
       If [recovery] is true then the function will first try to recover from a
       previously interrupted freeze. See {!needs_recovery}.
@@ -106,11 +105,10 @@ module type S = sig
     val wait_for_freeze : repo -> unit Lwt.t
 
     val freeze' :
-      ?min:commit list ->
-      ?max:commit list ->
-      ?squash:bool ->
-      ?copy_in_upper:bool ->
+      ?min_lower:commit list ->
+      ?max_lower:commit list ->
       ?min_upper:commit list ->
+      ?max_upper:commit list ->
       ?recovery:bool ->
       ?hook:
         [ `After_Clear

--- a/src/irmin-pack/layered/config.ml
+++ b/src/irmin-pack/layered/config.ml
@@ -2,7 +2,6 @@ module Default = struct
   let lower_root = Irmin_layers.Layer_id.to_string `Lower
   let upper0_root = Irmin_layers.Layer_id.to_string `Upper0
   let upper1_root = Irmin_layers.Layer_id.to_string `Upper1
-  let copy_in_upper = false
   let with_lower = true
   let blocking_copy_size = 64
 end
@@ -27,12 +26,6 @@ let upper_root0_key =
 
 let upper_root0 conf = Conf.get conf upper_root0_key
 
-let copy_in_upper_key =
-  Conf.key ~doc:"Copy the max commits in upper after a freeze." "copy_in_upper"
-    Conf.bool false
-
-let copy_in_upper conf = Conf.get conf copy_in_upper_key
-
 let with_lower_key =
   Conf.key ~doc:"Use a lower layer." "with-lower" Conf.bool Default.with_lower
 
@@ -49,13 +42,12 @@ let blocking_copy_size conf = Conf.get conf blocking_copy_size_key
 
 let v ?(conf = Conf.empty) ?(lower_root = Default.lower_root)
     ?(upper_root1 = Default.upper1_root) ?(upper_root0 = Default.upper0_root)
-    ?(copy_in_upper = Default.copy_in_upper) ?(with_lower = Default.with_lower)
+    ?(with_lower = Default.with_lower)
     ?(blocking_copy_size = Default.blocking_copy_size) () =
   let with_binding k v c = Conf.add c k v in
   conf
   |> with_binding lower_root_key lower_root
   |> with_binding upper_root1_key upper_root1
   |> with_binding upper_root0_key upper_root0
-  |> with_binding copy_in_upper_key copy_in_upper
   |> with_binding with_lower_key with_lower
   |> with_binding blocking_copy_size_key blocking_copy_size

--- a/src/irmin-pack/layered/config.mli
+++ b/src/irmin-pack/layered/config.mli
@@ -4,7 +4,6 @@ val lower_root : config -> string
 val upper_root0 : config -> string
 val upper_root1 : config -> string
 val with_lower : config -> bool
-val copy_in_upper : config -> bool
 val blocking_copy_size : config -> int
 
 val v :
@@ -12,7 +11,6 @@ val v :
   ?lower_root:string ->
   ?upper_root1:string ->
   ?upper_root0:string ->
-  ?copy_in_upper:bool ->
   ?with_lower:bool ->
   ?blocking_copy_size:int ->
   unit ->

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -644,13 +644,7 @@ struct
             f "@[<2>copy to next upper:@ min=%a,@ max=%a@]" pp_commits min
               pp_commits commits);
         let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
-        (* When copying to next upper, if the min is empty then we copy only the
-           max. *)
-        let min =
-          List.map (fun x -> `Commit (Commit.hash x)) min |> function
-          | [] -> max
-          | min -> min
-        in
+        let min = List.map (fun x -> `Commit (Commit.hash x)) min in
         on_next_upper t (fun u ->
             iter_copy ?cancel u ~skip_commits:(mem_commit_next t)
               ~skip_nodes:(mem_node_next t) ~skip_contents:(mem_contents_next t)
@@ -868,11 +862,11 @@ struct
       Irmin_layers.Stats.freeze_start t0 "wait for freeze lock";
       Irmin_layers.Stats.freeze_section "misc";
       let min_lower = Option.value min_lower ~default:[] in
-      let min_upper = Option.value min_upper ~default:[] in
       let* max_lower =
         match max_lower with Some l -> Lwt.return l | None -> Repo.heads t
       in
       let max_upper = Option.value max_upper ~default:max_lower in
+      let min_upper = Option.value min_upper ~default:max_upper in
       unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t
     in
     if t.X.Repo.closed then Lwt.fail_with "store is closed"

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -197,7 +197,6 @@ struct
         readonly : bool;
         blocking_copy_size : int;
         with_lower : bool;
-        copy_in_upper : bool;
         contents : read Contents.CA.t;
         node : read Node.CA.t;
         branch : Branch.t;
@@ -372,7 +371,6 @@ struct
         in
         let lower_index = Option.map (fun x -> x.lindex) lower in
         let readonly = Pack_config.readonly config in
-        let copy_in_upper = Config_layered.copy_in_upper config in
         let blocking_copy_size = Config_layered.blocking_copy_size config in
         {
           contents;
@@ -383,7 +381,6 @@ struct
           readonly;
           with_lower;
           blocking_copy_size;
-          copy_in_upper;
           lower_index;
           uppers_index = (upper1.index, upper0.index);
           flip;
@@ -757,23 +754,20 @@ struct
     end
   end
 
-  let copy ~cancel ~min ~max ~squash ~upper:(copy_in_upper, min_upper) t =
-    (* Copy commits to lower: if squash then copy only the max commits.
+  let copy ~cancel ~min_lower ~max_lower ~min_upper ~max_upper t =
+    (* Copy commits to lower.
        In case cancellation of the freeze, copies to the lower layer will not
        be reverted. Since the copying is performed in the [rev] order, the next
        freeze will resume copying where the previous freeze stopped. *)
     Irmin_layers.Stats.freeze_section "copy to lower";
     (if t.X.Repo.with_lower then
-     let min = if squash then max else min in
-     Copy.CopyToLower.copy ~cancel t ~min max
+     Copy.CopyToLower.copy ~cancel t ~min:min_lower max_lower
     else Lwt.return_unit)
     >>= fun () ->
-    (* Copy [min_upper, max] to next_upper. In case of cancellation of the
+    (* Copy [min_upper, max_upper] to next_upper. In case of cancellation of the
        freeze, the next upper will be cleared. *)
     Irmin_layers.Stats.freeze_section "copy to next upper";
-    (if copy_in_upper then Copy.CopyToUpper.copy t ~cancel ~min:min_upper max
-    else Lwt.return_unit)
-    >>= fun () ->
+    Copy.CopyToUpper.copy t ~cancel ~min:min_upper max_upper >>= fun () ->
     Irmin_layers.Stats.freeze_section "copy branches";
     (* Copy branches to both lower and next_upper *)
     Copy.copy_branches t
@@ -787,21 +781,19 @@ struct
       Fmt.list ~sep:(Fmt.unit "; ") pp ppf (List.filter (fun x -> x <> E) t)
 
     let commits k = function [] -> E | v -> F (pp_commits, k, v)
-    let bool k v = if not v then E else F (Fmt.bool, k, v)
-    let upper k = function false, _ | true, [] -> E | _, v -> commits k v
   end
 
   let pp_repo ppf t =
     Fmt.pf ppf "%a" Layered_store.pp_current_upper t.X.Repo.flip
 
-  let unsafe_freeze ~min ~max ~squash ~upper ?hook t =
+  let unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t =
     Log.info (fun l ->
         l "[%a] freeze starts { %a }" pp_repo t Field.pps
           [
-            Field.commits "min" min;
-            Field.commits "max" max;
-            Field.bool "squash" squash;
-            Field.upper "min_upper" upper;
+            Field.commits "min_lower" min_lower;
+            Field.commits "max_lower" max_lower;
+            Field.commits "min_upper" min_upper;
+            Field.commits "max_upper" max_upper;
           ]);
     let offset = X.Repo.offset t in
     let lock_file = lock_path t.root in
@@ -811,7 +803,7 @@ struct
     let cancel () = t.freeze.state = `Cancel in
     let copy () =
       may (fun f -> f `Before_Copy) hook >>= fun () ->
-      copy ~cancel ~min ~max ~squash ~upper t >>= fun () ->
+      copy ~cancel ~min_lower ~max_lower ~min_upper ~max_upper t >>= fun () ->
       Irmin_layers.Stats.freeze_section "flush lower";
       X.Repo.flush_next_lower t;
       may (fun f -> f `Before_Copy_Newies) hook >>= fun () ->
@@ -863,24 +855,25 @@ struct
   (** Main thread takes the [t.freeze.lock] at the begining of freeze and async
       thread releases it at the end. This is to ensure that no two freezes can
       run simultaneously. *)
-  let freeze' ?(min = []) ?(max = []) ?(squash = false) ?copy_in_upper
-      ?(min_upper = []) ?(recovery = false) ?hook t =
+  let freeze' ?min_lower ?max_lower ?min_upper ?max_upper ?(recovery = false)
+      ?hook t =
     let* () =
       if recovery then X.Repo.clear_previous_upper ~keep_generation:() t
       else Lwt.return_unit
     in
     let freeze () =
       let t0 = Mtime_clock.now () in
-      let upper =
-        ( (match copy_in_upper with None -> t.copy_in_upper | Some b -> b),
-          min_upper )
-      in
       Lwt_mutex.lock t.freeze.lock >>= fun () ->
       t.freeze.state <- `Running;
       Irmin_layers.Stats.freeze_start t0 "wait for freeze lock";
       Irmin_layers.Stats.freeze_section "misc";
-      let* max = match max with [] -> Repo.heads t | m -> Lwt.return m in
-      unsafe_freeze ~min ~max ~squash ~upper ?hook t
+      let min_lower = Option.value min_lower ~default:[] in
+      let min_upper = Option.value min_upper ~default:[] in
+      let* max_lower =
+        match max_lower with Some l -> Lwt.return l | None -> Repo.heads t
+      in
+      let max_upper = Option.value max_upper ~default:max_lower in
+      unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t
     in
     if t.X.Repo.closed then Lwt.fail_with "store is closed"
     else if t.readonly then raise RO_Not_Allowed

--- a/src/irmin-pack/layered/ext_layered.mli
+++ b/src/irmin-pack/layered/ext_layered.mli
@@ -19,7 +19,6 @@ val config :
   ?lower_root:string ->
   ?upper_root1:string ->
   ?upper_root0:string ->
-  ?copy_in_upper:bool ->
   ?with_lower:bool ->
   ?blocking_copy_size:int ->
   unit ->

--- a/src/irmin-pack/layered/irmin_pack_layered.mli
+++ b/src/irmin-pack/layered/irmin_pack_layered.mli
@@ -19,7 +19,6 @@ val config :
   ?lower_root:string ->
   ?upper_root1:string ->
   ?upper_root0:string ->
-  ?copy_in_upper:bool ->
   ?with_lower:bool ->
   ?blocking_copy_size:int ->
   unit ->
@@ -32,9 +31,6 @@ val config :
     default.
     @param upper_root0 is the root of one of the upper stores, "upper0" is the
     default.
-    @param copy_in_upper if true then at the end of a freee the max commits are
-    copied back in upper. This option can be overriden when calling a freeze
-    with the [copy_in_upper] argument set. By default it is set to false.
     @param with_lower if true (the default) use a lower layer during freezes.
     @param blocking_copy_size specifies the maximum size (in bytes) that can be
     copied in the blocking portion of the freeze. *)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2022,7 +2022,7 @@ let layered_suite (speed, x) =
         let (module S) = layered_store in
         let module T = Make (S) in
         let module TL = Layered_store.Make_Layered (S) in
-        let hook repo max = S.freeze repo ~max in
+        let hook repo max = S.freeze repo ~max_lower:max in
         [
           ("Basic operations on branches", speed, T.test_branches ~hook x);
           ("Basic merge operations", speed, T.test_simple_merges ~hook x);

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -21,7 +21,7 @@ module Store =
 
 let config root =
   let conf = Irmin_pack.config ~readonly:false ~fresh:true root in
-  Irmin_pack_layered.config ~conf ~copy_in_upper:true ~with_lower:true ()
+  Irmin_pack_layered.config ~conf ~with_lower:true ()
 
 let info = Irmin.Info.v ~date:0L ~author:"" ""
 
@@ -31,7 +31,7 @@ let create_store () =
   let* _t = Store.master repo in
   let* tree = Store.Tree.add Store.Tree.empty [ "a"; "b"; "c" ] "x1" in
   let* c = Store.Commit.v repo ~info ~parents:[] tree in
-  let* () = Store.freeze ~max:[ c ] ~copy_in_upper:false repo in
+  let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
   let* () = Store.PrivateLayer.wait_for_freeze repo in
   let* tree = Store.Tree.add tree [ "a"; "b"; "d" ] "x2" in
   let hash = Store.Commit.hash c in

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -389,7 +389,7 @@ module Test_corrupted_stores = struct
     check_commit ro c [ "a" ] "x" >>= fun () ->
     Log.app (fun l -> l "Freeze with recovery flag set");
     let* () =
-      S.freeze ~recovery:true ~max:[ c ] rw >>= fun () ->
+      S.freeze ~recovery:true ~max_lower:[ c ] rw >>= fun () ->
       S.PrivateLayer.wait_for_freeze rw
     in
     Alcotest.(check bool)
@@ -405,7 +405,7 @@ module Test_corrupted_stores = struct
           "If recovery flag is set, freeze proceeds with recovery even when it \
            isn't needed");
     let* () =
-      S.freeze ~recovery:true ~max:[ c ] rw >>= fun () ->
+      S.freeze ~recovery:true ~max_lower:[ c ] rw >>= fun () ->
       S.PrivateLayer.wait_for_freeze rw
     in
     check_upper rw "Upper after freeze" `Upper1;


### PR DESCRIPTION
Followup on #1238 and our recent need for a way to specify a different set of `max` commits for the copy to next upper.

I chose to simplify to a maximum:
- Before:  `?min ?max ?squash ?copy_in_upper ?min_upper` (+ `copy_in_upper` in repo config)
- Now: `?min_lower ?max_lower ?min_upper ?max_upper`


Only one change in the default behaviours: the default config of the layered store used to be `copy_in_upper=false`. This parameter is gone, and by default we copy to next upper.
