### PR TITLE
irmin-pack: add a missing equality on `info` in `Make_ext`

### DIFF
--- a/src/irmin-pack/ext.mli
+++ b/src/irmin-pack/ext.mli
@@ -18,4 +18,4 @@ module Maker
     (_ : Version.S)
     (_ : Conf.S)
     (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker) : S.Maker
+    (CT : Irmin.Private.Commit.Maker) : S.Maker with type info = CT.Info.t

--- a/src/irmin-pack/irmin_pack.mli
+++ b/src/irmin-pack/irmin_pack.mli
@@ -66,7 +66,7 @@ module Maker_ext
     (_ : Version.S)
     (_ : Conf.S)
     (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker) : Maker
+    (CT : Irmin.Private.Commit.Maker) : Maker with type info = CT.Info.t
 
 module Stats = Stats
 module Layout = Layout


### PR DESCRIPTION
Necessary to compile Tezos with Irmin master.