### PR TITLE
irmin-fsck: traverse head commit for stats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@
 - **irmin-mem**
   - Added `Irmin_mem.Content_addressable` (#1369, @samoht)
 
+- **irmin-pack**
+  - Added a `stat-store` command to `irmin-fsck` to output stats on the tree
+    under a specified commit (#1391, @icristescu, @Ngoguey42, @CraigFe).
+
 - **irmin-unix**
   - Update `irmin` CLI to raise an exception when an invalid/non-existent
     config file is specified (#1413, @zshipko)

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -285,13 +285,13 @@ module Make (M : Maker) = struct
               (fun x ->
                 match Repr.of_string Store.Hash.t x with
                 | Ok x -> Store.Commit.of_hash repo x
-                | _ -> Lwt.return None)
+                | Error (`Msg m) -> Fmt.kstr Lwt.fail_with "Invalid hash %S" m)
               heads
       in
       let* () =
         Store.integrity_check_inodes ~heads repo >|= function
-        | Ok (`Msg msg) -> Logs.app (fun l -> l "Ok -- %s" msg)
-        | Error (`Msg msg) -> Logs.err (fun l -> l "Error -- %s" msg)
+        | Ok (`Msg msg) -> Logs.app (fun l -> l "Ok: %s" msg)
+        | Error (`Msg msg) -> Fmt.failwith "Error: %s" msg
       in
       Store.Repo.close repo
 
@@ -312,6 +312,76 @@ module Make (M : Maker) = struct
         (term_internal $ setup_log, info ~doc "integrity-check-inodes")
   end
 
+  module Stats_commit = struct
+    let conf root = Conf.init ~readonly:true ~fresh:false root
+
+    let commit =
+      let open Cmdliner.Arg in
+      value
+      & opt (some string) None
+      & info [ "commit" ] ~doc:"The commit whose underlying tree is traversed."
+          ~docv:"COMMIT"
+
+    let dump_blob_paths_to =
+      let open Cmdliner.Arg in
+      value
+      & opt (some string) None
+      & info [ "dump_blob_paths_to" ]
+          ~doc:"Print all paths to a blob in the tree in a file."
+
+    let run_versioned_store ~root ~commit ~dump_blob_paths_to
+        (module Store : Versioned_store) =
+      let conf = conf root in
+      let* repo = Store.Repo.v conf in
+      let* commit =
+        match commit with
+        | None -> (
+            let* heads = Store.Repo.heads repo in
+            match heads with
+            | [] -> Lwt.fail_with "No heads found"
+            | [ head ] -> Lwt.return head
+            | ls ->
+                Fmt.kstr Lwt.fail_with
+                  "Several heads found, please specify one. Heads = %a"
+                  Fmt.(list ~sep:comma Store.Commit.pp_hash)
+                  ls)
+        | Some hash -> (
+            match Repr.of_string Store.Hash.t hash with
+            | Ok x -> (
+                Store.Commit.of_hash repo x >>= function
+                | None ->
+                    Fmt.kstr Lwt.fail_with "Commit with hash %s not found" hash
+                | Some x -> Lwt.return x)
+            | Error (`Msg m) -> Fmt.kstr Lwt.fail_with "Invalid hash %S" m)
+      in
+      let* () = Store.stats ~dump_blob_paths_to ~commit repo in
+      Store.Repo.close repo
+
+    let run ~root ~commit ~dump_blob_paths_to () =
+      match Stat.detect_version ~root with
+      | `V1 ->
+          run_versioned_store ~root ~commit ~dump_blob_paths_to
+            (module Store_V1)
+      | `V2 ->
+          run_versioned_store ~root ~commit ~dump_blob_paths_to
+            (module Store_V2)
+
+    let term_internal =
+      Cmdliner.Term.(
+        const (fun root commit dump_blob_paths_to () ->
+            Lwt_main.run (run ~root ~commit ~dump_blob_paths_to ()))
+        $ path
+        $ commit
+        $ dump_blob_paths_to)
+
+    let term =
+      let doc =
+        "Traverse one commit, specified with the --commit argument, in the \
+         store for stats. If no commit is specified the current head is used."
+      in
+      Cmdliner.Term.(term_internal $ setup_log, info ~doc "stat-store")
+  end
+
   module Cli = struct
     open Cmdliner
 
@@ -323,6 +393,7 @@ module Make (M : Maker) = struct
             Integrity_check.term;
             Integrity_check_inodes.term;
             Integrity_check_index.term;
+            Stats_commit.term;
           ]) () : empty =
       let default =
         let default_info =
