### PR TITLE
irmin: add support for multi-version objects

### DIFF
--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -87,8 +87,11 @@ let with_progress_bar ~message ~n ~unit =
   Progress_unix.with_reporters bar
 
 module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+  (* FIXME: code duplication *)
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  let v _ = { max_entries = 32; stable_hash = 256 }
 end
 
 module Info (I : Irmin.Info.S) = struct

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -30,10 +30,7 @@ module Info (I : Irmin.Info.S) : sig
   val f : I.f
 end
 
-module Conf : sig
-  val entries : int
-  val stable_hash : int
-end
+module Conf : Irmin_pack.Conf.S
 
 module FSHelper : sig
   val rm_dir : string -> unit

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -12,7 +12,9 @@
 (library
  (name bench_common)
  (modules bench_common)
- (libraries irmin-pack unix progress progress.unix uuidm))
+ (libraries irmin-pack unix progress progress.unix uuidm)
+ (preprocess
+  (pps ppx_irmin)))
 
 (library
  (name irmin_traces)

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -21,8 +21,9 @@ module V2 = struct
 end
 
 module Config = struct
-  let entries = 2
-  let stable_hash = 3
+  include Bench_common.Conf
+
+  let v _ = { max_entries = 2; stable_hash = 3 }
 end
 
 module KV = struct

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -261,6 +261,7 @@ end
 module Maker_ext (IO : IO) (Obj : Config) (Ref : Config) = struct
   type endpoint = unit
   type info = Irmin.Info.default
+  type version = unit
 
   module Make
       (M : Irmin.Metadata.S)

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -228,6 +228,7 @@ struct
     module X = struct
       module Hash = Dummy.Hash
       module Info = Irmin.Info.Default
+      module Version = Irmin.Version.None
 
       module Contents = struct
         module V = Dummy.Contents.Val
@@ -240,7 +241,7 @@ struct
         module CA = CA.Make (Hash) (V)
 
         include
-          Irmin.Private.Node.Store (Contents) (CA) (Hash) (V)
+          Irmin.Private.Node.Store (Contents) (CA) (Version) (Hash) (V)
             (Dummy.Node.Metadata)
             (P)
       end

--- a/src/irmin-git/node.mli
+++ b/src/irmin-git/node.mli
@@ -31,4 +31,5 @@ module Make (G : Git.S) (P : Irmin.Path.S) : sig
        and type hash = key
        and type step = P.step
        and type metadata = Metadata.t
+       and type version = unit
 end

--- a/src/irmin-git/private.ml
+++ b/src/irmin-git/private.ml
@@ -31,6 +31,7 @@ module Make
 struct
   module Hash = Irmin.Hash.Make (G.Hash)
   module Info = Irmin.Info.Default
+  module Version = Irmin.Version.None
 
   module Contents = struct
     module S = Contents.Make (G) (C)
@@ -41,7 +42,9 @@ struct
     module S = Node.Make (G) (P)
 
     include
-      Irmin.Private.Node.Store (Contents) (S) (S.Key) (S.Val) (Metadata) (P)
+      Irmin.Private.Node.Store (Contents) (S) (Version) (S.Key) (S.Val)
+        (Metadata)
+        (P)
   end
 
   module Commit = struct

--- a/src/irmin-git/private.mli
+++ b/src/irmin-git/private.mli
@@ -40,6 +40,7 @@ module Make
        and type Node.Path.step = P.step
        and type Node.Metadata.t = Metadata.t
        and type Branch.key = B.t
+       and type Version.t = unit
        and module Commit.Info = Irmin.Info.Default
 
   val git_of_repo : Repo.t -> G.t

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -432,6 +432,7 @@ end
 module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
   module X = struct
     module Hash = S.Hash
+    module Version = S.Private.Version
 
     module Contents = struct
       module X = struct
@@ -454,6 +455,7 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
       module Contents = Contents
       module Metadata = S.Metadata
       module Path = S.Key
+      module Version = Version
 
       let merge t =
         let f ~(old : Key.t option Irmin.Merge.promise) left right =

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -15,8 +15,10 @@
  *)
 
 module type S = sig
-  val entries : int
-  val stable_hash : int
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  val v : version -> t
 end
 
 module Default = struct

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -15,8 +15,10 @@
  *)
 
 module type S = sig
-  val entries : int
-  val stable_hash : int
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  val v : version -> t
 end
 
 val fresh_key : bool Irmin.Private.Conf.key

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -64,9 +64,10 @@ end
 
 module Maker_ext
     (_ : Version.S)
