### PR TITLE
irmin-pack: add a Version module to help version management

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@
     value larger than `stable_hash`. (#1292, @Ngoguey42)
   - Added number of objects to the output of `stat-pack` command in
     `irmin-fsck`. (#1311, @icristescu)
+  - Renamed the `Version` module type into `Version.S` and `io_version` into
+    `version`. The `Pack.File` and `Atomic_write` functors now take
+    `Version` as their first parameter (#1352, @samoht)
+
 - **irmin-layers**
   - Remove `copy_in_upper` from the repo configuration. The default is now to
     copy. (#1322, @Ngoguey42)

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -949,7 +949,7 @@ struct
   module Store =
     Irmin_pack.Make_ext
       (struct
-        let io_version = `V1
+        let version = `V1
       end)
       (Conf)
       (Metadata)

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -16,19 +16,13 @@
 
 open! Import
 
-type version = [ `V1 | `V2 ]
-
-module type Version = sig
-  val io_version : version
-end
-
 module type S = sig
   type t
   type path := string
 
   exception RO_Not_Allowed
 
-  val v : version:version option -> fresh:bool -> readonly:bool -> path -> t
+  val v : version:Version.t option -> fresh:bool -> readonly:bool -> path -> t
   val name : t -> string
   val clear : ?keep_generation:unit -> t -> unit
   val append : t -> string -> unit
@@ -39,7 +33,7 @@ module type S = sig
   val generation : t -> int63
   val force_generation : t -> int63
   val readonly : t -> bool
-  val version : t -> version
+  val version : t -> Version.t
   val flush : t -> unit
   val close : t -> unit
   val exists : string -> bool
@@ -53,7 +47,7 @@ module type S = sig
   val migrate :
     progress:(int63 -> unit) ->
     t ->
-    version ->
+    Version.t ->
     (unit, [> `Msg of string ]) result
   (** @raise Invalid_arg if the migration path is not supported. *)
 
@@ -61,14 +55,7 @@ module type S = sig
 end
 
 module type Sigs = sig
-  module type Version = Version
   module type S = S
-
-  type nonrec version = version
-
-  val pp_version : version Fmt.t
-
-  exception Invalid_version of { expected : version; found : version }
 
   module Unix : S
 

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -37,11 +37,11 @@ let path =
 
 module Make (M : Maker) = struct
   module V1 = struct
-    let io_version = `V1
+    let version = `V1
   end
 
   module V2 = struct
-    let io_version = `V2
+    let version = `V2
   end
 
   module Store_V1 = M (V1)
@@ -78,7 +78,7 @@ module Make (M : Maker) = struct
     }
     [@@deriving irmin]
 
-    let with_io : type a. I.version -> string -> (IO.t -> a) -> a option =
+    let with_io : type a. Version.t -> string -> (IO.t -> a) -> a option =
      fun version path f ->
       match IO.exists path with
       | false -> None
@@ -94,7 +94,7 @@ module Make (M : Maker) = struct
         match with_io current_version path Fun.id with
         | None -> Fmt.failwith "cannot read pack file"
         | Some _ -> current_version
-      with I.Invalid_version { expected = _; found } -> found
+      with Version.Invalid { expected = _; found } -> found
 
     let io ~version path =
       with_io version path @@ fun io ->

--- a/src/irmin-pack/checks_intf.ml
+++ b/src/irmin-pack/checks_intf.ml
@@ -39,8 +39,8 @@ module type S = sig
     type objects = { nb_commits : int; nb_nodes : int; nb_contents : int }
     [@@deriving irmin]
 
-    val v : root:string -> version:IO.version -> files
-    val detect_version : root:string -> IO.version
+    val v : root:string -> version:Version.t -> files
+    val detect_version : root:string -> Version.t
     val traverse_index : root:string -> int -> objects
   end
 
@@ -87,7 +87,7 @@ module type Versioned_store = sig
     ([> `Msg of string ], [> `Msg of string ]) result Lwt.t
 end
 
-module type Maker = functor (_ : IO.Version) -> Versioned_store
+module type Maker = functor (_ : Version.S) -> Versioned_store
 
 module type Sigs = sig
   type nonrec empty = empty

--- a/src/irmin-pack/ext.mli
+++ b/src/irmin-pack/ext.mli
@@ -18,10 +18,10 @@ module Pack_config = Config
 module Index = Pack_index
 
 exception RO_Not_Allowed
-exception Unsupported_version of IO.version
+exception Unsupported_version of Version.t
 
 module Make
-    (_ : IO.Version)
+    (_ : Version.S)
     (Config : Config.S)
     (Metadata : Irmin.Metadata.S)
     (Contents : Irmin.Contents.S)

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -27,8 +27,7 @@ module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
 module Make_ext = Ext.Make
 module Store = Store
-
-module type Version = IO.Version
+module Version = Version
 
 module type Maker = functor
   (Config : Config.S)
@@ -59,7 +58,7 @@ module type Maker = functor
 end
 
 module Make_with_version
-    (IO_version : IO.Version)
+    (V : Version.S)
     (Config : Config.S)
     (M : Irmin.Metadata.S)
     (C : Irmin.Contents.S)
@@ -69,15 +68,15 @@ module Make_with_version
 struct
   module XNode = Irmin.Private.Node.Make (H) (P) (M)
   module XCommit = Irmin.Private.Commit.Make (H)
-  include Make_ext (IO_version) (Config) (M) (C) (P) (B) (H) (XNode) (XCommit)
+  include Make_ext (V) (Config) (M) (C) (P) (B) (H) (XNode) (XCommit)
 end
 
 module Make = Make_with_version (struct
-  let io_version = `V1
+  let version = `V1
 end)
 
 module Make_V2 = Make_with_version (struct
-  let io_version = `V2
+  let version = `V2
 end)
 
 module KV (Config : Config.S) (C : Irmin.Contents.S) =

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -19,8 +19,7 @@ module Dict = Pack_dict
 module Index = Pack_index
 module Config = Config
 module Inode = Inode
-
-module type Version = IO.Version
+module Version = Version
 
 val config :
   ?fresh:bool ->
@@ -43,10 +42,10 @@ val config :
     not block but indefinitely expands the in-memory cache. *)
 
 exception RO_Not_Allowed
-exception Unsupported_version of IO.version
+exception Unsupported_version of Version.t
 
 module Make_ext
-    (_ : IO.Version)
+    (_ : Version.S)
     (Config : Config.S)
     (Metadata : Irmin.Metadata.S)
     (Contents : Irmin.Contents.S)
@@ -111,7 +110,7 @@ module Make : Maker
 module Make_V2 : Maker
 module KV (Config : Config.S) : Irmin.KV_maker
 
-module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) (_ : IO.Version) : sig
+module Atomic_write (_ : Version.S) (K : Irmin.Type.S) (V : Irmin.Hash.S) : sig
   include Irmin.Atomic_write.S with type key = K.t and type value = V.t
 
   val v : ?fresh:bool -> ?readonly:bool -> string -> t Lwt.t

--- a/src/irmin-pack/pack_dict.ml
+++ b/src/irmin-pack/pack_dict.ml
@@ -16,8 +16,8 @@ module type S = sig
   val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 end
 
-module Make (Io_version : IO.Version) = struct
-  include Dict.Make (Io_version) (IO.Unix)
+module Make (V : Version.S) = struct
+  include Dict.Make (V) (IO.Unix)
 
   (* Add IO caching around Dict.v *)
   let IO.Cache.{ v } =

--- a/src/irmin-pack/pack_dict.mli
+++ b/src/irmin-pack/pack_dict.mli
@@ -16,4 +16,4 @@ module type S = sig
   val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
 end
 
-module Make (_ : IO.Version) : S
+module Make (_ : Version.S) : S

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -70,7 +70,7 @@ module type S = sig
       [on_generation_change] is a callback for all pack instances to react to a
       generation change. *)
 
-  val version : 'a t -> IO.version
+  val version : 'a t -> Version.t
   val generation : 'a t -> int63
   val offset : 'a t -> int63
 
@@ -100,7 +100,8 @@ module type Sigs = sig
   module type Maker = Maker
 
   module File
+      (_ : Version.S)
       (Index : Pack_index.S)
-      (K : Irmin.Hash.S with type t = Index.key)
-      (_ : IO.Version) : Maker with type key = K.t and type index = Index.t
+      (K : Irmin.Hash.S with type t = Index.key) :
+    Maker with type key = K.t and type index = Index.t
 end

--- a/src/irmin-pack/store_intf.ml
+++ b/src/irmin-pack/store_intf.ml
@@ -41,12 +41,12 @@ end
 module type Sigs = sig
   module type S = S
 
-  module Atomic_write (K : Irmin.Type.S) (V : Irmin.Hash.S) (_ : IO.Version) :
+  module Atomic_write (_ : Version.S) (K : Irmin.Type.S) (V : Irmin.Hash.S) :
     S.Atomic_write.Store with type key = K.t and type value = V.t
 
   val migrate : Irmin.config -> unit
 
-  exception Unsupported_version of IO.version
+  exception Unsupported_version of Version.t
 
   module Checks (Index : Pack_index.S) : sig
     val integrity_check :

--- a/src/irmin-pack/version.mli
+++ b/src/irmin-pack/version.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013-2019 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,24 +14,25 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+(** Management of disk-format versions. *)
+
+type t = [ `V1 | `V2 ]
+(** The type for version numbers. *)
+
+val pp : t Fmt.t
+(** [pp] is the pretty-format for version numbers. *)
+
+val to_bin : t -> string
+(** [to_bin t] is the 8-bytes binary representation of [t]. *)
+
+val of_bin : string -> t option
+(** [of_bin s] is [Some t] is [to_bin t] is [s] and [None] otherwise. *)
+
+val invalid_arg : string -> 'a
+(** [invalid_arg str] raises [Invalid_argument]. *)
+
+exception Invalid of { expected : t; found : t }
+
 module type S = sig
-  type t
-
-  val find : t -> int -> string option
-  val index : t -> string -> int option
-  val flush : t -> unit
-
-  val sync : t -> unit
-  (** syncs a readonly dict with the file on disk. *)
-
-  val v : ?fresh:bool -> ?readonly:bool -> ?capacity:int -> string -> t
-  val clear : t -> unit
-  val close : t -> unit
-  val valid : t -> bool
-end
-
-module type Sigs = sig
-  module type S = S
-
-  module Make (_ : Version.S) (_ : IO.S) : S
+  val version : t
 end

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -9,7 +9,7 @@ module Conf = struct
   let stable_hash = 256
 end
 
-module Maker (V : Irmin_pack.Version) =
+module Maker (V : Irmin_pack.Version.S) =
   Irmin_pack.Make_ext (V) (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Path)
     (Irmin.Branch.String)

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -2,7 +2,7 @@ open Irmin.Export_for_backends
 module Int63 = Optint.Int63
 
 module Dict = Irmin_pack.Dict.Make (struct
-  let io_version = `V2
+  let version = `V2
 end)
 
 let get = function Some x -> x | None -> Alcotest.fail "None"
@@ -48,14 +48,13 @@ module H = Irmin.Hash.SHA1
 module I = Index
 module Index = Irmin_pack.Index.Make (H)
 
-module P =
-  Irmin_pack.Pack.File (Index) (H)
-    (struct
-      let io_version = `V2
-    end)
+module V2 = struct
+  let version = `V2
+end
 
+module P = Irmin_pack.Pack.File (V2) (Index) (H)
 module Pack = P.Make (S)
-module Branch = Irmin_pack.Atomic_write (Irmin.Branch.String) (H)
+module Branch = Irmin_pack.Atomic_write (V2) (Irmin.Branch.String) (H)
 
 module Make_context (Config : sig
   val root : string

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -24,7 +24,7 @@ module S = struct
   include
     Irmin_pack.Make_ext
       (struct
-        let io_version = `V2
+        let version = `V2
       end)
       (Conf)
       (M)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -37,7 +37,7 @@ struct
   include
     Irmin_pack.Make_ext
       (struct
-        let io_version = `V2
+        let version = `V2
       end)
       (Config)
       (M)
@@ -577,11 +577,12 @@ module Pack = struct
 end
 
 module Branch = struct
+  module V2 = struct
+    let version = `V2
+  end
+
   module Branch =
-    Irmin_pack.Atomic_write (Irmin.Branch.String) (Irmin.Hash.SHA1)
-      (struct
-        let io_version = `V2
-      end)
+    Irmin_pack.Atomic_write (V2) (Irmin.Branch.String) (Irmin.Hash.SHA1)
 
   let pp_hash = Irmin.Type.pp Irmin.Hash.SHA1.t
 


### PR DESCRIPTION
- Rename Version into Version.S (and change `val io_version` to `version`)
- Modify the order of functors to always keep the Version parameter first.