### PR TITLE
irmin: re-export Repr library

### DIFF
--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -1,7 +1,17 @@
 (library
  (name irmin)
  (public_name irmin)
- (libraries astring bheap digestif fmt jsonm logs lwt ocamlgraph uri uutf
-   repr)
+ (libraries
+  astring
+  bheap
+  digestif
+  fmt
+  jsonm
+  logs
+  lwt
+  ocamlgraph
+  uri
+  uutf
+  (re_export repr))
  (preprocess
   (pps ppx_irmin -- --lib "Type")))


### PR DESCRIPTION
This ensures that users have access to `Irmin.Type`, even if they're
using `(implicit_transitive_deps false)` without stating a dependency on
the `repr` library.