@@ -395,4 +466,237 @@ module Index (Index : Pack_index.S) = struct
     in
     Utils.Progress.finalise bar;
     result
+end
+
+module Stats (S : sig
+  type step
+
+  val step_t : step Irmin.Type.t
+
+  module Hash : Irmin.Hash.S
+end) =
+struct
+  type step = Node of S.step | Inode
+  type path = step list
+
+  module Metrics : sig
+    type max
+    type node
+
+    val max_length : node -> int
+    val all_paths : node -> path list
+    val mp : node -> max
+    val maximum : max -> int
+    val maximal_count : max -> int
+    val representative : max -> path
+
+    val v :
+      ?maximal_count:int -> maximum:int -> representative:path -> unit -> max
+
+    val empty_root_node : node
+    val empty_node : node
+    val empty_max : max
+    val update_node : node -> node -> step -> int -> node
+    val update_width : node -> int -> max -> max
+    val pp : max Fmt.t
+    val pp_all_paths : node Fmt.t
+  end = struct
+    type max = { maximum : int; maximal_count : int; representative : path }
+
+    type node = {
+      all_paths : path list;
+      (* All paths to a node. *)
+      max_length : int;
+      (* The max length of a path to a node. *)
+      mp : max;
+          (* The maximum size of a membership proof: the number of siblings at
+             every level along the path. *)
+    }
+
+    let max_length { max_length; _ } = max_length
+    let all_paths { all_paths; _ } = all_paths
+    let mp { mp; _ } = mp
+    let maximum { maximum; _ } = maximum
+    let representative { representative; _ } = representative
+    let maximal_count { maximal_count; _ } = maximal_count
+
+    let v ?(maximal_count = 1) ~maximum ~representative () =
+      { maximum; maximal_count; representative }
+
+    let empty_max = { maximum = 0; maximal_count = 0; representative = [] }
+
+    let empty_root_node =
+      let mp = empty_max in
+      { all_paths = [ [] ]; max_length = 0; mp }
+
+    let empty_node =
+      let mp = empty_max in
+      { all_paths = []; max_length = 0; mp }
+
+    let incr ({ maximal_count; _ } as t) =
+      { t with maximal_count = maximal_count + 1 }
+
+    let update_mp stat_k stat_pred step nb_siblings =
+      let mp = stat_k.maximum + nb_siblings in
+      if stat_pred.maximum > mp then stat_pred
+      else if stat_pred.maximum = mp && not (mp = 0) then incr stat_pred
+      else
+        let path_to_k = stat_k.representative in
+        let new_path_to_pred = step :: path_to_k in
+        v ~maximum:mp ~representative:new_path_to_pred ()
+
+    let update_width stat_k width_k max_width =
+      if max_width.maximum > width_k then max_width
+      else if max_width.maximum = width_k then incr max_width
+      else
+        let representative = List.hd stat_k.all_paths in
+        v ~maximum:width_k ~representative ()
+
+    let update_path paths_to_k step_k_to_n paths_to_n =
+      let new_paths_to_n =
+        List.rev_map (fun rev_path -> step_k_to_n :: rev_path) paths_to_k
+      in
+      List.rev_append new_paths_to_n paths_to_n
+
+    let update_node stat_k stat_pred step_k_to_pred nb_siblings =
+      let all_paths, max_length =
+        match step_k_to_pred with
+        | Inode ->
+            (* Do not update if pred is an inode. *)
+            (stat_k.all_paths, stat_k.max_length)
+        | Node _ ->
+            let paths_to_pred =
+              update_path stat_k.all_paths step_k_to_pred stat_pred.all_paths
+            in
+            let length =
+              (* The new current length to pred. *)
+              let lk = stat_k.max_length + 1 in
+              (* The previous max length to pred. *)
+              let ln = stat_pred.max_length in
+              max lk ln
+            in
+            (paths_to_pred, length)
+      in
+      let mp = update_mp stat_k.mp stat_pred.mp step_k_to_pred nb_siblings in
+      let stat_pred' = { all_paths; max_length; mp } in
+      stat_pred'
+
+    let pp_step ppf = function
+      | Inode -> Fmt.pf ppf "-"
+      | Node x -> Fmt.pf ppf "%a" (Irmin.Type.pp S.step_t) x
+
+    let pp_path = Fmt.list ~sep:(Fmt.any "/") pp_step
+
+    let pp_all_paths fmt stats =
+      List.iter
+        (fun l -> Fmt.pf fmt "%a\n" pp_path (List.rev l))
+        stats.all_paths
+
+    let pp =
+      let open Fmt.Dump in
+      record
+        [
+          field "maximum" (fun t -> t.maximum) Fmt.int;
+          field "maximal_count" (fun t -> t.maximal_count) Fmt.int;
+          field "representative" (fun t -> List.rev t.representative) pp_path;
+        ]
+  end
+
+  type t = {
+    visited : (S.Hash.t, Metrics.node) Hashtbl.t;
+    mutable max_width : Metrics.max;
+    mutable max_mp : int;
+    mutable max_length : int;
+  }
+
+  let v () =
+    let visited = Hashtbl.create 100 in
+    let max_width = Metrics.empty_max in
+    { visited; max_width; max_length = 0; max_mp = 0 }
+
+  let get t k =
+    try Hashtbl.find t.visited k with Not_found -> Metrics.empty_node
+
+  let visit_node t k preds ~nb_children ~width =
+    let preds =
+      List.map
+        (function None, x -> (Inode, x) | Some s, x -> (Node s, x))
+        preds
+    in
+    let stat_k = get t k in
+    let visit step pred =
+      let stat_pred = get t pred in
+      let nb_siblings = nb_children - 1 in
+      let stat_pred' = Metrics.update_node stat_k stat_pred step nb_siblings in
+      Hashtbl.replace t.visited pred stat_pred'
+    in
+    let () =
+      List.iter
+        (function
+          | Inode, `Inode x -> visit Inode x
+          | Node s, `Node x -> visit (Node s) x
+          | Node s, `Contents x -> visit (Node s) x
+          | _ -> assert false)
+        preds
+    in
+    (* Once we updated its preds we can remove the node from the
+       table. If its a max width, we update the max_width stats. *)
+    Hashtbl.remove t.visited k;
+    t.max_width <- Metrics.update_width stat_k width t.max_width
+
+  let visit_commit t root_node =
+    let stat = Metrics.empty_root_node in
+    Hashtbl.replace t.visited root_node stat
+
+  (* Update the max length and max_mp while traversing the contents. *)
+  let visit_contents t k =
+    let stat = get t k in
+    let max_length = Metrics.max_length stat in
+    if max_length > t.max_length then t.max_length <- max_length;
+    let maximum = Metrics.mp stat |> Metrics.maximum in
+    if maximum > t.max_mp then t.max_mp <- maximum
+
+  let pp_results ~dump_blob_paths_to t =
+    Log.app (fun l -> l "Max width = %a" Metrics.pp t.max_width);
+    let maximal_count, representative =
+      Hashtbl.fold
+        (fun _ (stat : Metrics.node) ((counter, _) as acc) ->
+          let maximum = Metrics.mp stat |> Metrics.maximum in
+          if maximum = t.max_mp then
+            let maximal_count = Metrics.mp stat |> Metrics.maximal_count in
+            let counter' = counter + maximal_count in
+            let repr = Metrics.mp stat |> Metrics.representative in
+            (counter', repr)
+          else acc)
+        t.visited (0, [])
+    in
+    let max_mp =
+      Metrics.v ~maximal_count ~representative ~maximum:t.max_mp ()
+    in
+    Log.app (fun l ->
+        l "Max number of path-adjacent nodes = %a" Metrics.pp max_mp);
+    (* Count all paths that have max length. *)
+    let maximal_count, representative =
+      Hashtbl.fold
+        (fun _ (stat : Metrics.node) acc ->
+          if Metrics.max_length stat = t.max_length then
+            List.fold_left
+              (fun ((counter, _) as acc) l ->
+                if List.length l = t.max_length then (counter + 1, l) else acc)
+              acc (Metrics.all_paths stat)
+          else acc)
+        t.visited (0, [])
+    in
+    let max_length =
+      Metrics.v ~maximal_count ~representative ~maximum:t.max_length ()
+    in
+    Log.app (fun l -> l "Max length = %a" Metrics.pp max_length);
+    match dump_blob_paths_to with
+    | None -> ()
+    | Some filename ->
+        let chan = open_out filename in
+        let fmt = Format.formatter_of_out_channel chan in
+        Hashtbl.iter (fun _ stats -> Metrics.pp_all_paths fmt stats) t.visited;
+        Fmt.flush fmt ();
+        close_out chan
 end

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -19,7 +19,11 @@ open! Import
 module type Value = sig
   include Irmin.Node.S
 
-  val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
+  val pred :
+    t ->
+    (step option * [ `Node of hash | `Inode of hash | `Contents of hash ]) list
+
+  val nb_children : t -> int
 end
 
 module type S = sig

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -502,7 +502,8 @@ module Maker' (Config : Conf.Pack.S) (Schema : Irmin.Schema.S) = struct
       | None -> []
       | Some v ->
           List.rev_map
