### PR TITLE
irmin-layers: make Repo.batch re-entrant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - **irmin-layers**
   - Do not fail on double-close errors for private nodes (#1421, @samoht)
+  - Fix `Repo.batch` to be re-entrant (#TODO, @samoht)
 
 ### Added
 

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -26,7 +26,8 @@ module type S = sig
     read U.t ->
     read L.t option ->
     flip:bool ->
-    freeze_in_progress:(unit -> bool) ->
+    record:(unit -> bool) ->
+    update_lock:Lwt_mutex.t ->
     read t
 
   val layer_id : read t -> key -> Irmin_layers.Layer_id.t Lwt.t

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -69,13 +69,7 @@ module type Atomic_write = sig
   module U : S
   module L : S
 
-  val v :
-    U.t ->
-    U.t ->
-    L.t option ->
-    flip:bool ->
-    freeze_in_progress:(unit -> bool) ->
-    t
+  val v : U.t -> U.t -> L.t option -> flip:bool -> record:(unit -> bool) -> t
 
   val copy :
     mem_commit_lower:(value -> bool Lwt.t) ->
@@ -101,7 +95,8 @@ module type Content_addressable = sig
     read U.t ->
     read L.t option ->
     flip:bool ->
-    freeze_in_progress:(unit -> bool) ->
+    record:(unit -> bool) ->
+    update_lock:Lwt_mutex.t ->
     read t
 
   val layer_id : read t -> key -> Irmin_layers.Layer_id.t Lwt.t


### PR DESCRIPTION
We want nested batches to work properly to avoid deadlocks.

I am not sure to understand what happens for the functions which are not in the Lwt monad (and thus can't take the lock, like `unsafe_append`). /cc @icristescu 