### PR TITLE
irmin-pack: internal renamings

### DIFF
--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -326,7 +326,7 @@ struct
   type index = P.index
   type key = P.key
 
-  module Make (V : Pack.ELT with type hash := key) = struct
+  module Make (V : Pack.Value with type hash := key) = struct
     module Upper = P.Make (V)
     include Content_addressable (H) (Index) (Upper) (Upper)
   end

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -150,7 +150,7 @@ module type Layered_pack_maker = sig
   type key
   type index
 
-  module Make (V : ELT with type hash := key) :
+  module Make (V : Value with type hash := key) :
     Layered_pack
       with type key = key
        and type value = V.t

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -75,7 +75,7 @@ struct
       IO.close t.block;
       Dict.close t.dict)
 
-  module Make (Val : ELT with type hash := K.t) = struct
+  module Make (Val : Value with type hash := K.t) = struct
     module H = struct
       include K
 

--- a/src/irmin-pack/pack_intf.ml
+++ b/src/irmin-pack/pack_intf.ml
@@ -17,7 +17,7 @@
 open! Import
 module Sigs = S
 
-module type ELT = sig
+module type Value = sig
   include Irmin.Type.S
 
   type hash
@@ -90,12 +90,12 @@ module type Maker = sig
 
   (** Save multiple kind of values in the same pack file. Values will be
       distinguished using [V.magic], so they have to all be different. *)
-  module Make (V : ELT with type hash := key) :
+  module Make (V : Value with type hash := key) :
     S with type key = key and type value = V.t and type index = index
 end
 
 module type Sigs = sig
-  module type ELT = ELT
+  module type Value = Value
   module type S = S
   module type Maker = Maker
 

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -33,7 +33,7 @@ module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
 module Node = Irmin.Private.Node.Make (H) (Path) (Metadata)
 module Index = Irmin_pack.Index.Make (H)
-module Inter = Irmin_pack.Inode.Make_intermediate (Conf) (H) (Node)
+module Inter = Irmin_pack.Inode.Make_internal (Conf) (H) (Node)
 module Inode = Irmin_pack.Inode.Make_ext (H) (Node) (Inter) (P)
 
 module Context = struct


### PR DESCRIPTION
- Rename Inode.Elt to Inode.Raw
- When appropriate, rename encode_bin, to_bin amd of_bin to encode_raw, to_raw
  and of_raw.
- Rename Inode.Intermediate to Inode.Internal