### PR TITLE
do not use gettimeofday in the test/benchs

### DIFF
--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -16,6 +16,8 @@
 
 open Irmin.Export_for_backends
 
+let now_s () = Mtime.Span.to_s (Mtime_clock.elapsed ())
+
 let reporter ?(prefix = "") () =
   let report src level ~over k msgf =
     let k _ =
@@ -24,7 +26,7 @@ let reporter ?(prefix = "") () =
     in
     let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
     let with_stamp h _tags k fmt =
-      let dt = Unix.gettimeofday () in
+      let dt = now_s () in
       Fmt.kpf k ppf
         ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
         prefix dt Logs_fmt.pp_header (level, h)
@@ -90,7 +92,7 @@ module Conf = struct
 end
 
 let info () =
-  let date = Int64.of_float (Unix.gettimeofday ()) in
+  let date = 0L in
   let author = Printf.sprintf "TESTS" in
   Irmin.Info.v ~date ~author "commit "
 
@@ -112,7 +114,7 @@ module FSHelper = struct
   let get_size root = size root
 
   let print_size_layers root =
-    let dt = Unix.gettimeofday () in
+    let dt = now_s () in
     let upper1 = Filename.concat root "upper1" in
     let upper0 = Filename.concat root "upper0" in
     let lower = Filename.concat root "lower" in

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -16,4 +16,4 @@
  (public_name irmin-test.bench)
  (modules Irmin_bench Rusage)
  (libraries fmt.tty fmt.cli cmdliner irmin logs.fmt logs.cli lwt lwt.unix
-   metrics metrics-unix))
+   metrics metrics-unix irmin-test))

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -16,6 +16,7 @@
  *)
 
 open Irmin.Export_for_backends
+open Irmin_test.Common
 
 type t = {
   root : string;
@@ -41,41 +42,6 @@ let src =
       ]
   in
   Src.v "bench" ~tags ~data
-
-(* logs *)
-
-let ignore_srcs src =
-  List.mem (Logs.Src.name src)
-    [
-      "git.inflater.decoder";
-      "git.deflater.encoder";
-      "git.encoder";
-      "git.decoder";
-      "git.loose";
-      "git.store";
-      "cohttp.lwt.io";
-    ]
-
-let reporter ?(prefix = "") () =
-  let report src level ~over k msgf =
-    let k _ =
-      over ();
-      k ()
-    in
-    let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
-    let with_stamp h _tags k fmt =
-      let dt = Unix.gettimeofday () in
-      Fmt.kpf k ppf
-        ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
-        prefix dt
-        Fmt.(styled `Magenta string)
-        (Logs.Src.name src) Logs_fmt.pp_header (level, h)
-    in
-    msgf @@ fun ?header ?tags fmt ->
-    if ignore_srcs src then Format.ikfprintf k ppf fmt
-    else with_stamp header tags k fmt
-  in
-  { Logs.report }
 
 (* cli *)
 

--- a/src/irmin-test/irmin_test.ml
+++ b/src/irmin-test/irmin_test.ml
@@ -16,3 +16,4 @@
 
 include Common
 module Store = Store
+module Common = Common

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -60,3 +60,5 @@ module Store : sig
     (Alcotest.speed_level * t) list ->
     unit
 end
+
+module Common = Common


### PR DESCRIPTION
Removing them from tests to make them reproducible
Changing them to mtime in benchmakrs to make them more precise