-            (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
+            (function
+              | _, `Inode x -> `Node x | _, ((`Node _ | `Contents _) as x) -> x)
             (X.Node.CA.Val.pred v)
 
     let always_false _ = false

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -154,5 +154,6 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
     let flush = X.Repo.flush
     let integrity_check ?ppf:_ ~auto_repair:_ _t = Ok `No_error
     let traverse_pack_file _ _ = ()
+    let stats ~dump_blob_paths_to:_ ~commit:_ _ = Lwt.return_unit
   end
 end

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -84,6 +84,9 @@ module type S = sig
     | `Check_and_fix_index ] ->
     Irmin.config ->
     unit
+
+  val stats :
+    dump_blob_paths_to:string option -> commit:commit -> repo -> unit Lwt.t
 end
 
 module S_is_a_store (X : S) : Irmin.S = X

--- a/src/irmin/object_graph_intf.ml
+++ b/src/irmin/object_graph_intf.ml
@@ -81,9 +81,9 @@ module type S = sig
     node:(vertex -> unit Lwt.t) ->
     unit ->
     unit Lwt.t
-  (** [breadth_first_traversal ?cache_size pred max node ()] traverses the graph
-      in breadth-first order over the closure graph starting with the [max]
-      nodes. It applies [node] on the nodes of the graph while traversing it. *)
+  (** [breadth_first_traversal ?cache_size pred max node ()] traverses the
+      closure graph in breadth-first order starting with the [max] nodes. It
+      applies [node] on the nodes of the graph while traversing it. *)
 
   val output :
     Format.formatter ->