-    (_ : Conf.S)
+    (Config : Conf.S)
     (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker) : Maker with type info = CT.Info.t
+    (CT : Irmin.Private.Commit.Maker with type Version.t = Config.version) :
+  Maker with type info = CT.Info.t and type version = Config.version
 
 module Stats = Stats
 module Layout = Layout

--- a/src/irmin-pack/layered/ext_layered.mli
+++ b/src/irmin-pack/layered/ext_layered.mli
@@ -15,6 +15,10 @@
  *)
 
 module Maker
-    (_ : Irmin_pack.Conf.S)
+    (Config : Irmin_pack.Conf.S)
     (_ : Irmin.Private.Node.Maker)
-    (_ : Irmin.Private.Commit.Maker) : S.Maker
+    (Commit : Irmin.Private.Commit.Maker with type Version.t = Config.version) :
+  S.Maker
+    with type info = Commit.Info.t
+     and type version = Commit.Version.t
+     and type endpoint = unit

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -23,7 +23,9 @@ module Make
     (Maker : S.Content_addressable_maker
                with type key = H.t
                 and type index = Index.Make(H).t)
-    (Node : Irmin.Private.Node.S with type hash = H.t) =
+    (Node : Irmin.Private.Node.S
+              with type hash = H.t
+               and type version = Conf.version) =
 struct
   type index = Maker.index
 

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -78,16 +78,19 @@ module type Sigs = sig
   module type S = S
 
   module Make
-      (_ : Irmin_pack.Conf.S)
+      (Conf : Irmin_pack.Conf.S)
       (H : Irmin.Hash.S)
       (_ : S.Content_addressable_maker
              with type key = H.t
               and type index = Index.Make(H).t)
-      (Node : Irmin.Private.Node.S with type hash = H.t) :
+      (Node : Irmin.Private.Node.S
+                with type hash = H.t
+                 and type version = Conf.version) :
     S
       with type key = H.t
        and type Val.metadata = Node.metadata
        and type Val.step = Node.step
+       and type Val.version = Node.version
        and type index = Index.Make(H).t
        and type U.index = Index.Make(H).t
        and type L.index = Index.Make(H).t

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -20,8 +20,19 @@ module Maker_ext = Ext_layered.Maker
 module type S = S.Store
 module type Maker = S.Maker
 
-module Maker (Config : Irmin_pack.Conf.S) =
-  Maker_ext (Config) (Irmin.Private.Node) (Irmin.Private.Commit)
+module Maker (Config : Irmin_pack.Conf.S) = struct
+  (* FIXME: duplication *)
+  module Version = struct
+    type t = Config.version
+
+    let t = Config.version_t
+    let default = Config.V0
+  end
+
+  module Info = Irmin.Info.Make (Version)
+  module Commit = Irmin.Private.Commit.Maker (Version) (Info)
+  include Maker_ext (Config) (Irmin.Private.Node) (Commit)
+end
 
 module Checks = Checks
 

--- a/src/irmin-pack/layered/irmin_pack_layered.mli
+++ b/src/irmin-pack/layered/irmin_pack_layered.mli
@@ -48,8 +48,12 @@ end
 module Maker (_ : Irmin_pack.Conf.S) : Maker
 
 module Maker_ext
-    (_ : Irmin_pack.Conf.S)
+    (Config : Irmin_pack.Conf.S)
     (_ : Irmin.Private.Node.Maker)
-    (_ : Irmin.Private.Commit.Maker) : Maker
+    (Commit : Irmin.Private.Commit.Maker with type Version.t = Config.version) :
+  Maker
+    with type info = Commit.Info.t
+     and type version = Commit.Info.version
+     and type endpoint = unit
 
 module Checks = Checks

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -33,6 +33,10 @@ module type Store = sig
 end
 
 module type Maker = sig
+  type version
+  type endpoint = unit
+  type info
+
   module Make
       (M : Irmin.Metadata.S)
       (C : Irmin.Contents.S)
@@ -46,6 +50,8 @@ module type Maker = sig
        and type contents = C.t
        and type branch = B.t
        and type hash = H.t
+       and type info = info
+       and type Info.version = version
 end
 
 module type Layered_general = sig

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -84,6 +84,7 @@ end
 module type Maker = sig
   type endpoint = unit
   type info
+  type version
 
   module Make
       (Metadata : Irmin.Metadata.S)
@@ -101,4 +102,5 @@ module type Maker = sig
        and type Key.step = Path.step
        and type Private.Remote.endpoint = endpoint
        and type info = info
+       and type Info.version = version
 end

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -112,6 +112,7 @@ module Make (S : S) = struct
 
   let test_nodes x () =
     let test repo =
