### PR TITLE
irmin-bench: CLI and PP for stat trace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)
   - New features in benchmarks for tree operations (#1314, #1326, #1357,
-    #1358, #1367, #1384, #1403, #1404 @Ngoguey42)
+    #1358, #1367, #1384, #1403, #1404, #1416 @Ngoguey42)
   - Check hash of commit in benchmarks for trees (#1328, @icristescu)
 
 - **irmin**

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -17,11 +17,11 @@
 (library
  (name irmin_traces)
  (modules trace_common trace_definitions trace_collection trace_stat_summary
-   trace_stat_summary_conf trace_stat_summary_utils)
+   trace_stat_summary_conf trace_stat_summary_utils trace_stat_summary_pp)
  (preprocess
   (pps ppx_repr ppx_deriving.enum))
- (libraries irmin irmin-pack unix lwt repr ppx_repr bentov mtime
-   mtime.clock.os))
+ (libraries irmin irmin-pack unix lwt repr ppx_repr bentov mtime printbox
+   printbox.unicode mtime.clock.os))
 
 (executable
  (name tree)
@@ -32,10 +32,15 @@
    unix cmdliner logs memtrace repr ppx_repr bench_common tezos-context-hash
    irmin_traces))
 
+(executable
+ (name trace_stats)
+ (modules trace_stats)
+ (libraries cmdliner irmin_traces))
+
 ;; Require the executables to compile during tests
 
 (rule
  (alias runtest)
  (package irmin-bench)
- (deps main.exe layers.exe tree.exe)
+ (deps main.exe layers.exe tree.exe trace_stats.exe)
  (action (progn)))

