### PR TITLE
WIP: better use of store properties in irmin-pack

### DIFF
--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -25,8 +25,8 @@ module type S = sig
   val copy : 'l layer_type * 'l -> read t -> key -> unit
   val mem_lower : 'a t -> key -> bool Lwt.t
   val mem_next : [> read ] t -> key -> bool Lwt.t
-  val next_upper : 'a t -> read U.t
-  val current_upper : 'a t -> read U.t
+  val next_upper : 'a t -> 'a U.t
+  val current_upper : 'a t -> 'a U.t
   val lower : 'a t -> read L.t
 
   include S.Layered_general with type 'a t := 'a t
@@ -47,12 +47,12 @@ module type S = sig
     'a t ->
     (unit, S.integrity_error) result
 
-  val flush : ?index:bool -> 'a t -> unit
-  val copy_from_lower : dst:'a U.t -> read t -> key -> unit Lwt.t
+  val flush : ?index:bool -> read_write t -> unit
+  val copy_from_lower : dst:read_write U.t -> read t -> key -> unit Lwt.t
   val consume_newies : 'a t -> key list
 
   val check :
-    'a t ->
+    read t ->
     ?none:(unit -> unit Lwt.t) ->
     ?some:(U.value -> unit Lwt.t) ->
     key ->

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -82,7 +82,7 @@ module type Layered_pack = sig
 
   val copy_from_lower :
     read t ->
-    dst:'a U.t ->
+    dst:read_write U.t ->
     ?aux:(value -> unit Lwt.t) ->
     string ->
     key ->
@@ -90,8 +90,8 @@ module type Layered_pack = sig
 
   val mem_lower : 'a t -> key -> bool Lwt.t
   val mem_next : [> read ] t -> key -> bool Lwt.t
-  val current_upper : 'a t -> read U.t
-  val next_upper : 'a t -> read U.t
+  val current_upper : 'a t -> 'a U.t
+  val next_upper : 'a t -> 'a U.t
   val lower : 'a t -> read L.t
   val clear_previous_upper : ?keep_generation:unit -> 'a t -> unit Lwt.t
 
@@ -121,7 +121,7 @@ module type Layered_pack = sig
   val consume_newies : 'a t -> key list
 
   val check :
-    'a t ->
+    read t ->
     ?none:(unit -> unit Lwt.t) ->
     ?some:(value -> unit Lwt.t) ->
     key ->

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -40,12 +40,6 @@ end
 module type S = sig
   include Irmin.Content_addressable.S
 
-  val add : 'a t -> value -> key Lwt.t
-  (** Overwrite [add] to work with a read-only database handler. *)
-
-  val unsafe_add : 'a t -> key -> value -> unit Lwt.t
-  (** Overwrite [unsafe_add] to work with a read-only database handler. *)
-
   type index
 
   val v :


### PR DESCRIPTION
Note: this breaks the tests and the testing framework as `dune exec -- test/irmin-pack/test.exe test LAYERED_PACK` just never completes properly. @CraigFe or @icristescu do you know why this makes Alcotest unhappy?

Running the test manually gives:

```
$ dune exec -- test/irmin-pack/test.exe test LAYERED_PACK 2 -v
[...]
FAIL line lcas 1

   Expected: `[{ hash = 53d68d5787b8de001aa1f184d99b7ddfbfa8a2f2;
                 value =
                  { node = be233efe3beb0c78b12eba0d01c007ceccd9ba1a;
                    parents = [494e789634937fa382fb9bf6848b78ef64b1a0ee];
                    info =
                     { date = 3;
                       author = "test";
                       message = "Test commit" } } }]'

   Received: `[]'
```

@icristescu do you know where that could come from? Are flushing too often maybe?