+      let version = P.Version.default in
       let g = g repo and n = n repo in
       let k = normal (P.Contents.Key.hash "foo") in
       let check_key = check P.Node.Key.t in
@@ -144,7 +145,7 @@ module Make (S : S) = struct
         check_val "find xx" None (P.Node.Val.find u "xx")
       in
       check_values u;
-      let w = P.Node.Val.v [ ("y", k); ("z", k); ("x", k) ] in
+      let w = P.Node.Val.v ~version [ ("y", k); ("z", k); ("x", k) ] in
       check P.Node.Val.t "v" u w;
       let l = P.Node.Val.list u in
       check_list "list all" [ ("x", k); ("y", k); ("z", k) ] l;
@@ -1192,8 +1193,9 @@ module Make (S : S) = struct
 
       (* Testing paginated lists *)
       let tree =
+        let version = P.Version.default in
         let c ?(info = S.Metadata.default) blob = `Contents (blob, info) in
-        S.Tree.of_concrete
+        S.Tree.of_concrete ~version
           (`Tree
             [
               ("aa", c "0");
@@ -1271,7 +1273,11 @@ module Make (S : S) = struct
         >>= with_binding [ "bar"; "d" ] "3"
         >>= with_binding [ "e" ] "4"
       in
-      let* t0 = c0 |> S.Tree.to_concrete >|= S.Tree.of_concrete in
+      let* t0 =
+        c0
+        |> S.Tree.to_concrete
+        >|= S.Tree.of_concrete ~version:P.Version.default
+      in
       let* () =
         let+ d0 = S.Tree.diff c0 t0 in
         check_diffs "concrete roundtrip" [] d0
@@ -1927,7 +1933,7 @@ module Make (S : S) = struct
       let tree_1 = S.Tree.shallow repo (`Node foo_k) in
       let tree_2 = S.Tree.shallow repo (`Node bar_k) in
       let node_3 =
-        S.Private.Node.Val.v
+        S.Private.Node.Val.v ~version:P.Version.default
           [
             ("foo", `Contents (foo_k, S.Metadata.default)); ("bar", `Node bar_k);
           ]

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -4,4 +4,6 @@
  (libraries astring cmdliner cohttp cohttp-lwt cohttp-lwt-unix conduit
    conduit-lwt-unix git-cohttp-unix fmt.cli fmt.tty git git-unix irmin
    irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack
-   irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml))
+   irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -282,8 +282,12 @@ module Store = struct
   let git_mem (module C : Irmin.Contents.S) = v_git (module Xgit.Mem.KV (C))
 
   module Inode_config = struct
-    let entries = 32
-    let stable_hash = 256
+    type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+    (* FIXME: this should be simpler in the tests *)
+    type version = V0 | V1 [@@deriving irmin]
+
+    let v _ = { max_entries = 32; stable_hash = 256 }
   end
 
   let pack = create (module Irmin_pack.V1 (Inode_config))

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -22,7 +22,9 @@ let src = Logs.Src.create "irmin.commit" ~doc:"Irmin commits"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Maker (Info : Info.S) = struct
+module Maker (Version : Version.S) (Info : Info.S with type version = Version.t) =
+struct
+  module Version = Version
   module Info = Info
 
   module Make (H : Type.S) = struct
@@ -559,4 +561,4 @@ module V1 = struct
   end
 end
 
-include Maker (Info.Default)
+include Maker (Version.None) (Info.Default)

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -42,7 +42,8 @@ module type S = sig
 end
 
 module type Maker = sig
-  module Info : Info.S
+  module Version : Version.S
+  module Info : Info.S with type version = Version.t
   module Make (H : Type.S) : S with type hash = H.t and module Info = Info
 end
 
@@ -163,7 +164,8 @@ module type Sigs = sig
 
   (** [Maker] provides a simple implementation of commit values, parameterized
       by commit info. *)
-  module Maker (I : Info.S) : Maker with module Info = I
+  module Maker (V : Version.S) (I : Info.S with type version = V.t) :
+    Maker with module Version = V and module Info = I
 
   (** V1 serialisation. *)
   module V1 : sig
@@ -184,7 +186,7 @@ module type Sigs = sig
   (** [Store] creates a new commit store. *)
   module Store
       (I : Info.S)
-      (N : Node.Store)
+      (N : Node.Store with type Version.t = I.version)
       (S : Content_addressable.S with type key = N.key)
       (K : Hash.S with type t = S.key)
       (V : S with type hash = S.key and type t = S.value and module Info = I) :