--- a/src/irmin/object_graph_intf.ml
+++ b/src/irmin/object_graph_intf.ml
@@ -74,6 +74,17 @@ module type S = sig
       seen. If [None] (by default) every traversed nodes is stored (and thus no
       entries are never removed from the LRU). *)
 
+  val breadth_first_traversal :
+    ?cache_size:int ->
+    pred:(vertex -> vertex list Lwt.t) ->
+    max:vertex list ->
+    node:(vertex -> unit Lwt.t) ->
+    unit ->
+    unit Lwt.t
+  (** [breadth_first_traversal ?cache_size pred max node ()] traverses the graph
+      in breadth-first order over the closure graph starting with the [max]
+      nodes. It applies [node] on the nodes of the graph while traversing it. *)
+
   val output :
     Format.formatter ->
     (vertex * Graph.Graphviz.DotAttributes.vertex list) list ->

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -368,6 +368,25 @@ module Make (P : Private.S) = struct
         | `Branch x -> pred_branch t x
       in
       Graph.iter ?cache_size ~pred ~min ~max ~node ?edge ~skip ~rev ()
+
+    let breadth_first_traversal ?cache_size ~max ?(branch = ignore_lwt)
+        ?(commit = ignore_lwt) ?(node = ignore_lwt) ?(contents = ignore_lwt)
+        ?(pred_branch = default_pred_branch)
+        ?(pred_commit = default_pred_commit) ?(pred_node = default_pred_node)
+        ?(pred_contents = default_pred_contents) t =
+      let node = function
+        | `Commit x -> commit x
+        | `Node x -> node x
+        | `Contents x -> contents x
+        | `Branch x -> branch x
+      in
+      let pred = function
+        | `Commit x -> pred_commit t x
+        | `Node x -> pred_node t x
+        | `Contents x -> pred_contents t x
+        | `Branch x -> pred_branch t x
+      in
+      Graph.breadth_first_traversal ?cache_size ~pred ~max ~node ()
   end
 
   type t = {

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -197,6 +197,20 @@ module type S = sig
         {!Repo.iter}. When [cache_size] is [None] (the default), no entries is
         ever evicted from the cache; hence every object is only traversed once,
         at the cost of having to store all the traversed objects in memory. *)
+
+    val breadth_first_traversal :
+      ?cache_size:int ->
+      max:elt list ->
+      ?branch:(branch -> unit Lwt.t) ->
+      ?commit:(hash -> unit Lwt.t) ->
+      ?node:(hash -> unit Lwt.t) ->
+      ?contents:(hash -> unit Lwt.t) ->
+      ?pred_branch:(t -> branch -> elt list Lwt.t) ->
+      ?pred_commit:(t -> hash -> elt list Lwt.t) ->
+      ?pred_node:(t -> hash -> elt list Lwt.t) ->
+      ?pred_contents:(t -> hash -> elt list Lwt.t) ->
+      t ->
+      unit Lwt.t
   end
 
   val empty : repo -> t Lwt.t

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -16,45 +16,89 @@
 
 open Lwt.Syntax
 
-let data_dir = "data/layered_pack_upper"
-
-let rm_dir () =
+let rm_dir data_dir =
   if Sys.file_exists data_dir then (
     let cmd = Printf.sprintf "rm -rf %s" data_dir in
     Fmt.epr "exec: %s\n%!" cmd;
     let _ = Sys.command cmd in
     ())
 
-module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+module Layered = struct
+  let data_dir = "data/layered_pack_upper"
+
+  module Conf = struct
+    let entries = 32
+    let stable_hash = 256
+  end
+
+  module Schema = Irmin.Schema.KV (Irmin.Contents.String)
+
+  module Store = struct
+    open Irmin_pack_layered.Maker (Conf)
+    include Make (Schema)
+  end
+
+  let config root =
+    let conf = Irmin_pack.config ~readonly:false ~fresh:true root in
+    Irmin_pack_layered.config ~with_lower:true conf
+
+  let info = Store.Info.empty
+
+  let create_store () =
+    rm_dir data_dir;
+    let* repo = Store.Repo.v (config data_dir) in
+    let* _t = Store.master repo in
+    let* tree = Store.Tree.add Store.Tree.empty [ "a"; "b"; "c" ] "x1" in
+    let* c = Store.Commit.v repo ~info ~parents:[] tree in
+    let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
+    let* () = Store.Private_layer.wait_for_freeze repo in
+    let* tree = Store.Tree.add tree [ "a"; "b"; "d" ] "x2" in
+    let hash = Store.Commit.hash c in
+    let* c3 = Store.Commit.v repo ~info ~parents:[ hash ] tree in
+    let* () = Store.Branch.set repo "master" c3 in
+    Store.Repo.close repo
 end
 
-module Schema = Irmin.Schema.KV (Irmin.Contents.String)
+module Simple = struct
+  let data_dir = "data/pack"
 
-module Store = struct
-  open Irmin_pack_layered.Maker (Conf)
-  include Make (Schema)
+  module Conf = struct
+    let entries = 2
+    let stable_hash = 3
+  end
+
+  module Schema = Irmin.Schema.KV (Irmin.Contents.String)
+
+  module Store = struct
+    open Irmin_pack.V2 (Conf)
+    include Make (Schema)
+  end
+
+  let config root = Irmin_pack.config ~readonly:false ~fresh:true root
+  let info = Store.Info.empty
+
+  let create_store () =
+    rm_dir data_dir;
+    let* rw = Store.Repo.v (config data_dir) in
+    let* tree =
+      Store.Tree.add Store.Tree.empty [ "a"; "b1"; "c1"; "d1"; "e1" ] "x1"
+    in
+    let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d2"; "e2" ] "x2" in
+    let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d3"; "e3" ] "x2" in
+    let* tree = Store.Tree.add tree [ "a"; "b2"; "c2"; "e3" ] "x2" in
+    let* c1 = Store.Commit.v rw ~parents:[] ~info tree in
+
+    let* tree = Store.Tree.add tree [ "a"; "b3" ] "x3" in
+    let* c2 = Store.Commit.v rw ~parents:[ Store.Commit.hash c1 ] ~info tree in
+
+    let* tree = Store.Tree.remove tree [ "a"; "b1"; "c1" ] in
+    let* _ = Store.Commit.v rw ~parents:[ Store.Commit.hash c2 ] ~info tree in
+
+    Store.Repo.close rw
 end
 
-let config root =
-  let conf = Irmin_pack.config ~readonly:false ~fresh:true root in
-  Irmin_pack_layered.config ~with_lower:true conf
+let generate () =
+  let* () = Layered.create_store () in
+  Simple.create_store ()
 
-let info = Store.Info.empty
-
-let create_store () =
-  rm_dir ();
-  let* repo = Store.Repo.v (config data_dir) in
-  let* _t = Store.master repo in
-  let* tree = Store.Tree.add Store.Tree.empty [ "a"; "b"; "c" ] "x1" in
-  let* c = Store.Commit.v repo ~info ~parents:[] tree in
-  let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
-  let* () = Store.Private_layer.wait_for_freeze repo in
-  let* tree = Store.Tree.add tree [ "a"; "b"; "d" ] "x2" in
-  let hash = Store.Commit.hash c in
-  let* c3 = Store.Commit.v repo ~info ~parents:[ hash ] tree in
-  let* () = Store.Branch.set repo "master" c3 in
-  Store.Repo.close repo
-
-let () = Lwt_main.run (create_store ())
+let () = Lwt_main.run (generate ())

--- a/test/irmin-pack/cli/irmin-fsck-help.txt
+++ b/test/irmin-pack/cli/irmin-fsck-help.txt
@@ -20,6 +20,11 @@ COMMANDS
        stat
            Print high-level statistics about the store.
 
+       stat-store
+           Traverse one commit, specified with the --commit argument, in the
+           store for stats. If no commit is specified the current head is
+           used.
+
 OPTIONS
        --help[=FMT] (default=auto)
            Show this help in format FMT. The value FMT must be one of `auto',

