### PR TITLE
Prepare 2.6.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 2.6.0 (2021-04-13)
 
+** Note: this release is based on 2.5.3, and does not contain 2.5.4. **
+
 ### Fixed
 
 - **irmin**
@@ -17,6 +19,27 @@
 
 - **irmin-git**
   - Upgrade `irmin-git` with `git.3.4.0`. (#1392, @dinosaure)
+
+## 2.5.4 (2021-04-29)
+
+### Fixed
+
+- **irmin-pack**
+  - Revert a patch introduced in 2.3.0 which was calling `Index.try_merge`.
+    This function was supposed to hint index to schedule merges after
+    every commit. However, `Index.try_merge` is buggy and stacks merges
+    which causes the node to block and wait for any existing merge to
+    complete. We will revisit that feature in future once we fix
+    `Index.try_merge` (#1409, @CraigFe)
+
+- **irmin**
+  - Fix peformance issue in `Tree.update_tree` and `Tree.add_tree` for
+    large directories (#1315, @Ngoguey42)
+
+### Added
+
+- **irmin-pack**
+  - Expose internal inode trees (#1273, @mattiasdrp, @samoht)
 
 ## 2.5.3 (2021-04-13)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
+## 2.6.1 (2021-04-29)
+
+This release contains 2.6.0 plus the changes described in 2.5.4.
+
 ## 2.6.0 (2021-04-13)
 
-** Note: this release is based on 2.5.3, and does not contain 2.5.4. **
+** Note: this release is based on 2.5.3, and does not contain 2.5.4. Use 2.6.1
+for access to those changes. **
 
 ### Fixed
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -262,6 +262,7 @@ struct
 
       let remove t step = G.Value.Tree.remove ~name:(of_step step) t
       let is_empty = G.Value.Tree.is_empty
+      let length t = G.Value.Tree.length t |> Int64.to_int
 
       let add t name value =
         let name = of_step name in

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -405,9 +405,11 @@ struct
               v :: acc)
             l []
 
-    let length t =
-      match t.v with Values vs -> StepMap.cardinal vs | Tree vs -> vs.length
+    let length_of_v = function
+      | Values vs -> StepMap.cardinal vs
+      | Tree vs -> vs.length
 
+    let length t = length_of_v t.v
     let stable t = t.stable
 
     type acc = {
@@ -420,7 +422,7 @@ struct
 
     let rec list_entry layout ~offset ~length acc = function
       | None -> acc
-      | Some i -> list_values layout ~offset ~length acc (Ptr.target layout i)
+      | Some i -> list_values layout ~offset ~length acc (Ptr.target layout i).v
 
     and list_tree layout ~offset ~length acc t =
       if acc.remaining <= 0 || offset + length <= acc.cursor then acc
@@ -428,10 +430,10 @@ struct
         { acc with cursor = t.length + acc.cursor }
       else Array.fold_left (list_entry layout ~offset ~length) acc t.entries
 
-    and list_values layout ~offset ~length acc t =
+    and list_values layout ~offset ~length acc v =
       if acc.remaining <= 0 || offset + length <= acc.cursor then acc
       else
-        match t.v with
+        match v with
         | Values vs ->
             let len = StepMap.cardinal vs in
             if acc.cursor + len < offset then
@@ -451,17 +453,19 @@ struct
               }
         | Tree t -> list_tree layout ~offset ~length acc t
 
-    let list layout ?(offset = 0) ?length t =
+    let list_v layout ?(offset = 0) ?length v =
       let length =
         match length with
         | Some n -> n
         | None -> (
-            match t.v with
+            match v with
             | Values vs -> StepMap.cardinal vs - offset
             | Tree i -> i.length - offset)
       in
-      let entries = list_values layout ~offset ~length (empty_acc length) t in
+      let entries = list_values layout ~offset ~length (empty_acc length) v in
       List.concat (List.rev entries.values)
+
+    let list layout ?offset ?length t = list_v layout ?offset ?length t.v
 
     let to_bin_v layout = function
       | Values vs ->
@@ -484,6 +488,174 @@ struct
     let to_bin layout t =
       let v = to_bin_v layout t.v in
       Bin.v ~stable:t.stable ~hash:t.hash v
+
+    module Concrete = struct
+      type kind = Contents | Contents_x of metadata | Node [@@deriving irmin]
+      type entry = { name : step; kind : kind; hash : hash } [@@deriving irmin]
+
+      type 'a pointer = { index : int; pointer : hash; tree : 'a }
+      [@@deriving irmin]
+
+      type 'a tree = { depth : int; length : int; pointers : 'a pointer list }
+      [@@deriving irmin]
+
+      type t = Tree of t tree | Value of entry list [@@deriving irmin]
+
+      let metadata_equal = Irmin.Type.(unstage (equal metadata_t))
+
+      let to_entry (name, v) =
+        match v with
+        | `Contents (hash, m) ->
+            if metadata_equal m Node.default then
+              { name; kind = Contents; hash }
+            else { name; kind = Contents_x m; hash }
+        | `Node hash -> { name; kind = Node; hash }
+
+      let of_entry e =
+        ( e.name,
+          match e.kind with
+          | Contents -> `Contents (e.hash, Node.default)
+          | Contents_x m -> `Contents (e.hash, m)
+          | Node -> `Node e.hash )
+
+      type error =
+        [ `Invalid_hash of hash * hash * t
+        | `Invalid_depth of int * int * t
+        | `Invalid_length of int * int * t
+        | `Duplicated_entries of t
+        | `Duplicated_pointers of t
+        | `Unsorted_entries of t
+        | `Unsorted_pointers of t
+        | `Empty ]
+      [@@deriving irmin]
+
+      let rec length = function
+        | Value l -> List.length l
+        | Tree t ->
+            List.fold_left (fun acc p -> acc + length p.tree) 0 t.pointers
+
+      let pp = Irmin.Type.pp_json t
+
+      let pp_error ppf = function
+        | `Invalid_hash (got, expected, t) ->
+            Fmt.pf ppf "invalid hash for %a@,got: %a@,expecting: %a" pp t
+              pp_hash got pp_hash expected
+        | `Invalid_depth (got, expected, t) ->
+            Fmt.pf ppf "invalid depth for %a@,got: %d@,expecting: %d" pp t got
+              expected
+        | `Invalid_length (got, expected, t) ->
+            Fmt.pf ppf "invalid length for %a@,got: %d@,expecting: %d" pp t got
+              expected
+        | `Duplicated_entries t -> Fmt.pf ppf "duplicated entries: %a" pp t
+        | `Duplicated_pointers t -> Fmt.pf ppf "duplicated pointers: %a" pp t
+        | `Unsorted_entries t -> Fmt.pf ppf "entries should be sorted: %a" pp t
+        | `Unsorted_pointers t ->
+            Fmt.pf ppf "pointers should be sorted: %a" pp t
+        | `Empty -> Fmt.pf ppf "concrete subtrees cannot be empty"
+    end
+
+    let to_concrete (la : 'ptr layout) (t : 'ptr t) =
+      let rec aux t =
+        match t.v with
+        | Tree tr ->
+            ( Lazy.force t.hash,
+              Concrete.Tree
+                {
+                  depth = tr.depth;
+                  length = tr.length;
+                  pointers =
+                    Array.fold_left
+                      (fun (i, acc) e ->
+                        match e with
+                        | None -> (i + 1, acc)
+                        | Some t ->
+                            let pointer, tree = aux (Ptr.target la t) in
+                            (i + 1, { Concrete.index = i; tree; pointer } :: acc))
+                      (0, []) tr.entries
+                    |> snd
+                    |> List.rev;
+                } )
+        | Values l ->
+            ( Lazy.force t.hash,
+              Concrete.Value (List.map Concrete.to_entry (StepMap.bindings l))
+            )
+      in
+      snd (aux t)
+
+    exception Invalid_hash of hash * hash * Concrete.t
+    exception Invalid_depth of int * int * Concrete.t
+    exception Invalid_length of int * int * Concrete.t
+    exception Empty
+    exception Duplicated_entries of Concrete.t
+    exception Duplicated_pointers of Concrete.t
+    exception Unsorted_entries of Concrete.t
+    exception Unsorted_pointers of Concrete.t
+
+    let hash_equal = Irmin.Type.(unstage (equal hash_t))
+
+    let of_concrete_exn t =
+      let sort_entries =
+        List.sort_uniq (fun x y -> compare x.Concrete.name y.Concrete.name)
+      in
+      let sort_pointers =
+        List.sort_uniq (fun x y -> compare x.Concrete.index y.Concrete.index)
+      in
+      let check_entries t es =
+        if es = [] then raise Empty;
+        let s = sort_entries es in
+        if List.length s <> List.length es then raise (Duplicated_entries t);
+        if s <> es then raise (Unsorted_entries t)
+      in
+      let check_pointers t ps =
+        if ps = [] then raise Empty;
+        let s = sort_pointers ps in
+        if List.length s <> List.length ps then raise (Duplicated_pointers t);
+        if s <> ps then raise (Unsorted_pointers t)
+      in
+      let hash v = Bin.V.hash (to_bin_v Total v) in
+      let rec aux depth t =
+        match t with
+        | Concrete.Value l ->
+            check_entries t l;
+            Values (StepMap.of_list (List.map Concrete.of_entry l))
+        | Concrete.Tree tr ->
+            let entries = Array.make Conf.entries None in
+            check_pointers t tr.pointers;
+            List.iter
+              (fun { Concrete.index; pointer; tree } ->
+                let v = aux (depth + 1) tree in
+                let hash = hash v in
+                if not (hash_equal hash pointer) then
+                  raise (Invalid_hash (hash, pointer, t));
+                let t = { hash = lazy pointer; stable = false; v } in
+                entries.(index) <- Some (Ptr.of_target Total t))
+              tr.pointers;
+            let length = Concrete.length t in
+            if depth <> tr.depth then raise (Invalid_depth (depth, tr.depth, t));
+            if length <> tr.length then
+              raise (Invalid_length (length, tr.length, t));
+            Tree { depth = tr.depth; length = tr.length; entries }
+      in
+      let v = aux 0 t in
+      let length = length_of_v v in
+      let stable, hash =
+        if length > Conf.stable_hash then (false, hash v)
+        else
+          let node = Node.v (list_v Total v) in
+          (true, Node.hash node)
+      in
+      { hash = lazy hash; stable; v }
+
+    let of_concrete t =
+      try Ok (of_concrete_exn t) with
+      | Invalid_hash (x, y, z) -> Error (`Invalid_hash (x, y, z))
+      | Invalid_depth (x, y, z) -> Error (`Invalid_depth (x, y, z))
+      | Invalid_length (x, y, z) -> Error (`Invalid_length (x, y, z))
+      | Empty -> Error `Empty
+      | Duplicated_entries t -> Error (`Duplicated_entries t)
+      | Duplicated_pointers t -> Error (`Duplicated_pointers t)
+      | Unsorted_entries t -> Error (`Unsorted_entries t)
+      | Unsorted_pointers t -> Error (`Unsorted_pointers t)
 
     let hash t = Lazy.force t.hash
 
@@ -925,6 +1097,13 @@ struct
         check_stable () && not (contains_empty_map_non_root ())
       in
       apply t { f }
+
+    module Concrete = I.Concrete
+
+    let to_concrete t = apply t { f = (fun la v -> I.to_concrete la v) }
+
+    let of_concrete t =
+      match I.of_concrete t with Ok t -> Ok (Total t) | Error _ as e -> e
   end
 end
 

--- a/src/irmin-pack/pack.ml
+++ b/src/irmin-pack/pack.ml
@@ -127,7 +127,7 @@ struct
       else false
 
     let flush ?(index = true) ?(index_merge = false) t =
-      if index_merge then Index.try_merge t.pack.index;
+      if index_merge then Index.merge t.pack.index;
       Dict.flush t.pack.dict;
       IO.flush t.pack.block;
       if index then Index.flush ~no_callback:() t.pack.index;
@@ -241,7 +241,7 @@ struct
       let* r = f (cast t) in
       if Tbl.length t.staging = 0 then Lwt.return r
       else (
-        flush ~index_merge:true t;
+        flush t;
         Lwt.return r)
 
     let auto_flush = 1024
@@ -270,11 +270,11 @@ struct
 
     let add t v =
       let k = V.hash v in
-      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
+      unsafe_append ~ensure_unique:true ~overcommit:false t k v;
       Lwt.return k
 
     let unsafe_add t k v =
-      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
+      unsafe_append ~ensure_unique:true ~overcommit:false t k v;
       Lwt.return ()
 
     let unsafe_close t =

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -114,6 +114,7 @@ struct
 
   let empty = StepMap.empty
   let is_empty e = StepMap.is_empty e
+  let length e = StepMap.cardinal e
 
   let add t k v =
     let e = to_entry (k, v) in
@@ -427,6 +428,7 @@ module V1 (N : S with type step = string) = struct
 
   let empty = { n = N.empty; entries = [] }
   let is_empty t = t.entries = []
+  let length e = N.length e.n
   let default = N.default
   let find t k = N.find t.n k
 

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -50,6 +50,9 @@ module type S = sig
   val is_empty : t -> bool
   (** [is_empty t] is true iff [t] is {!empty}. *)
 
+  val length : t -> int
+  (** [length t] is the number of entries in [t]. *)
+
   val find : t -> step -> value option
   (** [find t s] is the value associated with [s] in [t].
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -649,13 +649,13 @@ module Make (P : Private.S) = struct
         else
           let remove_count = StepMap.cardinal um in
           if (not val_is_empty) && remove_count = 0 then false
+          else if P.Node.Val.length v > remove_count then false
           else (
             (* Starting from this point the function is expensive, but there is
                no alternative. *)
             cnt.node_val_list <- cnt.node_val_list + 1;
             let entries = P.Node.Val.list v in
-            if List.is_longer_than remove_count entries then false
-            else List.for_all (fun (step, _) -> StepMap.mem step um) entries)
+            List.for_all (fun (step, _) -> StepMap.mem step um) entries)
 
     let is_empty =
       let empty_hash = hash (of_map StepMap.empty) in

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -52,6 +52,7 @@ module H_contents =
     end)
 
 let normal x = `Contents (x, Metadata.default)
+let node x = `Node x
 let foo = H_contents.hash "foo"
 let bar = H_contents.hash "bar"
 let check_hash = Alcotest.check_repr Inode.Val.hash_t
@@ -398,6 +399,39 @@ let test_truncated_inodes () =
   (iter_steps_with_failure @@ fun step -> Inode.Val.remove v3 step);
   Lwt.return_unit
 
+let test_concrete_inodes () =
+  rm_dir root;
+  let* t = Context.get_store () in
+  let pp_concrete = Irmin.Type.pp_json ~minify:false Inter.Val.Concrete.t in
+  let result_t = Irmin.Type.result Inode.Val.t Inter.Val.Concrete.error_t in
+  let testable =
+    Alcotest.testable
+      (Irmin.Type.pp_json ~minify:false result_t)
+      Irmin.Type.(unstage (equal result_t))
+  in
+  let check v =
+    let len = Inter.Val.length v in
+    integrity_check ~stable:(len <= Conf.stable_hash) v;
+    let c = Inter.Val.to_concrete v in
+    let r = Inter.Val.of_concrete c in
+    let msg = Fmt.str "%a" pp_concrete c in
+    Alcotest.check testable msg (Ok v) r
+  in
+  let v = Inode.Val.v [ ("a", normal foo) ] in
+  check v;
+  let v = Inode.Val.v [ ("a", normal foo); ("y", node bar) ] in
+  check v;
+  let v = Inode.Val.v [ ("x", node foo); ("a", normal foo); ("y", node bar) ] in
+  check v;
+  let v =
+    Inode.Val.v
+      [
+        ("x", normal foo); ("z", normal foo); ("a", normal foo); ("y", node bar);
+      ]
+  in
+  check v;
+  Context.close t
+
 let tests =
   [
     Alcotest.test_case "add values" `Quick (fun () ->
@@ -408,6 +442,8 @@ let tests =
         Lwt_main.run (test_remove_values ()));
     Alcotest.test_case "remove inodes" `Quick (fun () ->
         Lwt_main.run (test_remove_inodes ()));
+    Alcotest.test_case "test concrete inodes" `Quick (fun () ->
+        Lwt_main.run (test_concrete_inodes ()));
     Alcotest.test_case "test representation uniqueness" `Quick (fun () ->
         Lwt_main.run (test_representation_uniqueness_maxdepth_3 ()));
     Alcotest.test_case "test truncated inodes" `Quick (fun () ->


### PR DESCRIPTION
The UI does a poor job of rendering it, but this is `2.6.1` = merge(`2.6.0`, `2.5.4`)

```
*  2.6.1
|\
* | 2.6.0
| * 2.5.4
|/
* 2.5.3
* 2.5.2
```

cc. @samoht