@@ -212,5 +214,6 @@ module type Sigs = sig
        and type commit = C.key
        and type info = C.Info.t
 
-  include Maker with module Info = Info.Default
+  include
+    Maker with module Version = Version.None and module Info = Info.Default
 end

--- a/src/irmin/info.ml
+++ b/src/irmin/info.ml
@@ -16,26 +16,35 @@
 
 include Info_intf
 
-module Default = struct
+module Make (V : Version.S) = struct
   type author = string [@@deriving irmin]
   type message = string [@@deriving irmin]
+  type version = V.t [@@deriving irmin]
 
-  type t = { date : int64; author : author; message : message }
+  type t = {
+    date : int64;
+    author : author;
+    message : message;
+    version : version;
+  }
   [@@deriving irmin]
 
   type f = unit -> t
 
-  let empty = { date = 0L; author = ""; message = "" }
+  let empty = { date = 0L; author = ""; message = ""; version = V.default }
   let is_empty = Type.(unstage (equal t)) empty
 
-  let v ?(author = "") ?(message = "") date =
-    let r = { date; message; author } in
+  let v ?(author = "") ?(message = "") ?(version = V.default) date =
+    let r = { date; message; author; version } in
     if is_empty r then empty else r
 
   let date t = t.date
   let author t = t.author
   let message t = t.message
+  let version t = t.version
   let none () = empty
 end
+
+module Default = Make (Version.None)
 
 type default = Default.t

--- a/src/irmin/info_intf.ml
+++ b/src/irmin/info_intf.ml
@@ -19,11 +19,12 @@
 module type S = sig
   type author = string [@@deriving irmin]
   type message = string [@@deriving irmin]
+  type version [@@deriving irmin]
 
   type t [@@deriving irmin]
   (** The type for commit info. *)
 
-  val v : ?author:author -> ?message:message -> int64 -> t
+  val v : ?author:author -> ?message:message -> ?version:version -> int64 -> t
   (** Create a new commit info. *)
 
   val date : t -> int64
