### PR TITLE
Check hash of commit in tree benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ _build
 *.merlin
 _opam
 .envrc
-vendors/
 \#*
 .#*
 .*.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendors/tezos-context-hash"]
+	path = vendors/tezos-context-hash
+	url = https://github.com/tarides/tezos-context-hash

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)
   - New features in benchmarks for tree operations (#1314, #1326, @Ngoguey42)
+  - Check hash of commit in benchmarks for trees (#1328, @icristescu)
 - **irmin-pack**
   - Expose internal inode trees (#1273, @mattiasdrp, @samoht)
 

--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -31,7 +31,7 @@ let reset_stats () =
 
 let random_char () = char_of_int (Random.int 256)
 let random_string n = String.init n (fun _i -> random_char ())
-let random_blob () = random_string 10
+let random_blob () = random_string 10 |> Bytes.of_string
 let random_key () = random_string 5
 
 let default_results_dir =
@@ -113,7 +113,7 @@ module FSHelper = struct
 end
 
 module Generate_trees
-    (Store : Irmin.S with type contents = string and type key = string list) =
+    (Store : Irmin.S with type contents = bytes and type key = string list) =
 struct
   let key depth =
     let rec aux i acc =

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -9,7 +9,7 @@ val with_progress_bar :
   message:string -> n:int -> unit:string -> ((int64 -> unit) -> 'a) -> 'a
 
 val info : unit -> Irmin.Info.t
-val random_blob : unit -> string
+val random_blob : unit -> bytes
 
 module Conf : sig
   val entries : int
@@ -23,7 +23,7 @@ module FSHelper : sig
 end
 
 module Generate_trees
-    (Store : Irmin.S with type contents = string and type key = string list) : sig
+    (Store : Irmin.S with type contents = bytes and type key = string list) : sig
   val add_chain_trees : int -> int -> Store.tree -> Store.tree Lwt.t
   (** [add_chain_trees depth nb tree] adds [nb] random contents to [tree],
       depthwise. *)

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -29,4 +29,4 @@
   (pps ppx_deriving_yojson ppx_repr))
  (libraries irmin-pack irmin-pack.layered irmin-test.bench irmin-layers lwt
    unix cmdliner logs yojson ppx_deriving_yojson memtrace repr ppx_repr
-   bench_common mtime mtime.clock.os bentov encoding))
+   bench_common mtime mtime.clock.os bentov tezos-context-hash))

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -29,4 +29,4 @@
   (pps ppx_deriving_yojson ppx_repr))
  (libraries irmin-pack irmin-pack.layered irmin-test.bench irmin-layers lwt
    unix cmdliner logs yojson ppx_deriving_yojson memtrace repr ppx_repr
-   bench_common mtime mtime.clock.os bentov))
+   bench_common mtime mtime.clock.os bentov encoding))

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -18,8 +18,18 @@ type config = {
 
 module Hash = Irmin.Hash.SHA1
 
+module Contents = struct
+  type t = bytes
+
+  let ty = Irmin.Type.(pair (bytes_of `Int64) unit)
+  let pre_hash_ty = Irmin.Type.(unstage (pre_hash ty))
+  let pre_hash_v1 x = pre_hash_ty (x, ())
+  let t = Irmin.Type.(like bytes ~pre_hash:(stage @@ fun x -> pre_hash_v1 x))
+  let merge = Irmin.Merge.(idempotent (Irmin.Type.option t))
+end
+
 module Store =
-  Irmin_pack_layered.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack_layered.Make (Conf) (Irmin.Metadata.None) (Contents)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)


### PR DESCRIPTION
I added an `encoding` package directly in `irmin-pack/bench` and this is a copy of what we have in https://github.com/tarides/tezos-context-hash. I tried depending on that package instead but I got a complaint from dune
```
Error: Conflict between the following libraries:
- "irmin" in _build/default/src/irmin
- "irmin" in /Users/icristes/.opam/itezos/lib/irmin
```
I'm happy to retry if we don't want to duplicate the encodings.  