### PR TITLE
irmin-pack: avoid clearing the files too much

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 - **irmin-layers**
   - Do not fail on double-close errors for private nodes (#1421, @samoht)
 
+- **irmin-pack**
+  - Do not clear and bump the generation for empty files (#1420, @samoht)
+
 ### Added
 
 - **irmin-graphql**

--- a/src/irmin-pack/content_addressable.ml
+++ b/src/irmin-pack/content_addressable.ml
@@ -44,12 +44,13 @@ struct
   }
 
   let clear ?keep_generation t =
-    Index.clear t.index;
-    match V.version with
-    | `V1 -> IO.truncate t.block
-    | `V2 ->
-        IO.clear ?keep_generation t.block;
-        Dict.clear t.dict
+    if IO.offset t.block <> Int63.zero then (
+      Index.clear t.index;
+      match V.version with
+      | `V1 -> IO.truncate t.block
+      | `V2 ->
+          IO.clear ?keep_generation t.block;
+          Dict.clear t.dict)
 
   let valid t =
     if t.open_instances <> 0 then (


### PR DESCRIPTION
It's only needed when the pack file is really empty