@@ -46,6 +47,9 @@ module type S = sig
   val message : t -> message
   (** [message t] is [t]'s commit message. *)
 
+  val version : t -> version
+  (** [version t] is [t]'s version. *)
+
   val empty : t
   (** The empty commit info. *)
 
@@ -61,7 +65,8 @@ end
 module type Sigs = sig
   module type S = S
 
-  module Default : S
+  module Make (V : Version.S) : S with type version = V.t
+  module Default : S with type version = Version.None.t
 
   type default = Default.t
 end

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -25,6 +25,7 @@ module Contents = Contents
 module Merge = Merge
 module Branch = Branch
 module Info = Info
+module Version = Version
 module Dot = Dot.Make
 module Hash = Hash
 module Path = Path
@@ -38,6 +39,7 @@ module Maker_ext
     (N : Node.Maker)
     (CT : Commit.Maker) =
 struct
+  type version = CT.Version.t
   type endpoint = unit
   type info = CT.Info.t
 
@@ -52,6 +54,7 @@ struct
     module AW = Atomic_write.Check_closed (AW)
 
     module X = struct
+      module Version = CT.Version
       module Info = CT.Info
       module Hash = H
 
@@ -61,9 +64,9 @@ struct
       end
 
       module Node = struct
-        module V = N.Make (H) (P) (M)
+        module V = N.Make (Version) (H) (P) (M)
         module CA = CA.Make (H) (V)
-        include Node.Store (Contents) (CA) (H) (V) (M) (P)
+        include Node.Store (Contents) (CA) (Version) (H) (V) (M) (P)
       end
 
       module Commit = struct
@@ -153,7 +156,7 @@ module Private = struct
   module Lru = Lru
 end
 
-let version = Version.current
+let version = "%%VERSION%%"
 
 module Sync = Sync
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -44,6 +44,9 @@ module Type = Repr
     {{:https://github.com/mirage/irmin/blob/master/README_PPX.md} documentation
     for [ppx_irmin]})*)
 
+module Version = Version
+(** TODO *)
+
 module Info = Info
 (** Commit info are used to keep track of the origin of write operations in the
     stores. [Info] models the metadata associated with commit objects in Git. *)
@@ -445,7 +448,10 @@ module Dot (S : S) : Dot.S with type db = S.t
 (** Simple store creator. Use the same type of all of the internal keys and
     store all the values in the same store. *)
 module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
-  Maker with type endpoint = unit and type info = Info.default
+  Maker
+    with type endpoint = unit
+     and type info = Info.default
+     and type version = unit
 
 module Maker_ext
     (CA : Content_addressable.Maker)

--- a/src/irmin/private.ml
+++ b/src/irmin/private.ml
@@ -21,14 +21,18 @@ module type S = sig
   module Hash : Hash.S
   (** Internal hashes. *)
 
+  module Version : Version.S
+  (** Value versions. *)
+
   module Contents : Contents.Store with type key = Hash.t
   (** Private content store. *)
 
-  module Node : Node.Store with type key = Hash.t
   (** Private node store. *)
+  module Node : Node.Store with type key = Hash.t and type Version.t = Version.t
 
-  module Commit : Commit.Store with type key = Hash.t
   (** Private commit store. *)
+  module Commit :
+    Commit.Store with type key = Hash.t and type Info.version = Version.t
 
   module Branch : Branch.Store with type value = Hash.t
   (** Private branch store. *)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -1117,8 +1117,10 @@ module Json_tree (Store : S with type contents = Contents.json) = struct
     contents c []
 
   let set_tree (tree : Store.tree) key j : Store.tree Lwt.t =
+    (* FIXME(samoht): weird *)
+    let version = Store.Private.Version.default in
     let c = to_concrete_tree j in
-    let c = Store.Tree.of_concrete c in
+    let c = Store.Tree.of_concrete ~version c in
     Store.Tree.add_tree tree key c
 
   let get_tree (tree : Store.tree) key =

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -363,6 +363,7 @@ module type S = sig
          and type contents := contents
          and type node := node
          and type hash := hash
+         and type version := Info.version
 
     (** {1 Import/Export} *)
 
@@ -828,7 +829,8 @@ module type S = sig
   module Private : sig
     include
       Private.S
-        with type Contents.value = contents
+        with type Version.t = Info.version
+         and type Contents.value = contents
          and module Hash = Hash
          and module Node.Path = Key
          and type Node.Metadata.t = metadata
@@ -872,6 +874,7 @@ end
 module type Maker = sig
   type endpoint
   type info
+  type version
 
   module Make
       (M : Metadata.S)
@@ -888,6 +891,7 @@ module type Maker = sig
        and type hash = H.t
        and type Private.Remote.endpoint = endpoint
        and type info = info
+       and type Info.version = version
 end
 
 module type Json_tree = functor

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -24,6 +24,7 @@ module type S = sig
   type contents [@@deriving irmin]
   type node [@@deriving irmin]
   type hash [@@deriving irmin]
+  type version [@@deriving irmin]
 
   (** [Tree] provides immutable, in-memory partial mirror of the store, with
       lazy reads and delayed writes.
@@ -257,7 +258,7 @@ module type S = sig
   [@@deriving irmin]
   (** The type for concrete trees. *)
 
-  val of_concrete : concrete -> t
+  val of_concrete : version:version -> concrete -> t
   (** [of_concrete c] is the subtree equivalent of the concrete tree [c].
 
       @raise Invalid_argument if [c] contains duplicate bindings for a given
@@ -308,6 +309,7 @@ module type Sigs = sig
          and type metadata = P.Node.Metadata.t
          and type contents = P.Contents.value
          and type hash = P.Hash.t
+         and type version = P.Version.t
 
     type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]
 

--- a/src/irmin/version.ml
+++ b/src/irmin/version.ml
@@ -14,4 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let current = "%%VERSION%%"
+include Version_intf
+
+module None = struct
+  type t = unit [@@deriving irmin]
+
+  let default = ()
+end

--- a/src/irmin/version.mli
+++ b/src/irmin/version.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,9 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Maker
-    (_ : Version.S)
-    (Config : Conf.S)
-    (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker with type Version.t = Config.version) :
-  S.Maker with type info = CT.Info.t and type version = Config.version
+include Version_intf.Sigs
+(** @inline *)

--- a/src/irmin/version_intf.ml
+++ b/src/irmin/version_intf.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,9 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Maker
-    (_ : Version.S)
-    (Config : Conf.S)
-    (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker with type Version.t = Config.version) :
-  S.Maker with type info = CT.Info.t and type version = Config.version
+(** Node metadata. *)
+
+module type S = Type.Defaultable
+
+module type Sigs = sig
+  module type S = S
+
+  module None : S with type t = unit
+  (** A implementation of {!S} for systems that don't use versions. *)
+end

--- a/test/irmin-graphql/common.ml
+++ b/test/irmin-graphql/common.ml
@@ -75,7 +75,7 @@ let spawn_graphql_server () =
   let+ master = Store.master repo in
   let event_loop = server_of_repo repo
   and set_tree tree =
-    Store.Tree.of_concrete tree
+    Store.Tree.of_concrete ~version:Store.Private.Version.default tree
     |> Store.set_tree_exn ~info:Store.Info.none master []
   in
   { event_loop; set_tree }

--- a/test/irmin-pack/cli/dune
+++ b/test/irmin-pack/cli/dune
@@ -3,12 +3,16 @@
  (public_name irmin_fsck)
  (package irmin-pack)
  (modules irmin_fsck)
- (libraries irmin-pack irmin-pack.layered))
+ (libraries irmin-pack irmin-pack.layered)
+ (preprocess
+  (pps ppx_irmin)))
 
 (executable
  (name generate)
  (modules generate)
- (libraries irmin-pack irmin-pack.layered))
+ (libraries irmin-pack irmin-pack.layered)
+ (preprocess
+  (pps ppx_irmin)))
 
 (rule
  (alias generate-cli-test-data)

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -25,9 +25,14 @@ let rm_dir () =
     let _ = Sys.command cmd in
     ())
 
