### PR TITLE
irmin-pack: fix merge blocking issue with batches

### DIFF
--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -127,7 +127,7 @@ struct
       else false
 
     let flush ?(index = true) ?(index_merge = false) t =
-      if index_merge then Index.try_merge t.pack.index;
+      if index_merge then Index.merge t.pack.index;
       Dict.flush t.pack.dict;
       IO.flush t.pack.block;
       if index then Index.flush ~no_callback:() t.pack.index;
@@ -241,7 +241,7 @@ struct
       let* r = f (cast t) in
       if Tbl.length t.staging = 0 then Lwt.return r
       else (
-        flush ~index_merge:true t;
+        flush t;
         Lwt.return r)
 
     let auto_flush = 1024
@@ -270,11 +270,11 @@ struct
 
     let add t v =
       let k = V.hash v in
-      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
+      unsafe_append ~ensure_unique:true ~overcommit:false t k v;
       Lwt.return k
 
     let unsafe_add t k v =
-      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
+      unsafe_append ~ensure_unique:true ~overcommit:false t k v;
       Lwt.return ()
 
     let unsafe_close t =


### PR DESCRIPTION
This reverts commit 587e219351e9a147cb7e3cea281ab025b61098c2.

The implementation of `Index.try_merge` is broken: it will attempt a merge even when one is already running. As a result, whenever a batch was completed, the main thread blocked on the completion of an ongoing merge. This restores the old behaviour until a fix can be written and tested in Index.