### PR TITLE
irmin-pack: fix a bad performance regression for read-only instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 - **irmin-chunk**
   - use the pre_hash function to compute entry keys instead of
     their raw binary representation (#1308, @samoht)
+- **irmin-pack**
+  - Fix a performance regression where all caches where always cleaned by
+    `Store.sync` when using the V1 format (#1360, @samoht)
 
 ### Added
 

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -92,9 +92,16 @@ module Unix : S = struct
 
   let generation t = t.generation
 
-  let force_generation t =
-    t.generation <- Raw.Generation.get t.raw;
-    t.generation
+  let force_headers t =
+    match t.version with
+    | `V1 ->
+        (* There is no generation number in V1 *)
+        { offset = force_offset t; generation = Int63.zero }
+    | `V2 ->
+        let h = Raw.Header.get t.raw in
+        t.generation <- h.generation;
+        t.offset <- h.offset;
+        { offset = t.offset; generation = t.generation }
 
   let version t =
     Log.debug (fun l ->

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -16,6 +16,8 @@
 
 open! Import
 
+type headers = { offset : int63; generation : int63 }
+
 module type S = sig
   type t
   type path := string
@@ -27,9 +29,8 @@ module type S = sig
   val set : t -> off:int63 -> string -> unit
   val read : t -> off:int63 -> bytes -> int
   val offset : t -> int63
-  val force_offset : t -> int63
   val generation : t -> int63
-  val force_generation : t -> int63
+  val force_headers : t -> headers
   val readonly : t -> bool
   val version : t -> Version.t
   val flush : t -> unit

--- a/src/irmin-pack/store.ml
+++ b/src/irmin-pack/store.ml
@@ -85,10 +85,9 @@ struct
 
   let equal_val = Irmin.Type.(unstage (equal V.t))
 
-  let refill t ~from =
-    let len = IO.force_offset t.block in
+  let refill t ~to_ ~from =
     let rec aux offset =
-      if offset >= len then ()
+      if offset >= to_ then ()
       else
         let len = read_length32 ~off:offset t.block in
         let buf = Bytes.create (len + V.hash_size) in
@@ -111,9 +110,10 @@ struct
     aux from
 
   let sync_offset t =
+    let former_offset = IO.offset t.block in
     let former_generation = IO.generation t.block in
-    let generation = IO.force_generation t.block in
-    if former_generation <> generation then (
+    let h = IO.force_headers t.block in
+    if former_generation <> h.generation then (
       Log.debug (fun l -> l "[branches] generation changed, refill buffers");
       IO.close t.block;
       let io =
@@ -123,11 +123,9 @@ struct
       t.block <- io;
       Tbl.clear t.cache;
       Tbl.clear t.index;
-      refill t ~from:Int63.zero)
-    else
-      let former_log_offset = IO.offset t.block in
-      let log_offset = IO.force_offset t.block in
-      if log_offset > former_log_offset then refill t ~from:former_log_offset
+      refill t ~to_:h.offset ~from:Int63.zero)
+    else if h.offset > former_offset then
+      refill t ~to_:h.offset ~from:former_offset
 
   let unsafe_find t k =
     Log.debug (fun l -> l "[branches] find %a" pp_branch k);
@@ -186,7 +184,8 @@ struct
     let cache = Tbl.create 997 in
     let index = Tbl.create 997 in
     let t = { cache; index; block; w = watches; open_instances = 1 } in
-    refill t ~from:Int63.zero;
+    let h = IO.force_headers block in
+    refill t ~to_:h.offset ~from:Int63.zero;
     t
 
   let Cache.{ v = unsafe_v } =


### PR DESCRIPTION
Pack files do not have generation numbers in V1, so `force_generation` was
always returning a corrupted value, which was forcing a cleanup of all
the existing caches on every sync and reloading the dict file from scratch.

This is #1360 applied to `master`.