### PR TITLE
Bugfix: Tree.Node.t needs custom equality semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,10 @@
 - **irmin**
   - The `Tree.update_tree` and `Tree.add_tree` functions now interpret adding
     an empty subtree as a remove operation, rather than adding an empty
-    directory.  (#1335, @craigfe)
+    directory. (#1335, @craigfe)
+
+  - Fixed a bug causing equality functions derived from `Store.tree_t` to return
+    false-negatives. (#1371, @CraigFe)
 
 - **irmin-chunk**
   - use the pre_hash function to compute entry keys instead of

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -382,17 +382,6 @@ module Make (P : Private.S) = struct
       let info = { hash; map; value; findv_cache } in
       { v; info }
 
-    let t node = Type.map node of_v (fun t -> t.v)
-
-    let _, t =
-      Type.mu2 (fun _ y ->
-          let elt = elt_t y in
-          let v = v_t elt in
-          let t = t v in
-          (v, t))
-
-    let elt_t = elt_t t
-
     let rec clear_elt ~max_depth depth (_, v) =
       match v with
       | `Contents (c, _) -> if depth + 1 > max_depth then Contents.clear c
@@ -446,7 +435,6 @@ module Make (P : Private.S) = struct
           | None -> t.v <- Hash (repo, k)
           | Some k -> t.v <- Hash (repo, k))
 
-    let dump = Type.pp_json ~minify:false t
     let of_map m = of_v (Map m)
     let of_hash repo k = of_v (Hash (repo, k))
     let of_value ?updates repo v = of_v (Value (repo, v, updates))
@@ -904,6 +892,17 @@ module Make (P : Private.S) = struct
 
     let remove t step = update t step Remove
     let add t step v = update t step (Add v)
+    let t node = Type.map ~equal:(Type.stage equal) node of_v (fun t -> t.v)
+
+    let _, t =
+      Type.mu2 (fun _ y ->
+          let elt = elt_t y in
+          let v = v_t elt in
+          let t = t v in
+          (v, t))
+
+    let elt_t = elt_t t
+    let dump = Type.pp_json ~minify:false t
 
     let rec merge : type a. (t Merge.t -> a) -> a =
      fun k ->


### PR DESCRIPTION
This is a quick fix, but we should do a more thorough review of what behaviour these typereps are exposing and provide e.g. `is_empty` explicitly.