+(* FIXME: remove duplication *)
 module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  (* FIXME: this should be simpler in the tests *)
+  type version = V0 | V1 [@@deriving irmin]
+
+  let v _ = { max_entries = 32; stable_hash = 256 }
 end
 
 module Maker = Irmin_pack_layered.Maker (Conf)

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -18,12 +18,26 @@ module Hash = Irmin.Hash.BLAKE2B
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
 module Node = Irmin.Private.Node
-module Commit = Irmin.Private.Commit
 
+(* FIXME: remove duplication *)
 module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  (* FIXME: this should be simpler in the tests *)
+  type version = V0 | V1 [@@deriving irmin]
+
+  let v _ = { max_entries = 32; stable_hash = 256 }
 end
+
+module Version = struct
+  type t = Conf.version
+
+  let t = Conf.version_t
+  let default = Conf.V0
+end
+
+module Info = Irmin.Info.Make (Version)
+module Commit = Irmin.Private.Commit.Maker (Version) (Info)
 
 module Maker (V : Irmin_pack.Version.S) = struct
   module Maker = Irmin_pack.Maker_ext (V) (Conf) (Node) (Commit)

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -39,8 +39,11 @@ let random_letter () = char_of_int (Char.code 'a' + Random.int 26)
 let random_letters n = String.init n (fun _i -> random_letter ())
 
 module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+  (* FIXME: code duplication *)
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  let v _ = { max_entries = 32; stable_hash = 256 }
 end
 
 module S = struct

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -84,10 +84,7 @@ val sha1 : string -> H.t
 val rm_dir : string -> unit
 val index_log_size : int option
 
-module Conf : sig
-  val entries : int
-  val stable_hash : int
-end
+module Conf : Irmin_pack.Conf.S
 
 val random_string : int -> string
 val random_letters : int -> string

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -21,4 +21,6 @@
 (library
  (name common)
  (modules common)
- (libraries alcotest index irmin irmin-test irmin-pack logs lwt))
+ (libraries alcotest index irmin irmin-test irmin-pack logs lwt)
+ (preprocess
+  (pps ppx_irmin)))

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -33,8 +33,10 @@ let fresh_name =
 let index_log_size = Some 4
 
 module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  let v _ = { max_entries = 32; stable_hash = 256 }
   let lower_root = "_lower"
   let upper0_root = "0"
   let with_lower = true

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -164,8 +164,9 @@ end
 module Hash = Irmin.Hash.SHA1
 
 module V1_maker = Irmin_pack.V1 (struct
-  let entries = 2
-  let stable_hash = 3
+  include Conf
+
+  let v _ = { max_entries = 2; stable_hash = 3 }
 end)
 
 module V2_maker = Irmin_pack.V2 (Conf)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -23,15 +23,28 @@ let src = Logs.Src.create "tests.instances" ~doc:"Tests"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module Conf = struct
-  let entries = 2
+  (* FIXME: code duplication *)
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  let max_entries = 2
   let stable_hash = 3
+  let v _ = { max_entries; stable_hash }
+end
+
+(* FIXME: duplication *)
+module Version = struct
+  type t = Conf.version
+
+  let t = Conf.version_t
+  let default = Conf.V0
 end
 
 let log_size = 1000
 
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
-module Node = Irmin.Private.Node.Make (H) (Path) (Metadata)
+module Node = Irmin.Private.Node.Make (Version) (H) (Path) (Metadata)
 module Index = Irmin_pack.Index.Make (H)
 module Inter = Irmin_pack.Inode.Make_internal (Conf) (H) (Node)
 module Inode = Irmin_pack.Inode.Make_ext (H) (Node) (Inter) (P)