--- a/test/irmin-pack/cli/stat.t/run.t
+++ b/test/irmin-pack/cli/stat.t/run.t
@@ -114,3 +114,38 @@ Running check on a layered store that is not self contained
 
   $ PACK=layered ../irmin_fsck.exe check ../data/layered_pack_upper
   Error -- Upper layer is not self contained for heads 6a88b83f76c48b1b20a0d421c73de6e0e0e42553d44a40fccc07af074f304e0d9f10a7b5ab47b61205da0f2f599d2ebb1bf27452c05b926b0c7ef8f867778130: 2 phantom objects detected
+
+Traverse store for stats
+
+  $ PACK_LAYERED=false ../irmin_fsck.exe stat-store --commit=cb71b759dd9007c31f6d950122ec14d89519e965e8d68af5f4e73c1f348d97bc24dfe5127ed01dbdb5f54105e4e4548948925f423d809aea85b6d130d68d413f ../data/pack
+  >> Max width = { "maximum" = 3;
+                   "maximal_count" = 1;
+                   "representative" = a/b1/c1 }
+  >> Max number of path-adjacent nodes = { "maximum" = 3;
+                                           "maximal_count" = 2;
+                                           "representative" = a/b1/c1/-/d2/e2 }
+  >> Max length = { "maximum" = 5;
+                    "maximal_count" = 3;
+                    "representative" = a/b1/c1/d1/e1 }
+
+  $ PACK_LAYERED=false ../irmin_fsck.exe stat-store --commit=9ed4837f71df8bfd3d7b724451986698fd8ac48bf01c79df1d383ea9e041fe86fce66d1ba3e228b69b085f5b17c5f42491e22f52e08a20912c70e9d0a679cfa4 ../data/pack
+  >> Max width = { "maximum" = 3;
+                   "maximal_count" = 2;
+                   "representative" = a }
+  >> Max number of path-adjacent nodes = { "maximum" = 3;
+                                           "maximal_count" = 2;
+                                           "representative" = a/-/b1/c1/-/d2/e2 }
+  >> Max length = { "maximum" = 5;
+                    "maximal_count" = 3;
+                    "representative" = a/b1/c1/d1/e1 }
+
+  $ PACK_LAYERED=false ../irmin_fsck.exe stat-store --commit=04bc4d901a43c2efb65ddb0097a483e10acb1769f525d19e33f46cb33f6d85708c58216adc7d385152b5f6567523d0d869555d30804a37d6035607a3c938177a ../data/pack
+  >> Max width = { "maximum" = 2;
+                   "maximal_count" = 1;
+                   "representative" = a }
+  >> Max number of path-adjacent nodes = { "maximum" = 1;
+                                           "maximal_count" = 2;
+                                           "representative" = a/b2/c2/e3 }
+  >> Max length = { "maximum" = 4;
+                    "maximal_count" = 1;
+                    "representative" = a/b2/c2/e3 }

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -435,8 +435,9 @@ let test_intermediate_inode_as_root () =
   let* h_depth0 = Inode.batch t.store @@ fun store -> Inode.add store v0 in
   let (`Inode h_depth1) =
     match Inode.Val.pred v0 with
-    | [ (`Inode _ as pred) ] -> pred
+    | [ (_, (`Inode _ as pred)) ] -> pred
     | l ->
+        let l = List.map snd l in
         Alcotest.failf
           "Expected one `Inode predecessors, got [%a], a list of length %d."
           Fmt.(list ~sep:(any " ; ") pp_pred)


### PR DESCRIPTION
Added a new subcommand in irmin-fsck which traverses the graph under one commit and reports: the longest paths, the widest nodes, and the "biggest" Merklee proof = the chain from root to leaf that stores the most hashes, where for each node we store its siblings. For the first two, we need to visit all nodes, but for the MP we need to visit all inodes as well. I think this is what we want to compare inode configurations, let me know if I got it wrong. 
  
It also prints all paths in a separate file. It's still draft because I'm not sure how we want to print/report these.  
