### PR TITLE
irmin-bench: Add tree.exe's compilation to runtest

### DIFF
--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -19,7 +19,7 @@
 (rule
  (alias runtest)
  (package irmin-bench)
- (deps main.exe layers.exe)
+ (deps main.exe layers.exe tree.exe)
  (action (progn)))
 
 (executable

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -909,7 +909,7 @@ struct
         if i = config.freeze_commit then
           let* c = Store.Commit.of_hash repo commit_hash in
           let c = Option.get c in
-          Store.freeze repo ~max:[ c ] ~min_upper:[ c ]
+          Store.freeze repo ~max_lower:[ c ]
         else Lwt.return_unit
       in
       (* Something else than pause could be used here, like an Lwt_unix.sleep

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -27,10 +27,10 @@ depends: [
   "ppx_repr"
   "re"           {>= "1.9.0"}
   "fmt"
-  "bentov"
   "uuidm"
   "progress"
-  "mtime"
+  "bentov" {with-test}
+  "mtime" {with-test}
 ]
 
 synopsis: "Irmin benchmarking suite"


### PR DESCRIPTION
Same kind of mistake as #1286. Won't happen again!