@@ -126,7 +139,8 @@ module Inode_permutations_generator = struct
           let is_valid =
             indices
             |> List.mapi (fun depth i -> (depth, i))
-            |> List.for_all (fun (depth, i) -> Inter.Val.index ~depth s = i)
+            |> List.for_all (fun (depth, i) ->
+                   Inter.Val.index ~depth ~max_entries:Conf.max_entries s = i)
           in
           if is_valid then s else aux (i + 1)
       in
@@ -175,7 +189,7 @@ module Inode_permutations_generator = struct
           let contents =
             List.map (fun s -> StepMap.find s content_per_step) steps
           in
-          List.combine steps contents |> Inode.Val.v)
+          List.combine steps contents |> Inode.Val.v ~version:Conf.V0)
         steps_per_tree
     in
     let tree_per_steps : Inode.value StepSetMap.t =
@@ -225,7 +239,9 @@ let test_add_values () =
   let v2 = Inode.Val.add v1 "y" (normal bar) in
   check_node "node x+y" v2 t >>= fun () ->
   check_hardcoded_hash "hash v2" "d4b55db5d2d806283766354f0d7597d332156f74" v2;
-  let v3 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
+  let v3 =
+    Inode.Val.v ~version:Conf.V0 [ ("x", normal foo); ("y", normal bar) ]
+  in
   check_values "add x+y vs v x+y" v2 v3;
   Context.close t
 
@@ -240,10 +256,13 @@ let integrity_check ?(stable = true) v =
 let test_add_inodes () =
   rm_dir root;
   let* t = Context.get_store () in
-  let v1 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
+  let v1 =
+    Inode.Val.v ~version:Conf.V0 [ ("x", normal foo); ("y", normal bar) ]
+  in
   let v2 = Inode.Val.add v1 "z" (normal foo) in
   let v3 =
