### PR TITLE
[2.5] irmin-pack: fix a bad performance regression for read-only instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 2.5.2 (unreleased)
+
+- **irmin-pack**
+  - Fix a performance regression where all caches where always cleaned by
+    `Store.sync` when using the V1 format (#1360, @samoht)
+
 ## 2.5.1 (2021-02-19)
 
 - **irmin-git**

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -119,9 +119,16 @@ module Unix : S = struct
 
   let generation t = t.generation
 
-  let force_generation t =
-    t.generation <- Raw.Generation.get t.raw;
-    t.generation
+  let force_headers t =
+    match t.version with
+    | `V1 ->
+        (* There is no generation number in V1 *)
+        { offset = force_offset t; generation = 0L }
+    | `V2 ->
+        let h = Raw.Header.get t.raw in
+        t.generation <- h.generation;
+        t.offset <- h.offset;
+        { offset = t.offset; generation = t.generation }
 
   let version t =
     Log.debug (fun l ->

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -20,6 +20,8 @@ module type VERSION = sig
   val io_version : version
 end
 
+type headers = { offset : int64; generation : int64 }
+
 module type S = sig
   type t
   type path := string
@@ -33,9 +35,8 @@ module type S = sig
   val set : t -> off:int64 -> string -> unit
   val read : t -> off:int64 -> bytes -> int
   val offset : t -> int64
-  val force_offset : t -> int64
   val generation : t -> int64
-  val force_generation : t -> int64
+  val force_headers : t -> headers
   val readonly : t -> bool
   val version : t -> version
   val flush : t -> unit

--- a/src/irmin-pack/dict.ml
+++ b/src/irmin-pack/dict.ml
@@ -61,9 +61,10 @@ module Make (IO_version : IO.VERSION) (IO : IO.S) : S = struct
     (aux [@tailcall]) (Hashtbl.length t.cache) 0
 
   let sync_offset t =
+    let former_offset = IO.offset t.io in
     let former_generation = IO.generation t.io in
-    let generation = IO.force_generation t.io in
-    if former_generation <> generation then (
+    let h = IO.force_headers t.io in
+    if former_generation <> h.generation then (
       IO.close t.io;
       let io =
         IO.v ~fresh:false ~readonly:true ~version:(Some current_version)
@@ -73,10 +74,7 @@ module Make (IO_version : IO.VERSION) (IO : IO.S) : S = struct
       Hashtbl.clear t.cache;
       Hashtbl.clear t.index;
       refill ~from:0L t)
-    else
-      let former_log_offset = IO.offset t.io in
-      let log_offset = IO.force_offset t.io in
-      if log_offset > former_log_offset then refill ~from:former_log_offset t
+    else if h.offset > former_offset then refill ~from:former_offset t
 
   let sync t =
     if IO.readonly t.io then sync_offset t

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -302,9 +302,10 @@ struct
       Lru.clear t.lru
 
     let sync ?(on_generation_change = Fun.id) t =
+      let former_offset = IO.offset t.pack.block in
       let former_generation = IO.generation t.pack.block in
-      let generation = IO.force_generation t.pack.block in
-      if former_generation <> generation then (
+      let h = IO.force_headers t.pack.block in
+      if former_generation <> h.generation then (
         Log.debug (fun l -> l "[pack] generation changed, refill buffers");
         clear_caches t;
         on_generation_change ();
@@ -314,9 +315,11 @@ struct
             (IO.name t.pack.block)
         in
         t.pack.block <- block;
-        Dict.sync t.pack.dict)
-      else Dict.sync t.pack.dict;
-      Index.sync t.pack.index
+        Dict.sync t.pack.dict;
+        Index.sync t.pack.index)
+      else if h.offset > former_offset then (
+        Dict.sync t.pack.dict;
+        Index.sync t.pack.index)
 
     let version t = IO.version t.pack.block
     let generation t = IO.generation t.pack.block


### PR DESCRIPTION
Pack files do not have generation numbers in V1, so `force_generation` was
always returning a corrupted value, which was forcing a cleanup of all
the existing caches on every sync.