### PR TITLE
irmin-bench: Path conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@
 - **irmin-bench**
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)
-  - New features in benchmarks for tree operations (#1314, #1326, @Ngoguey42)
+  - New features in benchmarks for tree operations (#1314, #1326, #1357,
+    @Ngoguey42)
   - Check hash of commit in benchmarks for trees (#1328, @icristescu)
 - **irmin-pack**
   - Expose internal inode trees (#1273, @mattiasdrp, @samoht)

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -9,7 +9,7 @@ type config = {
   width : int;
   nlarge_trees : int;
   root : string;
-  flatten : bool;
+  path_conversion : [ `None | `V1 | `V0_and_v1 | `V0 ];
   inode_config : int * int;
   store_type : [ `Pack | `Pack_layered ];
   freeze_commit : int;
@@ -33,6 +33,12 @@ let pp_inode_config ppf (entries, stable_hash) =
 let pp_store_type ppf = function
   | `Pack -> Format.fprintf ppf "[pack store]"
   | `Pack_layered -> Format.fprintf ppf "[pack-layered store]"
+
+let pp_path_conversion ppf = function
+  | `None -> Format.fprintf ppf "[none]"
+  | `V0 -> Format.fprintf ppf "[v0]"
+  | `V1 -> Format.fprintf ppf "[v1]"
+  | `V0_and_v1 -> Format.fprintf ppf "[v0+v1]"
 
 let decoded_seq_of_encoded_chan_with_prefixes :
     'a Repr.ty -> in_channel -> 'a Seq.t =
@@ -184,60 +190,106 @@ module Bootstrap_trace = struct
     if String.length s <> 2 then false
     else s |> String.to_seq |> List.of_seq |> List.for_all is_hex_char
 
+  let all_6_2char_hex a b c d e f =
+    is_2char_hex a
+    && is_2char_hex b
+    && is_2char_hex c
+    && is_2char_hex d
+    && is_2char_hex e
+    && is_2char_hex f
+
   let is_30char_hex s =
     if String.length s <> 30 then false
     else s |> String.to_seq |> List.of_seq |> List.for_all is_hex_char
 
-  let rec flatten_key_suffix = function
-    | a :: b :: c :: d :: e :: f :: tl
-      when is_2char_hex a
-           && is_2char_hex b
-           && is_2char_hex c
-           && is_2char_hex d
-           && is_2char_hex e
-           && is_30char_hex f ->
-        (a ^ b ^ c ^ d ^ e ^ f) :: flatten_key_suffix tl
-    | hd :: tl -> hd :: flatten_key_suffix tl
-    | [] -> []
-
   (** This function flattens all the 6 step-long chunks forming 40 byte-long
-      hashes to a single step. Those flattenings are performed during the trace
-      replay, i.e. they count in the total time.
+      hashes to a single step.
+
+      Those flattenings are performed during the trace replay, i.e. they count
+      in the total time.
+
+      If a path contains 2 or more of those patterns, only the leftmost one is
+      converted.
+
+      A chopped hash has this form {v ([0-9a-f]{2}/){5}[0-9a-f]{30} v} and is
+      flattened to that form {v [0-9a-f]{40} v}. *)
+  let flatten_key_even_more key =
+    let rec aux rev_prefix suffix =
+      match suffix with
+      | a :: b :: c :: d :: e :: f :: tl
+        when is_2char_hex a
+             && is_2char_hex b
+             && is_2char_hex c
+             && is_2char_hex d
+             && is_2char_hex e
+             && is_30char_hex f ->
+          let prefix = List.rev rev_prefix in
+          let mid = a ^ b ^ c ^ d ^ e ^ f in
+          prefix @ [ mid ] @ tl
+      | hd :: tl -> aux (hd :: rev_prefix) tl
+      | [] -> List.rev rev_prefix
+    in
+    aux [] key
+
+  (** This function removes from the paths all the 6 step-long hashes of this
+      form {v ([0-9a-f]{2}/){6} v}.
+
+      Those flattenings are performed during the trace replay, i.e. they count
+      in the total time.
 
       The paths in tezos:
       https://www.dailambda.jp/blog/2020-05-11-plebeia/#tezos-path
 
-      A chopped hash has this form:
+      Tezos' PR introducing this flattening:
+      https://gitlab.com/tezos/tezos/-/merge_requests/2771 *)
+  let flatten_key = function
+    | "data" :: "contracts" :: "index" :: a :: b :: c :: d :: e :: f :: tl
+      when all_6_2char_hex a b c d e f -> (
+        match tl with
+        | hd :: "delegated" :: a :: b :: c :: d :: e :: f :: tl
+          when all_6_2char_hex a b c d e f ->
+            "data" :: "contracts" :: "index" :: hd :: "delegated" :: tl
+        | _ -> "data" :: "contracts" :: "index" :: tl)
+    | "data" :: "big_maps" :: "index" :: a :: b :: c :: d :: e :: f :: tl
+      when all_6_2char_hex a b c d e f ->
+        "data" :: "big_maps" :: "index" :: tl
+    | "data" :: "rolls" :: "index" :: _ :: _ :: tl ->
+        "data" :: "rolls" :: "index" :: tl
+    | "data" :: "rolls" :: "owner" :: "current" :: _ :: _ :: tl ->
+        "data" :: "rolls" :: "owner" :: "current" :: tl
+    | "data" :: "rolls" :: "owner" :: "snapshot" :: a :: b :: _ :: _ :: tl ->
+        "data" :: "rolls" :: "owner" :: "snapshot" :: a :: b :: tl
+    | l -> l
 
-      {v ([0-9a-f]{2}/){5}[0-9a-f]{30} v}
-
-      and is flattened to that form:
-
-      {v [0-9a-f]{40} v} *)
-  let flatten_key = flatten_key_suffix
-
-  let flatten_op = function
+  let flatten_op ~flatten_path = function
     | Checkout _ as op -> op
-    | Add op -> Add { op with key = flatten_key op.key }
+    | Add op -> Add { op with key = flatten_path op.key }
     | Remove (keys, in_ctx_id, out_ctx_id) ->
-        Remove (flatten_key keys, in_ctx_id, out_ctx_id)
+        Remove (flatten_path keys, in_ctx_id, out_ctx_id)
     | Copy op ->
         Copy
           {
             op with
-            key_src = flatten_key op.key_src;
-            key_dst = flatten_key op.key_dst;
+            key_src = flatten_path op.key_src;
+            key_dst = flatten_path op.key_dst;
           }
-    | Find (keys, b, ctx) -> Find (flatten_key keys, b, ctx)
-    | Mem (keys, b, ctx) -> Mem (flatten_key keys, b, ctx)
-    | Mem_tree (keys, b, ctx) -> Mem_tree (flatten_key keys, b, ctx)
+    | Find (keys, b, ctx) -> Find (flatten_path keys, b, ctx)
+    | Mem (keys, b, ctx) -> Mem (flatten_path keys, b, ctx)
+    | Mem_tree (keys, b, ctx) -> Mem_tree (flatten_path keys, b, ctx)
     | Commit _ as op -> op
 
   let open_ops_sequence path : op Seq.t =
     let chan = open_in_bin path in
     decoded_seq_of_encoded_chan_with_prefixes op_t chan
 
-  let open_commit_sequence max_ncommits flatten path : op list Seq.t =
+  let open_commit_sequence max_ncommits path_conversion path : op list Seq.t =
+    let flatten_path =
+      match path_conversion with
+      | `None -> Fun.id
+      | `V1 -> flatten_key
+      | `V0 -> flatten_key_even_more
+      | `V0_and_v1 -> fun p -> flatten_key p |> flatten_key_even_more
+    in
     let rec aux (ops_seq, commits_sent, ops) =
       if commits_sent >= max_ncommits then None
       else
@@ -247,7 +299,7 @@ module Bootstrap_trace = struct
             let ops = op :: ops |> List.rev in
             Some (ops, (ops_seq, commits_sent + 1, []))
         | Cons (op, ops_seq) ->
-            let op = if flatten then flatten_op op else op in
+            let op = flatten_op ~flatten_path op in
             aux (ops_seq, commits_sent, op :: ops)
     in
     let ops_seq = open_ops_sequence path in
@@ -479,8 +531,13 @@ module Generate_trees_from_trace (Store : Store) = struct
   }
 
   let pp_stats ppf
-      (summary, as_json, flatten, inode_config, store_type, elapsed_cpu, elapsed)
-      =
+      ( summary,
+        as_json,
+        path_conversion,
+        inode_config,
+        store_type,
+        elapsed_cpu,
+        elapsed ) =
     let stat_entry_t = Bootstrap_trace.Stats.stat_entry_t in
     let op_tags = Bootstrap_trace.Stats.op_tags in
     let mean histo =
@@ -535,18 +592,17 @@ module Generate_trees_from_trace (Store : Store) = struct
     in
     if as_json then
       Fmt.pf ppf
-        "{\"revision\":\"%s\", \"flatten\":%d, \"inode_config\":\"%a\", \
-         \"store_type\":\"%a\", \"elapsed_cpu\":\"%f\", \"elapsed\":\"%f\",@\n\
+        "{\"revision\":\"%s\", \"path_conversion\":%a, \
+         \"inode_config\":\"%a\", \"store_type\":\"%a\", \
+         \"elapsed_cpu\":\"%f\", \"elapsed\":\"%f\",@\n\
          \"max_durations\":{\n\
          %a},\n\
          \"moving_average_points\":{\n\
          %a},\n\
          \"histo_points\":{\n\
          %a}}"
-        "missing"
-        (if flatten then 1 else 0)
-        pp_inode_config inode_config pp_store_type store_type elapsed_cpu
-        elapsed
+        "missing" pp_path_conversion path_conversion pp_inode_config
+        inode_config pp_store_type store_type elapsed_cpu elapsed
         Fmt.(list ~sep:(any ",@\n") pp_max)
         op_tags
         Fmt.(list ~sep:(any ",@\n") pp_moving_average)
@@ -830,11 +886,13 @@ module Bench_suite (Store : Store) = struct
 
   let run_read_trace config stats =
     let commit_seq =
-      Bootstrap_trace.open_commit_sequence config.ncommits_trace config.flatten
-        config.commit_data_file
+      Bootstrap_trace.open_commit_sequence config.ncommits_trace
+        config.path_conversion config.commit_data_file
     in
     let* repo, on_commit, on_end, repo_pp = Store.create_repo config in
-    let check_hash = (not config.flatten) && config.inode_config = (32, 256) in
+    let check_hash =
+      config.path_conversion = `None && config.inode_config = (32, 256)
+    in
 
     let t0_cpu = Sys.time () in
     let t0 = Mtime_clock.counter () in
@@ -861,7 +919,7 @@ module Bench_suite (Store : Store) = struct
       "%a%!" Trees_trace.pp_stats
       ( stats,
         true,
-        config.flatten,
+        config.path_conversion,
         config.inode_config,
         config.store_type,
         elapsed_cpu,
@@ -880,7 +938,7 @@ module Bench_suite (Store : Store) = struct
         repo_pp Trees_trace.pp_stats
         ( stats,
           false,
-          config.flatten,
+          config.path_conversion,
           config.inode_config,
           config.store_type,
           elapsed_cpu,
@@ -1091,8 +1149,8 @@ let get_suite suite_filter =
     suite
 
 let main () ncommits ncommits_trace suite_filter inode_config store_type
-    freeze_commit flatten depth width nchain_trees nlarge_trees commit_data_file
-    results_dir =
+    freeze_commit path_conversion depth width nchain_trees nlarge_trees
+    commit_data_file results_dir =
   let default = match suite_filter with `Quick -> 10000 | _ -> 13315 in
   let ncommits_trace = Option.value ~default ncommits_trace in
   let config =
@@ -1100,7 +1158,7 @@ let main () ncommits ncommits_trace suite_filter inode_config store_type
       ncommits;
       ncommits_trace;
       root = "test-bench";
-      flatten;
+      path_conversion;
       depth;
       width;
       nchain_trees;
@@ -1153,11 +1211,12 @@ let freeze_commit =
   in
   Arg.(value @@ opt int 1664 doc)
 
-let flatten =
-  let doc =
-    Arg.info ~doc:"Flatten the paths in the trace benchmarks" [ "flatten" ]
+let path_conversion =
+  let mode =
+    [ ("none", `None); ("v0", `V0); ("v1", `V1); ("v0+v1", `V0_and_v1) ]
   in
-  Arg.(value @@ flag doc)
+  let doc = Arg.info ~doc:(Arg.doc_alts_enum mode) [ "p"; "path_conversion" ] in
+  Arg.(value @@ opt (Arg.enum mode) `None doc)
 
 let ncommits =
   let doc =
@@ -1224,7 +1283,7 @@ let main_term =
     $ inode_config
     $ store_type
     $ freeze_commit
-    $ flatten
+    $ path_conversion
     $ depth
     $ width
     $ nchain_trees

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -213,7 +213,7 @@ module Bootstrap_trace = struct
 
       A chopped hash has this form {v ([0-9a-f]{2}/){5}[0-9a-f]{30} v} and is
       flattened to that form {v [0-9a-f]{40} v}. *)
-  let flatten_key_even_more key =
+  let flatten_v0 key =
     let rec aux rev_prefix suffix =
       match suffix with
       | a :: b :: c :: d :: e :: f :: tl
@@ -242,7 +242,7 @@ module Bootstrap_trace = struct
 
       Tezos' PR introducing this flattening:
       https://gitlab.com/tezos/tezos/-/merge_requests/2771 *)
-  let flatten_key = function
+  let flatten_v1 = function
     | "data" :: "contracts" :: "index" :: a :: b :: c :: d :: e :: f :: tl
       when all_6_2char_hex a b c d e f -> (
         match tl with
@@ -286,9 +286,9 @@ module Bootstrap_trace = struct
     let flatten_path =
       match path_conversion with
       | `None -> Fun.id
-      | `V1 -> flatten_key
-      | `V0 -> flatten_key_even_more
-      | `V0_and_v1 -> fun p -> flatten_key p |> flatten_key_even_more
+      | `V1 -> flatten_v1
+      | `V0 -> flatten_v0
+      | `V0_and_v1 -> fun p -> flatten_v1 p |> flatten_v0
     in
     let rec aux (ops_seq, commits_sent, ops) =
       if commits_sent >= max_ncommits then None


### PR DESCRIPTION
extracted from #1332

Introduces the `--path_conversion` parameter to `tree.exe`. The possible values are `none`, `v0`, `v1`, `v0+v1`.

### Flattening patterns
Notation:
- `\d` is `[0-9]`
- `\x` is `[0-9a-f]`

The patterns:
- `v1`: from:`"(\x\x/){6}"`, to:`""`, origin:[tezos/tezos/2771](https://gitlab.com/tezos/tezos/-/merge_requests/2771).
- `v0`: from:`"(\x\x/){5}\x{30}/"`, to:`"\x{40}/"`, origin:`tree.exe`'s legacy method.

#### Occurrences of flattening patterns, over the first 654941 commits
3 columns:
- Prefix pattern.
- Unique number of directories matching the prefix pattern.
- Average number of unique entries seen, per unique prefix.

##### `v1` occurrences
| prefix                                                    | dirs | average  | comment                                                                                                      |
|-----------------------------------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------|
| `/data/contracts/index/`                                  | 1    | 315809   |                                                                                                              |
| `/data/contracts/index/(\x\x/){6}0000(\x{40})/delegated/` | 0    | n/a      | 650k commits is not enough<br>to witness this one. But <br>`v0` flattening occur here.<br>(see next table) |
| `/data/big_maps/index/`                                   | 0    | n/a      | 650k commits is not enough<br>to witness this one.                                                           |
| `/data/rolls/index/`                                      | 1    | 72671    |                                                                                                              |
| `/data/rolls/owner/current/`                              | 1    | 72671    |                                                                                                              |
| `/data/rolls/owner/snapshot/\d+/\d+/`                     | 160  | 46350.86 |                                                                                                              |

##### `v0` occurences
| prefix                                                                         |  dirs | average  |
|--------------------------------------------------------------------------------|-------|----------|
| `/data/commitments/`                                                           | 1     | 31525    |
| `/data/contracts/index/(\x\x/){6}0000(\x{40})/delegated/`                      | 320   |    32.72 |
| `/data/delegates_with_frozen_balance/\d+/(ed25519\|p256\|secp256k1)/`          | 348   |   136.86 |
| `/data/votes/(ballots\|listings\|proposals_count)/(ed25519\|p256\|secp256k1)/` | 9     |   159.44 |
| `/data/active_delegates_with_rolls/(ed25519\|p256\|secp256k1)/`                | 3     |   288.00 |
| `/data/delegates/(ed25519\|p256\|secp256k1)/`                                  | 3     |   646.33 |
| `/data/contracts/old_index/(ed25519\|originated\|p256\|secp256k1)/`            | 4     | 66842.25 |
| `/data/contracts/index/(ed25519\|originated\|p256\|secp256k1)/`                | 4     | 69438.25 |

### Impact of flattening patterns on replay performances

I ran a test on top of #1332 to highlight the differences between the flattening methods. Both flattening techniques are relevant when replaying the first 650k commits. The `v0+v1` flattening has the best perfs overall.
```
Block played count                    |       | 0 (before) |     163735.2     |     327470.5     |     491205.8     |   654941 (end)
Blocks progress                       |       |     0%     |       25%        |       50%        |       75%        |       100%

Wall time elapsed                     | none  |        0us |     1h1min       |    3h48min       |    7h55min       |   13h45min
                                      | v0    |        0us |   38min35s   63% |     2h3min   54% |    4h10min   53% |    8h48min   64%
                                      | v1    |        0us |     1h5min  106% |     4h2min  106% |    7h27min   94% |   10h16min   75%
                                      | v0+v1 |        0us |   38min20s   62% |     2h8min   56% |     4h4min   51% |    6h36min   48%

index_data bytes                      | none  |    0.000 M | 1422.027 M       | 3541.826 M       | 5775.751 M       | 8274.405 M
                                      | v0    |    0.000 M |  767.202 M   54% | 2007.086 M   57% | 3544.654 M   61% | 6051.797 M   73%
                                      | v1    |    0.000 M | 1422.060 M  100% | 3542.440 M  100% | 5512.505 M   95% | 6930.352 M   84%
                                      | v0+v1 |    0.000 M |  767.181 M   54% | 2007.102 M   57% | 3271.543 M   57% | 4697.771 M   57%

gc.minor_words allocated              | none  |    0.001 G |  484.215 G       | 1913.809 G       | 4078.715 G       | 7348.876 G
                                      | v0    |    0.001 G |  275.822 G   57% |  894.475 G   47% | 1970.083 G   48% | 4541.674 G   62%
                                      | v1    |    0.001 G |  470.556 G   97% | 1887.228 G   99% | 3748.112 G   92% | 5292.648 G   72%
                                      | v0+v1 |    0.001 G |  262.860 G   54% |  868.647 G   45% | 1699.832 G   42% | 2840.179 G   39%
```

The `v0` flattening pattern has a huge impact on performances up to the commit ~400k.

The `v1` flattening pattern has a huge impact on performances from the commit ~400k.
```
index_data bytes per block            | none  |        n/a |     11_256       |     12_099       |     15_472       |     16_160
                                      | v0    |        n/a |      6_070   54% |      7_421   61% |     15_124   98% |     16_204  100%
                                      | v1    |        n/a |     11_821  105% |     12_859  106% |      9_462   61% |      9_580   59%
                                      | v0+v1 |        n/a |      6_616   59% |      8_160   67% |      8_287   54% |      8_869   55%

gc.minor_words allocated per block    | none  |        n/a |    4.774 M       |    9.996 M       |   17.009 M       |   23.020 M
                                      | v0    |        n/a |    2.418 M   51% |    4.260 M   43% |   12.492 M   73% |   18.527 M   80%
                                      | v1    |        n/a |    4.785 M  100% |   10.242 M  102% |    9.155 M   54% |   10.912 M   47%
                                      | v0+v1 |        n/a |    2.385 M   50% |    4.366 M   44% |    5.855 M   34% |    7.735 M   34%
```

This can be explained by looking at the size of the 2 largest directries. 
```
/data/contracts/index entries         | none  |        n/a |                4 |                4 |              256 |              256
                                      | v0    |        n/a |                4 |                4 |              256 |              256
                                      | v1    |        n/a |                4 |                4 |          271_500 |          310_292
                                      | v0+v1 |        n/a |                4 |                4 |          271_500 |          310_292

/data/contracts/index/ed25519 entries | none  |        n/a |              256 |              256 |                0 |                0
                                      | v0    |        n/a |           31_603 |          240_254 |                0 |                0
                                      | v1    |        n/a |              256 |              256 |                0 |                0
                                      | v0+v1 |        n/a |           31_603 |          240_254 |                0 |                0
```

Unexpectedly, the size of the pack file seem to be lower with no flattening.
```
store_pack bytes                      | none  |    0.000 G |    2.885 G       |    7.644 G       |   12.825 G       |   18.934 G
                                      | v0    |    0.000 G |    2.879 G  100% |    8.035 G  105% |   13.696 G  107% |   19.806 G  105%
                                      | v1    |    0.000 G |    2.885 G  100% |    7.644 G  100% |   13.003 G  101% |   20.475 G  108%
                                      | v0+v1 |    0.000 G |    2.878 G  100% |    8.034 G  105% |   13.874 G  108% |   21.348 G  113%

store_pack bytes per block            | none  |        n/a |     23_663       |     28_307       |     36_288       |     37_587
                                      | v0    |        n/a |     26_487  112% |     31_249  110% |     36_553  101% |     37_593  100%
                                      | v1    |        n/a |     23_666  100% |     28_292  100% |     42_784  118% |     46_572  124%
                                      | v0+v1 |        n/a |     26_490  112% |     31_234  110% |     43_040  119% |     46_583  124%
```

### The full summary

<details>
<summary>Click me</summary>

```
Block played count                    |       | 0 (before) |     163735.2     |     327470.5     |     491205.8     |   654941 (end)
Blocks progress                       |       |     0%     |       25%        |       50%        |       75%        |       100%
                                      |       |            |                  |                  |                  |
Wall time elapsed                     | none  |        0us |     1h1min       |    3h48min       |    7h55min       |   13h45min
                                      | v0    |        0us |   38min35s   63% |     2h3min   54% |    4h10min   53% |    8h48min   64%
                                      | v1    |        0us |     1h5min  106% |     4h2min  106% |    7h27min   94% |   10h16min   75%
                                      | v0+v1 |        0us |   38min20s   62% |     2h8min   56% |     4h4min   51% |    6h36min   48%
                                      |       |            |                  |                  |                  |
Wall time progress                    | none  |         0% |         7%       |        28%       |        58%       |       100%
                                      | v0    |         0% |         7%       |        23%       |        47%       |       100%
                                      | v1    |         0% |        11%       |        39%       |        72%       |       100%
                                      | v0+v1 |         0% |        10%       |        32%       |        62%       |       100%
                                      |       |            |                  |                  |                  |
pack.finds per block                  | none  |        n/a |   1063.106       |   1611.013       |   1929.080       |   1994.200
                                      | v0    |        n/a |    437.650   41% |    650.746   40% |   1617.348   84% |   1726.325   87%
                                      | v1    |        n/a |   1011.008   95% |   1563.626   97% |    968.853   50% |    943.099   47%
                                      | v0+v1 |        n/a |    385.552   36% |    603.358   37% |    656.410   34% |    673.016   34%
                                      |       |            |                  |                  |                  |
pack.cache_misses per block           | none  |        n/a |     68.975       |     77.277       |     99.555       |     88.144
                                      | v0    |        n/a |     41.136   60% |     46.740   60% |     89.760   90% |     86.156   98%
                                      | v1    |        n/a |     45.401   66% |     54.298   70% |     48.781   49% |     39.447   45%
                                      | v0+v1 |        n/a |     23.478   34% |     29.493   38% |     40.181   40% |     38.101   43%
                                      |       |            |                  |                  |                  |
pack.appended_hashes per block        | none  |        n/a |  6.570e-02       |  3.520e-02       |  6.560e-02       |  9.613e-02
                                      | v0    |        n/a |  6.570e-02  100% |  3.520e-02  100% |  6.560e-02  100% |  9.613e-02  100%
                                      | v1    |        n/a |  6.570e-02  100% |  3.520e-02  100% |  6.560e-02  100% |  9.613e-02  100%
                                      | v0+v1 |        n/a |  6.570e-02  100% |  3.520e-02  100% |  6.560e-02  100% |  9.613e-02  100%
                                      |       |            |                  |                  |                  |
pack.appended_offsets per block       | none  |        n/a |   1308.662       |   1633.032       |   2053.009       |   2147.594
                                      | v0    |        n/a |   1395.216  107% |   1798.620  110% |   2065.191  101% |   2147.678  100%
                                      | v1    |        n/a |   1310.752  100% |   1633.432  100% |   2297.321  112% |   2421.566  113%
                                      | v0+v1 |        n/a |   1397.307  107% |   1799.020  110% |   2308.939  112% |   2421.670  113%
                                      |       |            |                  |                  |                  |
tree.contents_hash per block          | none  |        n/a |     70.122       |    126.107       |    134.083       |    138.201
                                      | v0    |        n/a |     70.122  100% |    126.107  100% |    134.083  100% |    138.201  100%
                                      | v1    |        n/a |     70.122  100% |    126.107  100% |    134.083  100% |    138.201  100%
                                      | v0+v1 |        n/a |     70.122  100% |    126.107  100% |    134.083  100% |    138.201  100%
                                      |       |            |                  |                  |                  |
tree.contents_find per block          | none  |        n/a |    165.418       |    183.345       |    199.447       |    206.391
                                      | v0    |        n/a |    165.418  100% |    183.345  100% |    199.447  100% |    206.391  100%
                                      | v1    |        n/a |    165.418  100% |    183.345  100% |    199.453  100% |    206.392  100%
                                      | v0+v1 |        n/a |    165.418  100% |    183.345  100% |    199.453  100% |    206.392  100%
                                      |       |            |                  |                  |                  |
tree.contents_add per block           | none  |        n/a |     62.990       |     69.651       |     75.705       |     75.955
                                      | v0    |        n/a |     62.990  100% |     69.704  100% |     75.754  100% |     76.007  100%
                                      | v1    |        n/a |     62.992  100% |     69.652  100% |     75.708  100% |     75.957  100%
                                      | v0+v1 |        n/a |     62.992  100% |     69.705  100% |     75.769  100% |     76.022  100%
                                      |       |            |                  |                  |                  |
tree.node_hash per block              | none  |        n/a |    192.634       |    210.035       |    256.972       |    261.274
                                      | v0    |        n/a |     74.222   39% |     80.390   38% |    247.682   96% |    260.760  100%
                                      | v1    |        n/a |    191.746  100% |    209.208  100% |     90.774   35% |     84.484   32%
                                      | v0+v1 |        n/a |     73.334   38% |     79.563   38% |     81.226   32% |     83.507   32%
                                      |       |            |                  |                  |                  |
tree.node_mem per block               | none  |        n/a |    191.836       |    209.324       |    255.574       |    260.374
                                      | v0    |        n/a |     73.770   38% |     80.064   38% |    246.654   97% |    260.258  100%
                                      | v1    |        n/a |    191.165  100% |    208.674  100% |     90.207   35% |     83.863   32%
                                      | v0+v1 |        n/a |     73.099   38% |     79.414   38% |     81.097   32% |     83.357   32%
                                      |       |            |                  |                  |                  |
tree.node_add per block               | none  |        n/a |    188.496       |    206.272       |    252.728       |    256.768
                                      | v0    |        n/a |     70.472   37% |     77.121   37% |    243.900   97% |    256.745  100%
                                      | v1    |        n/a |    187.864  100% |    205.647  100% |     87.226   35% |     80.300   31%
                                      | v0+v1 |        n/a |     69.840   37% |     76.496   37% |     78.230   31% |     79.913   31%
                                      |       |            |                  |                  |                  |
tree.node_find per block              | none  |        n/a |    278.620       |    680.929       |    740.793       |    762.027
                                      | v0    |        n/a |    159.431   57% |    305.633   45% |    471.566   64% |    494.984   65%
                                      | v1    |        n/a |    213.591   77% |    615.910   90% |    515.600   70% |    520.846   68%
                                      | v0+v1 |        n/a |     94.403   34% |    240.614   35% |    246.251   33% |    253.626   33%
                                      |       |            |                  |                  |                  |
tree.node_val_v per block             | none  |        n/a |  1.615e-10       |  1.540e-16       |  1.469e-22       |  1.401e-28
                                      | v0    |        n/a |  1.615e-10  100% |  1.540e-16  100% |  1.469e-22  100% |  1.401e-28  100%
                                      | v1    |        n/a |  1.615e-10  100% |  1.540e-16  100% |  1.469e-22  100% |  1.401e-28  100%
                                      | v0+v1 |        n/a |  1.615e-10  100% |  1.540e-16  100% |  1.469e-22  100% |  1.401e-28  100%
                                      |       |            |                  |                  |                  |
tree.node_val_find per block          | none  |        n/a |          0       |          0       |          0       |          0
                                      | v0    |        n/a |          0       |          0       |          0       |          0
                                      | v1    |        n/a |          0       |          0       |          0       |          0
                                      | v0+v1 |        n/a |          0       |          0       |          0       |          0
                                      |       |            |                  |                  |                  |
tree.node_val_list per block          | none  |        n/a |      1.760       |      1.397       |      1.973       |      1.478
                                      | v0    |        n/a |      1.407   80% |      1.269   91% |      1.810   92% |      1.460   99%
                                      | v1    |        n/a |      1.629   93% |      1.295   93% |      1.388   70% |      1.237   84%
                                      | v0+v1 |        n/a |      1.275   72% |      1.167   83% |      1.139   58% |      1.124   76%
                                      |       |            |                  |                  |                  |
index.bytes_read                      | none  |    0.000 G |  559.032 G       | 1860.623 G       | 3680.614 G       | 6431.118 G
                                      | v0    |    0.000 G |  404.818 G   72% | 1371.572 G   74% | 2598.860 G   71% | 4680.774 G   73%
                                      | v1    |    0.000 G |  548.101 G   98% | 1838.302 G   99% | 3502.862 G   95% | 5252.037 G   82%
                                      | v0+v1 |    0.000 G |  394.557 G   71% | 1348.369 G   72% | 2454.221 G   67% | 3994.348 G   62%
                                      |       |            |                  |                  |                  |
index.bytes_read per block            | none  |        n/a |    4.978 M       |    9.432 M       |   13.351 M       |   20.098 M
                                      | v0    |        n/a |    3.764 M   76% |    7.527 M   80% |   11.343 M   85% |   14.625 M   73%
                                      | v1    |        n/a |    4.966 M  100% |    9.561 M  101% |    9.565 M   72% |   12.274 M   61%
                                      | v0+v1 |        n/a |    3.722 M   75% |    7.579 M   80% |    8.135 M   61% |    8.149 M   41%
                                      |       |            |                  |                  |                  |
index.bytes_read per sec              | none  |        n/a |  189.393 M       |  190.838 M       |  150.388 M       |  199.074 M
                                      | v0    |        n/a |  237.166 M  125% |  335.775 M  176% |  183.282 M  122% |  151.012 M   76%
                                      | v1    |        n/a |  179.039 M   95% |  179.809 M   94% |  236.394 M  157% |  287.297 M  144%
                                      | v0+v1 |        n/a |  248.052 M  131% |  357.902 M  188% |  309.280 M  206% |  225.161 M  113%
                                      |       |            |                  |                  |                  |
index.nb_reads                        | none  |    0.000 M |  190.348 M       |  520.779 M       |  894.311 M       | 1310.496 M
                                      | v0    |    0.000 M |  148.224 M   78% |  436.114 M   84% |  772.735 M   86% | 1186.327 M   91%
                                      | v1    |    0.000 M |  173.611 M   91% |  484.615 M   93% |  824.224 M   92% | 1174.120 M   90%
                                      | v0+v1 |    0.000 M |  137.175 M   72% |  411.938 M   79% |  720.171 M   81% | 1067.939 M   81%
                                      |       |            |                  |                  |                  |
index.nb_reads per block              | none  |        n/a |   1636.252       |   2046.244       |   2534.382       |   2569.097
                                      | v0    |        n/a |   1349.623   82% |   1826.874   89% |   2486.901   98% |   2552.843   99%
                                      | v1    |        n/a |   1524.165   93% |   1924.833   94% |   2104.482   83% |   2137.511   83%
                                      | v0+v1 |        n/a |   1275.582   78% |   1760.605   86% |   2045.752   81% |   2149.336   84%
                                      |       |            |                  |                  |                  |
index.nb_reads per sec                | none  |        n/a |     81_210       |     65_172       |     62_696       |     57_573
                                      | v0    |        n/a |     91_907  113% |     95_799  147% |     63_770  102% |     59_614  104%
                                      | v1    |        n/a |     73_933   91% |     59_464   91% |     95_138  152% |     92_218  160%
                                      | v0+v1 |        n/a |     93_602  115% |    100_603  154% |    106_367  170% |    103_679  180%
                                      |       |            |                  |                  |                  |
index.bytes_written                   | none  |    0.000 G |   95.302 G       |  571.025 G       | 1487.662 G       | 3058.326 G
                                      | v0    |    0.000 G |   30.499 G   32% |  190.770 G   33% |  571.093 G   38% | 1647.767 G   54%
                                      | v1    |    0.000 G |   95.293 G  100% |  571.088 G  100% | 1368.107 G   92% | 2162.316 G   71%
                                      | v0+v1 |    0.000 G |   30.445 G   32% |  190.717 G   33% |  494.875 G   33% | 1007.012 G   33%
                                      |       |            |                  |                  |                  |
index.bytes_written per block         | none  |        n/a |    1.335 M       |    3.706 M       |    7.673 M       |   11.689 M
                                      | v0    |        n/a |    0.414 M   31% |    1.313 M   35% |    4.569 M   60% |    8.520 M   73%
                                      | v1    |        n/a |    1.401 M  105% |    3.936 M  106% |    4.590 M   60% |    5.878 M   50%
                                      | v0+v1 |        n/a |    0.444 M   33% |    1.440 M   39% |    2.396 M   31% |    3.678 M   31%
                                      |       |            |                  |                  |                  |
index.bytes_written per sec           | none  |        n/a |  1_855_282       |  1_392_660       |  1_423_767       |  1_331_501
                                      | v0    |        n/a |  2_392_968  129% |  2_134_820  153% |  1_449_519  102% |  1_382_156  104%
                                      | v1    |        n/a |  1_780_010   96% |  1_344_172   97% |  2_489_060  175% |  2_520_572  189%
                                      | v0+v1 |        n/a |  3_338_975  180% |  2_247_588  161% |  2_803_591  197% |  2_782_701  209%
                                      |       |            |                  |                  |                  |
index.nb_writes                       | none  |         19 |    757_161       |  1_547_465       |  2_347_683       |  3_195_833
                                      | v0    |         19 |    724_019   96% |  1_450_579   94% |  2_200_763   94% |  3_019_737   94%
                                      | v1    |         19 |    756_715  100% |  1_547_019  100% |  2_327_227   99% |  3_075_929   96%
                                      | v0+v1 |         19 |    723_499   96% |  1_450_039   94% |  2_177_455   93% |  2_929_027   92%
                                      |       |            |                  |                  |                  |
index.nb_writes per block             | none  |        n/a |      4.558       |      4.833       |      4.974       |      5.418
                                      | v0    |        n/a |      4.267   94% |      4.514   93% |      5.075  102% |      5.061   93%
                                      | v1    |        n/a |      4.586  101% |      4.884  101% |      4.550   91% |      4.690   87%
                                      | v0+v1 |        n/a |      4.288   94% |      4.565   94% |      4.532   91% |      4.447   82%
                                      |       |            |                  |                  |                  |
index.nb_writes per sec               | none  |        n/a |    218.303       |    138.734       |    112.945       |    101.104
                                      | v0    |        n/a |    297.943  136% |    224.523  162% |    117.147  104% |    105.174  104%
                                      | v1    |        n/a |    209.742   96% |    132.452   95% |    199.648  177% |    191.227  189%
                                      | v0+v1 |        n/a |    315.831  145% |    241.456  174% |    228.323  202% |    213.498  211%
                                      |       |            |                  |                  |                  |
index.nb_merge                        | none  |          0 |        126       |        314       |        509       |        731
                                      | v0    |          0 |         68   54% |        178   57% |        312   61% |        534   73%
                                      | v1    |          0 |        126  100% |        314  100% |        488   96% |        614   84%
                                      | v0+v1 |          0 |         68   54% |        178   57% |        290   57% |        416   57%
                                      |       |            |                  |                  |                  |
gc.minor_words allocated              | none  |    0.001 G |  484.215 G       | 1913.809 G       | 4078.715 G       | 7348.876 G
                                      | v0    |    0.001 G |  275.822 G   57% |  894.475 G   47% | 1970.083 G   48% | 4541.674 G   62%
                                      | v1    |    0.001 G |  470.556 G   97% | 1887.228 G   99% | 3748.112 G   92% | 5292.648 G   72%
                                      | v0+v1 |    0.001 G |  262.860 G   54% |  868.647 G   45% | 1699.832 G   42% | 2840.179 G   39%
                                      |       |            |                  |                  |                  |
gc.minor_words allocated per block    | none  |        n/a |    4.774 M       |    9.996 M       |   17.009 M       |   23.020 M
                                      | v0    |        n/a |    2.418 M   51% |    4.260 M   43% |   12.492 M   73% |   18.527 M   80%
                                      | v1    |        n/a |    4.785 M  100% |   10.242 M  102% |    9.155 M   54% |   10.912 M   47%
                                      | v0+v1 |        n/a |    2.385 M   50% |    4.366 M   44% |    5.855 M   34% |    7.735 M   34%
                                      |       |            |                  |                  |                  |
gc.minor_words allocated per sec      | none  |        n/a |  147.733 M       |  157.007 M       |  160.058 M       |  149.907 M
                                      | v0    |        n/a |  128.563 M   87% |  127.927 M   81% |  157.514 M   98% |  156.018 M  104%
                                      | v1    |        n/a |  139.246 M   94% |  148.334 M   94% |  121.682 M   76% |  114.993 M   77%
                                      | v0+v1 |        n/a |  133.751 M   91% |  134.832 M   86% |  131.864 M   82% |  125.757 M   84%
                                      |       |            |                  |                  |                  |
gc.promoted_words                     | none  |    0.000 G |   16.166 G       |   46.713 G       |   81.218 G       |  121.845 G
                                      | v0    |    0.000 G |   10.341 G   64% |   26.779 G   57% |   48.384 G   60% |   88.289 G   72%
                                      | v1    |    0.000 G |   15.155 G   94% |   44.675 G   96% |   73.897 G   91% |   92.578 G   76%
                                      | v0+v1 |    0.000 G |    9.496 G   59% |   25.080 G   54% |   41.622 G   51% |   59.444 G   49%
                                      |       |            |                  |                  |                  |
gc.major_words allocated              | none  |    0.001 G |   28.408 G       |  119.593 G       |  270.910 G       |  510.889 G
                                      | v0    |    0.001 G |   14.287 G   50% |   51.172 G   43% |  121.256 G   45% |  298.345 G   58%
                                      | v1    |    0.001 G |   27.396 G   96% |  117.561 G   98% |  248.353 G   92% |  368.018 G   72%
                                      | v0+v1 |    0.001 G |   13.432 G   47% |   49.461 G   41% |  104.800 G   39% |  187.776 G   37%
                                      |       |            |                  |                  |                  |
gc.major_words allocated per block    | none  |        n/a |    300_065       |    657_311       |  1_218_456       |  1_730_388
                                      | v0    |        n/a |    132_573   44% |    264_679   40% |    808_101   66% |  1_331_385   77%
                                      | v1    |        n/a |    302_312  101% |    680_792  104% |    702_582   58% |    861_326   50%
                                      | v0+v1 |        n/a |    131_525   44% |    275_922   42% |    409_892   34% |    581_202   34%
                                      |       |            |                  |                  |                  |
gc.major_words allocated per sec      | none  |        n/a |  6_615_858       |  6_101_907       |  6_081_056       |  5_643_360
                                      | v0    |        n/a |  5_692_063   86% |  5_310_903   87% |  5_905_417   97% |  5_810_520  103%
                                      | v1    |        n/a |  6_109_687   92% |  5_681_722   93% |  5_343_597   88% |  5_096_889   90%
                                      | v0+v1 |        n/a |  5_818_338   88% |  5_471_080   90% |  5_704_223   94% |  5_493_203   97%
                                      |       |            |                  |                  |                  |
gc.minor_collections                  | none  |    0.000 M |    1.851 M       |    7.312 M       |   15.581 M       |   28.075 M
                                      | v0    |    0.000 M |    1.053 M   57% |    3.418 M   47% |    7.527 M   48% |   17.348 M   62%
                                      | v1    |    0.000 M |    1.799 M   97% |    7.210 M   99% |   14.317 M   92% |   20.218 M   72%
                                      | v0+v1 |    0.000 M |    1.004 M   54% |    3.320 M   45% |    6.494 M   42% |   10.849 M   39%
                                      |       |            |                  |                  |                  |
gc.minor_collections per block        | none  |        n/a |     18.251       |     38.174       |     64.972       |     87.968
                                      | v0    |        n/a |      9.245   51% |     16.289   43% |     47.702   73% |     70.772   80%
                                      | v1    |        n/a |     18.294  100% |     39.112  102% |     34.971   54% |     41.695   47%
                                      | v0+v1 |        n/a |      9.120   50% |     16.694   44% |     22.359   34% |     29.541   34%
                                      |       |            |                  |                  |                  |
gc.minor_collections per sec          | none  |        n/a |    563.763       |    599.081       |    610.644       |    571.936
                                      | v0    |        n/a |    490.515   87% |    488.133   81% |    600.945   98% |    595.244  104%
                                      | v1    |        n/a |    531.396   94% |    565.914   94% |    464.184   76% |    438.610   77%
                                      | v0+v1 |        n/a |    510.363   91% |    514.442   86% |    503.010   82% |    479.689   84%
                                      |       |            |                  |                  |                  |
gc.major_collections                  | none  |          1 |      1_937       |      6_573       |     12_378       |     20_115
                                      | v0    |          1 |        890   46% |      2_644   40% |      5_379   43% |     11_141   55%
                                      | v1    |          1 |      1_561   81% |      4_688   71% |      7_786   63% |      9_809   49%
                                      | v0+v1 |          1 |        706   36% |      1_934   29% |      3_327   27% |      4_813   24%
                                      |       |            |                  |                  |                  |
gc.compactions                        | none  |          0 |         76       |        245       |        440       |        661
                                      | v0    |          0 |         35   46% |        102   42% |        193   44% |        382   58%
                                      | v1    |          0 |         64   84% |        162   66% |        252   57% |        315   48%
                                      | v0+v1 |          0 |         33   43% |         88   36% |        144   33% |        208   31%
                                      |       |            |                  |                  |                  |
index_data bytes                      | none  |    0.000 M | 1422.027 M       | 3541.826 M       | 5775.751 M       | 8274.405 M
                                      | v0    |    0.000 M |  767.202 M   54% | 2007.086 M   57% | 3544.654 M   61% | 6051.797 M   73%
                                      | v1    |    0.000 M | 1422.060 M  100% | 3542.440 M  100% | 5512.505 M   95% | 6930.352 M   84%
                                      | v0+v1 |    0.000 M |  767.181 M   54% | 2007.102 M   57% | 3271.543 M   57% | 4697.771 M   57%
                                      |       |            |                  |                  |                  |
index_data bytes per block            | none  |        n/a |     11_256       |     12_099       |     15_472       |     16_160
                                      | v0    |        n/a |      6_070   54% |      7_421   61% |     15_124   98% |     16_204  100%
                                      | v1    |        n/a |     11_821  105% |     12_859  106% |      9_462   61% |      9_580   59%
                                      | v0+v1 |        n/a |      6_616   59% |      8_160   67% |      8_287   54% |      8_869   55%
                                      |       |            |                  |                  |                  |
index_data bytes per sec              | none  |        n/a |    406.378       |    176.470       |    172.586       |    126.787
                                      | v0    |        n/a |    341.165   84% |    179.180  102% |    241.897  140% |    175.733  139%
                                      | v1    |        n/a |    301.884   74% |    210.474  119% |    103.307   60% |     84.380   67%
                                      | v0+v1 |        n/a |    326.727   80% |    164.288   93% |    115.927   67% |     75.546   60%
                                      |       |            |                  |                  |                  |
store_pack bytes                      | none  |    0.000 G |    2.885 G       |    7.644 G       |   12.825 G       |   18.934 G
                                      | v0    |    0.000 G |    2.879 G  100% |    8.035 G  105% |   13.696 G  107% |   19.806 G  105%
                                      | v1    |    0.000 G |    2.885 G  100% |    7.644 G  100% |   13.003 G  101% |   20.475 G  108%
                                      | v0+v1 |    0.000 G |    2.878 G  100% |    8.034 G  105% |   13.874 G  108% |   21.348 G  113%
                                      |       |            |                  |                  |                  |
store_pack bytes per block            | none  |        n/a |     23_663       |     28_307       |     36_288       |     37_587
                                      | v0    |        n/a |     26_487  112% |     31_249  110% |     36_553  101% |     37_593  100%
                                      | v1    |        n/a |     23_666  100% |     28_292  100% |     42_784  118% |     46_572  124%
                                      | v0+v1 |        n/a |     26_490  112% |     31_234  110% |     43_040  119% |     46_583  124%
                                      |       |            |                  |                  |                  |
store_pack bytes per sec              | none  |        n/a |  1_216_449       |    935_330       |    949_689       |    883_216
                                      | v0    |        n/a |  1_862_755  153% |  1_668_858  178% |    990_696  104% |    918_970  104%
                                      | v1    |        n/a |  1_171_314   96% |    894_548   96% |  2_027_895  214% |  2_080_470  236%
                                      | v0+v1 |        n/a |  1_974_305  162% |  1_796_349  192% |  2_312_131  243% |  2_319_204  263%
                                      |       |            |                  |                  |                  |
index_log bytes                       | none  |    0.000 M |   22.500 M       |   22.500 M       |   22.500 M       |   22.500 M
                                      | v0    |    0.000 M |   22.500 M  100% |   22.500 M  100% |   22.500 M  100% |   22.500 M  100%
                                      | v1    |    0.000 M |   22.500 M  100% |   22.500 M  100% |   22.500 M  100% |   22.500 M  100%
                                      | v0+v1 |    0.000 M |   22.501 M  100% |   22.501 M  100% |   22.501 M  100% |   22.501 M  100%
                                      |       |            |                  |                  |                  |
disk.index_log_async                  | none  |    0.000 M |   22.500 M       |   22.500 M       |   22.500 M       |   22.500 M
                                      | v0    |    0.000 M |   22.500 M  100% |   22.500 M  100% |   22.500 M  100% |   22.500 M  100%
                                      | v1    |    0.000 M |   22.500 M  100% |   22.500 M  100% |   22.500 M  100% |   22.500 M  100%
                                      | v0+v1 |    0.000 M |   22.499 M  100% |   22.500 M  100% |   22.500 M  100% |   22.500 M  100%
                                      |       |            |                  |                  |                  |
store_dict bytes                      | none  |         24 |  2_458_592       |  2_458_592       |  2_458_592       |  2_458_592
                                      | v0    |         24 |  3_010_262  122% |  3_010_262  122% |  3_010_262  122% |  3_010_262  122%
                                      | v1    |         24 |  2_458_592  100% |  2_458_592  100% |  2_458_592  100% |  2_458_592  100%
                                      | v0+v1 |         24 |  3_010_262  122% |  3_010_262  122% |  3_010_262  122% |  3_010_262  122%
                                      |       |            |                  |                  |                  |
/data/contracts/index entries         | none  |        n/a |                4 |                4 |              256 |              256
                                      | v0    |        n/a |                4 |                4 |              256 |              256
                                      | v1    |        n/a |                4 |                4 |          271_500 |          310_292
                                      | v0+v1 |        n/a |                4 |                4 |          271_500 |          310_292
                                      |       |            |                  |                  |                  |
/data/big_maps/index entries          | none  |        n/a |                0 |                0 |                0 |                0
                                      | v0    |        n/a |                0 |                0 |                0 |                0
                                      | v1    |        n/a |                0 |                0 |                0 |                0
                                      | v0+v1 |        n/a |                0 |                0 |                0 |                0
                                      |       |            |                  |                  |                  |
/data/rolls/index entries             | none  |        n/a |              256 |              256 |              256 |              256
                                      | v0    |        n/a |              256 |              256 |              256 |              256
                                      | v1    |        n/a |           44_475 |           51_136 |           70_393 |           72_208
                                      | v0+v1 |        n/a |           44_475 |           51_136 |           70_393 |           72_208
                                      |       |            |                  |                  |                  |
/data/rolls/owner/current entries     | none  |        n/a |              256 |              256 |              256 |              256
                                      | v0    |        n/a |              256 |              256 |              256 |              256
                                      | v1    |        n/a |           44_930 |           51_562 |           70_164 |           72_463
                                      | v0+v1 |        n/a |           44_930 |           51_562 |           70_164 |           72_463
                                      |       |            |                  |                  |                  |
/data/commitments entries             | none  |        n/a |              256 |              256 |              256 |              256
                                      | v0    |        n/a |           18_302 |           16_052 |           12_443 |           10_670
                                      | v1    |        n/a |              256 |              256 |              256 |              256
                                      | v0+v1 |        n/a |           18_302 |           16_052 |           12_443 |           10_670
                                      |       |            |                  |                  |                  |
/data/contracts/index/ed25519 entries | none  |        n/a |              256 |              256 |                0 |                0
                                      | v0    |        n/a |           31_603 |          240_254 |                0 |                0
                                      | v1    |        n/a |              256 |              256 |                0 |                0
                                      | v0+v1 |        n/a |           31_603 |          240_254 |                0 |                0
```

</details>