--- a/bench/irmin-pack/trace_definitions.ml
+++ b/bench/irmin-pack/trace_definitions.ml
@@ -135,7 +135,7 @@ end
 
 (** Trace of a tezos node run, or a replay run.
 
-    May summarised to a JSON file.
+    May be summarised to a JSON file.
 
     {3 Implicitly Auto-Upgradable File Format}
 

--- a/bench/irmin-pack/trace_stat_summary_pp.ml
+++ b/bench/irmin-pack/trace_stat_summary_pp.ml
@@ -1,0 +1,537 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Pretty printing of one or more summaries.
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files.
+
+    This file contains A LOT of uninteresting boilerplate in order to build the
+    pretty-printable table. Doing this using pandas-like multi-level dataframes
+    would make the thing much more simpler. *)
+
+open Trace_stat_summary
+module Utils = Trace_stat_summary_utils
+module Summary = Trace_stat_summary
+
+module Pb = struct
+  include PrintBox
+
+  let () = PrintBox_unicode.setup ()
+
+  (* Some utilities to work with lists instead of array *)
+
+  let transpose_matrix l =
+    l
+    |> List.map Array.of_list
+    |> Array.of_list
+    |> PrintBox.transpose
+    |> Array.to_list
+    |> List.map Array.to_list
+
+  let matrix_to_text m = List.map (List.map PrintBox.text) m
+  let align_matrix where = List.map (List.map (PrintBox.align ~h:where ~v:`Top))
+
+  (** Dirty trick to only have vertical bars, and not the horizontal ones *)
+  let matrix_with_column_spacers =
+    let rec interleave sep = function
+      | ([ _ ] | []) as l -> l
+      | hd :: tl -> hd :: sep :: interleave sep tl
+    in
+    List.map (interleave (PrintBox.text " | "))
+end
+
+type summary = Summary.t
+
+type scalar_type = [ `R | `S | `P ]
+(** Real, Seconds, Percent *)
+
+type summary_floor =
+  [ `Spacer | `Data of scalar_type * string * (string * curve) list ]
+(** A [summary_floor] of tag [`Data] contains all the data necessary in order to
+    print a bunch of rows, 1 per summary, all displaying the same summary entry. *)
+
+let summary_config_entries =
+  [
+    `Hostname;
+    `Word_size;
+    `Timeofday;
+    `Inode_config;
+    `Store_type;
+    `Replay_path_conversion;
+  ]
+
+let name_of_summary_config_entry = function
+  | `Hostname -> "Hostname"
+  | `Word_size -> "Word Size"
+  | `Timeofday -> "Start Time"
+  | `Inode_config -> "Inode Config"
+  | `Store_type -> "Store Type"
+  | `Replay_path_conversion -> "Path Conversion"
+
+let cell_of_summary_config (s : summary) = function
+  | `Hostname -> s.hostname
+  | `Word_size -> Printf.sprintf "%d bits" s.word_size
+  | `Timeofday ->
+      let open Unix in
+      let t = gmtime s.timeofday in
+      Printf.sprintf "%04d/%02d/%02d %02d:%02d:%02d (GMT)" (1900 + t.tm_year)
+        (t.tm_mon + 1) t.tm_mday t.tm_hour t.tm_min t.tm_sec
+  | `Inode_config ->
+      let a, b, c = s.config.inode_config in
+      Printf.sprintf "mls:%d bf:%d sh:%d" a b c
+  | `Store_type -> (
+      match s.config.store_type with
+      | `Pack -> "pack"
+      | `Pack_layered -> "pack-layered")
+  | `Replay_path_conversion -> (
+      match s.config.setup with
+      | `Play _ -> "n/a"
+      | `Replay s -> (
+          match s.path_conversion with
+          | `None -> "none"
+          | `V1 -> "v1"
+          | `V0_and_v1 -> "v0+v1"
+          | `V0 -> "v0"))
+
+let box_of_summaries_config summary_names (summaries : summary list) =
+  let row0 =
+    if List.length summary_names = 1 then [] else [ "" :: summary_names ]
+  in
+  let rows =
+    List.map
+      (fun e ->
+        let n = name_of_summary_config_entry e in
+        let l = List.map (fun s -> cell_of_summary_config s e) summaries in
+        n :: l)
+      summary_config_entries
+  in
+  row0 @ rows |> Pb.matrix_to_text
+
+let sum_curves curves =
+  curves
+  |> Pb.transpose_matrix
+  |> List.map
+       (List.fold_left
+          (fun acc v -> if Float.is_nan v then acc else acc +. v)
+          0.)
+
+let div_curves a b = List.map2 ( /. ) a b
+let mul_curves a b = List.map2 ( *. ) a b
+
+let all_9_ops =
+  [ `Add; `Remove; `Find; `Mem; `Mem_tree; `Checkout; `Copy; `Commit; `Unseen ]
+
+let all_8_ops =
+  [ `Add; `Remove; `Find; `Mem; `Mem_tree; `Checkout; `Copy; `Commit ]
+
+let all_buildup_seen_ops =
+  [ `Add; `Remove; `Find; `Mem; `Mem_tree; `Checkout; `Copy ]
+
+let all_buildup_ro_ops = [ `Find; `Mem; `Mem_tree ]
+let all_buildup_rw_ops = [ `Add; `Remove; `Copy ]
+
+let floors_of_summaries : string list -> summary list -> summary_floor list =
+ fun summary_names summaries ->
+  (* Step 1/3 - Prepare the "/data/..." directories floors *)
+  let floor_per_node : summary_floor list =
+    List.map
+      (fun key ->
+        let path = List.assoc key Def.path_per_watched_node in
+        let name = Printf.sprintf "%s *S" path in
+        let curves =
+          List.map
+            (fun s ->
+              (Summary.Watched_node.Map.find key s.store.watched_nodes).value
+                .evolution)
+            summaries
+        in
+        let l = List.combine summary_names curves in
+        `Data (`R, name, l))
+      Def.watched_nodes
+  in
+
+  (* Step 2/3 - Prepare the functions to build all the simple floors *)
+  let zip : (summary -> curve) -> (string * curve) list =
+   fun curve_of_summary ->
+    List.map2
+      (fun sname s -> (sname, curve_of_summary s))
+      summary_names summaries
+  in
+  let zip_per_block_to_per_sec : (summary -> curve) -> (string * curve) list =
+    let sec_per_block =
+      List.map
+        (fun s ->
+          all_9_ops
+          |> List.map (fun op ->
+                 mul_curves Summary.(Op.Map.find op s.ops).duration.evolution
+                   Summary.(Op.Map.find op s.ops).count.evolution)
+          |> sum_curves)
+        summaries
+    in
+    fun curve_of_summary ->
+      List.map2
+        (fun (sname, sec_per_block) s ->
+          (sname, div_curves (curve_of_summary s) sec_per_block))
+        (List.combine summary_names sec_per_block)
+        summaries
+  in
+
+  let v : string -> (summary -> Summary.linear_bag_stat) -> summary_floor =
+   fun stat_name lbs_of_summary ->
+    let curves = zip (fun s -> (lbs_of_summary s).value.evolution) in
+    `Data (`R, stat_name, curves)
+  in
+  let pb : string -> (summary -> Summary.linear_bag_stat) -> summary_floor =
+   fun stat_name lbs_of_summary ->
+    let curves = zip (fun s -> (lbs_of_summary s).diff_per_block.evolution) in
+    `Data (`R, stat_name, curves)
+  in
+  let ps : string -> (summary -> Summary.linear_bag_stat) -> summary_floor =
+   fun stat_name lbs_of_summary ->
+    let curves =
+      zip_per_block_to_per_sec (fun s ->
+          (lbs_of_summary s).diff_per_block.evolution)
+    in
+    `Data (`R, stat_name, curves)
+  in
+
+  let op_count : string -> Op.Key.t -> summary_floor =
+   fun name op ->
+    let curves =
+      zip (fun s -> Summary.(Op.Map.find op s.ops).count.evolution)
+    in
+    `Data (`R, name, curves)
+  in
+  let op_duration : string -> Op.Key.t -> summary_floor =
+   fun name op ->
+    let curves =
+      zip (fun s -> Summary.(Op.Map.find op s.ops).duration.evolution)
+    in
+    `Data (`S, name, curves)
+  in
+  let op_every_sec : string -> Op.Key.t -> summary_floor =
+   fun name op ->
+    let curves =
+      zip_per_block_to_per_sec (fun s ->
+          Summary.(Op.Map.find op s.ops).count.evolution)
+    in
+    `Data (`R, name, curves)
+  in
+
+  let seen_duration =
+    zip (fun s ->
+        all_buildup_seen_ops
+        |> List.map (fun op ->
+               mul_curves Summary.(Op.Map.find op s.ops).duration.evolution
+                 Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+  let all_ops_cumu_count =
+    zip (fun s ->
+        all_8_ops
+        |> List.map (fun op ->
+               Summary.(Op.Map.find op s.ops).cumu_count.evolution)
+        |> sum_curves)
+  in
+  let ro_ops_per_sec =
+    zip_per_block_to_per_sec (fun s ->
+        all_buildup_ro_ops
+        |> List.map (fun op -> Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+  let rw_ops_per_sec =
+    zip_per_block_to_per_sec (fun s ->
+        all_buildup_rw_ops
+        |> List.map (fun op -> Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+  let sum_op_durations_per_block =
+    zip (fun s ->
+        all_9_ops
+        |> List.map (fun op ->
+               mul_curves Summary.(Op.Map.find op s.ops).duration.evolution
+                 Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+
+  (* Step 3/3 - Build the final list of floors *)
+  [
+    `Spacer;
+    `Data (`S, "Wall time elapsed *C", zip (fun s -> s.elapsed_wall_over_blocks));
+    `Data (`S, "CPU time elapsed *C", zip (fun s -> s.elapsed_cpu_over_blocks));
+    (* ops counts *)
+    `Spacer;
+    `Data (`R, "Ops count *C", all_ops_cumu_count);
+    `Data (`R, "Read only ops per sec *LA", ro_ops_per_sec);
+    `Data (`R, "Read write ops per sec *LA", rw_ops_per_sec);
+    (* <op> every sec *)
+    `Spacer;
+    op_every_sec "Commit every sec *LA" `Commit;
+    op_every_sec "Add every sec *LA" `Add;
+    op_every_sec "Remove every sec *LA" `Remove;
+    op_every_sec "Find every sec *LA" `Find;
+    op_every_sec "Mem every sec *LA" `Mem;
+    op_every_sec "Mem_tree every sec *LA" `Mem_tree;
+    op_every_sec "Copy every sec *LA" `Copy;
+    (* <op> per block *)
+    `Spacer;
+    op_count "Add count per block *LA" `Add;
+    op_count "Remove count per block *LA" `Remove;
+    op_count "Find count per block *LA" `Find;
+    op_count "Mem count per block *LA" `Mem;
+    op_count "Mem_tree count per block *LA" `Mem_tree;
+    op_count "Copy count per block *LA" `Copy;
+    (* <phase> duration *)
+    `Spacer;
+    `Data (`S, "Block duration *LA", sum_op_durations_per_block);
+    `Data (`S, "Buildup seen duration *LA", seen_duration);
+    op_duration "Buildup unseen duration *LA" `Unseen;
+    op_duration "Commit duration *LA" `Commit;
+    `Spacer;
+    (* <op> duration *)
+    op_duration "Add duration *LA" `Add;
+    op_duration "Remove duration *LA" `Remove;
+    op_duration "Find duration *LA" `Find;
+    op_duration "Mem duration *LA" `Mem;
+    op_duration "Mem_tree duration *LA" `Mem_tree;
+    op_duration "Copy duration *LA" `Copy;
+    op_duration "Checkout duration *LA" `Checkout;
+    (* derived from bag_of_stat *)
+    `Spacer;
+    pb "pack.finds per block *LA" (fun s -> s.pack.finds);
+    pb "pack.cache_misses per block *LA" (fun s -> s.pack.cache_misses);
+    pb "pack.appended_hashes per block *LA" (fun s -> s.pack.appended_hashes);
+    pb "pack.appended_offsets per block *LA" (fun s -> s.pack.appended_offsets);
+    `Spacer;
+    pb "tree.contents_hash per block *LA" (fun s -> s.tree.contents_hash);
+    pb "tree.contents_find per block *LA" (fun s -> s.tree.contents_find);
+    pb "tree.contents_add per block *LA" (fun s -> s.tree.contents_add);
+    pb "tree.node_hash per block *LA" (fun s -> s.tree.node_hash);
+    pb "tree.node_mem per block *LA" (fun s -> s.tree.node_mem);
+    pb "tree.node_add per block *LA" (fun s -> s.tree.node_add);
+    pb "tree.node_find per block *LA" (fun s -> s.tree.node_find);
+    pb "tree.node_val_v per block *LA" (fun s -> s.tree.node_val_v);
+    pb "tree.node_val_find per block *LA" (fun s -> s.tree.node_val_find);
+    pb "tree.node_val_list per block *LA" (fun s -> s.tree.node_val_list);
+    `Spacer;
+    v "index.bytes_read *C" (fun s -> s.index.bytes_read);
+    pb "index.bytes_read per block *LA" (fun s -> s.index.bytes_read);
+    ps "index.bytes_read per sec *LA" (fun s -> s.index.bytes_read);
+    v "index.nb_reads *C" (fun s -> s.index.nb_reads);
+    pb "index.nb_reads per block *LA" (fun s -> s.index.nb_reads);
+    ps "index.nb_reads per sec *LA" (fun s -> s.index.nb_reads);
+    v "index.bytes_written *C" (fun s -> s.index.bytes_written);
+    pb "index.bytes_written per block *LA" (fun s -> s.index.bytes_written);
+    ps "index.bytes_written per sec *LA" (fun s -> s.index.bytes_written);
+    v "index.nb_writes *C" (fun s -> s.index.nb_writes);
+    pb "index.nb_writes per block *LA" (fun s -> s.index.nb_writes);
+    ps "index.nb_writes per sec *LA" (fun s -> s.index.nb_writes);
+    v "index.nb_merge *C" (fun s -> s.index.nb_merge);
+    `Spacer;
+    v "gc.minor_words allocated *C" (fun s -> s.gc.minor_words);
+    pb "gc.minor_words allocated per block *LA" (fun s -> s.gc.minor_words);
+    ps "gc.minor_words allocated per sec *LA" (fun s -> s.gc.minor_words);
+    v "gc.promoted_words *C" (fun s -> s.gc.promoted_words);
+    v "gc.major_words allocated *C" (fun s -> s.gc.major_words);
+    pb "gc.major_words allocated per block *LA" (fun s -> s.gc.major_words);
+    ps "gc.major_words allocated per sec *LA" (fun s -> s.gc.major_words);
+    v "gc.minor_collections *C" (fun s -> s.gc.minor_collections);
+    pb "gc.minor_collections per block *LA" (fun s -> s.gc.minor_collections);
+    ps "gc.minor_collections per sec *LA" (fun s -> s.gc.minor_collections);
+    v "gc.major_collections *C" (fun s -> s.gc.major_collections);
+    pb "gc.major_collections per block *LA" (fun s -> s.gc.major_collections);
+    ps "gc.major_collections per sec *LA" (fun s -> s.gc.major_collections);
+    v "gc.compactions *C" (fun s -> s.gc.compactions);
+    `Data
+      ( `R,
+        "gc.major heap bytes top *C",
+        zip (fun s -> s.gc.major_heap_top_bytes) );
+    v "gc.major heap bytes *LA" (fun s -> s.gc.major_heap_bytes);
+    `Spacer;
+    v "index_data bytes *S" (fun s -> s.disk.index_data);
+    pb "index_data bytes per block *LA" (fun s -> s.disk.index_data);
+    ps "index_data bytes per sec *LA" (fun s -> s.disk.index_data);
+    v "store_pack bytes *S" (fun s -> s.disk.store_pack);
+    pb "store_pack bytes per block *LA" (fun s -> s.disk.store_pack);
+    ps "store_pack bytes per sec *LA" (fun s -> s.disk.store_pack);
+    v "index_log bytes *S" (fun s -> s.disk.index_log);
+    v "index_log_async *S" (fun s -> s.disk.index_log_async);
+    v "store_dict bytes *S" (fun s -> s.disk.store_dict);
+    `Spacer;
+  ]
+  @ floor_per_node
+
+let resample_curves_of_floor sample_count = function
+  | `Data (a, b, names_and_curves) ->
+      let names, curves = List.split names_and_curves in
+      let curves =
+        List.map
+          (fun curve ->
+            Utils.Resample.resample_vector `Next_neighbor curve sample_count)
+          curves
+      in
+      `Data (a, b, List.combine names curves)
+  | `Spacer -> `Spacer
+
+let matrix_of_data_floor (`Data (scalar_type, floor_name, names_and_curves)) =
+  let only_one_summary = List.length names_and_curves = 1 in
+  let _, curves = List.split names_and_curves in
+  let pp_real = Utils.create_pp_real (List.concat curves) in
+  let pp_seconds = Utils.create_pp_seconds (List.concat curves) in
+  let curve0 = List.hd curves in
+  let box_of_scalar row_idx col_idx (v0, v) =
+    let ratio = v /. v0 in
+    let show_percent =
+      if only_one_summary then
+        (* Percents are only needed for comparisons between summaries. *)
+        `No
+      else if col_idx = 0 then
+        (* The first columns is usually full of NaNs, showing percents there
+           is a waste of space. *)
+        `No
+      else if Float.is_finite ratio = false then
+        (* Nan and infinite percents are ugly. *)
+        `Shadow
+      else if row_idx = 0 then
+        (* The first row of a floor is always 100%, it is prettier without
+           displaying it. *)
+        `Shadow
+      else `Yes
+    in
+    (match (scalar_type, show_percent) with
+    | `R, `Yes -> Fmt.str "%a %a" pp_real v Utils.pp_percent ratio
+    | `R, `Shadow -> Fmt.str "%a     " pp_real v
+    | `R, `No -> Fmt.str "%a" pp_real v
+    | `S, `Yes -> Fmt.str "%a %a" pp_seconds v Utils.pp_percent ratio
+    | `S, `Shadow -> Fmt.str "%a     " pp_seconds v
+    | `S, `No -> Fmt.str "%a" pp_seconds v
+    | `P, `Yes -> Fmt.str "%.0f%%  %a" (v *. 100.) Utils.pp_percent ratio
+    | `P, `Shadow -> Fmt.str "%.0f%%     " (v *. 100.)
+    | `P, `No -> Fmt.str "%.0f%%" (v *. 100.))
+    |> Pb.text
+    |> Pb.align ~h:`Right ~v:`Top
+  in
+  let rows =
+    List.mapi
+      (fun row_idx (summary_name, curve) ->
+        let a = Pb.text (if row_idx = 0 then floor_name else "") in
+        let b = if only_one_summary then [] else [ Pb.text summary_name ] in
+        let c = List.mapi (box_of_scalar row_idx) (List.combine curve0 curve) in
+        a :: b @ c)
+      names_and_curves
+  in
+  rows
+
+let matrix_of_floor col_count = function
+  | `Spacer -> [ List.init col_count (Fun.const "") ] |> Pb.matrix_to_text
+  | `Data _ as floor -> matrix_of_data_floor floor
+
+let unsafe_pp sample_count ppf summary_names (summaries : Summary.t list) =
+  let block_count =
+    let l = List.map (fun s -> s.block_count) summaries in
+    let v = List.hd l in
+    if List.exists (fun v' -> v' <> v) l then
+      failwith "Can't pp together summaries with a different `block_count`";
+    v
+  in
+  let moving_average_half_life_ratio =
+    let l = List.map (fun s -> s.moving_average_half_life_ratio) summaries in
+    let v = List.hd l in
+    if List.exists (fun v' -> v' <> v) l then
+      failwith
+        "Can't pp together summaries with a different \
+         `moving_average_half_life_ratio`";
+    v
+  in
+  let tbl0 =
+    box_of_summaries_config summary_names summaries
+    |> Pb.matrix_with_column_spacers
+    |> Pb.grid_l ~bars:false
+    |> PrintBox_text.to_string
+  in
+  let header_rows =
+    let only_one_summary = List.length summaries = 1 in
+    let s = List.hd summaries in
+    let played_count_curve =
+      List.init Conf.curves_sample_count (fun i ->
+          float_of_int i
+          /. float_of_int (Conf.curves_sample_count - 1)
+          *. float_of_int s.block_count)
+    in
+    let played_count_curve =
+      Utils.Resample.resample_vector `Next_neighbor played_count_curve
+        sample_count
+      |> Array.of_list
+    in
+    let header_cells_per_col_idx col_idx =
+      let played_count = played_count_curve.(col_idx) in
+      let progress_blocks = played_count /. float_of_int s.block_count in
+      let h0 =
+        if progress_blocks = 0. then "0 (before)"
+        else if progress_blocks = 1. then
+          Printf.sprintf "%.0f (end)" played_count
+        else if Float.is_integer played_count then
+          Printf.sprintf "%.0f" played_count
+        else Printf.sprintf "%.1f" played_count
+      in
+      let h1 = Printf.sprintf "%.0f%%" (progress_blocks *. 100.) in
+      [ h0; h1 ]
+    in
+    let col_a =
+      [ [ "Block played count *C"; "Blocks progress *C" ] ] |> Pb.matrix_to_text
+    in
+    let col_b =
+      (if only_one_summary then [] else [ [ ""; "" ] ])
+      |> Pb.matrix_to_text
+      |> Pb.align_matrix `Center
+    in
+    let cols_c =
+      List.init sample_count header_cells_per_col_idx
+      |> Pb.matrix_to_text
+      |> Pb.align_matrix `Center
+    in
+    col_a @ col_b @ cols_c |> Pb.transpose_matrix
+  in
+  let body_rows =
+    let col_count =
+      sample_count + 1 + if List.length summaries = 1 then 0 else 1
+    in
+    floors_of_summaries summary_names summaries
+    |> List.map (resample_curves_of_floor sample_count)
+    |> List.map (matrix_of_floor col_count)
+    |> List.concat
+  in
+  let tbl1 =
+    header_rows @ body_rows
+    |> Pb.matrix_with_column_spacers
+    |> Pb.grid_l ~bars:false
+    |> PrintBox_text.to_string
+  in
+  Format.fprintf ppf
+    "%s\n\n\
+     %s\n\n\
+     Types of curves:\n\
+    \  *C: Cumulative. No smoothing.\n\
+    \  *LA: Local Average. Smoothed using a weighted sum of the value in the\n\
+    \       block and the exponentially decayed values of the previous blocks.\n\
+    \       Every %.2f blocks, half of the past is forgotten.\n\
+    \  *S: Size. E.g. directory entries, file bytes. No smoothing." tbl0 tbl1
+    (moving_average_half_life_ratio *. float_of_int (block_count + 1))
+
+let pp sample_count ppf (summary_names, summaries) =
+  if List.length summaries = 0 then ()
+  else unsafe_pp sample_count ppf summary_names summaries

--- a/bench/irmin-pack/trace_stat_summary_utils.ml
+++ b/bench/irmin-pack/trace_stat_summary_utils.ml
@@ -17,6 +17,100 @@
 type histo = (float * int) list [@@deriving repr]
 type curve = float list [@@deriving repr]
 
+let snap_to_integer ~significant_digits v =
+  if not @@ Float.is_finite v then v
+  else if Float.is_integer v then v
+  else
+    let significant_digits = float_of_int significant_digits in
+    let v' = Float.round v in
+    if v' = 0. then v
+    else
+      let diff = Float.abs (v -. v') in
+      assert (diff <= 0.5);
+      let significant_digits' = -.Float.log10 (diff /. v) in
+      assert (significant_digits' > 0.);
+      if significant_digits' >= significant_digits then v' else v
+
+let pp_six_digits_with_spacer ppf v =
+  let s = Printf.sprintf "%.6f" v in
+  let len = String.length s in
+  let a = String.sub s 0 (len - 3) in
+  let b = String.sub s (len - 3) 3 in
+  Format.fprintf ppf "%s_%s" a b
+
+let create_pp_real ?(significant_digits = 7) examples =
+  let examples = List.map (snap_to_integer ~significant_digits) examples in
+  let all_integer =
+    List.for_all
+      (fun v -> Float.is_integer v || not (Float.is_finite v))
+      examples
+  in
+  let absmax =
+    List.fold_left
+      (fun acc v ->
+        if not @@ Float.is_finite acc then v
+        else if not @@ Float.is_finite v then acc
+        else Float.abs v |> max acc)
+      Float.neg_infinity examples
+  in
+  let finite_pp =
+    if absmax /. 1e12 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%.3f T" (v /. 1e12)
+    else if absmax /. 1e9 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%.3f G" (v /. 1e9)
+    else if absmax /. 1e6 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%.3f M" (v /. 1e6)
+    else if absmax /. 1e3 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%#d" (Float.round v |> int_of_float)
+    else if all_integer then fun ppf v ->
+      Format.fprintf ppf "%#d" (Float.round v |> int_of_float)
+    else if absmax /. 1. >= 10. then fun ppf v -> Format.fprintf ppf "%.3f" v
+    else if absmax /. 1e-3 >= 10. then pp_six_digits_with_spacer
+    else fun ppf v -> Format.fprintf ppf "%.3e" v
+  in
+  fun ppf v ->
+    if Float.is_nan v then Format.fprintf ppf "n/a"
+    else if Float.is_infinite v then Format.fprintf ppf "%f" v
+    else finite_pp ppf v
+
+let create_pp_seconds examples =
+  let absmax =
+    List.fold_left
+      (fun acc v ->
+        if not @@ Float.is_finite acc then v
+        else if not @@ Float.is_finite v then acc
+        else Float.abs v |> max acc)
+      Float.neg_infinity examples
+  in
+  let finite_pp =
+    if absmax >= 60. then fun ppf v -> Mtime.Span.pp_float_s ppf v
+    else if absmax < 100. *. 1e-12 then fun ppf v ->
+      Format.fprintf ppf "%.3e s" v
+    else if absmax < 100. *. 1e-9 then fun ppf v ->
+      Format.fprintf ppf "%.3f ns" (v *. 1e9)
+    else if absmax < 100. *. 1e-6 then fun ppf v ->
+      Format.fprintf ppf "%.3f \xc2\xb5s" (v *. 1e6)
+    else if absmax < 100. *. 1e-3 then fun ppf v ->
+      Format.fprintf ppf "%.3f ms" (v *. 1e3)
+    else fun ppf v -> Format.fprintf ppf "%.3f  s" v
+  in
+  fun ppf v ->
+    if Float.is_nan v then Format.fprintf ppf "n/a"
+    else if Float.is_infinite v then Format.fprintf ppf "%f" v
+    else finite_pp ppf v
+
+let pp_percent ppf v =
+  if not @@ Float.is_finite v then Format.fprintf ppf "%4f" v
+  else if v = 0. then Format.fprintf ppf "  0%%"
+  else if v < 10. /. 100. then Format.fprintf ppf "%3.1f%%" (v *. 100.)
+  else if v < 1000. /. 100. then Format.fprintf ppf "%3.0f%%" (v *. 100.)
+  else if v < 1000. then Format.fprintf ppf "%3.0fx" v
+  else if v < 9.5e9 then (
+    let long_repr = Printf.sprintf "%.0e" v in
+    assert (String.length long_repr = 5);
+    Format.fprintf ppf "%ce%cx" long_repr.[0] long_repr.[4])
+  else Format.fprintf ppf "++++"
+
 module Exponential_moving_average = struct
   type t = {
     momentum : float;

--- a/bench/irmin-pack/trace_stat_summary_utils.mli
+++ b/bench/irmin-pack/trace_stat_summary_utils.mli
@@ -6,6 +6,32 @@
 type histo = (float * int) list [@@deriving repr]
 type curve = float list [@@deriving repr]
 
+val create_pp_real :
+  ?significant_digits:int -> float list -> Format.formatter -> float -> unit
+(** [create_pp_real examples] is [pp_real], a float pretty-printer that adapts
+    to the [examples] shown to it.
+
+    It is highly recommended, but not mandatory, for all the numbers passed to
+    [pp_real] to be included [examples].
+
+    [significant_digits] is used to snap certain numbers to the nearest integer. *)
+
+val create_pp_seconds : float list -> Format.formatter -> float -> unit
+(** [create_pp_seconds examples] is [pp_seconds], a time span pretty-printer
+    that adapts to the [examples] shown to it.
+
+    It is highly recommended, but not mandatory, for all the numbers passed to
+    [pp_seconds] to be included [examples]. *)
+
+val pp_percent : Format.formatter -> float -> unit
+(** Pretty prints a percent in a way that always takes 4 chars.
+
+    Examples: [0.] is ["  0%"], [0.00001] is ["0.0%"], [0.003] is ["0.3%"],
+    [0.15] is [" 15%"], [9.0] is [900%], [700.] is [700x], [410_000.0] is
+    ["4e6x"] and [1e100] is ["++++"].
+
+    Negative inputs are undefined. *)
+
 (** Functional Exponential Moving Average (EMA). *)
 module Exponential_moving_average : sig
   type t

--- a/bench/irmin-pack/trace_stat_summary_utils.mli
+++ b/bench/irmin-pack/trace_stat_summary_utils.mli
@@ -12,7 +12,7 @@ val create_pp_real :
     to the [examples] shown to it.
 
     It is highly recommended, but not mandatory, for all the numbers passed to
-    [pp_real] to be included [examples].
+    [pp_real] to be included in [examples].
 
     [significant_digits] is used to snap certain numbers to the nearest integer. *)
 

--- a/bench/irmin-pack/trace_stat_summary_utils.mli
+++ b/bench/irmin-pack/trace_stat_summary_utils.mli
@@ -6,6 +6,19 @@
 type histo = (float * int) list [@@deriving repr]
 type curve = float list [@@deriving repr]
 
+val snap_to_integer : significant_digits:int -> float -> float
+(** [snap_to_integer ~significant_digits v] is [Float.round v] if [v] is close
+    to [Float.round v], otherwise the result is [v]. [significant_digits]
+    defines how close things are.
+
+    Examples:
+
+    When [significant_digits] is [4] and [v] is [42.00001], [snap_to_integer v]
+    is [42.].
+
+    When [significant_digits] is [4] and [v] is [42.001], [snap_to_integer v] is
+    [v]. *)
+
 val create_pp_real :
   ?significant_digits:int -> float list -> Format.formatter -> float -> unit
 (** [create_pp_real examples] is [pp_real], a float pretty-printer that adapts
@@ -14,7 +27,10 @@ val create_pp_real :
     It is highly recommended, but not mandatory, for all the numbers passed to
     [pp_real] to be included in [examples].
 
-    [significant_digits] is used to snap certain numbers to the nearest integer. *)
+    When all the [examples] are integers, the display may be different. The
+    examples that aren't integer, but that are very close to be a integers are
+    counted as integers. [significant_digits] is used internally to snap the
+    examples to integers. *)
 
 val create_pp_seconds : float list -> Format.formatter -> float -> unit
 (** [create_pp_seconds examples] is [pp_seconds], a time span pretty-printer

--- a/bench/irmin-pack/trace_stats.ml
+++ b/bench/irmin-pack/trace_stats.ml
@@ -1,0 +1,185 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** [trace_stats.exe].
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files. *)
+
+open Irmin_traces
+module Def = Trace_definitions.Stat_trace
+module Summary = Trace_stat_summary
+
+let is_trace_magic s = Trace_common.Magic.to_string Def.magic = s
+
+let summarise path =
+  Summary.(summarise path |> Fmt.pr "%a\n" (Irmin.Type.pp_json t))
+
+let class_of_path p =
+  let chan = open_in_bin p in
+  if in_channel_length chan < 8 then
+    Fmt.invalid_arg "File \"%s\" should be a stat trace or a json." p;
+  let magic = really_input_string chan 8 in
+  close_in chan;
+  if is_trace_magic magic then
+    let block_count =
+      Def.open_reader p
+      |> snd
+      |> Seq.fold_left
+           (fun count op -> match op with `Commit _ -> count + 1 | _ -> count)
+           0
+    in
+    `Trace block_count
+  else
+    let chan = open_in_bin p in
+    let raw = really_input_string chan (in_channel_length chan) in
+    close_in chan;
+    match Irmin.Type.of_json_string Summary.t raw with
+    | Error (`Msg msg) ->
+        Fmt.invalid_arg
+          "File \"%s\" should be a stat trace or a json.\nError: %s" p msg
+    | Ok s -> `Summary s
+
+let pp name_per_path paths cols_opt =
+  let class_per_path = List.map class_of_path paths in
+  let block_count =
+    (* When pretty printing, all the summaries will have to have the same number of
+       blocks, i.e. the smallest of all inputs. *)
+    let trace_lengths =
+      List.filter_map
+        (function `Trace v -> Some v | `Summary _ -> None)
+        class_per_path
+    in
+    let summary_lengths =
+      List.filter_map
+        (function `Trace _ -> None | `Summary s -> Some s.Summary.block_count)
+        class_per_path
+    in
+    let s = List.length summary_lengths > 0 in
+    let t = List.length trace_lengths > 0 in
+    let min_trace_length = List.fold_left min max_int trace_lengths in
+    let min_summary_length = List.fold_left min max_int summary_lengths in
+    let max_summary_length = List.fold_left max 0 summary_lengths in
+    if s && min_summary_length <> max_summary_length then
+      invalid_arg
+        "Can't pretty print 2 summaries with a different number of blocks.";
+    if s && t && min_summary_length > min_trace_length then
+      invalid_arg
+        "Can't pretty print a trace alongside a summary that has a higher \
+         block count.";
+    min min_trace_length min_summary_length
+  in
+  let summaries =
+    List.map2
+      (fun path -> function
+        | `Summary s -> s
+        | `Trace _ -> Summary.summarise ~block_count path)
+      paths class_per_path
+  in
+  let col_count =
+    match cols_opt with
+    | Some v -> v
+    | None -> if List.length summaries > 1 then 4 else 5
+  in
+  Fmt.pr "%a\n" (Trace_stat_summary_pp.pp col_count) (name_per_path, summaries)
+
+let pp paths named_paths cols_opt =
+  let name_per_path, paths =
+    List.mapi (fun i v -> (string_of_int i, v)) paths @ named_paths
+    |> List.split
+  in
+  if List.length paths = 0 then
+    invalid_arg "trace_stats.exe pp: At least one path should be provided";
+  pp name_per_path paths cols_opt
+
+open Cmdliner
+
+let term_summarise =
+  let stat_trace_file =
+    let doc = Arg.info ~docv:"PATH" ~doc:"A stat trace file" [] in
+    Arg.(required @@ pos 0 (some string) None doc)
+  in
+  Term.(const summarise $ stat_trace_file)
+
+let term_pp =
+  let arg_indexed_files =
+    let open Arg in
+    let a = pos_all non_dir_file [] (info [] ~docv:"FILE") in
+    value a
+  in
+  let arg_named_files =
+    let open Arg in
+    let a =
+      opt_all (pair string non_dir_file) []
+        (info [ "f"; "named-file" ]
+           ~doc:
+             "A comma-separated pair of short name / path to trace or summary. \
+              The short name is used to tag the rows inside the pretty printed \
+              table.")
+    in
+    value a
+  in
+  let arg_columns =
+    let open Arg in
+    let doc =
+      Arg.info ~doc:"Number of sample columns to show." [ "c"; "columns" ]
+    in
+    let a = opt (some int) None doc in
+    value a
+  in
+  Term.(const pp $ arg_indexed_files $ arg_named_files $ arg_columns)
+
+let () =
+  let man = [] in
+  let i =
+    Term.info ~man ~doc:"Processing of stat traces and stat trace summaries."
+      "trace_stats"
+  in
+
+  let man =
+    [
+      `P "From stat trace (repr) to summary (json).";
+      `S "EXAMPLE";
+      `P "trace_stats.exe summarise run0.repr > run0.json";
+    ]
+  in
+  let j = Term.info ~man ~doc:"Stat Trace to Summary" "summarise" in
+
+  let man =
+    [
+      `P
+        "Accepts both stat traces (repr) and summaries (json). The file type \
+         is automatically infered.";
+      `P
+        "When a single file is provided, a subset of the summary of that file \
+         is computed and shown.";
+      `P
+        "When multiple files are provided, a subset of the summary of each \
+         file is computed and shown in a way that makes comparisons between \
+         files easy.";
+      `S "EXAMPLES";
+      `P "trace_stats.exe pp run0.json";
+      `Noblank;
+      `P "trace_stats.exe pp run1.repr";
+      `Noblank;
+      `P "trace_stats.exe pp run0.json run1.repr run3.json";
+      `Noblank;
+      `P "trace_stats.exe pp -f r0,run0.json -f r1,run1.repr";
+    ]
+  in
+  let k = Term.info ~man ~doc:"Comparative Pretty Printing" "pp" in
+  Term.exit
+  @@ Term.eval_choice (term_summarise, i) [ (term_summarise, j); (term_pp, k) ]

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -436,12 +436,15 @@ module Trace_replay (Store : Store) = struct
             Lwt.return_unit)
           else Lwt.return (Stat_collector.remove stats))
     in
-    Option.iter
-      (fun s ->
+    match summary_opt with
+    | Some summary ->
         let p = Filename.concat config.artefacts_dir "boostrap_summary.json" in
-        Trace_stat_summary.save_to_json s p)
-      summary_opt;
-    fun ppf -> Format.fprintf ppf "\n%t\n" repo_pp
+        Trace_stat_summary.save_to_json summary p;
+        fun ppf ->
+          Format.fprintf ppf "\n%t\n%a" repo_pp
+            (Trace_stat_summary_pp.pp 5)
+            ([ "" ], [ summary ])
+    | None -> fun ppf -> Format.fprintf ppf "\n%t\n" repo_pp
 end
 
 module Benchmark = struct

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -34,6 +34,7 @@ depends: [
   "ppx_deriving" {with-test}
   "alcotest"   {with-test}
   "rusage"
+  "printbox" {with-test}
 ]
 
 synopsis: "Irmin benchmarking suite"

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -29,14 +29,14 @@ depends: [
   "fmt"
   "uuidm"
   "progress"
-  "bentov"
-  "mtime"
-  "ppx_deriving"
-  "alcotest"   {with-test}
+  "bentov"       {with-test}
+  "mtime"        {with-test}
+  "ppx_deriving" {with-test}
+  "alcotest"     {with-test}
   "rusage"
-  "uutf"
-  "uucp"
-  "printbox"
+  "uutf"         {with-test}
+  "uucp"         {with-test}
+  "printbox"     {with-test}
 ]
 
 synopsis: "Irmin benchmarking suite"

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -29,12 +29,14 @@ depends: [
   "fmt"
   "uuidm"
   "progress"
-  "bentov" {with-test}
-  "mtime" {with-test}
-  "ppx_deriving" {with-test}
+  "bentov"
+  "mtime"
+  "ppx_deriving"
   "alcotest"   {with-test}
   "rusage"
-  "printbox" {with-test}
+  "uutf"
+  "uucp"
+  "printbox"
 ]
 
 synopsis: "Irmin benchmarking suite"

--- a/test/irmin-bench/misc.ml
+++ b/test/irmin-bench/misc.ml
@@ -1,0 +1,45 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+
+let snap_around_42 () =
+  let f ~sd =
+    Irmin_traces.Trace_stat_summary_utils.snap_to_integer ~significant_digits:sd
+  in
+  Alcotest.(check (float 0.)) "Already integer" (f ~sd:0 42.) 42.;
+  Alcotest.(check (float 0.)) "Always snap" (f ~sd:0 42.1) 42.;
+  Alcotest.(check (float 0.)) "Always snap" (f ~sd:0 42.4999999999) 42.;
+  Alcotest.(check (float 0.)) "Always snap" (f ~sd:0 42.5000000001) 43.;
+
+  Alcotest.(check (float 0.)) "No snap" (f ~sd:4 42.1) 42.1;
+  Alcotest.(check (float 0.)) "No snap" (f ~sd:4 42.01) 42.01;
+  Alcotest.(check (float 0.)) "No snap" (f ~sd:4 42.00110000) 42.00110000;
+  Alcotest.(check (float 0.)) "No snap" (f ~sd:4 42.00100000) 42.00100000;
+  Alcotest.(check (float 0.)) "No snap" (f ~sd:4 42.00099999) 42.00099999;
+  Alcotest.(check (float 0.)) "No snap" (f ~sd:4 42.00011000) 42.00011000;
+
+  Alcotest.(check (float 0.)) "Snap" (f ~sd:4 42.00009999) 42.;
+  Alcotest.(check (float 0.)) "Snap" (f ~sd:4 42.00001100) 42.;
+  Alcotest.(check (float 0.)) "Snap" (f ~sd:4 42.00001000) 42.;
+  Alcotest.(check (float 0.)) "Snap" (f ~sd:4 42.00000999) 42.;
+  Alcotest.(check (float 0.)) "Already integer" (f ~sd:4 42.) 42.
+
+let test_cases =
+  [
+    ( "snap_to_integer",
+      [ Alcotest.test_case "snap_around_42" `Quick snap_around_42 ] );
+  ]

--- a/test/irmin-bench/test.ml
+++ b/test/irmin-bench/test.ml
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let () = Alcotest.run "irmin-bench" Ema.test_cases
+let () = Alcotest.run "irmin-bench" (Ema.test_cases @ Misc.test_cases)


### PR DESCRIPTION
Last PR extracted from #1332

I'm not totally happy with `trace_stat_summary_pp.ml`. I will improve it when new features are needed.

A single summary pretty print:
```
dune exec -- ./bench/irmin-pack/trace_stats.exe pp /data/ngoguey/irmin/_artefacts/master_none/boostrap_summary.json
Hostname        | comanche
Word Size       | 64 bits
Start Time      | 2021/04/15 19:12:54 (GMT)
Inode Config    | mls:32 bf:32 sh:256
Store Type      | pack
Path Conversion | none

Block played count *C                  | 0 (before) |   335874   |   671748   |  1007622   | 1343496 (end)
Blocks progress *C                     |     0%     |    25%     |    50%     |    75%     |     100%
                                       |            |            |            |            |
Wall time elapsed *C                   |        0us |    3h53min |   13h34min |       1d7h |         2d14h
CPU time elapsed *C                    |        0us |    3h50min |   13h22min |       1d6h |         2d13h
                                       |            |            |            |            |
Ops count *C                           |    0.000 M |  178.693 M |  404.025 M |  693.862 M |    1089.854 M
Read only ops per sec *LA              |        n/a |   6451.800 |   3888.361 |   3024.875 |      2492.405
Read write ops per sec *LA             |        n/a |   2432.414 |   1408.054 |   1024.541 |       784.451
                                       |            |            |            |            |
Commit every sec *LA                   |        n/a |     14.895 |      7.110 |      4.294 |         2.344
Add every sec *LA                      |        n/a |   2417.993 |   1383.707 |   1014.295 |       773.094
Remove every sec *LA                   |        n/a |     14.363 |     24.112 |     10.230 |        11.123
Find every sec *LA                     |        n/a |   4845.606 |   2700.683 |   2126.733 |      1663.274
Mem every sec *LA                      |        n/a |   1114.650 |    906.733 |    756.435 |       751.784
Mem_tree every sec *LA                 |        n/a |    491.544 |    280.945 |    141.708 |        77.346
Copy every sec *LA                     |        n/a |  0.057_881 |  0.234_617 |  0.016_686 |     0.233_792
                                       |            |            |            |            |
Add count per block *LA                |        n/a |    162.336 |    194.616 |    236.202 |       329.843
Remove count per block *LA             |        n/a |  0.964_275 |  3.391_339 |  2.382_319 |     4.745_588
Find count per block *LA               |        n/a |    325.317 |    379.847 |    495.259 |       709.640
Mem count per block *LA                |        n/a |     74.834 |    127.531 |    176.153 |       320.751
Mem_tree count per block *LA           |        n/a |     33.001 |     39.514 |     33.000 |        33.000
Copy count per block *LA               |        n/a |  0.003_886 |  0.032_999 |  0.003_886 |     0.099_748
                                       |            |            |            |            |
Block duration *LA                     |   0.000  s |   0.067  s |   0.141  s |   0.233  s |      0.427  s
Buildup seen duration *LA              |   0.000 ms |   5.401 ms |   6.814 ms |   8.866 ms |     12.523 ms
Buildup unseen duration *LA            |        n/a |   1.893 ms |   2.330 ms |   2.906 ms |      4.478 ms
Commit duration *LA                    |        n/a |   0.060  s |   0.132  s |   0.221  s |      0.410  s
                                       |            |            |            |            |
Add duration *LA                       |        n/a |  11.945 µs |  11.188 µs |   9.969 µs |      9.556 µs
Remove duration *LA                    |        n/a |  11.436 µs |  12.412 µs |  34.320 µs |     32.297 µs
Find duration *LA                      |        n/a |   9.389 µs |   9.486 µs |   9.294 µs |      9.272 µs
Mem duration *LA                       |        n/a |   4.159 µs |   6.907 µs |   9.856 µs |      7.912 µs
Mem_tree duration *LA                  |        n/a |   2.439 µs |   2.659 µs |   2.597 µs |      2.829 µs
Copy duration *LA                      |        n/a |  15.937 µs |  27.897 µs |  34.672 µs |     13.476 µs
Checkout duration *LA                  |        n/a |   4.294 µs |   4.816 µs |   4.282 µs |      5.624 µs
                                       |            |            |            |            |
pack.finds per block *LA               |        n/a |   1610.005 |   2046.639 |   2303.584 |      2859.420
pack.cache_misses per block *LA        |        n/a |     79.175 |    132.383 |    134.764 |       206.057
pack.appended_hashes per block *LA     |        n/a |  0.035_388 |  0.093_458 |  0.165_040 |     0.073_375
pack.appended_offsets per block *LA    |        n/a |   1628.925 |   2160.399 |   2614.423 |      3576.880
                                       |            |            |            |            |
tree.contents_hash per block *LA       |        n/a |    125.817 |    141.760 |    150.103 |       176.406
tree.contents_find per block *LA       |        n/a |    185.714 |    217.273 |    263.228 |       348.266
tree.contents_add per block *LA        |        n/a |     69.662 |     77.439 |     88.737 |       107.554
tree.node_hash per block *LA           |        n/a |    210.284 |    269.217 |    310.486 |       412.139
tree.node_mem per block *LA            |        n/a |    209.476 |    266.932 |    308.375 |       407.885
tree.node_add per block *LA            |        n/a |    206.451 |    263.796 |    305.862 |       404.644
tree.node_find per block *LA           |        n/a |    679.684 |    798.250 |    819.762 |       965.929
tree.node_val_v per block *LA          |        n/a |  7.873e-11 |  7.508e-17 |  7.160e-23 |     6.829e-29
tree.node_val_find per block *LA       |        n/a |          0 |          0 |          0 |             0
tree.node_val_list per block *LA       |        n/a |  1.412_514 |  1.606_290 |  2.894_259 |     4.800_511
                                       |            |            |            |            |
index.bytes_read *C                    |    0.000 T |    1.949 T |    6.791 T |   15.083 T |      29.132 T
index.bytes_read per block *LA         |        n/a |    9.451 M |   20.271 M |   31.753 M |      54.879 M
index.bytes_read per sec *LA           |        n/a |  140.771 M |  144.128 M |  136.351 M |     128.626 M
index.nb_reads *C                      |    0.000 M |  538.390 M | 1363.607 M | 2355.447 M |    3604.103 M
index.nb_reads per block *LA           |        n/a |   2044.656 |   2739.774 |   3126.620 |      4459.369
index.nb_reads per sec *LA             |        n/a |     30_455 |     19_480 |     13_426 |        10_452
index.bytes_written *C                 |    0.000 T |    0.607 T |    3.261 T |    9.320 T |      20.580 T
index.bytes_written per block *LA      |        n/a |    3.796 M |   11.607 M |   23.318 M |      46.457 M
index.bytes_written per sec *LA        |        n/a |   56.537 M |   82.524 M |  100.133 M |     108.887 M
index.nb_writes *C                     |         19 |  1_589_261 |  3_289_249 |  5_038_345 |     6_933_419
index.nb_writes per block *LA          |        n/a |  4.858_136 |  5.441_777 |  5.558_851 |     5.790_718
index.nb_writes per sec *LA            |        n/a |     72.362 |     38.691 |     23.871 |        13.572
index.nb_merge *C                      |          0 |        324 |        755 |      1_279 |         1_903
                                       |            |            |            |            |
gc.minor_words allocated *C            |    0.000 T |    1.446 T |    4.694 T |   10.052 T |      18.370 T
gc.minor_words allocated per block *LA |        n/a |    6.577 M |   12.108 M |   18.868 M |      32.311 M
gc.minor_words allocated per sec *LA   |        n/a |   97.960 M |   86.089 M |   81.023 M |      75.731 M
gc.promoted_words *C                   |    0.000 G |   47.428 G |  122.658 G |  215.213 G |     329.477 G
gc.major_words allocated *C            |    0.001 G |  124.727 G |  536.367 G | 1397.732 G |    2941.268 G
gc.major_words allocated per block *LA |        n/a |    663_964 |  1_715_571 |  3_243_565 |     6_301_567
gc.major_words allocated per sec *LA   |        n/a |    9.890 M |   12.198 M |   13.928 M |      14.770 M
gc.minor_collections *C                |    0.000 M |    5.536 M |   17.966 M |   38.459 M |      70.255 M
gc.minor_collections per block *LA     |        n/a |     25.179 |     46.332 |     72.184 |       123.448
gc.minor_collections per sec *LA       |        n/a |    375.044 |    329.414 |    309.972 |       289.341
gc.major_collections *C                |          1 |      7_575 |     27_197 |     58_358 |        98_374
gc.major_collections per block *LA     |        n/a |  0.037_021 |  0.080_940 |  0.117_803 |     0.128_702
gc.major_collections per sec *LA       |        n/a |  0.551_435 |  0.575_481 |  0.505_869 |     0.301_655
gc.compactions *C                      |          0 |        164 |        386 |        662 |           987
gc.major heap bytes top *C             |    7.172 M | 1984.500 M | 4547.162 M | 4547.162 M |    4547.162 M
gc.major heap bytes *LA                |    7.172 M |  648.729 M |  892.735 M | 1059.946 M |     535.695 M
                                       |            |            |            |            |
index_data bytes *S                    |    0.000 G |    3.654 G |    8.546 G |   14.461 G |      21.520 G
index_data bytes per block *LA         |        n/a |     12_547 |     15_941 |     18_663 |        24_901
index_data bytes per sec *LA           |        n/a |    186_894 |    113_339 |     80_142 |        58_363
store_pack bytes *S                    |    0.000 G |    7.884 G |   19.594 G |   34.066 G |      51.802 G
store_pack bytes per block *LA         |        n/a |     28_265 |     38_251 |     45_745 |        62_508
store_pack bytes per sec *LA           |        n/a |    421_006 |    271_964 |    196_439 |       146_509
index_log bytes *S                     |    0.000 M |   22.500 M |   22.500 M |   22.500 M |      22.500 M
index_log_async *S                     |    0.000 M |   22.500 M |   22.500 M |   22.500 M |      22.500 M
store_dict bytes *S                    |         24 |  2_458_592 |  2_458_592 |  2_458_592 |     2_458_592
                                       |            |            |            |            |
/data/contracts/index *S               |        n/a |          4 |        256 |        256 |           256
/data/big_maps/index *S                |        n/a |          0 |         15 |         52 |           205
/data/rolls/index *S                   |        n/a |        256 |        256 |        256 |           256
/data/rolls/owner/current *S           |        n/a |        256 |        256 |        256 |           256
/data/commitments *S                   |        n/a |        256 |        256 |        256 |           256
/data/contracts/index/ed25519 *S       |        n/a |        256 |          0 |          0 |             0
/data/contracts/index/originated *S    |        n/a |        256 |          0 |          0 |             0

Types of curves:
  *C: Cumulative. No smoothing.
  *LA: Local Average. Smoothed using a weighted sum of the value in the
       block and the exponentially decayed values of the previous blocks.
       Every 16793.71 blocks, half of the past is forgotten.
  *S: Size. E.g. directory entries, file bytes. No smoothing.
```

A multi summary pretty print:
```
dune exec -- ./bench/irmin-pack/trace_stats.exe pp /data/ngoguey/irmin/_artefacts/master_none/boostrap_summary.json   /data/ngoguey/irmin/_artefacts/master_v0+v1/boostrap_summary.json
                | 0                         | 1
Hostname        | comanche                  | comanche
Word Size       | 64 bits                   | 64 bits
Start Time      | 2021/04/15 19:12:54 (GMT) | 2021/04/19 19:19:24 (GMT)
Inode Config    | mls:32 bf:32 sh:256       | mls:32 bf:32 sh:256
Store Type      | pack                      | pack
Path Conversion | none                      | v0+v1

Block played count *C                  |   | 0 (before) |    450071.2     |    900142.3     |  1343496 (end)
Blocks progress *C                     |   |     0%     |       34%       |       67%       |      100%
                                       |   |            |                 |                 |
Wall time elapsed *C                   | 0 |        0us |    6h18min      |         1d      |      2d14h
                                       | 1 |        0us |    3h11min  50% |   10h36min  43% |   23h49min  38%
CPU time elapsed *C                    | 0 |        0us |    6h14min      |         1d      |      2d13h
                                       | 1 |        0us |    3h11min  51% |   10h26min  43% |   23h29min  38%
                                       |   |            |                 |                 |
Ops count *C                           | 0 |    0.000 M |  250.775 M      |  592.948 M      | 1089.854 M
                                       | 1 |    0.000 M |  250.775 M 100% |  592.948 M 100% | 1089.854 M 100%
Read only ops per sec *LA              | 0 |        n/a |      5_638      |      3_184      |      2_492
                                       | 1 |        n/a |     10_843 192% |      7_966 250% |      6_870 276%
Read write ops per sec *LA             | 0 |        n/a |   2119.146      |   1105.795      |    784.451
                                       | 1 |        n/a |   4075.949 192% |   2766.265 250% |   2162.382 276%
                                       |   |            |                 |                 |
Commit every sec *LA                   | 0 |        n/a |     12.208      |      5.000      |      2.344
                                       | 1 |        n/a |     23.480 192% |     12.508 250% |      6.461 276%
Add every sec *LA                      | 0 |        n/a |   2102.175      |   1097.681      |    773.094
                                       | 1 |        n/a |   4043.305 192% |   2745.969 250% |   2131.077 276%
Remove every sec *LA                   | 0 |        n/a |     16.924      |      8.093      |     11.123
                                       | 1 |        n/a |     32.551 192% |     20.247 250% |     30.661 276%
Find every sec *LA                     | 0 |        n/a |   4178.387      |   2274.828      |   1663.274
                                       | 1 |        n/a |   8036.676 192% |   5690.728 250% |   4584.906 276%
Mem every sec *LA                      | 0 |        n/a |   1056.270      |    744.592      |    751.784
                                       | 1 |        n/a |   2031.620 192% |   1862.677 250% |   2072.335 276%
Mem_tree every sec *LA                 | 0 |        n/a |    402.851      |    165.002      |     77.346
                                       | 1 |        n/a |    774.841 192% |    412.771 250% |    213.209 276%
Copy every sec *LA                     | 0 |        n/a |  0.047_900      |  0.019_613      |  0.233_792
                                       | 1 |        n/a |  0.092_130 192% |  0.049_065 250% |  0.644_460 276%
                                       |   |            |                 |                 |
Add count per block *LA                | 0 |        n/a |    172.202      |    219.537      |    329.843
                                       | 1 |        n/a |    172.202 100% |    219.537 100% |    329.843 100%
Remove count per block *LA             | 0 |        n/a |  1.386_346      |  1.618_699      |  4.745_588
                                       | 1 |        n/a |  1.386_346 100% |  1.618_699 100% |  4.745_588 100%
Find count per block *LA               | 0 |        n/a |    342.277      |    454.967      |    709.640
                                       | 1 |        n/a |    342.277 100% |    454.967 100% |    709.640 100%
Mem count per block *LA                | 0 |        n/a |     86.525      |    148.919      |    320.751
                                       | 1 |        n/a |     86.525 100% |    148.919 100% |    320.751 100%
Mem_tree count per block *LA           | 0 |        n/a |     33.000      |     33.001      |     33.000
                                       | 1 |        n/a |     33.000 100% |     33.001 100% |     33.000 100%
Copy count per block *LA               | 0 |        n/a |  0.003_924      |  0.003_923      |  0.099_748
                                       | 1 |        n/a |  0.003_924 100% |  0.003_923 100% |  0.099_748 100%
                                       |   |            |                 |                 |
Block duration *LA                     | 0 |   0.000  s |   0.082  s      |   0.200  s      |   0.427  s
                                       | 1 |   0.000  s |   0.043  s  52% |   0.080  s  40% |   0.155  s  36%
Buildup seen duration *LA              | 0 |   0.000 ms |   5.776 ms      |   8.010 ms      |  12.523 ms
                                       | 1 |   0.000 ms |   3.905 ms  68% |   4.992 ms  62% |   7.768 ms  62%
Buildup unseen duration *LA            | 0 |        n/a |   2.015 ms      |   2.659 ms      |   4.478 ms
                                       | 1 |        n/a |   3.152 ms 156% |   3.492 ms 131% |   5.222 ms 117%
Commit duration *LA                    | 0 |        n/a |   0.074  s      |   0.189  s      |   0.410  s
                                       | 1 |        n/a |   0.036  s  48% |   0.071  s  38% |   0.142  s  35%
                                       |   |            |                 |                 |
Add duration *LA                       | 0 |        n/a |  11.870 µs      |  10.397 µs      |   9.556 µs
                                       | 1 |        n/a |   7.403 µs  62% |   6.228 µs  60% |   5.462 µs  57%
Remove duration *LA                    | 0 |        n/a |  11.996 µs      |  30.224 µs      |  32.297 µs
                                       | 1 |        n/a |   6.425 µs  54% |  14.448 µs  48% |  15.280 µs  47%
Find duration *LA                      | 0 |        n/a |   9.696 µs      |   9.233 µs      |   9.272 µs
                                       | 1 |        n/a |   6.659 µs  69% |   5.794 µs  63% |   5.983 µs  65%
Mem duration *LA                       | 0 |        n/a |   3.597 µs      |   9.274 µs      |   7.912 µs
                                       | 1 |        n/a |   2.693 µs  75% |   6.023 µs  65% |   4.931 µs  62%
Mem_tree duration *LA                  | 0 |        n/a |   2.439 µs      |   2.787 µs      |   2.829 µs
                                       | 1 |        n/a |   3.150 µs 129% |   1.886 µs  68% |   1.781 µs  63%
Copy duration *LA                      | 0 |        n/a |  18.139 µs      |  38.074 µs      |  13.476 µs
                                       | 1 |        n/a |  16.061 µs  89% |  14.802 µs  39% |  11.111 µs  82%
Checkout duration *LA                  | 0 |        n/a |   4.571 µs      |   4.527 µs      |   5.624 µs
                                       | 1 |        n/a |   5.143 µs 113% |   6.044 µs 134% |   6.500 µs 116%
                                       |   |            |                 |                 |
pack.finds per block *LA               | 0 |        n/a |   1710.372      |   2225.523      |   2859.420
                                       | 1 |        n/a |    630.879  37% |    739.917  33% |    955.487  33%
pack.cache_misses per block *LA        | 0 |        n/a |     88.360      |    121.048      |    206.057
                                       | 1 |        n/a |     33.407  38% |     53.979  45% |     93.906  46%
pack.appended_hashes per block *LA     | 0 |        n/a |  0.064_756      |  0.133_749      |  0.073_375
                                       | 1 |        n/a |  0.064_756 100% |  0.133_749 100% |  0.073_375 100%
pack.appended_offsets per block *LA    | 0 |        n/a |   1755.590      |   2463.144      |   3576.880
                                       | 1 |        n/a |   1941.100 111% |   2857.382 116% |   4194.988 117%
                                       |   |            |                 |                 |
tree.contents_hash per block *LA       | 0 |        n/a |    132.200      |    145.706      |    176.406
                                       | 1 |        n/a |    132.200 100% |    145.706 100% |    176.406 100%
tree.contents_find per block *LA       | 0 |        n/a |    195.419      |    248.149      |    348.266
                                       | 1 |        n/a |    195.419 100% |    248.161 100% |    348.359 100%
tree.contents_add per block *LA        | 0 |        n/a |     73.823      |     86.314      |    107.554
                                       | 1 |        n/a |     73.896 100% |     86.425 100% |    107.750 100%
tree.node_hash per block *LA           | 0 |        n/a |    222.388      |    296.157      |    412.139
                                       | 1 |        n/a |     82.650  37% |     86.508  29% |    115.339  28%
tree.node_mem per block *LA            | 0 |        n/a |    221.439      |    294.614      |    407.885
                                       | 1 |        n/a |     82.518  37% |     86.318  29% |    114.910  28%
tree.node_add per block *LA            | 0 |        n/a |    218.287      |    292.239      |    404.644
                                       | 1 |        n/a |     79.566  36% |     84.330  29% |    112.608  28%
tree.node_find per block *LA           | 0 |        n/a |    705.821      |    803.104      |    965.929
                                       | 1 |        n/a |    247.814  35% |    263.319  33% |    314.188  33%
tree.node_val_v per block *LA          | 0 |        n/a |  7.065e-13      |  6.047e-21      |  6.829e-29
                                       | 1 |        n/a |  7.065e-13 100% |  6.047e-21 100% |  6.829e-29 100%
tree.node_val_find per block *LA       | 0 |        n/a |          0      |          0      |          0
                                       | 1 |        n/a |          0      |          0      |          0
tree.node_val_list per block *LA       | 0 |        n/a |  1.690_392      |  2.235_998      |  4.800_511
                                       | 1 |        n/a |  1.157_440  68% |  1.190_748  53% |  1.514_817  32%
                                       |   |            |                 |                 |
index.bytes_read *C                    | 0 |    0.000 T |    3.149 T      |   11.840 T      |   29.132 T
                                       | 1 |    0.000 T |    2.134 T  68% |    6.756 T  57% |   14.625 T  50%
index.bytes_read per block *LA         | 0 |        n/a |   10.182 M      |   26.096 M      |   54.879 M
                                       | 1 |        n/a |    6.652 M  65% |   13.610 M  52% |   25.444 M  46%
index.bytes_read per sec *LA           | 0 |        n/a |  124.298 M      |  130.477 M      |  128.626 M
                                       | 1 |        n/a |  156.181 M 126% |  170.238 M 130% |  164.390 M 128%
index.nb_reads *C                      | 0 |    0.000 M |  788.413 M      | 2022.180 M      | 3604.103 M
                                       | 1 |    0.000 M |  636.667 M  81% | 1661.028 M  82% | 3088.435 M  86%
index.nb_reads per block *LA           | 0 |        n/a |   2216.740      |   2947.196      |   4459.369
                                       | 1 |        n/a |   1857.579  84% |   2523.268  86% |   4051.360  91%
index.nb_reads per sec *LA             | 0 |        n/a |     27_061      |     14_736      |     10_452
                                       | 1 |        n/a |     43_616 161% |     31_561 214% |     26_175 250%
index.bytes_written *C                 | 0 |    0.000 T |    1.185 T      |    6.940 T      |   20.580 T
                                       | 1 |    0.000 T |    0.399 T  34% |    2.260 T  33% |    6.629 T  32%
index.bytes_written per block *LA      | 0 |        n/a |    5.607 M      |   19.195 M      |   46.457 M
                                       | 1 |        n/a |    2.001 M  36% |    6.265 M  33% |   15.882 M  34%
index.bytes_written per sec *LA        | 0 |        n/a |   68.451 M      |   95.977 M      |  108.887 M
                                       | 1 |        n/a |   46.979 M  69% |   78.360 M  82% |  102.612 M  94%
index.nb_writes *C                     | 0 |         19 |  2_140_791      |  4_448_755      |  6_933_419
                                       | 1 |         19 |  1_990_265  93% |  4_057_497  91% |  6_167_447  89%
index.nb_writes per block *LA          | 0 |        n/a |  4.728_969      |  5.271_985      |  5.790_718
                                       | 1 |        n/a |  4.446_586  94% |  4.736_967  90% |  5.010_228  87%
index.nb_writes per sec *LA            | 0 |        n/a |     57.729      |     26.360      |     13.572
                                       | 1 |        n/a |    104.406 181% |     59.250 225% |     32.371 239%
index.nb_merge *C                      | 0 |          0 |        454      |      1_103      |      1_903
                                       | 1 |          0 |        260  57% |        626  57% |      1_076  57%
                                       |   |            |                 |                 |
gc.minor_words allocated *C            | 0 |    0.000 T |    2.300 T      |    8.088 T      |   18.370 T
                                       | 1 |    0.000 T |    1.071 T  47% |    3.153 T  39% |    6.801 T  37%
gc.minor_words allocated per block *LA | 0 |        n/a |    7.770 M      |   16.512 M      |   32.311 M
                                       | 1 |        n/a |    3.355 M  43% |    5.890 M  36% |   11.875 M  37%
gc.minor_words allocated per sec *LA   | 0 |        n/a |   94.856 M      |   82.558 M      |   75.731 M
                                       | 1 |        n/a |   78.784 M  83% |   73.669 M  89% |   76.725 M 101%
gc.promoted_words *C                   | 0 |    0.000 G |   69.636 G      |  183.911 G      |  329.477 G
                                       | 1 |    0.000 G |   36.201 G  52% |   86.016 G  47% |  151.900 G  46%
gc.major_words allocated *C            | 0 |    0.001 G |  220.272 G      | 1065.090 G      | 2941.268 G
                                       | 1 |    0.001 G |   87.045 G  40% |  373.020 G  35% |  993.472 G  34%
gc.major_words allocated per block *LA | 0 |        n/a |    910_013      |  2_710_317      |  6_301_567
                                       | 1 |        n/a |    351_540  39% |    914_365  34% |  2_198_077  35%
gc.major_words allocated per sec *LA   | 0 |        n/a |   11.109 M      |   13.552 M      |   14.770 M
                                       | 1 |        n/a |    8.254 M  74% |   11.437 M  84% |   14.202 M  96%
gc.minor_collections *C                | 0 |    0.000 M |    8.804 M      |   30.945 M      |   70.255 M
                                       | 1 |    0.000 M |    4.099 M  47% |   12.074 M  39% |   26.031 M  37%
gc.minor_collections per block *LA     | 0 |        n/a |     29.732      |     63.156      |    123.448
                                       | 1 |        n/a |     12.850  43% |     22.548  36% |     45.434  37%
gc.minor_collections per sec *LA       | 0 |        n/a |    362.954      |    315.777      |    289.341
                                       | 1 |        n/a |    301.712  83% |    282.030  89% |    293.546 101%
gc.major_collections *C                | 0 |          1 |     12_316      |     46_096      |     98_374
                                       | 1 |          1 |      5_031  41% |     18_238  40% |     39_634  40%
gc.major_collections per block *LA     | 0 |        n/a |  0.043_392      |  0.099_340      |  0.128_702
                                       | 1 |        n/a |  0.018_733  43% |  0.040_777  41% |  0.065_500  51%
gc.major_collections per sec *LA       | 0 |        n/a |  0.529_714      |  0.496_700      |  0.301_655
                                       | 1 |        n/a |  0.439_847  83% |  0.510_036 103% |  0.423_190 140%
gc.compactions *C                      | 0 |          0 |        232      |        571      |        987
                                       | 1 |          0 |        138  59% |        322  56% |        547  55%
gc.major heap bytes top *C             | 0 |    7.172 M | 2493.854 M      | 4547.162 M      | 4547.162 M
                                       | 1 |    7.172 M | 2054.713 M  82% | 2622.525 M  58% | 3530.043 M  78%
gc.major heap bytes *LA                | 0 |    7.172 M |  849.887 M      | 1066.414 M      |  535.695 M
                                       | 1 |    7.172 M |  671.678 M  79% |  825.680 M  77% | 1141.486 M 213%
                                       |   |            |                 |                 |
index_data bytes *S                    | 0 |    0.000 G |    5.126 G      |   12.480 G      |   21.520 G
                                       | 1 |    0.000 G |    2.934 G  57% |    7.061 G  57% |   12.143 G  56%
index_data bytes per block *LA         | 0 |        n/a |     13_007      |     17_869      |     24_901
                                       | 1 |        n/a |      7_995  61% |     10_214  57% |     15_020  60%
index_data bytes per sec *LA           | 0 |        n/a |    158_780      |     89_347      |     58_363
                                       | 1 |        n/a |    187_729 118% |    127_758 143% |     97_040 166%
store_pack bytes *S                    | 0 |    0.000 G |   11.320 G      |   29.187 G      |   51.802 G
                                       | 1 |    0.000 G |   11.800 G 104% |   34.633 G 119% |   71.232 G 138%
store_pack bytes per block *LA         | 0 |        n/a |     30_421      |     43_427      |     62_508
                                       | 1 |        n/a |     34_217 112% |     61_092 141% |     94_505 151%
store_pack bytes per sec *LA           | 0 |        n/a |    371_363      |    217_132      |    146_509
                                       | 1 |        n/a |    803_414 216% |    764_144 352% |    610_589 417%
index_log bytes *S                     | 0 |    0.000 M |   22.500 M      |   22.500 M      |   22.500 M
                                       | 1 |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
index_log_async *S                     | 0 |    0.000 M |   22.500 M      |   22.500 M      |   22.500 M
                                       | 1 |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
store_dict bytes *S                    | 0 |         24 |  2_458_592      |  2_458_592      |  2_458_592
                                       | 1 |         24 |  3_074_852 125% |  3_074_852 125% |  3_074_852 125%
                                       |   |            |                 |                 |
/data/contracts/index *S               | 0 |        n/a |          4      |        256      |        256
                                       | 1 |        n/a |          4 100% |    464_138 2e3x |  1_016_194 4e3x
/data/big_maps/index *S                | 0 |        n/a |          0      |         31      |        205
                                       | 1 |        n/a |          0      |         32 103% |        417 203%
/data/rolls/index *S                   | 0 |        n/a |        256      |        256      |        256
                                       | 1 |        n/a |     55_938 219x |     81_987 320x |     85_410 334x
/data/rolls/owner/current *S           | 0 |        n/a |        256      |        256      |        256
                                       | 1 |        n/a |     56_401 220x |     81_118 317x |     84_614 331x
/data/commitments *S                   | 0 |        n/a |        256      |        256      |        256
                                       | 1 |        n/a |     13_445  53x |      8_287  32x |      5_935  23x
/data/contracts/index/ed25519 *S       | 0 |        n/a |        256      |          0      |          0
                                       | 1 |        n/a |    247_726 968x |          0      |          0
/data/contracts/index/originated *S    | 0 |        n/a |        256      |          0      |          0
                                       | 1 |        n/a |     18_856  74x |          0      |          0

Types of curves:
  *C: Cumulative. No smoothing.
  *LA: Local Average. Smoothed using a weighted sum of the value in the
       block and the exponentially decayed values of the previous blocks.
       Every 16793.71 blocks, half of the past is forgotten.
  *S: Size. E.g. directory entries, file bytes. No smoothing.
```