### PR TITLE
irmin-containers: partially revert 046ec54f38103e00561fa71144e6466e97…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,7 +78,6 @@
     `Irmin.Content_addressable.S` (#1369, @samoht)
   - Renamed `Irmin_containers.CAS_maker` to
     `Irmin_containers.Content_addressable` (#1369, @samoht)
-  - Removed extra unit argument to all functors (#1369, @samoht)
 
 - **irmin-fs**
   - Renamed `Irmin_fs.Make` into `Irmin_fs.Maker` (#1369, @samoht)

--- a/src/irmin-containers/linked_log.ml
+++ b/src/irmin-containers/linked_log.ml
@@ -100,7 +100,8 @@ module Make
     (C : Stores.Content_addressable)
     (T : Time.S)
     (K : Irmin.Hash.S)
-    (V : Irmin.Type.S) =
+    (V : Irmin.Type.S)
+    () =
 struct
   module L = Linked_log (C) (T) (K) (V)
   module Store = Backend.Make (L)
@@ -161,8 +162,8 @@ struct
   let read_all ~path t = get_cursor t ~path >>= read ~num_items:max_int >|= fst
 end
 
-module FS (C : Stores.Content_addressable) (V : Irmin.Type.S) =
-  Make (Irmin_unix.FS.KV) (C) (Time.Machine) (Irmin.Hash.SHA1) (V)
+module FS (C : Stores.Content_addressable) (V : Irmin.Type.S) () =
+  Make (Irmin_unix.FS.KV) (C) (Time.Machine) (Irmin.Hash.SHA1) (V) ()
 
-module Mem (C : Stores.Content_addressable) (V : Irmin.Type.S) =
-  Make (Irmin_mem.KV) (C) (Time.Machine) (Irmin.Hash.SHA1) (V)
+module Mem (C : Stores.Content_addressable) (V : Irmin.Type.S) () =
+  Make (Irmin_mem.KV) (C) (Time.Machine) (Irmin.Hash.SHA1) (V) ()

--- a/src/irmin-containers/linked_log.mli
+++ b/src/irmin-containers/linked_log.mli
@@ -47,7 +47,8 @@ module Make
     (C : Stores.Content_addressable)
     (T : Time.S)
     (K : Irmin.Hash.S)
-    (V : Irmin.Type.S) :
+    (V : Irmin.Type.S)
+    () :
   S
     with type value = V.t
      and type Store.branch = string
@@ -56,7 +57,7 @@ module Make
 
 (** Linked log instantiated using the {{!Irmin_unix.FS} FS backend} provided by
     [Irmin_unix], timestamp method {!Time.Unix} and hash {!Irmin.Hash.SHA1} *)
-module FS (C : Stores.Content_addressable) (V : Irmin.Type.S) :
+module FS (C : Stores.Content_addressable) (V : Irmin.Type.S) () :
   S
     with type value = V.t
      and type Store.branch = string
@@ -65,7 +66,7 @@ module FS (C : Stores.Content_addressable) (V : Irmin.Type.S) :
 
 (** Linked log instantiated using the {{!Irmin_mem} in-memory backend} provided
     by [Irmin_mem], timestamp method {!Time.Unix} and hash {!Irmin.Hash.SHA1} *)
-module Mem (C : Stores.Content_addressable) (V : Irmin.Type.S) :
+module Mem (C : Stores.Content_addressable) (V : Irmin.Type.S) () :
   S
     with type value = V.t
      and type Store.branch = string

--- a/test/irmin-containers/linked_log.ml
+++ b/test/irmin-containers/linked_log.ml
@@ -24,7 +24,7 @@ module CAS = struct
   let config = Irmin_mem.config ()
 end
 
-module L = Irmin_containers.Linked_log.Mem (CAS) (Irmin.Contents.String)
+module L = Irmin_containers.Linked_log.Mem (CAS) (Irmin.Contents.String) ()
 
 let merge_into_exn = merge_into_exn (module L.Store)
 let path = [ "tmp"; "link" ]


### PR DESCRIPTION
…7aa63c

This did contain an unrelated change which ; the generive functors are needed
for Irmin_containers.Linked_log as there is some global state.

Any given instantiation of Linked_log is not interoperable with any other,
since the instantiations define pools over which the logs are shared

Spotted by @CraigFe