### PR TITLE
Require specific Info implementation for `Commit.V1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@
     (#1401, @samoht)
   - `Info` implementations are not part of store: use `S.Info.v`
     instead of `Irmin.Info.v` (#1400, @samoht)
+  - Rename `Commit.V1` to `Commit.V1.Make` (#1431, @CraigFe)
 
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -32,9 +32,10 @@ module Make (G : Git.S) = struct
   include Content_addressable.Check_closed (Content_addressable.Make (G) (V))
 
   module Val = struct
+    module Info = Info
+
     type t = G.Value.Commit.t
     type hash = Key.t [@@deriving irmin]
-    type info = Info.t [@@deriving irmin]
 
     let info_of_git author message =
       let id = author.Git.User.name in

--- a/src/irmin-git/commit.mli
+++ b/src/irmin-git/commit.mli
@@ -30,5 +30,5 @@ module Make (G : Git.S) : sig
     Irmin.Private.Commit.S
       with type t = value
        and type hash = key
-       and type info = Info.t
+       and module Info = Info
 end


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/mirage/irmin/pull/1400 that caused the format of V1 commits to change.

Alternative to https://github.com/mirage/irmin/pull/1428.