### PR TITLE
irmin-bench: More summaries and new tables in PP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,9 @@
 - **irmin-bench**
   - Benchmarks for tree operations now support layered stores
     (#1293, @Ngoguey42)
-  - New features in benchmarks for tree operations (#1314, #1326, #1357,
-    #1358, #1367, #1384, #1403, #1404, #1416, #1429, #1430 @Ngoguey42)
+  - New features in benchmarks for tree operations (TODO: A pretty description
+    just before release) (#1314, #1326, #1357, #1358, #1367, #1384, #1403,
+    #1404, #1416, #1429, #1430, #1438 @Ngoguey42)
   - Check hash of commit in benchmarks for trees (#1328, @icristescu)
 
 - **irmin**


### PR DESCRIPTION
This shows a slowdown on the [Copy](https://github.com/mirage/irmin/blob/master/bench/irmin-pack/trace_replay.ml#L212-L215) operation:

```
                              |       |      min      |       max        |      avg
Copy duration (s)             | jan   | 0.800 µs      |    0.101 ms      |  6.481 µs     
                              | feb   | 0.868 µs 108% |    0.452 ms 448% |  7.601 µs 117%
                              | mars  | 0.909 µs 114% |    1.044 ms  10x |  8.547 µs 132%
                              | april | 1.059 µs 132% |    1.815 ms  18x | 16.110 µs 249%
                              | may   | 0.967 µs 121% |    2.070 ms  21x | 10.933 µs 169%
```

I'm not 100% sure this is relevant.


<details>
  <summary>The full (approximate) diff on PP</summary>

```diff
  -- setups --
                  | jan                       | feb                       | mars                      | april                     | may
  Hostname        | am-c3-small-x86-01        | am-c3-small-x86-01        | am-c3-small-x86-01        | am-c3-small-x86-01        | am-c3-small-x86-01
  Word Size       | 64 bits                   | 64 bits                   | 64 bits                   | 64 bits                   | 64 bits
  Start Time      | 2021/05/05 15:27:43 (GMT) | 2021/05/05 07:30:54 (GMT) | 2021/05/04 20:21:08 (GMT) | 2021/05/04 19:28:08 (GMT) | 2021/05/04 21:17:06 (GMT)
  Inode Config    | mls:32 bf:32 sh:256       | mls:32 bf:32 sh:256       | mls:32 bf:32 sh:256       | mls:32 bf:32 sh:256       | mls:32 bf:32 sh:256
  Store Type      | pack                      | pack                      | pack                      | pack                      | pack
  Path Conversion | none                      | none                      | none                      | none                      | none
  
                           |    jan    |      feb       |      mars      |     april      |      may
  -- main metrics --       |           |                |                |                | 
  CPU time elapsed         |    44m59s |    44m54s 100% |    44m50s 100% |    43m16s  96% |    39m03s  87%
  TZ-transactions per sec  |   160.890 |   161.185 100% |   161.408 100% |   167.295 104% |   185.299 115%
  TZ-operations per sec    |  1439.315 |  1441.960 100% |  1443.955 100% |  1496.614 104% |  1657.679 115%
  Context.set per sec      |  6913.286 |  6925.991 100% |  6935.574 100% |  7188.503 104% |  7962.130 115%
  tail latency (1)         |  26.344 s |  26.378 s 100% |  26.494 s 101% |  25.376 s  96% |  12.121 s  46%
                           |           |                |                |                | 
  -- resource usage --     |           |                |                |                | 
  disk IO (total)          |           |                |                |                | 
    IOPS (op/sec)          |    95_958 |    96_135 100% |    96_268 100% |    99_781 104% |   103_485 108%
    throughput (bytes/sec) | 362.259 M | 362.928 M 100% | 363.427 M 100% | 376.682 M 104% | 326.393 M  90%
    total (bytes)          | 977.701 G | 977.709 G 100% | 977.700 G 100% | 977.704 G 100% | 764.862 G  78%
  disk IO (read)           |           |                |                |                | 
    IOPS (op/sec)          |    95_612 |    95_788 100% |    95_920 100% |    99_421 104% |   103_104 108%
    throughput (bytes/sec) | 300.409 M | 300.962 M 100% | 301.377 M 100% | 312.369 M 104% | 289.558 M  96%
    total (bytes)          | 810.773 G | 810.776 G 100% | 810.773 G 100% | 810.776 G 100% | 678.542 G  84%
  disk IO (write)          |           |                |                |                | 
    IOPS (op/sec)          |       346 |       347 100% |       347 100% |       360 104% |       381 110%
    throughput (bytes/sec) |  61.850 M |  61.966 M 100% |  62.050 M 100% |  64.313 M 104% |  36.836 M  60%
    total (bytes)          | 166.928 G | 166.933 G 100% | 166.928 G 100% | 166.928 G 100% |  86.320 G  52%
                           |           |                |                |                | 
  max memory usage         |   2.081 G |   1.863 G  90% |   1.770 G  85% |   1.720 G  83% |   2.326 G 112%
  mean CPU usage           |       91% |       91%      |       91%      |       90%      |       95%     
  
   - (1) Longest Context.commit.
   - The "per sec" stats are calculated over CPU time.
   - "TZ-transactions" and "TZ-operations" are approximations.
   - "max memory usage" is the max size of OCaml's major heap.
   - "mean CPU usage" is inexact.
  
+ -- global --
+                          |       | min per block |  max per block  | avg per block |   avg per sec
+                          |       |               |                 |               | 
+ Add count                | jan   |        3      |    123_869      |   93.291      |   6265.079     
+                          | feb   |        3 100% |    123_869 100% |   93.291 100% |   6280.231 100%
+                          | mars  |        3 100% |    123_869 100% |   93.291 100% |   6285.378 100%
+                          | april |        3 100% |    123_869 100% |   93.291 100% |   6486.891 104%
+                          | may   |        3 100% |    123_869 100% |   93.291 100% |   7576.116 121%
+ Remove count             | jan   |        0      |     15_385      |    2.741      |    184.050     
+                          | feb   |        0      |     15_385 100% |    2.741 100% |    184.495 100%
+                          | mars  |        0      |     15_385 100% |    2.741 100% |    184.647 100%
+                          | april |        0      |     15_385 100% |    2.741 100% |    190.567 104%
+                          | may   |        0      |     15_385 100% |    2.741 100% |    222.565 121%
+ Find count               | jan   |        2      |    105_935      |  267.307      |  17951.291     
+                          | feb   |        2 100% |    105_935 100% |  267.307 100% |  17994.705 100%
+                          | mars  |        2 100% |    105_935 100% |  267.307 100% |  18009.452 100%
+                          | april |        2 100% |    105_935 100% |  267.307 100% |  18586.846 104%
+                          | may   |        2 100% |    105_935 100% |  267.307 100% |  21707.797 121%
+ Mem count                | jan   |        0      |     93_342      |   65.326      |   4387.018     
+                          | feb   |        0      |     93_342 100% |   65.326 100% |   4397.628 100%
+                          | mars  |        0      |     93_342 100% |   65.326 100% |   4401.232 100%
+                          | april |        0      |     93_342 100% |   65.326 100% |   4542.338 104%
+                          | may   |        0      |     93_342 100% |   65.326 100% |   5305.050 121%
+ Mem_tree count           | jan   |        0      |         39      |   33.001      |   2216.190     
+                          | feb   |        0      |         39 100% |   33.001 100% |   2221.550 100%
+                          | mars  |        0      |         39 100% |   33.001 100% |   2223.370 100%
+                          | april |        0      |         39 100% |   33.001 100% |   2294.653 104%
+                          | may   |        0      |         39 100% |   33.001 100% |   2679.952 121%
+ Copy count               | jan   |        0      |          7      |    0.004      |      0.265     
+                          | feb   |        0      |          7 100% |    0.004 100% |      0.265 100%
+                          | mars  |        0      |          7 100% |    0.004 100% |      0.265 100%
+                          | april |        0      |          7 100% |    0.004 100% |      0.274 104%
+                          | may   |        0      |          7 100% |    0.004 100% |      0.320 121%
+ Commit count             | jan   |        1      |          1      |    1.000      |     67.156     
+                          | feb   |        1 100% |          1 100% |    1.000 100% |     67.319 100%
+                          | mars  |        1 100% |          1 100% |    1.000 100% |     67.374 100%
+                          | april |        1 100% |          1 100% |    1.000 100% |     69.534 104%
+                          | may   |        1 100% |          1 100% |    1.000 100% |     81.209 121%
+                          |       |               |                 |               | 
+ Disk bytes read          | jan   |        0      | 3726.755 M      |  4.054 M      |  272.242 M     
+                          | feb   |        0      | 3727.655 M 100% |  4.054 M 100% |  272.901 M 100%
+                          | mars  |        0      | 3733.955 M 100% |  4.054 M 100% |  273.124 M 100%
+                          | april |        0      | 3731.705 M 100% |  4.054 M 100% |  281.881 M 104%
+                          | may   |        0      | 1913.208 M  51% |  3.393 M  84% |  275.519 M 101%
+ Disk bytes written       | jan   |        0      | 3778.940 M      |  0.835 M      |   56.051 M     
+                          | feb   |        0      | 3778.940 M 100% |  0.835 M 100% |   56.188 M 100%
+                          | mars  |        0      | 3789.329 M 100% |  0.835 M 100% |   56.233 M 100%
+                          | april |        0      | 3784.135 M 100% |  0.835 M 100% |   58.035 M 104%
+                          | may   |        0      | 1889.931 M  50% |  0.432 M  52% |   35.050 M  63%
+ Disk bytes both          | jan   |        0      | 7505.696 M      |  4.889 M      |  328.293 M     
+                          | feb   |        0      | 7506.596 M 100% |  4.889 M 100% |  329.090 M 100%
+                          | mars  |        0      | 7523.285 M 100% |  4.889 M 100% |  329.356 M 100%
+                          | april |        0      | 7515.840 M 100% |  4.889 M 100% |  339.917 M 104%
+                          | may   |        0      | 3803.139 M  51% |  3.824 M  78% |  310.569 M  95%
+                          |       |               |                 |               | 
+ Disk reads               | jan   |        0      |    262_573      | 1290.238      |  86647.327     
+                          | feb   |        0      |    262_573 100% | 1290.238 100% |  86856.882 100%
+                          | mars  |        0      |    262_573 100% | 1290.238 100% |  86928.058 100%
+                          | april |        0      |    262_531 100% | 1290.274 100% |  89717.569 104%
+                          | may   |        0      |    242_369  92% | 1208.058  94% |  98105.473 113%
+ Disk writes              | jan   |        0      |      1_520      |    4.670      |    313.630     
+                          | feb   |        0      |      1_520 100% |    4.670 100% |    314.389 100%
+                          | mars  |        0      |      1_524 100% |    4.670 100% |    314.646 100%
+                          | april |        0      |      1_522 100% |    4.670 100% |    324.734 104%
+                          | may   |        0      |      1_282  84% |    4.461  96% |    362.269 116%
+ Disk both                | jan   |        0      |    262_627      | 1294.908      |  86960.957     
+                          | feb   |        0      |    262_627 100% | 1294.908 100% |  87171.271 100%
+                          | mars  |        0      |    262_627 100% | 1294.908 100% |  87242.704 100%
+                          | april |        0      |    262_585 100% | 1294.945 100% |  90042.303 104%
+                          | may   |        0      |    242_389  92% | 1212.519  94% |  98467.742 113%
+                          |       |               |                 |               | 
+ pack.finds               | jan   |        0      |    128_319      |  887.845      |  59624.224     
+                          | feb   |        0      |    128_321 100% |  889.845 100% |  59903.058 100%
+                          | mars  |        0      |    127_346  99% |  887.563 100% |  59798.389 100%
+                          | april |        0      |    127_347  99% |  887.565 100% |  61715.670 104%
+                          | may   |        0      |    127_351  99% |  892.561 101% |  72484.209 122%
+ pack.cache_misses        | jan   |        0      |     60_157      |   58.480      |   3927.274     
+                          | feb   |        0      |     60_157 100% |   58.480 100% |   3936.772 100%
+                          | mars  |        0      |     60_156 100% |   58.480 100% |   3939.995 100%
+                          | april |        0      |     60_156 100% |   58.485 100% |   4066.710 104%
+                          | may   |        0      |     60_156 100% |   58.485 100% |   4749.554 121%
+ pack.appended_hashes     | jan   |        0      |        156      |    0.093      |      6.229     
+                          | feb   |        0      |        156 100% |    0.093 100% |      6.244 100%
+                          | mars  |        0      |        156 100% |    0.093 100% |      6.249 100%
+                          | april |        0      |        156 100% |    0.093 100% |      6.450 104%
+                          | may   |        0      |        156 100% |    0.093 100% |      7.533 121%
+ pack.appended_offsets    | jan   |        0      |    251_219      | 1051.721      |  70629.461     
+                          | feb   |        0      |    251_219 100% | 1051.721 100% |  70800.275 100%
+                          | mars  |        0      |    251_219 100% | 1051.721 100% |  70858.298 100%
+                          | april |        0      |    251_219 100% | 1051.721 100% |  73130.056 104%
+                          | may   |        0      |    251_219 100% | 1051.721 100% |  85409.455 121%
+                          |       |               |                 |               | 
+ tree.contents_hash       | jan   |        0      |     62_693      |   60.099      |   4036.030     
+                          | feb   |        0      |     62_693 100% |   60.099 100% |   4045.791 100%
+                          | mars  |        0      |     62_693 100% |   60.122 100% |   4050.650 100%
+                          | april |        0      |     62_693 100% |   60.122 100% |   4180.516 104%
+                          | may   |        0      |     62_693 100% |   60.122 100% |   4882.474 121%
+ tree.contents_find       | jan   |        0      |     55_773      |  146.600      |   9845.059     
+                          | feb   |        0      |     55_775 100% |  148.600 101% |  10003.504 102%
+                          | mars  |        0      |     54_800  98% |  146.307 100% |   9857.210 100%
+                          | april |        0      |     54_800  98% |  146.307 100% |  10173.238 103%
+                          | may   |        0      |     54_800  98% |  146.307 100% |  11881.444 121%
+ tree.contents_add        | jan   |        0      |     36_134      |   52.712      |   3539.908     
+                          | feb   |        0      |     36_134 100% |   52.712 100% |   3548.469 100%
+                          | mars  |        0      |     36_134 100% |   52.728 100% |   3552.475 100%
+                          | april |        0      |     36_134 100% |   52.728 100% |   3666.369 104%
+                          | may   |        0      |     36_134 100% |   52.728 100% |   4281.996 121%
+ tree.node_hash           | jan   |        0      |    166_818      |  163.701      |  10993.541     
+                          | feb   |        0      |    166_818 100% |  163.701 100% |  11020.128 100%
+                          | mars  |        0      |    166_818 100% |  163.701 100% |  11029.159 100%
+                          | april |        0      |    166_818 100% |  163.701 100% |  11382.761 104%
+                          | may   |        0      |    166_818 100% |  163.701 100% |  13294.060 121%
+ tree.node_mem            | jan   |        0      |    166_778      |  162.869      |  10937.674     
+                          | feb   |        0      |    166_778 100% |  162.869 100% |  10964.126 100%
+                          | mars  |        0      |    166_778 100% |  162.869 100% |  10973.113 100%
+                          | april |        0      |    166_778 100% |  162.869 100% |  11324.918 104%
+                          | may   |        0      |    166_778 100% |  162.869 100% |  13226.505 121%
+ tree.node_add            | jan   |        0      |    166_778      |  160.280      |  10763.749     
+                          | feb   |        0      |    166_778 100% |  160.280 100% |  10789.780 100%
+                          | mars  |        0      |    166_778 100% |  160.280 100% |  10798.623 100%
+                          | april |        0      |    166_778 100% |  160.280 100% |  11144.833 104%
+                          | may   |        0      |    166_778 100% |  160.280 100% |  13016.182 121%
+ tree.node_find           | jan   |        0      |     56_658      |  248.026      |  16656.445     
+                          | feb   |        0      |     56_658 100% |  248.026 100% |  16696.728 100%
+                          | mars  |        0      |     56_658 100% |  248.031 100% |  16710.779 100%
+                          | april |        0      |     56_659 100% |  248.035 100% |  17246.786 104%
+                          | may   |        0      |     56_663 100% |  253.031 102% |  20548.475 123%
+ tree.node_val_v          | jan   |        0      |        578      |    0.426      |     28.602     
+                          | feb   |        0      |        578 100% |    0.426 100% |     28.672 100%
+                          | mars  |        0      |          2 0.3% |    0.000 0.0% |      0.001 0.0%
+                          | april |        0      |          2 0.3% |    0.000 0.0% |      0.001 0.0%
+                          | may   |        0      |          2 0.3% |    0.000 0.0% |      0.001 0.0%
+ tree.node_val_find       | jan   |        0      |          0      |        0      |          0     
+                          | feb   |        0      |          0      |        0      |          0     
+                          | mars  |        0      |          0      |        0      |          0     
+                          | april |        0      |          0      |        0      |          0     
+                          | may   |        0      |          0      |        0      |          0     
+ tree.node_val_list       | jan   |        0      |      1_274      |    2.353      |    158.036     
+                          | feb   |        0      |      1_274 100% |    2.353 100% |    158.419 100%
+                          | mars  |        0      |      2_036 160% |    2.426 103% |    163.456 103%
+                          | april |        0      |        696  55% |    1.913  81% |    133.031  84%
+                          | may   |        0      |        696  55% |    1.913  81% |    155.369  98%
+                          |       |               |                 |               | 
+ index.cumu_data_bytes    | jan   |        0      |          0      |        0      |          0     
+                          | feb   |        0      |          0      |        0      |          0     
+                          | mars  |        0      |          0      |        0      |          0     
+                          | april |        0      |          0      |        0      |          0     
+                          | may   |        0      | 1871.698 M      |  393_266      | 31_936_832     
+                          |       |               |                 |               | 
+ gc.minor_words allocated | jan   |  0.014 M      | 5420.606 M      |  3.613 M      |  242.603 M     
+                          | feb   |  0.015 M 104% | 5415.510 M 100% |  3.669 M 102% |  247.003 M 102%
+                          | mars  |  0.015 M 104% | 4844.416 M  89% |  3.474 M  96% |  234.078 M  96%
+                          | april |  0.015 M 103% | 1855.255 M  34% |  2.806 M  78% |  195.077 M  80%
+                          | may   |  0.015 M 103% | 1060.621 M  20% |  2.614 M  72% |  212.269 M  87%
+ gc.major_words allocated | jan   |        0      |  484.464 M      |  0.216 M      |   14.494 M     
+                          | feb   |        0      |  480.216 M  99% |  0.218 M 101% |   14.665 M 101%
+                          | mars  |        0      |  481.478 M  99% |  0.216 M 100% |   14.544 M 100%
+                          | april |        0      |  480.603 M  99% |  0.215 M 100% |   14.950 M 103%
+                          | may   |        0      |  243.507 M  50% |  0.164 M  76% |   13.307 M  92%
+ gc.minor_collections     | jan   |        0      |     20_783      |   13.809      |    927.372     
+                          | feb   |        0      |     20_762 100% |   14.026 102% |    944.197 102%
+                          | mars  |        0      |     18_586  89% |   13.277  96% |    894.524  96%
+                          | april |        0      |      7_234  35% |   10.741  78% |    746.851  81%
+                          | may   |        0      |      4_148  20% |    9.986  72% |    810.958  87%
+ gc.major_collections     | jan   |        0      |         27      |    0.014      |      0.924     
+                          | feb   |        0      |         34 126% |    0.014 104% |      0.967 105%
+                          | mars  |        0      |         32 119% |    0.014 102% |      0.948 103%
+                          | april |        0      |         34 126% |    0.014 104% |      0.999 108%
+                          | may   |        0      |         15  56% |    0.008  62% |      0.690  75%
+ 
+                               |       |      min      |       max        |      avg
+                               |       |               |                  | 
+ Block duration (s)            | jan   | 0.144 ms      |    26.346 s      | 14.891 ms     
+                               | feb   | 0.179 ms 124% |    26.384 s 100% | 14.855 ms 100%
+                               | mars  | 0.516 ms 358% |    26.498 s 101% | 14.843 ms 100%
+                               | april | 0.509 ms 354% |    25.378 s  96% | 14.382 ms  97%
+                               | may   | 0.254 ms 176% |    12.123 s  46% | 12.314 ms  83%
+ Buildup duration (s)          | jan   | 0.047 ms      |     1.080 s      |  2.561 ms     
+                               | feb   | 0.071 ms 152% |     2.789 s 258% |  2.769 ms 108%
+                               | mars  | 0.256 ms 545% |     1.237 s 115% |  2.629 ms 103%
+                               | april | 0.249 ms 531% |     1.183 s 110% |  2.587 ms 101%
+                               | may   | 0.129 ms 276% |     1.444 s 134% |  2.670 ms 104%
+ Commit duration (s)           | jan   | 0.025 ms      |    26.344 s      | 12.330 ms     
+                               | feb   | 0.026 ms 103% |    26.378 s 100% | 12.086 ms  98%
+                               | mars  | 0.026 ms 102% |    26.494 s 101% | 12.214 ms  99%
+                               | april | 0.025 ms 100% |    25.376 s  96% | 11.795 ms  96%
+                               | may   | 0.026 ms 103% |    12.121 s  46% |  9.644 ms  78%
+                               |       |               |                  | 
+ Add duration (s)              | jan   | 0.163 µs      |  578.155 ms      |  4.182 µs     
+                               | feb   | 0.167 µs 102% |  659.717 ms 114% |  4.780 µs 114%
+                               | mars  | 0.164 µs 101% |  621.928 ms 108% |  5.197 µs 124%
+                               | april | 0.167 µs 102% |  647.888 ms 112% |  5.235 µs 125%
+                               | may   | 0.166 µs 102% | 1187.109 ms 205% |  4.939 µs 118%
+ Remove duration (s)           | jan   | 0.304 µs      |  284.493 ms      | 16.113 µs     
+                               | feb   | 0.301 µs  99% |  306.023 ms 108% | 14.805 µs  92%
+                               | mars  | 0.246 µs  81% |  283.594 ms 100% | 11.875 µs  74%
+                               | april | 0.320 µs 105% |    4.358 ms 1.5% |  2.873 µs  18%
+                               | may   | 0.233 µs  77% |    4.531 ms 1.6% |  2.789 µs  17%
+ Find duration (s)             | jan   | 0.094 µs      |  612.092 ms      |  4.744 µs     
+                               | feb   | 0.096 µs 102% |  672.335 ms 110% |  5.097 µs 107%
+                               | mars  | 0.086 µs  91% |  661.461 ms 108% |  4.825 µs 102%
+                               | april | 0.089 µs  95% |  656.053 ms 107% |  4.724 µs 100%
+                               | may   | 0.087 µs  93% | 1252.647 ms 205% |  4.796 µs 101%
+ Mem duration (s)              | jan   | 0.161 µs      |  469.066 ms      |  2.336 µs     
+                               | feb   | 0.165 µs 102% |  601.370 ms 128% |  2.583 µs 111%
+                               | mars  | 0.142 µs  88% |  604.611 ms 129% |  2.158 µs  92%
+                               | april | 0.146 µs  91% |  626.354 ms 134% |  2.123 µs  91%
+                               | may   | 0.139 µs  86% | 1061.932 ms 226% |  2.274 µs  97%
+ Mem_tree duration (s)         | jan   | 0.268 µs      |  590.356 ms      |  1.663 µs     
+                               | feb   | 0.280 µs 104% |  626.645 ms 106% |  1.825 µs 110%
+                               | mars  | 0.210 µs  78% |  610.529 ms 103% |  1.327 µs  80%
+                               | april | 0.212 µs  79% |  249.164 ms  42% |  1.220 µs  73%
+                               | may   | 0.210 µs  78% |   10.744 ms 1.8% |  1.168 µs  70%
+ Copy duration (s)             | jan   | 0.800 µs      |    0.101 ms      |  6.481 µs     
+                               | feb   | 0.868 µs 108% |    0.452 ms 448% |  7.601 µs 117%
+                               | mars  | 0.909 µs 114% |    1.044 ms  10x |  8.547 µs 132%
+                               | april | 1.059 µs 132% |    1.815 ms  18x | 16.110 µs 249%
+                               | may   | 0.967 µs 121% |    2.070 ms  21x | 10.933 µs 169%
+ Unseen duration (s)           | jan   | 0.043 ms      |     0.634 s      |  0.649 ms     
+                               | feb   | 0.067 ms 155% |     2.780 s 439% |  0.689 ms 106%
+                               | mars  | 0.118 ms 274% |     0.645 s 102% |  0.635 ms  98%
+                               | april | 0.119 ms 276% |     0.643 s 101% |  0.647 ms 100%
+                               | may   | 0.120 ms 277% |     1.184 s 187% |  0.730 ms 113%
+                               |       |               |                  | 
+ Major heap bytes after commit | jan   |  7.664 M      |  1951.486 M      | 713.092 M     
+                               | feb   |  7.664 M 100% |  1511.346 M  77% | 581.045 M  81%
+                               | mars  |  7.664 M 100% |  1403.023 M  72% | 549.105 M  77%
+                               | april |  7.664 M 100% |  1300.746 M  67% | 580.188 M  81%
+                               | may   |  7.172 M  94% |  2075.066 M 106% | 858.935 M 120%
+                               |       |               |                  | 
+ CPU Usage                     | jan   |       4%      |        123%      |      102%     
+                               | feb   |      10%      |        121%      |      102%     
+                               | mars  |      46%      |        124%      |      102%     
+                               | april |      40%      |        125%      |      102%     
+                               | may   |      16%      |        129%      |      102%     
+
  -- evolution through blocks --
  Block played count *C                  |       | 0 (before) |      67000      |     134000      |  200000 (end)
  Blocks progress *C                     |       |     0%     |       34%       |       67%       |      100%
                                         |       |            |                 |                 | 
  Wall time elapsed *C                   | jan   |        0us |    7min14s      |   23min52s      |   49min38s     
                                         | feb   |        0us |     7min7s  99% |   23min33s  99% |   49min30s 100%
                                         | mars  |        0us |     7min3s  98% |   23min35s  99% |   49min28s 100%
                                         | april |        0us |     7min2s  97% |   23min12s  97% |   47min56s  97%
                                         | may   |        0us |    6min39s  92% |   20min53s  87% |    41min2s  83%
  CPU time elapsed *C                    | jan   |        0us |     7min6s      |   22min24s      |   44min58s     
                                         | feb   |        0us |    6min59s  98% |    22min5s  99% |   44min53s 100%
                                         | mars  |        0us |    6min55s  98% |    22min8s  99% |   44min50s 100%
                                         | april |        0us |    6min54s  97% |   21min44s  97% |   43min15s  96%
                                         | may   |        0us |    6min38s  94% |   20min16s  90% |    39min3s  87%
+ CPU Usage *LA                          | jan   |        n/a |       101%      |       101%      |       101%     
+                                        | feb   |        n/a |       102%      |       101%      |       101%     
+                                        | mars  |        n/a |       102%      |       101%      |       101%     
+                                        | april |        n/a |       102%      |       101%      |       101%     
+                                        | may   |        n/a |       102%      |       101%      |       101%     
                                         |       |            |                 |                 | 
  Approx. TZ-transaction count *C        | jan   |          0 |     40_189      |    143_179      |    434_225     
                                         | feb   |          0 |     40_189 100% |    143_179 100% |    434_225 100%
                                         | mars  |          0 |     40_189 100% |    143_179 100% |    434_225 100%
                                         | april |          0 |     40_189 100% |    143_179 100% |    434_225 100%
                                         | may   |          0 |     40_189 100% |    143_179 100% |    434_225 100%
  Approx. TZ-operations count *C         | jan   |          0 |    763_445      |  2_154_604      |  3_884_565     
                                         | feb   |          0 |    763_445 100% |  2_154_604 100% |  3_884_565 100%
                                         | mars  |          0 |    763_445 100% |  2_154_604 100% |  3_884_565 100%
                                         | april |          0 |    763_445 100% |  2_154_604 100% |  3_884_565 100%
                                         | may   |          0 |    763_445 100% |  2_154_604 100% |  3_884_565 100%
  Op count *C                            | jan   |    0.000 M |   24.081 M      |   55.429 M      |   92.734 M     
                                         | feb   |    0.000 M |   24.081 M 100% |   55.429 M 100% |   92.734 M 100%
                                         | mars  |    0.000 M |   24.081 M 100% |   55.429 M 100% |   92.734 M 100%
                                         | april |    0.000 M |   24.081 M 100% |   55.429 M 100% |   92.734 M 100%
                                         | may   |    0.000 M |   24.081 M 100% |   55.429 M 100% |   92.734 M 100%
                                         |       |            |                 |                 | 
  Commit per sec *LA *N                  | jan   |        n/a |    105.125      |     58.122      |     23.860     
                                         | feb   |        n/a |    105.757 101% |     60.277 104% |     23.893 100%
                                         | mars  |        n/a |    103.859  99% |     59.410 102% |     23.738  99%
                                         | april |        n/a |    106.451 101% |     60.436 104% |     24.320 102%
                                         | may   |        n/a |    111.257 106% |     71.074 122% |     31.244 131%
  Add per sec *LA *N                     | jan   |        n/a |   9013.704      |   5905.723      |   6654.787     
                                         | feb   |        n/a |   9067.904 101% |   6124.687 104% |   6664.015 100%
                                         | mars  |        n/a |   8905.188  99% |   6036.619 102% |   6620.707  99%
                                         | april |        n/a |   9127.394 101% |   6140.822 104% |   6783.243 102%
                                         | may   |        n/a |   9539.538 106% |   7221.740 122% |   8714.406 131%
  Remove per sec *LA *N                  | jan   |        n/a |    182.032      |     75.197      |    484.558     
                                         | feb   |        n/a |    183.126 101% |     77.985 104% |    485.230 100%
                                         | mars  |        n/a |    179.840  99% |     76.863 102% |    482.076  99%
                                         | april |        n/a |    184.328 101% |     78.190 104% |    493.911 102%
                                         | may   |        n/a |    192.651 106% |     91.953 122% |    634.526 131%
  Find per sec *LA *N                    | jan   |        n/a |  27072.759      |  16214.345      |  12952.895     
                                         | feb   |        n/a |  27235.550 101% |  16815.517 104% |  12970.857 100%
                                         | mars  |        n/a |  26746.830  99% |  16573.723 102% |  12886.562  99%
                                         | april |        n/a |  27414.229 101% |  16859.815 104% |  13202.922 102%
                                         | may   |        n/a |  28652.108 106% |  19827.511 122% |  16961.742 131%
  Mem per sec *LA *N                     | jan   |        n/a |   5092.591      |   3590.920      |   6380.263     
                                         | feb   |        n/a |   5123.213 101% |   3724.059 104% |   6389.110 100%
                                         | mars  |        n/a |   5031.281  99% |   3670.510 102% |   6347.589  99%
                                         | april |        n/a |   5156.824 101% |   3733.869 104% |   6503.419 102%
                                         | may   |        n/a |   5389.679 106% |   4391.112 122% |   8354.918 131%
  Mem_tree per sec *LA *N                | jan   |        n/a |   3469.157      |   1918.023      |    787.382     
                                         | feb   |        n/a |   3490.017 101% |   1989.137 104% |    788.474 100%
                                         | mars  |        n/a |   3427.391  99% |   1960.535 102% |    783.350  99%
                                         | april |        n/a |   3512.913 101% |   1994.377 104% |    802.580 102%
                                         | may   |        n/a |   3671.537 106% |   2345.431 122% |   1031.072 131%
  Copy per sec *LA *N                    | jan   |        n/a |      0.405      |      0.228      |      0.095     
                                         | feb   |        n/a |      0.407 101% |      0.237 104% |      0.095 100%
                                         | mars  |        n/a |      0.400  99% |      0.233 102% |      0.094  99%
                                         | april |        n/a |      0.410 101% |      0.237 104% |      0.097 102%
                                         | may   |        n/a |      0.428 106% |      0.279 122% |      0.124 131%
                                         |       |            |                 |                 | 
  Add count per block *LA                | jan   |        n/a |     85.743      |    101.609      |    278.911     
                                         | feb   |        n/a |     85.743 100% |    101.609 100% |    278.911 100%
                                         | mars  |        n/a |     85.743 100% |    101.609 100% |    278.911 100%
                                         | april |        n/a |     85.743 100% |    101.609 100% |    278.911 100%
                                         | may   |        n/a |     85.743 100% |    101.609 100% |    278.911 100%
  Remove count per block *LA             | jan   |        n/a |      1.732      |      1.294      |     20.308     
                                         | feb   |        n/a |      1.732 100% |      1.294 100% |     20.308 100%
                                         | mars  |        n/a |      1.732 100% |      1.294 100% |     20.308 100%
                                         | april |        n/a |      1.732 100% |      1.294 100% |     20.308 100%
                                         | may   |        n/a |      1.732 100% |      1.294 100% |     20.308 100%
  Find count per block *LA               | jan   |        n/a |    257.530      |    278.971      |    542.874     
                                         | feb   |        n/a |    257.530 100% |    278.971 100% |    542.874 100%
                                         | mars  |        n/a |    257.530 100% |    278.971 100% |    542.874 100%
                                         | april |        n/a |    257.530 100% |    278.971 100% |    542.874 100%
                                         | may   |        n/a |    257.530 100% |    278.971 100% |    542.874 100%
  Mem count per block *LA                | jan   |        n/a |     48.443      |     61.783      |    267.406     
                                         | feb   |        n/a |     48.443 100% |     61.783 100% |    267.406 100%
                                         | mars  |        n/a |     48.443 100% |     61.783 100% |    267.406 100%
                                         | april |        n/a |     48.443 100% |     61.783 100% |    267.406 100%
                                         | may   |        n/a |     48.443 100% |     61.783 100% |    267.406 100%
  Mem_tree count per block *LA           | jan   |        n/a |     33.000      |     33.000      |     33.000     
                                         | feb   |        n/a |     33.000 100% |     33.000 100% |     33.000 100%
                                         | mars  |        n/a |     33.000 100% |     33.000 100% |     33.000 100%
                                         | april |        n/a |     33.000 100% |     33.000 100% |     33.000 100%
                                         | may   |        n/a |     33.000 100% |     33.000 100% |     33.000 100%
  Copy count per block *LA               | jan   |        n/a |      0.004      |      0.004      |      0.004     
                                         | feb   |        n/a |      0.004 100% |      0.004 100% |      0.004 100%
                                         | mars  |        n/a |      0.004 100% |      0.004 100% |      0.004 100%
                                         | april |        n/a |      0.004 100% |      0.004 100% |      0.004 100%
                                         | may   |        n/a |      0.004 100% |      0.004 100% |      0.004 100%
                                         |       |            |                 |                 | 
  Block duration *LA                     | jan   |        n/a |   9.513 ms      |  17.205 ms      |  41.911 ms     
                                         | feb   |        n/a |   9.456 ms  99% |  16.590 ms  96% |  41.853 ms 100%
                                         | mars  |        n/a |   9.628 ms 101% |  16.832 ms  98% |  42.127 ms 101%
                                         | april |        n/a |   9.394 ms  99% |  16.547 ms  96% |  41.118 ms  98%
                                         | may   |        n/a |   8.988 ms  94% |  14.070 ms  82% |  32.006 ms  76%
  Buildup duration *LA                   | jan   |        n/a |   2.465 ms      |   2.782 ms      |   5.592 ms     
                                         | feb   |        n/a |   2.667 ms 108% |   3.119 ms 112% |   5.676 ms 102%
                                         | mars  |        n/a |   2.408 ms  98% |   2.822 ms 101% |   5.627 ms 101%
                                         | april |        n/a |   2.534 ms 103% |   2.848 ms 102% |   5.579 ms 100%
                                         | may   |        n/a |   2.423 ms  98% |   3.148 ms 113% |   6.368 ms 114%
  Commit duration *LA                    | jan   |        n/a |   7.048 ms      |  14.423 ms      |  36.319 ms     
                                         | feb   |        n/a |   6.788 ms  96% |  13.471 ms  93% |  36.177 ms 100%
                                         | mars  |        n/a |   7.221 ms 102% |  14.010 ms  97% |  36.500 ms 100%
                                         | april |        n/a |   6.860 ms  97% |  13.699 ms  95% |  35.539 ms  98%
                                         | may   |        n/a |   6.565 ms  93% |  10.922 ms  76% |  25.638 ms  71%
                                         |       |            |                 |                 | 
  Add duration *LA                       | jan   |        n/a |   4.612 µs      |   4.387 µs      |   4.879 µs     
                                         | feb   |        n/a |   6.349 µs 138% |   5.287 µs 121% |   5.084 µs 104%
                                         | mars  |        n/a |   5.526 µs 120% |   5.597 µs 128% |   4.746 µs  97%
                                         | april |        n/a |   5.846 µs 127% |   6.593 µs 150% |   5.847 µs 120%
                                         | may   |        n/a |   5.073 µs 110% |   5.203 µs 119% |   4.433 µs  91%
  Remove duration *LA                    | jan   |        n/a |  59.890 µs      |  48.368 µs      |  30.538 µs     
                                         | feb   |        n/a |  68.444 µs 114% |  47.910 µs  99% |  27.457 µs  90%
                                         | mars  |        n/a |  52.498 µs  88% |  37.133 µs  77% |  24.463 µs  80%
                                         | april |        n/a |   5.487 µs 9.2% |   4.502 µs 9.3% |   3.862 µs  13%
                                         | may   |        n/a |   9.744 µs  16% |   5.014 µs  10% |   4.592 µs  15%
  Find duration *LA                      | jan   |        n/a |   4.828 µs      |   5.271 µs      |   4.967 µs     
                                         | feb   |        n/a |   5.167 µs 107% |   5.613 µs 106% |   5.059 µs 102%
                                         | mars  |        n/a |   4.698 µs  97% |   5.244 µs  99% |   5.184 µs 104%
                                         | april |        n/a |   4.788 µs  99% |   4.989 µs  95% |   5.060 µs 102%
                                         | may   |        n/a |   4.851 µs 100% |   5.379 µs 102% |   5.958 µs 120%
  Mem duration *LA                       | jan   |        n/a |   2.674 µs      |   2.494 µs      |   2.095 µs     
                                         | feb   |        n/a |   2.979 µs 111% |   2.630 µs 105% |   2.149 µs 103%
                                         | mars  |        n/a |   2.204 µs  82% |   2.184 µs  88% |   1.816 µs  87%
                                         | april |        n/a |   2.337 µs  87% |   2.160 µs  87% |   1.741 µs  83%
                                         | may   |        n/a |   2.191 µs  82% |   6.187 µs 248% |   2.106 µs 101%
  Mem_tree duration *LA                  | jan   |        n/a |   1.815 µs      |   1.705 µs      |   2.801 µs     
                                         | feb   |        n/a |   1.627 µs  90% |   1.697 µs 100% |   2.423 µs  86%
                                         | mars  |        n/a |   1.104 µs  61% |   1.291 µs  76% |   2.213 µs  79%
                                         | april |        n/a |   2.812 µs 155% |   1.063 µs  62% |   2.175 µs  78%
                                         | may   |        n/a |   1.051 µs  58% |   1.271 µs  75% |   1.476 µs  53%
  Copy duration *LA                      | jan   |        n/a |   6.021 µs      |   5.603 µs      |  18.818 µs     
                                         | feb   |        n/a |   5.491 µs  91% |   5.597 µs 100% |  10.904 µs  58%
                                         | mars  |        n/a |   5.309 µs  88% |   5.584 µs 100% |  11.195 µs  59%
                                         | april |        n/a |  13.762 µs 229% |  33.029 µs 589% |  28.887 µs 154%
                                         | may   |        n/a |   5.367 µs  89% |  14.805 µs 264% |  10.869 µs  58%
  Checkout duration *LA                  | jan   |        n/a |   1.576 µs      |   1.719 µs      |   2.412 µs     
                                         | feb   |        n/a |   1.742 µs 111% |   1.774 µs 103% |   2.190 µs  91%
                                         | mars  |        n/a |   1.618 µs 103% |   1.674 µs  97% |   2.032 µs  84%
                                         | april |        n/a |   2.012 µs 128% |   1.973 µs 115% |   2.175 µs  90%
                                         | may   |        n/a |   1.628 µs 103% |   2.296 µs 134% |   2.245 µs  93%
                                         |       |            |                 |                 | 
  Disk bytes    read *C                  | jan   |    0.000 G |  112.441 G      |  419.866 G      |  810.773 G     
                                         | feb   |    0.000 G |  112.441 G 100% |  419.868 G 100% |  810.776 G 100%
                                         | mars  |    0.000 G |  112.441 G 100% |  419.866 G 100% |  810.773 G 100%
                                         | april |    0.000 G |  112.441 G 100% |  419.867 G 100% |  810.776 G 100%
                                         | may   |    0.000 G |   99.626 G  89% |  367.096 G  87% |  678.542 G  84%
  Disk bytes written *C                  | jan   |    0.000 G |    8.049 G      |   56.330 G      |  166.928 G     
                                         | feb   |    0.000 G |    8.049 G 100% |   56.330 G 100% |  166.933 G 100%
                                         | mars  |    0.000 G |    8.049 G 100% |   56.330 G 100% |  166.928 G 100%
                                         | april |    0.000 G |    8.051 G 100% |   56.330 G 100% |  166.928 G 100%
                                         | may   |    0.000 G |    4.575 G  57% |   29.764 G  53% |   86.320 G  52%
+ Disk bytes    both *C                  | jan   |    0.000 G |  120.490 G      |  476.196 G      |  977.701 G     
+                                        | feb   |    0.000 G |  120.490 G 100% |  476.197 G 100% |  977.709 G 100%
+                                        | mars  |    0.000 G |  120.490 G 100% |  476.196 G 100% |  977.700 G 100%
+                                        | april |    0.000 G |  120.492 G 100% |  476.197 G 100% |  977.704 G 100%
+                                        | may   |    0.000 G |  104.201 G  86% |  396.860 G  83% |  764.862 G  78%
  Disk bytes read    per block *LA       | jan   |        n/a |  2_949_067      |  5_404_709      |  9_815_068     
                                         | feb   |        n/a |  2_949_022 100% |  5_404_822 100% |  9_815_816 100%
                                         | mars  |        n/a |  2_949_108 100% |  5_404_773 100% |  9_815_158 100%
                                         | april |        n/a |  2_949_032 100% |  5_404_688 100% |  9_815_025 100%
                                         | may   |        n/a |  2_565_235  87% |  5_404_608 100% |  7_117_881  73%
  Disk bytes written per block *LA       | jan   |        n/a |    240_146      |    939_358      |  2_995_781     
                                         | feb   |        n/a |    240_161 100% |    939_101 100% |  2_997_054 100%
                                         | mars  |        n/a |    240_161 100% |    939_403 100% |  2_995_915 100%
                                         | april |        n/a |    240_687 100% |    939_403 100% |  2_995_770 100%
                                         | may   |        n/a |    133_385  56% |    482_759  51% |  1_520_179  51%
+ Disk bytes both    per block *LA       | jan   |        n/a |  3_189_213      |  6_344_066      | 12_810_849     
+                                        | feb   |        n/a |  3_189_183 100% |  6_343_923 100% | 12_812_870 100%
+                                        | mars  |        n/a |  3_189_268 100% |  6_344_176 100% | 12_811_073 100%
+                                        | april |        n/a |  3_189_719 100% |  6_344_091 100% | 12_810_795 100%
+                                        | may   |        n/a |  2_698_620  85% |  5_887_367  93% |  8_638_060  67%
  Disk bytes read    per sec *LA *N      | jan   |        n/a |  310.020 M      |  314.132 M      |  234.186 M     
                                         | feb   |        n/a |  311.879 M 101% |  325.786 M 104% |  234.529 M 100%
                                         | mars  |        n/a |  306.292 M  99% |  321.098 M 102% |  232.989 M  99%
                                         | april |        n/a |  313.926 M 101% |  326.636 M 104% |  238.706 M 102%
                                         | may   |        n/a |  285.401 M  92% |  384.125 M 122% |  222.394 M  95%
  Disk bytes written per sec *LA *N      | jan   |        n/a |   25.245 M      |   54.597 M      |   71.479 M     
                                         | feb   |        n/a |   25.399 M 101% |   56.606 M 104% |   71.608 M 100%
                                         | mars  |        n/a |   24.943 M  99% |   55.810 M 102% |   71.116 M  99%
                                         | april |        n/a |   25.621 M 101% |   56.773 M 104% |   72.858 M 102%
                                         | may   |        n/a |   14.840 M  59% |   34.311 M  63% |   47.497 M  66%
  Disk bytes both    per sec *LA *N      | jan   |        n/a |  335.265 M      |  368.729 M      |  305.665 M     
                                         | feb   |        n/a |  337.278 M 101% |  382.392 M 104% |  306.137 M 100%
                                         | mars  |        n/a |  331.234 M  99% |  376.908 M 102% |  304.105 M  99%
                                         | april |        n/a |  339.548 M 101% |  383.409 M 104% |  311.564 M 102%
                                         | may   |        n/a |  300.241 M  90% |  418.437 M 113% |  269.891 M  88%
                                         |       |            |                 |                 | 
  Disk read  count *C                    | jan   |    0.000 M |   45.904 M      |  141.671 M      |  258.048 M     
                                         | feb   |    0.000 M |   45.904 M 100% |  141.671 M 100% |  258.048 M 100%
                                         | mars  |    0.000 M |   45.904 M 100% |  141.671 M 100% |  258.048 M 100%
                                         | april |    0.000 M |   45.904 M 100% |  141.673 M 100% |  258.055 M 100%
                                         | may   |    0.000 M |   42.624 M  93% |  132.927 M  94% |  241.612 M  94%
  Disk write count *C                    | jan   |         19 |    316_251      |    622_375      |    934_051     
                                         | feb   |         19 |    316_251 100% |    622_375 100% |    934_053 100%
                                         | mars  |         19 |    316_251 100% |    622_375 100% |    934_051 100%
                                         | april |         19 |    316_253 100% |    622_375 100% |    934_051 100%
                                         | may   |         23 |    311_925  99% |    601_961  97% |    892_209  96%
+ Disk both  count *C                    | jan   |    0.000 M |   46.220 M      |  142.293 M      |  258.982 M     
+                                        | feb   |    0.000 M |   46.220 M 100% |  142.293 M 100% |  258.982 M 100%
+                                        | mars  |    0.000 M |   46.220 M 100% |  142.293 M 100% |  258.982 M 100%
+                                        | april |    0.000 M |   46.220 M 100% |  142.295 M 100% |  258.989 M 100%
+                                        | may   |    0.000 M |   42.936 M  93% |  133.529 M  94% |  242.504 M  94%
  Disk read  count per block *LA         | jan   |        n/a |   1145.009      |   1537.636      |   2340.117     
                                         | feb   |        n/a |   1145.009 100% |   1537.636 100% |   2340.118 100%
                                         | mars  |        n/a |   1145.009 100% |   1537.636 100% |   2340.117 100%
                                         | april |        n/a |   1145.005 100% |   1537.636 100% |   2340.216 100%
                                         | may   |        n/a |   1094.200  96% |   1456.985  95% |   2015.933  86%
  Disk write count per block *LA         | jan   |        n/a |      4.500      |      4.565      |      5.625     
                                         | feb   |        n/a |      4.500 100% |      4.565 100% |      5.625 100%
                                         | mars  |        n/a |      4.500 100% |      4.565 100% |      5.625 100%
                                         | april |        n/a |      4.501 100% |      4.565 100% |      5.625 100%
                                         | may   |        n/a |      4.390  98% |      4.315  95% |      5.042  90%
+ Disk both  count per block *LA         | jan   |        n/a |   1149.509      |   1542.201      |   2345.741     
+                                        | feb   |        n/a |   1149.509 100% |   1542.201 100% |   2345.744 100%
+                                        | mars  |        n/a |   1149.509 100% |   1542.201 100% |   2345.741 100%
+                                        | april |        n/a |   1149.506 100% |   1542.201 100% |   2345.841 100%
+                                        | may   |        n/a |   1098.591  96% |   1461.300  95% |   2020.975  86%
  Disk read  count per sec *LA *N        | jan   |        n/a |    120_369      |     89_370      |     55_835     
                                         | feb   |        n/a |    121_092 101% |     92_684 104% |     55_912 100%
                                         | mars  |        n/a |    118_920  99% |     91_351 102% |     55_549  99%
                                         | april |        n/a |    121_887 101% |     92_928 104% |     56_915 102%
                                         | may   |        n/a |    121_738 101% |    103_553 116% |     62_987 113%
  Disk write count per sec *LA *N        | jan   |        n/a |        473      |        265      |        134     
                                         | feb   |        n/a |        476 101% |        275 104% |        134 100%
                                         | mars  |        n/a |        467  99% |        271 102% |        134  99%
                                         | april |        n/a |        479 101% |        276 104% |        137 102%
                                         | may   |        n/a |        488 103% |        307 116% |        158 117%
  Disk both  count per sec *LA *N        | jan   |        n/a |    120_842      |     89_636      |     55_969     
                                         | feb   |        n/a |    121_568 101% |     92_959 104% |     56_047 100%
                                         | mars  |        n/a |    119_387  99% |     91_622 102% |     55_682  99%
                                         | april |        n/a |    122_366 101% |     93_204 104% |     57_052 102%
                                         | may   |        n/a |    122_226 101% |    103_860 116% |     63_144 113%
                                         |       |            |                 |                 | 
  pack.finds per block *LA               | jan   |        n/a |    773.079      |   1008.525      |   1634.632     
                                         | feb   |        n/a |    775.079 100% |   1010.525 100% |   1636.632 100%
                                         | mars  |        n/a |    772.860 100% |   1008.279 100% |   1634.277 100%
                                         | april |        n/a |    772.830 100% |   1008.283 100% |   1634.281 100%
                                         | may   |        n/a |    777.826 101% |   1013.279 100% |   1639.277 100%
  pack.cache_misses per block *LA        | jan   |        n/a |     56.099      |     66.558      |    114.512     
                                         | feb   |        n/a |     56.099 100% |     66.558 100% |    114.512 100%
                                         | mars  |        n/a |     56.099 100% |     66.558 100% |    114.511 100%
                                         | april |        n/a |     56.098 100% |     66.557 100% |    114.527 100%
                                         | may   |        n/a |     56.098 100% |     66.557 100% |    114.526 100%
  pack.appended_hashes per block *LA     | jan   |        n/a |  0.036_897      |  0.049_560      |  0.230_581     
                                         | feb   |        n/a |  0.036_897 100% |  0.049_560 100% |  0.230_581 100%
                                         | mars  |        n/a |  0.036_897 100% |  0.049_560 100% |  0.230_581 100%
                                         | april |        n/a |  0.036_897 100% |  0.049_560 100% |  0.230_581 100%
                                         | may   |        n/a |  0.036_897 100% |  0.049_560 100% |  0.230_581 100%
  pack.appended_offsets per block *LA    | jan   |        n/a |    896.006      |   1235.673      |   2249.057     
                                         | feb   |        n/a |    896.006 100% |   1235.673 100% |   2249.057 100%
                                         | mars  |        n/a |    896.006 100% |   1235.673 100% |   2249.057 100%
                                         | april |        n/a |    896.006 100% |   1235.673 100% |   2249.057 100%
                                         | may   |        n/a |    896.006 100% |   1235.673 100% |   2249.057 100%
                                         |       |            |                 |                 | 
  tree.contents_hash per block *LA       | jan   |        n/a |     55.232      |     67.287      |    151.856     
                                         | feb   |        n/a |     55.232 100% |     67.287 100% |    151.856 100%
                                         | mars  |        n/a |     55.264 100% |     67.306 100% |    151.895 100%
                                         | april |        n/a |     55.264 100% |     67.306 100% |    151.895 100%
                                         | may   |        n/a |     55.264 100% |     67.306 100% |    151.895 100%
  tree.contents_find per block *LA       | jan   |        n/a |    146.552      |    166.022      |    206.460     
                                         | feb   |        n/a |    148.552 101% |    168.022 101% |    208.460 101%
                                         | mars  |        n/a |    146.331 100% |    165.775 100% |    206.104 100%
                                         | april |        n/a |    146.331 100% |    165.775 100% |    206.104 100%
                                         | may   |        n/a |    146.331 100% |    165.775 100% |    206.104 100%
  tree.contents_add per block *LA        | jan   |        n/a |     49.897      |     60.409      |    106.304     
                                         | feb   |        n/a |     49.897 100% |     60.409 100% |    106.304 100%
                                         | mars  |        n/a |     49.898 100% |     60.410 100% |    106.305 100%
                                         | april |        n/a |     49.898 100% |     60.410 100% |    106.305 100%
                                         | may   |        n/a |     49.898 100% |     60.410 100% |    106.305 100%
  tree.node_hash per block *LA           | jan   |        n/a |    151.019      |    185.092      |    327.926     
                                         | feb   |        n/a |    151.019 100% |    185.092 100% |    327.926 100%
                                         | mars  |        n/a |    151.019 100% |    185.092 100% |    327.926 100%
                                         | april |        n/a |    151.019 100% |    185.092 100% |    327.926 100%
                                         | may   |        n/a |    151.019 100% |    185.092 100% |    327.926 100%
  tree.node_mem per block *LA            | jan   |        n/a |    150.539      |    184.464      |    327.000     
                                         | feb   |        n/a |    150.539 100% |    184.464 100% |    327.000 100%
                                         | mars  |        n/a |    150.539 100% |    184.464 100% |    327.000 100%
                                         | april |        n/a |    150.539 100% |    184.464 100% |    327.000 100%
                                         | may   |        n/a |    150.539 100% |    184.464 100% |    327.000 100%
  tree.node_add per block *LA            | jan   |        n/a |    148.087      |    181.245      |    324.165     
                                         | feb   |        n/a |    148.087 100% |    181.245 100% |    324.165 100%
                                         | mars  |        n/a |    148.087 100% |    181.245 100% |    324.165 100%
                                         | april |        n/a |    148.087 100% |    181.245 100% |    324.165 100%
                                         | may   |        n/a |    148.087 100% |    181.245 100% |    324.165 100%
  tree.node_find per block *LA           | jan   |        n/a |    238.728      |    270.695      |    336.598     
                                         | feb   |        n/a |    238.728 100% |    270.695 100% |    336.598 100%
                                         | mars  |        n/a |    238.729 100% |    270.695 100% |    336.599 100%
                                         | april |        n/a |    238.732 100% |    270.699 100% |    336.603 100%
                                         | may   |        n/a |    243.729 102% |    275.695 102% |    341.599 101%
  tree.node_val_v per block *LA          | jan   |        n/a |  0.274_607      |  0.239_935      |  0.362_888     
                                         | feb   |        n/a |  0.274_607 100% |  0.239_935 100% |  0.362_888 100%
                                         | mars  |        n/a |  0.000_000 0.0% |  0.000_000 0.0% |  0.000_000 0.0%
                                         | april |        n/a |  0.000_000 0.0% |  0.000_000 0.0% |  0.000_000 0.0%
                                         | may   |        n/a |  0.000_000 0.0% |  0.000_000 0.0% |  0.000_000 0.0%
  tree.node_val_find per block *LA       | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |          0      |          0      |          0     
  tree.node_val_list per block *LA       | jan   |        n/a |  1.740_670      |  1.677_683      |  2.127_425     
                                         | feb   |        n/a |  1.740_670 100% |  1.677_683 100% |  2.127_425 100%
                                         | mars  |        n/a |  1.818_378 104% |  1.781_918 106% |  2.247_511 106%
                                         | april |        n/a |  1.461_257  84% |  1.433_937  85% |  1.760_123  83%
                                         | may   |        n/a |  1.461_257  84% |  1.433_937  85% |  1.760_123  83%
                                         |       |            |                 |                 | 
  index.nb_merge *C                      | jan   |          0 |         34      |         96      |        168     
                                         | feb   |          0 |         34 100% |         96 100% |        168 100%
                                         | mars  |          0 |         34 100% |         96 100% |        168 100%
                                         | april |          0 |         34 100% |         96 100% |        168 100%
                                         | may   |          0 |         17  50% |         48  50% |         84  50%
  index.cumu_data_bytes *C               | jan   |    0.000 G |    0.000 G      |    0.000 G      |    0.000 G     
                                         | feb   |    0.000 G |    0.000 G      |    0.000 G      |    0.000 G     
                                         | mars  |    0.000 G |    0.000 G      |    0.000 G      |    0.000 G     
                                         | april |    0.000 G |    0.000 G      |    0.000 G      |    0.000 G     
                                         | may   |    0.000 G |    3.069 G      |   25.447 G      |   78.653 G     
  index.cumu_data_bytes per block *LA    | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |    100_188      |    440_142      |  1_439_721     
                                         |       |            |                 |                 | 
  gc.minor_words allocated *C            | jan   |    0.001 G |  108.168 G      |  346.431 G      |  722.505 G     
                                         | feb   |    0.001 G |  110.338 G 102% |  352.820 G 102% |  733.835 G 102%
                                         | mars  |    0.001 G |  105.098 G  97% |  336.010 G  97% |  694.865 G  96%
                                         | april |    0.001 G |   98.677 G  91% |  290.802 G  84% |  561.102 G  78%
                                         | may   |    0.001 G |   96.580 G  89% |  277.741 G  80% |  522.771 G  72%
  gc.minor_words allocated per block *LA | jan   |        n/a |    2.344 M      |    4.059 M      |   10.536 M     
                                         | feb   |        n/a |    2.394 M 102% |    4.127 M 102% |   10.634 M 101%
                                         | mars  |        n/a |    2.301 M  98% |    3.923 M  97% |    9.999 M  95%
                                         | april |        n/a |    2.105 M  90% |    3.166 M  78% |    7.611 M  72%
                                         | may   |        n/a |    2.048 M  87% |    2.962 M  73% |    6.876 M  65%
  gc.promoted_words *C                   | jan   |    0.000 G |    4.644 G      |   12.267 G      |   21.785 G     
                                         | feb   |    0.000 G |    4.787 G 103% |   12.579 G 103% |   22.242 G 102%
                                         | mars  |    0.000 G |    4.580 G  99% |   12.277 G 100% |   21.856 G 100%
                                         | april |    0.000 G |    4.544 G  98% |   12.180 G  99% |   21.683 G 100%
                                         | may   |    0.000 G |    4.537 G  98% |   12.172 G  99% |   21.679 G 100%
  gc.major_words allocated *C            | jan   |    0.001 G |    5.710 G      |   19.520 G      |   43.166 G     
                                         | feb   |    0.001 G |    5.851 G 102% |   19.814 G 102% |   43.570 G 101%
                                         | mars  |    0.001 G |    5.642 G  99% |   19.507 G 100% |   43.175 G 100%
                                         | april |    0.001 G |    5.606 G  98% |   19.411 G  99% |   43.002 G 100%
                                         | may   |    0.001 G |    5.152 G  90% |   16.031 G  82% |   32.773 G  76%
  gc.major_words allocated per block *LA | jan   |        n/a |    125_636      |    240_382      |    640_019     
                                         | feb   |        n/a |    127_947 102% |    242_734 101% |    643_843 101%
                                         | mars  |        n/a |    126_362 101% |    241_751 101% |    642_989 100%
                                         | april |        n/a |    125_653 100% |    240_703 100% |    641_149 100%
                                         | may   |        n/a |    111_968  89% |    182_965  76% |    454_719  71%
  gc.minor_collections *C                | jan   |          4 |    412_876      |  1_323_914      |  2_761_843     
                                         | feb   |          4 |    421_164 102% |  1_348_335 102% |  2_805_166 102%
                                         | mars  |          4 |    401_169  97% |  1_283_651  97% |  2_655_415  96%
                                         | april |          4 |    376_678  91% |  1_113_472  84% |  2_148_173  78%
                                         | may   |          4 |    368_595  89% |  1_060_532  80% |  1_997_210  72%
  gc.minor_collections per block *LA     | jan   |        n/a |      8.945      |     15.536      |     40.277     
                                         | feb   |        n/a |      9.139 102% |     15.797 102% |     40.654 101%
                                         | mars  |        n/a |      8.781  98% |     15.004  97% |     38.230  95%
                                         | april |        n/a |      8.034  90% |     12.157  78% |     29.159  72%
                                         | may   |        n/a |      7.818  87% |     11.306  73% |     26.310  65%
  gc.major_collections *C                | jan   |          1 |        500      |      1_378      |      2_752     
                                         | feb   |          1 |        524 105% |      1_428 104% |      2_874 104%
                                         | mars  |          1 |        508 102% |      1_424 103% |      2_816 102%
                                         | april |          1 |        520 104% |      1_479 107% |      2_875 104%
                                         | may   |          1 |        332  66% |        892  65% |      1_700  62%
  gc.major_collections per block *LA     | jan   |        n/a |  0.008_873      |  0.015_476      |  0.037_383     
                                         | feb   |        n/a |  0.010_089 114% |  0.014_245  92% |  0.041_863 112%
                                         | mars  |        n/a |  0.010_308 116% |  0.014_987  97% |  0.040_616 109%
                                         | april |        n/a |  0.010_111 114% |  0.016_957 110% |  0.042_054 112%
                                         | may   |        n/a |  0.006_195  70% |  0.009_137  59% |  0.022_528  60%
  gc.compactions *C                      | jan   |          0 |         17      |         53      |        107     
                                         | feb   |          0 |         17 100% |         48  91% |         84  79%
                                         | mars  |          0 |         17 100% |         48  91% |         84  79%
                                         | april |          0 |         17 100% |         48  91% |         84  79%
                                         | may   |          0 |         12  71% |         37  70% |         70  65%
                                         |       |            |                 |                 | 
  gc.major heap bytes top *C             | jan   |    7.664 M | 1328.480 M      | 2021.028 M      | 2080.928 M     
                                         | feb   |    7.664 M | 1062.646 M  80% | 1511.346 M  75% | 1862.832 M  90%
                                         | mars  |    7.664 M | 1073.304 M  81% | 1283.633 M  64% | 1769.714 M  85%
                                         | april |    7.664 M | 1102.594 M  83% | 1473.942 M  73% | 1720.238 M  83%
                                         | may   |    7.172 M | 1668.887 M 126% | 2075.066 M 103% | 2326.278 M 112%
  gc.major heap bytes *LA                | jan   |    7.664 M |  732.090 M      |  628.429 M      | 1076.163 M     
                                         | feb   |    7.664 M |  607.564 M  83% |  543.957 M  87% |  914.051 M  85%
                                         | mars  |    7.664 M |  502.628 M  69% |  524.280 M  83% | 1011.835 M  94%
                                         | april |    7.664 M |  659.132 M  90% |  802.836 M 128% | 1131.082 M 105%
                                         | may   |    7.172 M |  589.853 M  81% |  661.262 M 105% | 1329.029 M 123%
                                         |       |            |                 |                 | 
  index_data bytes *S                    | jan   |    0.000 M |  383.625 M      | 1084.455 M      | 1894.649 M     
                                         | feb   |    0.000 M |  383.625 M 100% | 1084.455 M 100% | 1894.649 M 100%
                                         | mars  |    0.000 M |  383.625 M 100% | 1084.455 M 100% | 1894.649 M 100%
                                         | april |    0.000 M |  383.625 M 100% | 1084.455 M 100% | 1894.649 M 100%
                                         | may   |    0.000 M |  361.049 M  94% | 1059.599 M  98% | 1871.698 M  99%
  index_data bytes per block *LA         | jan   |        n/a |      6_654      |     10_065      |     17_897     
                                         | feb   |        n/a |      6_654 100% |     10_065 100% |     17_897 100%
                                         | mars  |        n/a |      6_654 100% |     10_065 100% |     17_897 100%
                                         | april |        n/a |      6_654 100% |     10_065 100% |     17_897 100%
                                         | may   |        n/a |      6_642 100% |      9_613  96% |     17_786  99%
  store_pack bytes *S                    | jan   |    0.000 M |  760.269 M      | 2181.555 M      | 3904.512 M     
                                         | feb   |    0.000 M |  760.269 M 100% | 2181.555 M 100% | 3904.512 M 100%
                                         | mars  |    0.000 M |  760.269 M 100% | 2181.555 M 100% | 3904.512 M 100%
                                         | april |    0.000 M |  760.269 M 100% | 2181.555 M 100% | 3904.512 M 100%
                                         | may   |    0.000 M |  760.269 M 100% | 2181.555 M 100% | 3904.512 M 100%
  store_pack bytes per block *LA         | jan   |        n/a |     17_212      |     22_498      |     42_412     
                                         | feb   |        n/a |     17_212 100% |     22_498 100% |     42_412 100%
                                         | mars  |        n/a |     17_212 100% |     22_498 100% |     42_412 100%
                                         | april |        n/a |     17_212 100% |     22_498 100% |     42_412 100%
                                         | may   |        n/a |     17_212 100% |     22_498 100% |     42_412 100%
  index_log bytes *S                     | jan   |    0.000 M |   22.500 M      |   22.500 M      |   22.500 M     
                                         | feb   |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
                                         | mars  |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
                                         | april |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
                                         | may   |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
  index_log_async *S                     | jan   |    0.000 M |   22.500 M      |   22.500 M      |   22.500 M     
                                         | feb   |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
                                         | mars  |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
                                         | april |    0.000 M |   22.500 M 100% |   22.500 M 100% |   22.500 M 100%
                                         | may   |    0.000 M |   19.737 M  88% |   15.213 M  68% |   21.423 M  95%
  store_dict bytes *S                    | jan   |         24 |  2_158_055      |  2_458_600      |  2_458_600     
                                         | feb   |         24 |  2_158_047 100% |  2_458_592 100% |  2_458_592 100%
                                         | mars  |         24 |  2_158_047 100% |  2_458_592 100% |  2_458_592 100%
                                         | april |         24 |  2_158_047 100% |  2_458_592 100% |  2_458_592 100%
                                         | may   |         24 |  2_158_047 100% |  2_458_592 100% |  2_458_592 100%
                                         |       |            |                 |                 | 
  /data/contracts/index *S               | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |          4      |          4      |          4     
  /data/big_maps/index *S                | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |          0      |          0      |          0     
  /data/rolls/index *S                   | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |        256      |        256      |        256     
  /data/rolls/owner/current *S           | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |        256      |        256      |        256     
  /data/commitments *S                   | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |        256      |        256      |        256     
  /data/contracts/index/ed25519 *S       | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |        256      |        256      |        256     
  /data/contracts/index/originated *S    | jan   |        n/a |          0      |          0      |          0     
                                         | feb   |        n/a |          0      |          0      |          0     
                                         | mars  |        n/a |          0      |          0      |          0     
                                         | april |        n/a |          0      |          0      |          0     
                                         | may   |        n/a |        256      |        256      |        256     
  
  Types of curves:
   *C: Cumulative. No smoothing.
   *LA: Local Average. Smoothed using a weighted sum of the value in the
        block and the exponentially decayed values of the previous blocks.
        Every 2500.01 blocks, half of the past is forgotten.
   *S: Size. E.g. directory entries, file bytes. No smoothing.
   *N: Very noisy.  
<details>