-    Inode.Val.v [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
+    Inode.Val.v ~version:Conf.V0
+      [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
   in
   check_values "add x+y+z vs v x+z+y" v2 v3;
   check_hardcoded_hash "hash v3" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v3;
@@ -251,7 +270,7 @@ let test_add_inodes () =
   integrity_check v2;
   let v4 = Inode.Val.add v2 "a" (normal foo) in
   let v5 =
-    Inode.Val.v
+    Inode.Val.v ~version:Conf.V0
       [
         ("x", normal foo);
         ("z", normal foo);
@@ -268,9 +287,11 @@ let test_add_inodes () =
 let test_remove_values () =
   rm_dir root;
   let* t = Context.get_store () in
-  let v1 = Inode.Val.v [ ("x", normal foo); ("y", normal bar) ] in
+  let v1 =
+    Inode.Val.v ~version:Conf.V0 [ ("x", normal foo); ("y", normal bar) ]
+  in
   let v2 = Inode.Val.remove v1 "y" in
-  let v3 = Inode.Val.v [ ("x", normal foo) ] in
+  let v3 = Inode.Val.v ~version:Conf.V0 [ ("x", normal foo) ] in
   check_values "node x obtained two ways" v2 v3;
   check_hardcoded_hash "hash v2" "a1996f4309ea31cc7ba2d4c81012885aa0e08789" v2;
   let v4 = Inode.Val.remove v2 "x" in
@@ -286,15 +307,18 @@ let test_remove_inodes () =
   rm_dir root;
   let* t = Context.get_store () in
   let v1 =
-    Inode.Val.v [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
+    Inode.Val.v ~version:Conf.V0
+      [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
   in
   check_hardcoded_hash "hash v1" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v1;
   let v2 = Inode.Val.remove v1 "x" in
-  let v3 = Inode.Val.v [ ("y", normal bar); ("z", normal foo) ] in
+  let v3 =
+    Inode.Val.v ~version:Conf.V0 [ ("y", normal bar); ("z", normal foo) ]
+  in
   check_values "node y+z obtained two ways" v2 v3;
   check_hardcoded_hash "hash v2" "ea22a2936eed53978bde62f0185cee9d8bbf9489" v2;
   let v4 =
-    Inode.Val.v
+    Inode.Val.v ~version:Conf.V0
       [
         ("x", normal foo);
         ("z", normal foo);
@@ -330,7 +354,7 @@ let test_remove_inodes () =
     lazily loads subtrees, this won't be caught here. *)
 let test_representation_uniqueness_maxdepth_3 () =
   let module P = Inode_permutations_generator in
-  let p = P.v ~entries:Conf.entries ~maxdepth_of_test:3 in
+  let p = P.v ~entries:Conf.max_entries ~maxdepth_of_test:3 in
   let f steps tree s =
     (* [steps, tree] is one of the known pair built using [Val.v]. Let's try to
        add or remove [s] from it and see if something breaks. *)
@@ -395,7 +419,8 @@ let test_truncated_inodes () =
   in
   (* v1 is a Truncated inode of tag Values. No pointers. *)
   let v1 =
-    Inode.Val.v [ (s00, normal foo); (s10, normal foo) ] |> to_truncated
+    Inode.Val.v ~version:Conf.V0 [ (s00, normal foo); (s10, normal foo) ]
+    |> to_truncated
   in
   Inode.Val.list v1 |> ignore;
   (iter_steps @@ fun step -> Inode.Val.find v1 step);
@@ -411,7 +436,8 @@ let test_truncated_inodes () =
   (* v3 is just a Truncated inode of tag Tree. The pointers are built before
      the call to [to_truncated], they are [Broken]. *)
   let v3 =
-    Inode.Val.v [ (s00, normal foo); (s10, normal bar); (s01, normal bar) ]
+    Inode.Val.v ~version:Conf.V0
+      [ (s00, normal foo); (s10, normal bar); (s01, normal bar) ]
     |> to_truncated
   in
   (with_failure @@ fun () -> Inode.Val.list v3 |> ignore);
@@ -428,7 +454,8 @@ let test_intermediate_inode_as_root () =
       (gen_step [ 0; 0; 0 ], gen_step [ 0; 0; 1 ], gen_step [ 0; 1; 0 ])
   in
   let v0 =
-    Inode.Val.v [ (s000, normal foo); (s001, normal bar); (s010, normal foo) ]
+    Inode.Val.v ~version:Conf.V0
+      [ (s000, normal foo); (s001, normal bar); (s010, normal foo) ]
   in
   let* h_depth0 = Inode.batch t.store @@ fun store -> Inode.add store v0 in
   let (`Inode h_depth1) =
@@ -494,14 +521,17 @@ let test_concrete_inodes () =
     let msg = Fmt.str "%a" pp_concrete c in
     Alcotest.check testable msg (Ok v) r
   in
-  let v = Inode.Val.v [ ("a", normal foo) ] in
+  let v = Inode.Val.v ~version:Conf.V0 [ ("a", normal foo) ] in
   check v;
-  let v = Inode.Val.v [ ("a", normal foo); ("y", node bar) ] in
-  check v;
-  let v = Inode.Val.v [ ("x", node foo); ("a", normal foo); ("y", node bar) ] in
+  let v = Inode.Val.v ~version:Conf.V0 [ ("a", normal foo); ("y", node bar) ] in
   check v;
   let v =
-    Inode.Val.v
+    Inode.Val.v ~version:Conf.V0
+      [ ("x", node foo); ("a", normal foo); ("y", node bar) ]
+  in
+  check v;
+  let v =
+    Inode.Val.v ~version:Conf.V0
       [
         ("x", normal foo); ("z", normal foo); ("a", normal foo); ("y", node bar);
       ]

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -22,14 +22,33 @@ module V2 = struct
 end
 
 module Config = struct
-  let entries = 2
+  (* FIXME: code duplication *)
+  type version = V0 | V1 [@@deriving irmin]
+  type t = { max_entries : int; stable_hash : int } [@@deriving irmin]
+
+  let max_entries = 2
   let stable_hash = 3
+  let v _ = { max_entries; stable_hash }
+end
+
+(* FIXME: duplication *)
+module Version = struct
+  type t = Config.version
+
+  let t = Config.version_t
+  let default = Config.V0
+end
+
+(* FIXME: duplication *)
+module Commit = struct
+  module Info = Irmin.Info.Make (Version)
+  module X = Irmin.Private.Commit.Maker (Version) (Info)
 end
 
 let test_dir = Filename.concat "_build" "test-db-pack"
 
 module Irmin_pack_maker =
-  Irmin_pack.Maker_ext (V2) (Config) (Irmin.Private.Node) (Irmin.Private.Commit)
+  Irmin_pack.Maker_ext (V2) (Config) (Irmin.Private.Node) (Commit.X)
 
 let suite =
   let store =


### PR DESCRIPTION
First tentative to implement #1439 

Currently:
- only multi-version nodes are supported (we should do the same for contents).
- the code compiles but the tests are broken
- there's various cleanup patches that can be separated in tree.ml and upstreamed directly
- we need a more clever migration function in Tree.ml as the current one is partial (and probably broken)
- more tests tests tests