### PR TITLE
Avoid unnecessary Make indirections for multi-argument functors

### DIFF
--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -44,10 +44,9 @@ module Contents = struct
   let merge = Irmin.Merge.(idempotent (Irmin.Type.option t))
 end
 
-module Maker = Irmin_pack_layered.Maker (Conf)
-
 module Store =
-  Maker.Make (Irmin.Metadata.None) (Contents) (Irmin.Path.String_list)
+  Irmin_pack_layered.Maker (Conf) (Irmin.Metadata.None) (Contents)
+    (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)
 

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -169,8 +169,12 @@ struct
   type store_config = config
 
   open Tezos_context_hash_irmin.Encoding
-  module Maker = Irmin_pack_layered.Maker_ext (Conf) (Node) (Commit)
-  module Store = Maker.Make (Metadata) (Contents) (Path) (Branch) (Hash)
+
+  module Store =
+    Irmin_pack_layered.Maker_ext (Conf) (Node) (Commit) (Metadata) (Contents)
+      (Path)
+      (Branch)
+      (Hash)
 
   let create_repo config =
     let conf = Irmin_pack.config ~readonly:false ~fresh:true config.store_dir in

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -112,165 +112,165 @@ module Chunk (K : Irmin.Hash.S) = struct
   let t = Irmin.Type.(map string) of_string to_string
 end
 
-module Content_addressable (S : Irmin.Append_only.Maker) = struct
-  module Make (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
-    module Chunk = Chunk (K)
-    module AO = S.Make (K) (Chunk)
-    module Maker = Irmin.Content_addressable.Make (S)
-    module CA = Maker.Make (K) (Chunk)
+module Content_addressable
+    (Make_append_only : Irmin.Append_only.Maker)
+    (K : Irmin.Hash.S)
+    (V : Irmin.Type.S) =
+struct
+  module Chunk = Chunk (K)
+  module AO = Make_append_only (K) (Chunk)
+  module CA = Irmin.Content_addressable.Make (Make_append_only) (K) (Chunk)
 
-    type key = CA.key
+  type key = CA.key
 
-    let pp_key = Irmin.Type.pp K.t
+  let pp_key = Irmin.Type.pp K.t
 
-    type value = V.t
+  type value = V.t
 
-    type 'a t = {
-      chunking : [ `Max | `Best_fit ];
-      db : 'a CA.t;
-      (* An handler to the underlying database. *)
-      chunk_size : int;
-      (* the size of chunks. *)
-      max_children : int;
-      (* the maximum number of children a node can have. *)
-      max_data : int;
-          (* the maximum length (in bytes) of data stored in one
-                            chunk. *)
-    }
+  type 'a t = {
+    chunking : [ `Max | `Best_fit ];
+    db : 'a CA.t;
+    (* An handler to the underlying database. *)
+    chunk_size : int;
+    (* the size of chunks. *)
+    max_children : int;
+    (* the maximum number of children a node can have. *)
+    max_data : int;
+        (* the maximum length (in bytes) of data stored in one
+                          chunk. *)
+  }
 
-    let index t i =
-      let v = Chunk.Index i in
-      match t.chunking with
-      | `Max -> { Chunk.v; len = t.chunk_size }
-      | `Best_fit -> { Chunk.v; len = Chunk.size_of_v v }
+  let index t i =
+    let v = Chunk.Index i in
+    match t.chunking with
+    | `Max -> { Chunk.v; len = t.chunk_size }
+    | `Best_fit -> { Chunk.v; len = Chunk.size_of_v v }
 
-    let data t s =
-      let v = Chunk.Data s in
-      match t.chunking with
-      | `Max -> { Chunk.v; len = t.chunk_size }
-      | `Best_fit -> { Chunk.v; len = Chunk.size_of_v v }
+  let data t s =
+    let v = Chunk.Data s in
+    match t.chunking with
+    | `Max -> { Chunk.v; len = t.chunk_size }
+    | `Best_fit -> { Chunk.v; len = Chunk.size_of_v v }
 
-    module Tree = struct
-      (* return all the tree leaves *)
-      let find_leaves t root =
-        let rec aux acc { Chunk.v; _ } =
-          match v with
-          | Chunk.Data d -> Lwt.return (d :: acc)
-          | Chunk.Index i ->
-              Lwt_list.fold_left_s
-                (fun acc key ->
-                  CA.find t.db key >>= function
-                  | None -> Lwt.return acc
-                  | Some v -> aux acc v)
-                acc i
-        in
-        aux [] root >|= List.rev
-
-      (* partition a list into a list of elements of at most size [n] *)
-      let list_partition n l =
-        let rec aux done_ i acc = function
-          | [] -> List.rev (List.rev acc :: done_)
-          | h :: t ->
-              if i >= n then aux (List.rev acc :: done_) 1 [ h ] t
-              else aux done_ (i + 1) (h :: acc) t
-        in
-        aux [] 0 [] l
-
-      let add t ~key l =
-        let rec aux = function
-          | [] -> invalid_arg "Irmin_chunk.Tree.add"
-          | [ k ] -> Lwt.return k
-          | l -> (
-              let n =
-                if List.length l >= t.max_children then t.max_children
-                else List.length l
-              in
-              match list_partition n l with
-              | [ i ] -> AO.add t.db key (index t i) >|= fun () -> key
-              | l -> Lwt_list.map_p (fun i -> CA.add t.db (index t i)) l >>= aux
-              )
-        in
-        aux l
-    end
-
-    let v config =
-      let module C = Irmin.Private.Conf in
-      let chunk_size = C.get config Conf.chunk_size in
-      let max_data = chunk_size - Chunk.size_of_data_header in
-      let max_children =
-        (chunk_size - Chunk.size_of_index_header) / K.hash_size
+  module Tree = struct
+    (* return all the tree leaves *)
+    let find_leaves t root =
+      let rec aux acc { Chunk.v; _ } =
+        match v with
+        | Chunk.Data d -> Lwt.return (d :: acc)
+        | Chunk.Index i ->
+            Lwt_list.fold_left_s
+              (fun acc key ->
+                CA.find t.db key >>= function
+                | None -> Lwt.return acc
+                | Some v -> aux acc v)
+              acc i
       in
-      let chunking = C.get config Conf.chunking in
-      (if max_children <= 1 then
-       let min = Chunk.size_of_index_header + (K.hash_size * 2) in
-       err_too_small ~min chunk_size);
-      Log.debug (fun l ->
-          l "config: chunk-size=%d digest-size=%d max-data=%d max-children=%d"
-            chunk_size K.hash_size max_data max_children);
-      let+ db = CA.v config in
-      { chunking; db; chunk_size; max_children; max_data }
+      aux [] root >|= List.rev
 
-    let close _ = Lwt.return_unit
-    let clear t = CA.clear t.db
-    let batch t f = CA.batch t.db (fun db -> f { t with db })
-
-    let find_leaves t key =
-      AO.find t.db key >>= function
-      | None -> Lwt.return_none (* shallow objects *)
-      | Some x -> Tree.find_leaves t x >|= Option.some
-
-    let equal_hash = Irmin.Type.(unstage (equal K.t))
-    let of_bin_string = Irmin.Type.(unstage (of_bin_string V.t))
-    let to_bin_string = Irmin.Type.(unstage (to_bin_string V.t))
-    let pre_hash = Irmin.Type.(unstage (pre_hash V.t))
-
-    let check_hash k v =
-      let k' = K.hash (pre_hash v) in
-      if equal_hash k k' then Lwt.return_unit
-      else
-        Fmt.kstrf Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
-          pp_key k' pp_key k
-
-    let find t key =
-      find_leaves t key >>= function
-      | None -> Lwt.return_none
-      | Some bufs -> (
-          let buf = String.concat "" bufs in
-          match of_bin_string buf with
-          | Ok va -> check_hash key va >|= fun () -> Some va
-          | Error _ -> Lwt.return_none)
-
-    let list_range ~init ~stop ~step =
-      let rec aux acc n =
-        if n >= stop then List.rev acc else aux (n :: acc) (n + step)
+    (* partition a list into a list of elements of at most size [n] *)
+    let list_partition n l =
+      let rec aux done_ i acc = function
+        | [] -> List.rev (List.rev acc :: done_)
+        | h :: t ->
+            if i >= n then aux (List.rev acc :: done_) 1 [ h ] t
+            else aux done_ (i + 1) (h :: acc) t
       in
-      aux [] init
+      aux [] 0 [] l
 
-    let unsafe_add_buffer t key buf =
-      let len = String.length buf in
-      if len <= t.max_data then
-        AO.add t.db key (data t buf) >|= fun () ->
-        Log.debug (fun l -> l "add -> %a (no split)" pp_key key)
-      else
-        let offs = list_range ~init:0 ~stop:len ~step:t.max_data in
-        let aux off =
-          let len = min t.max_data (String.length buf - off) in
-          let payload = String.sub buf off len in
-          CA.add t.db (data t payload)
-        in
-        let+ k = Lwt_list.map_s aux offs >>= Tree.add ~key t in
-        Log.debug (fun l -> l "add -> %a (split)" pp_key k)
-
-    let add t v =
-      let buf = to_bin_string v in
-      let key = K.hash (pre_hash v) in
-      let+ () = unsafe_add_buffer t key buf in
-      key
-
-    let unsafe_add t key v =
-      let buf = to_bin_string v in
-      unsafe_add_buffer t key buf
-
-    let mem t key = CA.mem t.db key
+    let add t ~key l =
+      let rec aux = function
+        | [] -> invalid_arg "Irmin_chunk.Tree.add"
+        | [ k ] -> Lwt.return k
+        | l -> (
+            let n =
+              if List.length l >= t.max_children then t.max_children
+              else List.length l
+            in
+            match list_partition n l with
+            | [ i ] -> AO.add t.db key (index t i) >|= fun () -> key
+            | l -> Lwt_list.map_p (fun i -> CA.add t.db (index t i)) l >>= aux)
+      in
+      aux l
   end
+
+  let v config =
+    let module C = Irmin.Private.Conf in
+    let chunk_size = C.get config Conf.chunk_size in
+    let max_data = chunk_size - Chunk.size_of_data_header in
+    let max_children =
+      (chunk_size - Chunk.size_of_index_header) / K.hash_size
+    in
+    let chunking = C.get config Conf.chunking in
+    (if max_children <= 1 then
+     let min = Chunk.size_of_index_header + (K.hash_size * 2) in
+     err_too_small ~min chunk_size);
+    Log.debug (fun l ->
+        l "config: chunk-size=%d digest-size=%d max-data=%d max-children=%d"
+          chunk_size K.hash_size max_data max_children);
+    let+ db = CA.v config in
+    { chunking; db; chunk_size; max_children; max_data }
+
+  let close _ = Lwt.return_unit
+  let clear t = CA.clear t.db
+  let batch t f = CA.batch t.db (fun db -> f { t with db })
+
+  let find_leaves t key =
+    AO.find t.db key >>= function
+    | None -> Lwt.return_none (* shallow objects *)
+    | Some x -> Tree.find_leaves t x >|= Option.some
+
+  let equal_hash = Irmin.Type.(unstage (equal K.t))
+  let of_bin_string = Irmin.Type.(unstage (of_bin_string V.t))
+  let to_bin_string = Irmin.Type.(unstage (to_bin_string V.t))
+  let pre_hash = Irmin.Type.(unstage (pre_hash V.t))
+
+  let check_hash k v =
+    let k' = K.hash (pre_hash v) in
+    if equal_hash k k' then Lwt.return_unit
+    else
+      Fmt.kstrf Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
+        pp_key k' pp_key k
+
+  let find t key =
+    find_leaves t key >>= function
+    | None -> Lwt.return_none
+    | Some bufs -> (
+        let buf = String.concat "" bufs in
+        match of_bin_string buf with
+        | Ok va -> check_hash key va >|= fun () -> Some va
+        | Error _ -> Lwt.return_none)
+
+  let list_range ~init ~stop ~step =
+    let rec aux acc n =
+      if n >= stop then List.rev acc else aux (n :: acc) (n + step)
+    in
+    aux [] init
+
+  let unsafe_add_buffer t key buf =
+    let len = String.length buf in
+    if len <= t.max_data then
+      AO.add t.db key (data t buf) >|= fun () ->
+      Log.debug (fun l -> l "add -> %a (no split)" pp_key key)
+    else
+      let offs = list_range ~init:0 ~stop:len ~step:t.max_data in
+      let aux off =
+        let len = min t.max_data (String.length buf - off) in
+        let payload = String.sub buf off len in
+        CA.add t.db (data t payload)
+      in
+      let+ k = Lwt_list.map_s aux offs >>= Tree.add ~key t in
+      Log.debug (fun l -> l "add -> %a (split)" pp_key k)
+
+  let add t v =
+    let buf = to_bin_string v in
+    let key = K.hash (pre_hash v) in
+    let+ () = unsafe_add_buffer t key buf in
+    key
+
+  let unsafe_add t key v =
+    let buf = to_bin_string v in
+    unsafe_add_buffer t key buf
+
+  let mem t key = CA.mem t.db key
 end

--- a/src/irmin-containers/stores.ml
+++ b/src/irmin-containers/stores.ml
@@ -16,7 +16,7 @@
  *)
 
 module type Content_addressable = sig
-  include Irmin.Content_addressable.Maker
+  module Make : Irmin.Content_addressable.Maker
 
   val config : Irmin.config
 end

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -231,13 +231,13 @@ struct
 
       module Contents = struct
         module V = Dummy.Contents.Val
-        module CA = CA.Make (Hash) (V)
+        module CA = CA (Hash) (V)
         include Irmin.Contents.Store (CA) (Hash) (V)
       end
 
       module Node = struct
         module V = Dummy.Node.Val
-        module CA = CA.Make (Hash) (V)
+        module CA = CA (Hash) (V)
 
         include
           Irmin.Private.Node.Store (Contents) (CA) (Hash) (V)
@@ -247,14 +247,14 @@ struct
 
       module Commit = struct
         module V = Dummy.Commit.Val
-        module CA = CA.Make (Hash) (V)
+        module CA = CA (Hash) (V)
         include Irmin.Private.Commit.Store (Info) (Node) (CA) (Hash) (V)
       end
 
       module Branch = struct
         module Key = Dummy.Branch.Key
         module Val = Dummy.Branch.Val
-        include AW.Make (Key) (Val)
+        include AW (Key) (Val)
       end
 
       module Slice = Dummy.Slice

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -32,55 +32,52 @@ module Maker_ext
     (CA : Irmin.Content_addressable.Maker)
     (AW : Irmin.Atomic_write.Maker)
     (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker) =
+    (CT : Irmin.Private.Commit.Maker)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) =
 struct
-  module Make
-      (M : Irmin.Metadata.S)
-      (C : Irmin.Contents.S)
-      (P : Irmin.Path.S)
-      (B : Irmin.Branch.S)
-      (H : Irmin.Hash.S) =
-  struct
-    module Maker = Irmin.Maker_ext (CA) (AW) (N) (CT)
-    include Maker.Make (M) (C) (P) (B) (H)
+  module Maker = Irmin.Maker_ext (CA) (AW) (N) (CT)
+  include Maker.Make (M) (C) (P) (B) (H)
 
-    let freeze ?min_lower:_ ?max_lower:_ ?min_upper:_ ?max_upper:_ ?recovery:_
-        _repo =
+  let freeze ?min_lower:_ ?max_lower:_ ?min_upper:_ ?max_upper:_ ?recovery:_
+      _repo =
+    Lwt.fail_with "not implemented"
+
+  type store_handle =
+    | Commit_t : hash -> store_handle
+    | Node_t : hash -> store_handle
+    | Content_t : hash -> store_handle
+
+  let layer_id _repo _store_handle = Lwt.fail_with "not implemented"
+  let async_freeze _ = failwith "not implemented"
+  let upper_in_use _repo = failwith "not implemented"
+  let self_contained ?min:_ ~max:_ _repo = failwith "not implemented"
+  let check_self_contained ?heads:_ _ = failwith "not implemented"
+  let needs_recovery _ = failwith "not implemented"
+
+  module Private_layer = struct
+    module Hook = struct
+      type 'a t = unit
+
+      let v _ = failwith "not implemented"
+    end
+
+    let wait_for_freeze _ = Lwt.fail_with "not implemented"
+
+    let freeze' ?min_lower:_ ?max_lower:_ ?min_upper:_ ?max_upper:_ ?recovery:_
+        ?hook:_ _repo =
       Lwt.fail_with "not implemented"
 
-    type store_handle =
-      | Commit_t : hash -> store_handle
-      | Node_t : hash -> store_handle
-      | Content_t : hash -> store_handle
-
-    let layer_id _repo _store_handle = Lwt.fail_with "not implemented"
-    let async_freeze _ = failwith "not implemented"
-    let upper_in_use _repo = failwith "not implemented"
-    let self_contained ?min:_ ~max:_ _repo = failwith "not implemented"
-    let check_self_contained ?heads:_ _ = failwith "not implemented"
-    let needs_recovery _ = failwith "not implemented"
-
-    module Private_layer = struct
-      module Hook = struct
-        type 'a t = unit
-
-        let v _ = failwith "not implemented"
-      end
-
-      let wait_for_freeze _ = Lwt.fail_with "not implemented"
-
-      let freeze' ?min_lower:_ ?max_lower:_ ?min_upper:_ ?max_upper:_
-          ?recovery:_ ?hook:_ _repo =
-        Lwt.fail_with "not implemented"
-
-      let upper_in_use = upper_in_use
-    end
+    let upper_in_use = upper_in_use
   end
 end
 
 module Maker
     (CA : Irmin.Content_addressable.Maker)
     (AW : Irmin.Atomic_write.Maker) =
-  Maker_ext (CA) (AW) (Irmin.Private.Node) (Irmin.Private.Commit)
+  Maker_ext (CA) (AW) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
 
 module Stats = Stats

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -126,21 +126,20 @@ module type S = sig
   end
 end
 
-module type Maker = sig
-  module Make
-      (M : Irmin.Metadata.S)
-      (C : Irmin.Contents.S)
-      (P : Irmin.Path.S)
-      (B : Irmin.Branch.S)
-      (H : Irmin.Hash.S) :
-    S
-      with type key = P.t
-       and type step = P.step
-       and type metadata = M.t
-       and type contents = C.t
-       and type branch = B.t
-       and type hash = H.t
-end
+module type Maker = functor
+  (M : Irmin.Metadata.S)
+  (C : Irmin.Contents.S)
+  (P : Irmin.Path.S)
+  (B : Irmin.Branch.S)
+  (H : Irmin.Hash.S)
+  ->
+  S
+    with type key = P.t
+     and type step = P.step
+     and type metadata = M.t
+     and type contents = C.t
+     and type branch = B.t
+     and type hash = H.t
 
 module type Sigs = sig
   module Layer_id : sig

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -72,7 +72,7 @@ struct
       end
 
       module Node = struct
-        module Node = Node.Make (H) (P) (M)
+        module Node = Node (H) (P) (M)
         module CA = Inode.Make (Config) (H) (Pack) (Node)
         include Irmin.Private.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
       end

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -38,7 +38,7 @@ module type Specifics = S.Specifics
 let migrate = Migrate.run
 
 module Maker (V : Version.S) (Config : Conf.S) =
-  Maker_ext (V) (Config) (Irmin.Private.Node) (Irmin.Private.Commit)
+  Maker_ext (V) (Config) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
 
 module V1 = Maker (struct
   let version = `V1

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -37,880 +37,869 @@ let lock_path root = Filename.concat root "lock"
 module Maker
     (Config : Conf.Pack.S)
     (Node : Irmin.Private.Node.Maker)
-    (Commit : Irmin.Private.Commit.Maker) =
+    (Commit : Irmin.Private.Commit.Maker)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) =
 struct
-  module Make
-      (M : Irmin.Metadata.S)
-      (C : Irmin.Contents.S)
-      (P : Irmin.Path.S)
-      (B : Irmin.Branch.S)
-      (H : Irmin.Hash.S) =
-  struct
-    module Index = Irmin_pack.Index.Make (H)
-    module Pack = Irmin_pack.Content_addressable.Maker (V) (Index) (H)
+  module Index = Irmin_pack.Index.Make (H)
+  module Pack = Irmin_pack.Content_addressable.Maker (V) (Index) (H)
 
-    type store_handle =
-      | Commit_t : H.t -> store_handle
-      | Node_t : H.t -> store_handle
-      | Content_t : H.t -> store_handle
+  type store_handle =
+    | Commit_t : H.t -> store_handle
+    | Node_t : H.t -> store_handle
+    | Content_t : H.t -> store_handle
 
-    module X = struct
-      module Hash = H
-      module Info = Commit.Info
+  module X = struct
+    module Hash = H
+    module Info = Commit.Info
 
-      type 'a value = { magic : char; hash : H.t; v : 'a }
+    type 'a value = { magic : char; hash : H.t; v : 'a }
 
-      let value a =
-        let open Irmin.Type in
-        record "value" (fun hash magic v -> { magic; hash; v })
-        |+ field "hash" H.t (fun v -> v.hash)
-        |+ field "magic" char (fun v -> v.magic)
-        |+ field "v" a (fun v -> v.v)
-        |> sealr
+    let value a =
+      let open Irmin.Type in
+      record "value" (fun hash magic v -> { magic; hash; v })
+      |+ field "hash" H.t (fun v -> v.hash)
+      |+ field "magic" char (fun v -> v.magic)
+      |+ field "v" a (fun v -> v.v)
+      |> sealr
 
-      module Contents = struct
-        (* FIXME: remove duplication with irmin-pack/ext.ml *)
-        module CA = struct
-          module CA_Pack = Pack.Make (struct
-            include C
-            module H = Irmin.Hash.Typed (H) (C)
+    module Contents = struct
+      (* FIXME: remove duplication with irmin-pack/ext.ml *)
+      module CA = struct
+        module CA_Pack = Pack.Make (struct
+          include C
+          module H = Irmin.Hash.Typed (H) (C)
 
-            let hash = H.hash
-            let magic = 'B'
-            let value = value C.t
-            let encode_value = Irmin.Type.(unstage (encode_bin value))
-            let decode_value = Irmin.Type.(unstage (decode_bin value))
+          let hash = H.hash
+          let magic = 'B'
+          let value = value C.t
+          let encode_value = Irmin.Type.(unstage (encode_bin value))
+          let decode_value = Irmin.Type.(unstage (decode_bin value))
 
-            let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { magic; hash; v }
+          let encode_bin ~dict:_ ~offset:_ v hash =
+            encode_value { magic; hash; v }
 
-            let decode_bin ~dict:_ ~hash:_ s off =
-              let _, t = decode_value s off in
-              t.v
+          let decode_bin ~dict:_ ~hash:_ s off =
+            let _, t = decode_value s off in
+            t.v
 
-            let magic _ = magic
-          end)
+          let magic _ = magic
+        end)
 
-          module CA = Irmin_pack.Content_addressable.Closeable (CA_Pack)
-          include Layered_store.Content_addressable (H) (Index) (CA) (CA)
-        end
-
-        include Irmin.Contents.Store (CA) (H) (C)
+        module CA = Irmin_pack.Content_addressable.Closeable (CA_Pack)
+        include Layered_store.Content_addressable (H) (Index) (CA) (CA)
       end
 
-      module Node = struct
-        module Pa = Layered_store.Pack_maker (H) (Index) (Pack)
-        module Node = Node.Make (H) (P) (M)
-        module CA = Inode_layers.Make (Config) (H) (Pa) (Node)
-        include Irmin.Private.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
-      end
-
-      module Commit = struct
-        module Commit = Commit.Make (H)
-
-        module CA = struct
-          module CA_Pack = Pack.Make (struct
-            include Commit
-            module H = Irmin.Hash.Typed (H) (Commit)
-
-            let hash = H.hash
-            let value = value Commit.t
-            let magic = 'C'
-            let encode_value = Irmin.Type.(unstage (encode_bin value))
-            let decode_value = Irmin.Type.(unstage (decode_bin value))
-
-            let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { magic; hash; v }
-
-            let decode_bin ~dict:_ ~hash:_ s off =
-              let _, v = decode_value s off in
-              v.v
-
-            let magic _ = magic
-          end)
-
-          module CA = Irmin_pack.Content_addressable.Closeable (CA_Pack)
-          include Layered_store.Content_addressable (H) (Index) (CA) (CA)
-        end
-
-        include Irmin.Private.Commit.Store (Info) (Node) (CA) (H) (Commit)
-      end
-
-      module Branch = struct
-        module Key = B
-        module Val = H
-        module AW = Irmin_pack.Atomic_write.Make (V) (Key) (Val)
-        module Closeable_AW = Irmin_pack.Atomic_write.Closeable (AW)
-        include Layered_store.Atomic_write (Key) (Closeable_AW) (Closeable_AW)
-      end
-
-      module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
-      module Remote = Irmin.Private.Remote.None (H) (B)
-
-      module Repo = struct
-        type upper_layer = {
-          contents : read Contents.CA.U.t;
-          node : read Node.CA.U.t;
-          commit : read Commit.CA.U.t;
-          branch : Branch.U.t;
-          index : Index.t;
-        }
-
-        type lower_layer = {
-          lcontents : read Contents.CA.L.t;
-          lnode : read Node.CA.L.t;
-          lcommit : read Commit.CA.L.t;
-          lbranch : Branch.L.t;
-          lindex : Index.t;
-        }
-
-        type freeze_info = {
-          throttle : Conf.Pack.freeze_throttle;
-          lock : Lwt_mutex.t;
-          mutable state : [ `None | `Running | `Cancel ];
-        }
-
-        type t = {
-          root : string;
-          readonly : bool;
-          blocking_copy_size : int;
-          with_lower : bool;
-          contents : read Contents.CA.t;
-          node : read Node.CA.t;
-          branch : Branch.t;
-          commit : read Commit.CA.t;
-          lower_index : Index.t option;
-          uppers_index : Index.t * Index.t;
-          mutable flip : bool;
-          mutable closed : bool;
-          flip_file : IO_layers.t;
-          batch_lock : Lwt_mutex.t;
-          freeze : freeze_info;
-        }
-
-        let contents_t t = t.contents
-        let node_t t = (contents_t t, t.node)
-        let commit_t t = (node_t t, t.commit)
-        let branch_t t = t.branch
-
-        module Iterate = struct
-          module Contents = struct
-            include Contents.CA
-
-            type t = read Contents.CA.t
-          end
-
-          module Nodes = struct
-            include Node.CA
-
-            type t = read Node.CA.t
-          end
-
-          module Commits = struct
-            include Commit.CA
-
-            type t = read Commit.CA.t
-          end
-
-          type 'a store_fn = {
-            f : 't. (module S.Layered with type t = 't) -> 't -> 'a;
-          }
-          [@@ocaml.unboxed]
-
-          let iter_lwt (f : unit Lwt.t store_fn) t : unit Lwt.t =
-            f.f (module Contents) t.contents >>= fun () ->
-            f.f (module Nodes) t.node >>= fun () ->
-            f.f (module Commits) t.commit >>= fun () ->
-            f.f (module Branch) t.branch
-
-          let iter (f : unit store_fn) t : unit =
-            f.f (module Contents) t.contents;
-            f.f (module Nodes) t.node;
-            f.f (module Commits) t.commit;
-            f.f (module Branch) t.branch
-        end
-
-        let batch t f =
-          Lwt_mutex.with_lock t.batch_lock @@ fun () ->
-          Contents.CA.batch t.contents (fun contents ->
-              Node.CA.batch t.node (fun node ->
-                  Commit.CA.batch t.commit (fun commit ->
-                      let contents : 'a Contents.t = contents in
-                      let node : 'a Node.t = (contents, node) in
-                      let commit : 'a Commit.t = (node, commit) in
-                      f contents node commit)))
-
-        let unsafe_v_upper root config =
-          let fresh = Conf.Pack.fresh config in
-          let lru_size = Conf.Pack.lru_size config in
-          let readonly = Conf.Pack.readonly config in
-          let log_size = Conf.Pack.index_log_size config in
-          let throttle = Conf.Pack.merge_throttle config in
-          let f = ref (fun () -> ()) in
-          let index =
-            Index.v
-              ~flush_callback:(fun () -> !f ())
-                (* backpatching to add pack flush before an index flush *)
-              ~fresh ~readonly ~throttle ~log_size root
-          in
-          let* contents =
-            Contents.CA.U.v ~fresh ~readonly ~lru_size ~index root
-          in
-          let* node = Node.CA.U.v ~fresh ~readonly ~lru_size ~index root in
-          let* commit = Commit.CA.U.v ~fresh ~readonly ~lru_size ~index root in
-          let+ branch = Branch.U.v ~fresh ~readonly root in
-          (f := fun () -> Contents.CA.U.flush ~index:false contents);
-          ({ index; contents; node; commit; branch } : upper_layer)
-
-        let unsafe_v_lower root config =
-          let fresh = Conf.Pack.fresh config in
-          let lru_size = Conf.Pack.lru_size config in
-          let readonly = Conf.Pack.readonly config in
-          let log_size = Conf.Pack.index_log_size config in
-          let throttle = Conf.Pack.merge_throttle config in
-          let f = ref (fun () -> ()) in
-          let index =
-            Index.v
-              ~flush_callback:(fun () -> !f ())
-              ~fresh ~readonly ~throttle ~log_size root
-          in
-          let* lcontents =
-            Contents.CA.L.v ~fresh ~readonly ~lru_size ~index root
-          in
-          let* lnode = Node.CA.L.v ~fresh ~readonly ~lru_size ~index root in
-          let* lcommit = Commit.CA.L.v ~fresh ~readonly ~lru_size ~index root in
-          let+ lbranch = Branch.L.v ~fresh ~readonly root in
-          (f := fun () -> Contents.CA.L.flush ~index:false lcontents);
-          ({ lindex = index; lcontents; lnode; lcommit; lbranch } : lower_layer)
-
-        let v_layer ~v root config =
-          Lwt.catch
-            (fun () -> v root config)
-            (function
-              | Irmin_pack.Version.Invalid { expected; found } as e
-                when expected = V.version ->
-                  Log.err (fun m ->
-                      m "[%s] Attempted to open store of unsupported version %a"
-                        root Irmin_pack.Version.pp found);
-                  Lwt.fail e
-              | e -> Lwt.fail e)
-
-        let freeze_info throttle =
-          { throttle; state = `None; lock = Lwt_mutex.create () }
-
-        let v config =
-          let root = Conf.Pack.root config in
-          let upper1 = Filename.concat root (Conf.upper_root1 config) in
-          let* upper1 = v_layer ~v:unsafe_v_upper upper1 config in
-          let upper0 = Filename.concat root (Conf.upper_root0 config) in
-          let* upper0 = v_layer ~v:unsafe_v_upper upper0 config in
-          let with_lower = Conf.with_lower config in
-          let lower_root = Filename.concat root (Conf.lower_root config) in
-          let* lower =
-            if with_lower then
-              v_layer ~v:unsafe_v_lower lower_root config >|= Option.some
-            else Lwt.return_none
-          in
-          let file = Layout_layered.flip ~root in
-          let* flip_file = IO_layers.v file in
-          let* flip = IO_layers.read_flip flip_file in
-          (* A fresh store has to unlink the lock file as well. *)
-          let fresh = Conf.Pack.fresh config in
-          let freeze = freeze_info (Conf.Pack.freeze_throttle config) in
-          let lock_file = lock_path root in
-          let freeze_in_progress () = freeze.state = `Running in
-          let always_false () = false in
-          let batch_lock = Lwt_mutex.create () in
-          let+ () =
-            if fresh && Lock.test lock_file then Lock.unlink lock_file
-            else Lwt.return_unit
-          in
-          let lower_contents = Option.map (fun x -> x.lcontents) lower in
-          let contents =
-            Contents.CA.v upper1.contents upper0.contents lower_contents ~flip
-              ~freeze_in_progress:always_false
-          in
-          let lower_node = Option.map (fun x -> x.lnode) lower in
-          let node =
-            Node.CA.v upper1.node upper0.node lower_node ~flip
-              ~freeze_in_progress:always_false
-          in
-          let lower_commit = Option.map (fun x -> x.lcommit) lower in
-          let commit =
-            Commit.CA.v upper1.commit upper0.commit lower_commit ~flip
-              ~freeze_in_progress
-          in
-          let lower_branch = Option.map (fun x -> x.lbranch) lower in
-          let branch =
-            Branch.v upper1.branch upper0.branch lower_branch ~flip
-              ~freeze_in_progress
-          in
-          let lower_index = Option.map (fun x -> x.lindex) lower in
-          let readonly = Conf.Pack.readonly config in
-          let blocking_copy_size = Conf.blocking_copy_size config in
-          {
-            contents;
-            node;
-            commit;
-            branch;
-            root;
-            readonly;
-            with_lower;
-            blocking_copy_size;
-            lower_index;
-            uppers_index = (upper1.index, upper0.index);
-            flip;
-            closed = false;
-            flip_file;
-            freeze;
-            batch_lock;
-          }
-
-        let unsafe_close t =
-          t.closed <- true;
-          (match t.lower_index with Some x -> Index.close x | None -> ());
-          Index.close (fst t.uppers_index);
-          Index.close (snd t.uppers_index);
-          IO_layers.close t.flip_file >>= fun () ->
-          let f : unit Lwt.t Iterate.store_fn =
-            {
-              f =
-                (fun (type a) (module C : S.Layered with type t = a) (x : a) ->
-                  C.close x);
-            }
-          in
-          Iterate.iter_lwt f t
-
-        let close t =
-          Lwt_mutex.with_lock t.freeze.lock (fun () -> unsafe_close t)
-
-        (** RO uses the generation to sync the stores, so to prevent races
-            (async reads of flip and generation) the generation is used to
-            update the flip. The first store reads the flip and syncs with the
-            files on disk, the other stores only need to update the flip. *)
-        let sync t =
-          let on_generation_change () =
-            Node.CA.clear_caches t.node;
-            Commit.CA.clear_caches t.commit
-          in
-          let on_generation_change_next_upper () =
-            Node.CA.clear_caches_next_upper t.node;
-            Commit.CA.clear_caches_next_upper t.commit
-          in
-          let flip =
-            Contents.CA.sync ~on_generation_change
-              ~on_generation_change_next_upper t.contents
-          in
-          t.flip <- flip;
-          let f : unit Iterate.store_fn =
-            {
-              f =
-                (fun (type a) (module C : S.Layered with type t = a) (x : a) ->
-                  C.update_flip ~flip x);
-            }
-          in
-          Iterate.iter f t
-
-        let clear t = Contents.CA.clear t.contents
-
-        (** migrate can be called on a layered store where only one layer exists
-            on disk. As migration fails on an empty store, we check which layer
-            is in the wrong version. *)
-        let migrate config =
-          if Conf.Pack.readonly config then raise Irmin_pack.RO_not_allowed;
-          let root = Conf.Pack.root config in
-          Conf.[ upper_root1; upper_root0; lower_root ]
-          |> List.map (fun name ->
-                 let root = Filename.concat root (name config) in
-                 let config =
-                   Irmin.Private.Conf.add config Conf.Pack.root_key (Some root)
-                 in
-                 try
-                   let io =
-                     IO.v ~version:(Some V.version) ~fresh:false ~readonly:true
-                       (Layout.pack ~root)
-                   in
-                   (config, Some io)
-                 with
-                 | Irmin_pack.Version.Invalid _ -> (config, None)
-                 | e -> raise e)
-          |> List.fold_left
-               (fun to_migrate (config, io) ->
-                 match io with
-                 | None -> config :: to_migrate
-                 | Some io ->
-                     IO.close io;
-                     to_migrate)
-               []
-          |> List.iter (fun config -> Irmin_pack.migrate config)
-
-        let layer_id t store_handler =
-          match store_handler with
-          | Commit_t k -> Commit.CA.layer_id t.commit k
-          | Node_t k -> Node.CA.layer_id t.node k
-          | Content_t k -> Contents.CA.layer_id t.contents k
-
-        let flush t =
-          Contents.CA.flush t.contents;
-          Branch.flush t.branch
-
-        let flush_next_lower t =
-          Contents.CA.flush_next_lower t.contents;
-          Branch.flush_next_lower t.branch
-
-        (** Store share instances of the underlying IO files, so it is enough to
-            call clear on one store. However, each store has its own caches,
-            which need to be cleared too. *)
-        let clear_previous_upper ?keep_generation t =
-          Log.debug (fun l -> l "clear previous upper");
-          Contents.CA.clear_previous_upper ?keep_generation t.contents
-          >>= fun () ->
-          Node.CA.clear_caches_next_upper t.node;
-          Commit.CA.clear_caches_next_upper t.commit;
-          Branch.clear_previous_upper t.branch
-
-        let flip_upper t =
-          t.flip <- not t.flip;
-          let f : unit Iterate.store_fn =
-            {
-              f =
-                (fun (type a) (module C : S.Layered with type t = a) (x : a) ->
-                  C.flip_upper x);
-            }
-          in
-          Iterate.iter f t
-
-        let write_flip t = IO_layers.write_flip t.flip t.flip_file
-        let upper_in_use t = if t.flip then `Upper1 else `Upper0
-        let offset t = Contents.CA.offset t.contents
-      end
+      include Irmin.Contents.Store (CA) (H) (C)
     end
 
-    let integrity_check ?ppf ~auto_repair t =
-      let module Checks = Irmin_pack.Checks.Index (Index) in
-      let contents = X.Repo.contents_t t in
-      let nodes = X.Repo.node_t t |> snd in
-      let commits = X.Repo.commit_t t |> snd in
-      let integrity_check_layer ~layer index =
-        let check ~kind ~offset ~length k =
-          match kind with
-          | `Contents ->
-              X.Contents.CA.integrity_check ~offset ~length ~layer k contents
-          | `Node -> X.Node.CA.integrity_check ~offset ~length ~layer k nodes
-          | `Commit ->
-              X.Commit.CA.integrity_check ~offset ~length ~layer k commits
+    module Node = struct
+      module Pa = Layered_store.Pack_maker (H) (Index) (Pack)
+      module Node = Node (H) (P) (M)
+      module CA = Inode_layers.Make (Config) (H) (Pa) (Node)
+      include Irmin.Private.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+    end
+
+    module Commit = struct
+      module Commit = Commit.Make (H)
+
+      module CA = struct
+        module CA_Pack = Pack.Make (struct
+          include Commit
+          module H = Irmin.Hash.Typed (H) (Commit)
+
+          let hash = H.hash
+          let value = value Commit.t
+          let magic = 'C'
+          let encode_value = Irmin.Type.(unstage (encode_bin value))
+          let decode_value = Irmin.Type.(unstage (decode_bin value))
+
+          let encode_bin ~dict:_ ~offset:_ v hash =
+            encode_value { magic; hash; v }
+
+          let decode_bin ~dict:_ ~hash:_ s off =
+            let _, v = decode_value s off in
+            v.v
+
+          let magic _ = magic
+        end)
+
+        module CA = Irmin_pack.Content_addressable.Closeable (CA_Pack)
+        include Layered_store.Content_addressable (H) (Index) (CA) (CA)
+      end
+
+      include Irmin.Private.Commit.Store (Info) (Node) (CA) (H) (Commit)
+    end
+
+    module Branch = struct
+      module Key = B
+      module Val = H
+      module AW = Irmin_pack.Atomic_write.Make (V) (Key) (Val)
+      module Closeable_AW = Irmin_pack.Atomic_write.Closeable (AW)
+      include Layered_store.Atomic_write (Key) (Closeable_AW) (Closeable_AW)
+    end
+
+    module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
+    module Remote = Irmin.Private.Remote.None (H) (B)
+
+    module Repo = struct
+      type upper_layer = {
+        contents : read Contents.CA.U.t;
+        node : read Node.CA.U.t;
+        commit : read Commit.CA.U.t;
+        branch : Branch.U.t;
+        index : Index.t;
+      }
+
+      type lower_layer = {
+        lcontents : read Contents.CA.L.t;
+        lnode : read Node.CA.L.t;
+        lcommit : read Commit.CA.L.t;
+        lbranch : Branch.L.t;
+        lindex : Index.t;
+      }
+
+      type freeze_info = {
+        throttle : Conf.Pack.freeze_throttle;
+        lock : Lwt_mutex.t;
+        mutable state : [ `None | `Running | `Cancel ];
+      }
+
+      type t = {
+        root : string;
+        readonly : bool;
+        blocking_copy_size : int;
+        with_lower : bool;
+        contents : read Contents.CA.t;
+        node : read Node.CA.t;
+        branch : Branch.t;
+        commit : read Commit.CA.t;
+        lower_index : Index.t option;
+        uppers_index : Index.t * Index.t;
+        mutable flip : bool;
+        mutable closed : bool;
+        flip_file : IO_layers.t;
+        batch_lock : Lwt_mutex.t;
+        freeze : freeze_info;
+      }
+
+      let contents_t t = t.contents
+      let node_t t = (contents_t t, t.node)
+      let commit_t t = (node_t t, t.commit)
+      let branch_t t = t.branch
+
+      module Iterate = struct
+        module Contents = struct
+          include Contents.CA
+
+          type t = read Contents.CA.t
+        end
+
+        module Nodes = struct
+          include Node.CA
+
+          type t = read Node.CA.t
+        end
+
+        module Commits = struct
+          include Commit.CA
+
+          type t = read Commit.CA.t
+        end
+
+        type 'a store_fn = {
+          f : 't. (module S.Layered with type t = 't) -> 't -> 'a;
+        }
+        [@@ocaml.unboxed]
+
+        let iter_lwt (f : unit Lwt.t store_fn) t : unit Lwt.t =
+          f.f (module Contents) t.contents >>= fun () ->
+          f.f (module Nodes) t.node >>= fun () ->
+          f.f (module Commits) t.commit >>= fun () ->
+          f.f (module Branch) t.branch
+
+        let iter (f : unit store_fn) t : unit =
+          f.f (module Contents) t.contents;
+          f.f (module Nodes) t.node;
+          f.f (module Commits) t.commit;
+          f.f (module Branch) t.branch
+      end
+
+      let batch t f =
+        Lwt_mutex.with_lock t.batch_lock @@ fun () ->
+        Contents.CA.batch t.contents (fun contents ->
+            Node.CA.batch t.node (fun node ->
+                Commit.CA.batch t.commit (fun commit ->
+                    let contents : 'a Contents.t = contents in
+                    let node : 'a Node.t = (contents, node) in
+                    let commit : 'a Commit.t = (node, commit) in
+                    f contents node commit)))
+
+      let unsafe_v_upper root config =
+        let fresh = Conf.Pack.fresh config in
+        let lru_size = Conf.Pack.lru_size config in
+        let readonly = Conf.Pack.readonly config in
+        let log_size = Conf.Pack.index_log_size config in
+        let throttle = Conf.Pack.merge_throttle config in
+        let f = ref (fun () -> ()) in
+        let index =
+          Index.v
+            ~flush_callback:(fun () -> !f ())
+              (* backpatching to add pack flush before an index flush *)
+            ~fresh ~readonly ~throttle ~log_size root
         in
-        Checks.integrity_check ?ppf ~auto_repair ~check index
+        let* contents =
+          Contents.CA.U.v ~fresh ~readonly ~lru_size ~index root
+        in
+        let* node = Node.CA.U.v ~fresh ~readonly ~lru_size ~index root in
+        let* commit = Commit.CA.U.v ~fresh ~readonly ~lru_size ~index root in
+        let+ branch = Branch.U.v ~fresh ~readonly root in
+        (f := fun () -> Contents.CA.U.flush ~index:false contents);
+        ({ index; contents; node; commit; branch } : upper_layer)
+
+      let unsafe_v_lower root config =
+        let fresh = Conf.Pack.fresh config in
+        let lru_size = Conf.Pack.lru_size config in
+        let readonly = Conf.Pack.readonly config in
+        let log_size = Conf.Pack.index_log_size config in
+        let throttle = Conf.Pack.merge_throttle config in
+        let f = ref (fun () -> ()) in
+        let index =
+          Index.v
+            ~flush_callback:(fun () -> !f ())
+            ~fresh ~readonly ~throttle ~log_size root
+        in
+        let* lcontents =
+          Contents.CA.L.v ~fresh ~readonly ~lru_size ~index root
+        in
+        let* lnode = Node.CA.L.v ~fresh ~readonly ~lru_size ~index root in
+        let* lcommit = Commit.CA.L.v ~fresh ~readonly ~lru_size ~index root in
+        let+ lbranch = Branch.L.v ~fresh ~readonly root in
+        (f := fun () -> Contents.CA.L.flush ~index:false lcontents);
+        ({ lindex = index; lcontents; lnode; lcommit; lbranch } : lower_layer)
+
+      let v_layer ~v root config =
+        Lwt.catch
+          (fun () -> v root config)
+          (function
+            | Irmin_pack.Version.Invalid { expected; found } as e
+              when expected = V.version ->
+                Log.err (fun m ->
+                    m "[%s] Attempted to open store of unsupported version %a"
+                      root Irmin_pack.Version.pp found);
+                Lwt.fail e
+            | e -> Lwt.fail e)
+
+      let freeze_info throttle =
+        { throttle; state = `None; lock = Lwt_mutex.create () }
+
+      let v config =
+        let root = Conf.Pack.root config in
+        let upper1 = Filename.concat root (Conf.upper_root1 config) in
+        let* upper1 = v_layer ~v:unsafe_v_upper upper1 config in
+        let upper0 = Filename.concat root (Conf.upper_root0 config) in
+        let* upper0 = v_layer ~v:unsafe_v_upper upper0 config in
+        let with_lower = Conf.with_lower config in
+        let lower_root = Filename.concat root (Conf.lower_root config) in
+        let* lower =
+          if with_lower then
+            v_layer ~v:unsafe_v_lower lower_root config >|= Option.some
+          else Lwt.return_none
+        in
+        let file = Layout_layered.flip ~root in
+        let* flip_file = IO_layers.v file in
+        let* flip = IO_layers.read_flip flip_file in
+        (* A fresh store has to unlink the lock file as well. *)
+        let fresh = Conf.Pack.fresh config in
+        let freeze = freeze_info (Conf.Pack.freeze_throttle config) in
+        let lock_file = lock_path root in
+        let freeze_in_progress () = freeze.state = `Running in
+        let always_false () = false in
+        let batch_lock = Lwt_mutex.create () in
+        let+ () =
+          if fresh && Lock.test lock_file then Lock.unlink lock_file
+          else Lwt.return_unit
+        in
+        let lower_contents = Option.map (fun x -> x.lcontents) lower in
+        let contents =
+          Contents.CA.v upper1.contents upper0.contents lower_contents ~flip
+            ~freeze_in_progress:always_false
+        in
+        let lower_node = Option.map (fun x -> x.lnode) lower in
+        let node =
+          Node.CA.v upper1.node upper0.node lower_node ~flip
+            ~freeze_in_progress:always_false
+        in
+        let lower_commit = Option.map (fun x -> x.lcommit) lower in
+        let commit =
+          Commit.CA.v upper1.commit upper0.commit lower_commit ~flip
+            ~freeze_in_progress
+        in
+        let lower_branch = Option.map (fun x -> x.lbranch) lower in
+        let branch =
+          Branch.v upper1.branch upper0.branch lower_branch ~flip
+            ~freeze_in_progress
+        in
+        let lower_index = Option.map (fun x -> x.lindex) lower in
+        let readonly = Conf.Pack.readonly config in
+        let blocking_copy_size = Conf.blocking_copy_size config in
+        {
+          contents;
+          node;
+          commit;
+          branch;
+          root;
+          readonly;
+          with_lower;
+          blocking_copy_size;
+          lower_index;
+          uppers_index = (upper1.index, upper0.index);
+          flip;
+          closed = false;
+          flip_file;
+          freeze;
+          batch_lock;
+        }
+
+      let unsafe_close t =
+        t.closed <- true;
+        (match t.lower_index with Some x -> Index.close x | None -> ());
+        Index.close (fst t.uppers_index);
+        Index.close (snd t.uppers_index);
+        IO_layers.close t.flip_file >>= fun () ->
+        let f : unit Lwt.t Iterate.store_fn =
+          {
+            f =
+              (fun (type a) (module C : S.Layered with type t = a) (x : a) ->
+                C.close x);
+          }
+        in
+        Iterate.iter_lwt f t
+
+      let close t = Lwt_mutex.with_lock t.freeze.lock (fun () -> unsafe_close t)
+
+      (** RO uses the generation to sync the stores, so to prevent races (async
+          reads of flip and generation) the generation is used to update the
+          flip. The first store reads the flip and syncs with the files on disk,
+          the other stores only need to update the flip. *)
+      let sync t =
+        let on_generation_change () =
+          Node.CA.clear_caches t.node;
+          Commit.CA.clear_caches t.commit
+        in
+        let on_generation_change_next_upper () =
+          Node.CA.clear_caches_next_upper t.node;
+          Commit.CA.clear_caches_next_upper t.commit
+        in
+        let flip =
+          Contents.CA.sync ~on_generation_change
+            ~on_generation_change_next_upper t.contents
+        in
+        t.flip <- flip;
+        let f : unit Iterate.store_fn =
+          {
+            f =
+              (fun (type a) (module C : S.Layered with type t = a) (x : a) ->
+                C.update_flip ~flip x);
+          }
+        in
+        Iterate.iter f t
+
+      let clear t = Contents.CA.clear t.contents
+
+      (** migrate can be called on a layered store where only one layer exists
+          on disk. As migration fails on an empty store, we check which layer is
+          in the wrong version. *)
+      let migrate config =
+        if Conf.Pack.readonly config then raise Irmin_pack.RO_not_allowed;
+        let root = Conf.Pack.root config in
+        Conf.[ upper_root1; upper_root0; lower_root ]
+        |> List.map (fun name ->
+               let root = Filename.concat root (name config) in
+               let config =
+                 Irmin.Private.Conf.add config Conf.Pack.root_key (Some root)
+               in
+               try
+                 let io =
+                   IO.v ~version:(Some V.version) ~fresh:false ~readonly:true
+                     (Layout.pack ~root)
+                 in
+                 (config, Some io)
+               with
+               | Irmin_pack.Version.Invalid _ -> (config, None)
+               | e -> raise e)
+        |> List.fold_left
+             (fun to_migrate (config, io) ->
+               match io with
+               | None -> config :: to_migrate
+               | Some io ->
+                   IO.close io;
+                   to_migrate)
+             []
+        |> List.iter (fun config -> Irmin_pack.migrate config)
+
+      let layer_id t store_handler =
+        match store_handler with
+        | Commit_t k -> Commit.CA.layer_id t.commit k
+        | Node_t k -> Node.CA.layer_id t.node k
+        | Content_t k -> Contents.CA.layer_id t.contents k
+
+      let flush t =
+        Contents.CA.flush t.contents;
+        Branch.flush t.branch
+
+      let flush_next_lower t =
+        Contents.CA.flush_next_lower t.contents;
+        Branch.flush_next_lower t.branch
+
+      (** Store share instances of the underlying IO files, so it is enough to
+          call clear on one store. However, each store has its own caches, which
+          need to be cleared too. *)
+      let clear_previous_upper ?keep_generation t =
+        Log.debug (fun l -> l "clear previous upper");
+        Contents.CA.clear_previous_upper ?keep_generation t.contents
+        >>= fun () ->
+        Node.CA.clear_caches_next_upper t.node;
+        Commit.CA.clear_caches_next_upper t.commit;
+        Branch.clear_previous_upper t.branch
+
+      let flip_upper t =
+        t.flip <- not t.flip;
+        let f : unit Iterate.store_fn =
+          {
+            f =
+              (fun (type a) (module C : S.Layered with type t = a) (x : a) ->
+                C.flip_upper x);
+          }
+        in
+        Iterate.iter f t
+
+      let write_flip t = IO_layers.write_flip t.flip t.flip_file
+      let upper_in_use t = if t.flip then `Upper1 else `Upper0
+      let offset t = Contents.CA.offset t.contents
+    end
+  end
+
+  let integrity_check ?ppf ~auto_repair t =
+    let module Checks = Irmin_pack.Checks.Index (Index) in
+    let contents = X.Repo.contents_t t in
+    let nodes = X.Repo.node_t t |> snd in
+    let commits = X.Repo.commit_t t |> snd in
+    let integrity_check_layer ~layer index =
+      let check ~kind ~offset ~length k =
+        match kind with
+        | `Contents ->
+            X.Contents.CA.integrity_check ~offset ~length ~layer k contents
+        | `Node -> X.Node.CA.integrity_check ~offset ~length ~layer k nodes
+        | `Commit ->
+            X.Commit.CA.integrity_check ~offset ~length ~layer k commits
       in
-      [
-        (`Upper1, Some (fst t.X.Repo.uppers_index));
-        (`Upper0, Some (snd t.X.Repo.uppers_index));
-        (`Lower, t.lower_index);
-      ]
-      |> List.map (fun (layer, index) ->
-             match index with
-             | Some index -> (integrity_check_layer ~layer index, layer)
-             | None -> (Ok `No_error, layer))
+      Checks.integrity_check ?ppf ~auto_repair ~check index
+    in
+    [
+      (`Upper1, Some (fst t.X.Repo.uppers_index));
+      (`Upper0, Some (snd t.X.Repo.uppers_index));
+      (`Lower, t.lower_index);
+    ]
+    |> List.map (fun (layer, index) ->
+           match index with
+           | Some index -> (integrity_check_layer ~layer index, layer)
+           | None -> (Ok `No_error, layer))
 
-    include Irmin.Of_private (X)
+  include Irmin.Of_private (X)
 
-    let sync = X.Repo.sync
-    let clear = X.Repo.clear
-    let migrate = X.Repo.migrate
-    let flush = X.Repo.flush
-    let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash
+  let sync = X.Repo.sync
+  let clear = X.Repo.clear
+  let migrate = X.Repo.migrate
+  let flush = X.Repo.flush
+  let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash
 
-    module Copy = struct
-      let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
-      let mem_commit_next t = X.Commit.CA.mem_next t.X.Repo.commit
-      let mem_node_lower t = X.Node.CA.mem_lower t.X.Repo.node
-      let mem_node_next t = X.Node.CA.mem_next t.X.Repo.node
-      let mem_contents_lower t = X.Contents.CA.mem_lower t.X.Repo.contents
-      let mem_contents_next t = X.Contents.CA.mem_next t.X.Repo.contents
+  module Copy = struct
+    let mem_commit_lower t = X.Commit.CA.mem_lower t.X.Repo.commit
+    let mem_commit_next t = X.Commit.CA.mem_next t.X.Repo.commit
+    let mem_node_lower t = X.Node.CA.mem_lower t.X.Repo.node
+    let mem_node_next t = X.Node.CA.mem_next t.X.Repo.node
+    let mem_contents_lower t = X.Contents.CA.mem_lower t.X.Repo.contents
+    let mem_contents_next t = X.Contents.CA.mem_next t.X.Repo.contents
 
-      let copy_branches t =
-        X.Branch.copy ~mem_commit_lower:(mem_commit_lower t)
-          ~mem_commit_upper:(mem_commit_next t) t.X.Repo.branch
+    let copy_branches t =
+      X.Branch.copy ~mem_commit_lower:(mem_commit_lower t)
+        ~mem_commit_upper:(mem_commit_next t) t.X.Repo.branch
 
-      let skip_with_stats ~skip h =
-        skip h >|= fun should_skip ->
-        Irmin_layers.Stats.skip_test should_skip;
-        should_skip
+    let skip_with_stats ~skip h =
+      skip h >|= fun should_skip ->
+      Irmin_layers.Stats.skip_test should_skip;
+      should_skip
 
-      let no_skip _ = Lwt.return false
+    let no_skip _ = Lwt.return false
 
-      let pred_node t k =
-        let n = snd (X.Repo.node_t t) in
-        X.Node.CA.find n k >|= function
-        | None -> []
-        | Some v ->
-            List.rev_map
-              (function
-                | `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
-              (X.Node.CA.Val.pred v)
+    let pred_node t k =
+      let n = snd (X.Repo.node_t t) in
+      X.Node.CA.find n k >|= function
+      | None -> []
+      | Some v ->
+          List.rev_map
+            (function `Inode x -> `Node x | (`Node _ | `Contents _) as x -> x)
+            (X.Node.CA.Val.pred v)
 
-      let always_false _ = false
-      let with_cancel cancel f = if cancel () then Lwt.fail Cancelled else f ()
+    let always_false _ = false
+    let with_cancel cancel f = if cancel () then Lwt.fail Cancelled else f ()
 
+    let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
+        ?(cancel = always_false) ?(skip_nodes = no_skip)
+        ?(skip_contents = no_skip) t ?(min = []) max =
+      (* if node or contents are already in dst then they are skipped by
+         Graph.iter; there is no need to check this again when the object is
+         copied *)
+      let commit k =
+        with_cancel cancel @@ fun () ->
+        X.Commit.CA.copy commits t.X.Repo.commit "Commit" k;
+        Irmin_layers.Stats.freeze_yield ();
+        let* () = Lwt.pause () in
+        Irmin_layers.Stats.freeze_yield_end ();
+        Lwt.return_unit
+      in
+      let node k =
+        with_cancel cancel @@ fun () ->
+        X.Node.CA.copy nodes t.X.Repo.node k;
+        Lwt.return_unit
+      in
+      let contents k =
+        with_cancel cancel @@ fun () ->
+        X.Contents.CA.copy contents t.X.Repo.contents "Contents" k;
+        Lwt.return_unit
+      in
+      let skip_node h = skip_with_stats ~skip:skip_nodes h in
+      let skip_contents h = skip_with_stats ~skip:skip_contents h in
+      let skip_commit h = skip_with_stats ~skip:skip_commits h in
+      let+ () =
+        Repo.iter ~cache_size ~min ~max ~commit ~node ~contents ~skip_node
+          ~skip_contents ~pred_node ~skip_commit t
+      in
+      X.Repo.flush t
+
+    module CopyToLower = struct
+      let on_lower t f =
+        let contents =
+          (X.Contents.CA.Lower, X.Contents.CA.lower t.X.Repo.contents)
+        in
+        let nodes = (X.Node.CA.Lower, X.Node.CA.lower t.X.Repo.node) in
+        let commits = (X.Commit.CA.Lower, X.Commit.CA.lower t.X.Repo.commit) in
+        f (contents, nodes, commits)
+
+      let copy ?cancel ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to lower:@ min=%a,@ max=%a@]" pp_commits min pp_commits
+              commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        let min = List.map (fun x -> `Commit (Commit.hash x)) min in
+        on_lower t (fun l ->
+            iter_copy ?cancel l ~skip_commits:(mem_commit_lower t)
+              ~skip_nodes:(mem_node_lower t)
+              ~skip_contents:(mem_contents_lower t) t ~min max)
+    end
+
+    module CopyToUpper = struct
+      let on_next_upper t f =
+        let contents =
+          (X.Contents.CA.Upper, X.Contents.CA.next_upper t.X.Repo.contents)
+        in
+        let nodes = (X.Node.CA.Upper, X.Node.CA.next_upper t.X.Repo.node) in
+        let commits =
+          (X.Commit.CA.Upper, X.Commit.CA.next_upper t.X.Repo.commit)
+        in
+        f (contents, nodes, commits)
+
+      let copy ?cancel ?(min = []) t commits =
+        Log.debug (fun f ->
+            f "@[<2>copy to next upper:@ min=%a,@ max=%a@]" pp_commits min
+              pp_commits commits);
+        let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
+        let min = List.map (fun x -> `Commit (Commit.hash x)) min in
+        on_next_upper t (fun u ->
+            iter_copy ?cancel u ~skip_commits:(mem_commit_next t)
+              ~skip_nodes:(mem_node_next t) ~skip_contents:(mem_contents_next t)
+              ~min t max)
+
+      (** Newies are the objects added in current upper during the freeze. They
+          are copied to the next upper before the freeze ends. When copying the
+          newies we have to traverse them as well, to ensure that all objects
+          used by a newies are also copied in the next upper. We only keep track
+          of commit newies and rely on `Repo.iter` to compute the transitive
+          closures of all the newies. *)
+      let copy_newies ~cancel t =
+        let newies = X.Commit.CA.consume_newies t.X.Repo.commit in
+        let newies = List.rev_map (fun x -> `Commit x) newies in
+        Log.debug (fun l -> l "copy newies");
+        (* we want to copy all the new commits; stop whenever one
+           commmit already in the other upper or in lower. *)
+        let skip_commits k =
+          mem_commit_next t k >>= function
+          | true -> Lwt.return true
+          | false -> mem_commit_lower t k
+        in
+        on_next_upper t (fun u ->
+            iter_copy u ?cancel ~skip_commits ~skip_nodes:(mem_node_next t)
+              ~skip_contents:(mem_contents_next t) t newies)
+        >>= fun () -> X.Branch.copy_newies_to_next_upper t.branch
+
+      (** Repeatedly call [copy_newies] as long as there are many newies (more
+          than newies_limit bytes added). *)
+      let rec copy_newies_to_next_upper ~cancel t former_offset =
+        let newies_limit = Int63.of_int t.X.Repo.blocking_copy_size in
+        let offset = X.Repo.offset t in
+        if offset -- former_offset >= newies_limit then (
+          Irmin_layers.Stats.copy_newies_loop ();
+          copy_newies ~cancel t >>= fun () ->
+          (copy_newies_to_next_upper ~cancel t offset [@tail]))
+        else Lwt.return_unit
+    end
+
+    module CopyFromLower = struct
+      (* FIXME(samoht): copy/paste from iter_copy with s/copy/copy_from_lower *)
       let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
           ?(cancel = always_false) ?(skip_nodes = no_skip)
-          ?(skip_contents = no_skip) t ?(min = []) max =
+          ?(skip_contents = no_skip) t ?(min = []) cs =
         (* if node or contents are already in dst then they are skipped by
            Graph.iter; there is no need to check this again when the object is
            copied *)
         let commit k =
           with_cancel cancel @@ fun () ->
-          X.Commit.CA.copy commits t.X.Repo.commit "Commit" k;
-          Irmin_layers.Stats.freeze_yield ();
-          let* () = Lwt.pause () in
-          Irmin_layers.Stats.freeze_yield_end ();
-          Lwt.return_unit
+          X.Commit.CA.copy_from_lower ~dst:commits t.X.Repo.commit "Commit" k
         in
         let node k =
           with_cancel cancel @@ fun () ->
-          X.Node.CA.copy nodes t.X.Repo.node k;
-          Lwt.return_unit
+          X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k
         in
         let contents k =
           with_cancel cancel @@ fun () ->
-          X.Contents.CA.copy contents t.X.Repo.contents "Contents" k;
-          Lwt.return_unit
+          X.Contents.CA.copy_from_lower ~dst:contents t.X.Repo.contents
+            "Contents" k
         in
         let skip_node h = skip_with_stats ~skip:skip_nodes h in
         let skip_contents h = skip_with_stats ~skip:skip_contents h in
         let skip_commit h = skip_with_stats ~skip:skip_commits h in
+        let max = List.map (fun c -> `Commit c) cs in
+        let min = List.map (fun c -> `Commit c) min in
         let+ () =
           Repo.iter ~cache_size ~min ~max ~commit ~node ~contents ~skip_node
             ~skip_contents ~pred_node ~skip_commit t
         in
         X.Repo.flush t
 
-      module CopyToLower = struct
-        let on_lower t f =
-          let contents =
-            (X.Contents.CA.Lower, X.Contents.CA.lower t.X.Repo.contents)
-          in
-          let nodes = (X.Node.CA.Lower, X.Node.CA.lower t.X.Repo.node) in
-          let commits =
-            (X.Commit.CA.Lower, X.Commit.CA.lower t.X.Repo.commit)
-          in
-          f (contents, nodes, commits)
+      let on_current_upper t f =
+        let contents = X.Contents.CA.current_upper t.X.Repo.contents in
+        let nodes = X.Node.CA.current_upper t.X.Repo.node in
+        let commits = X.Commit.CA.current_upper t.X.Repo.commit in
+        f (contents, nodes, commits)
 
-        let copy ?cancel ?(min = []) t commits =
-          Log.debug (fun f ->
-              f "@[<2>copy to lower:@ min=%a,@ max=%a@]" pp_commits min
-                pp_commits commits);
-          let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
-          let min = List.map (fun x -> `Commit (Commit.hash x)) min in
-          on_lower t (fun l ->
-              iter_copy ?cancel l ~skip_commits:(mem_commit_lower t)
-                ~skip_nodes:(mem_node_lower t)
-                ~skip_contents:(mem_contents_lower t) t ~min max)
-      end
+      (** An object can be in either lower or upper or both. We can't skip an
+          object already in upper as some predecessors could still be in lower. *)
+      let self_contained ?min ~max t =
+        let max = List.map (fun x -> Commit.hash x) max in
+        let min =
+          match min with
+          | None -> max (* if min is empty then copy only the max commits *)
+          | Some min -> List.map (fun x -> Commit.hash x) min
+        in
+        (* FIXME(samoht): do this in 2 steps: 1/ find the shallow
+           hashes in upper 2/ iterates with max=shallow
 
-      module CopyToUpper = struct
-        let on_next_upper t f =
-          let contents =
-            (X.Contents.CA.Upper, X.Contents.CA.next_upper t.X.Repo.contents)
-          in
-          let nodes = (X.Node.CA.Upper, X.Node.CA.next_upper t.X.Repo.node) in
-          let commits =
-            (X.Commit.CA.Upper, X.Commit.CA.next_upper t.X.Repo.commit)
-          in
-          f (contents, nodes, commits)
-
-        let copy ?cancel ?(min = []) t commits =
-          Log.debug (fun f ->
-              f "@[<2>copy to next upper:@ min=%a,@ max=%a@]" pp_commits min
-                pp_commits commits);
-          let max = List.map (fun x -> `Commit (Commit.hash x)) commits in
-          let min = List.map (fun x -> `Commit (Commit.hash x)) min in
-          on_next_upper t (fun u ->
-              iter_copy ?cancel u ~skip_commits:(mem_commit_next t)
-                ~skip_nodes:(mem_node_next t)
-                ~skip_contents:(mem_contents_next t) ~min t max)
-
-        (** Newies are the objects added in current upper during the freeze.
-            They are copied to the next upper before the freeze ends. When
-            copying the newies we have to traverse them as well, to ensure that
-            all objects used by a newies are also copied in the next upper. We
-            only keep track of commit newies and rely on `Repo.iter` to compute
-            the transitive closures of all the newies. *)
-        let copy_newies ~cancel t =
-          let newies = X.Commit.CA.consume_newies t.X.Repo.commit in
-          let newies = List.rev_map (fun x -> `Commit x) newies in
-          Log.debug (fun l -> l "copy newies");
-          (* we want to copy all the new commits; stop whenever one
-             commmit already in the other upper or in lower. *)
-          let skip_commits k =
-            mem_commit_next t k >>= function
-            | true -> Lwt.return true
-            | false -> mem_commit_lower t k
-          in
-          on_next_upper t (fun u ->
-              iter_copy u ?cancel ~skip_commits ~skip_nodes:(mem_node_next t)
-                ~skip_contents:(mem_contents_next t) t newies)
-          >>= fun () -> X.Branch.copy_newies_to_next_upper t.branch
-
-        (** Repeatedly call [copy_newies] as long as there are many newies (more
-            than newies_limit bytes added). *)
-        let rec copy_newies_to_next_upper ~cancel t former_offset =
-          let newies_limit = Int63.of_int t.X.Repo.blocking_copy_size in
-          let offset = X.Repo.offset t in
-          if offset -- former_offset >= newies_limit then (
-            Irmin_layers.Stats.copy_newies_loop ();
-            copy_newies ~cancel t >>= fun () ->
-            (copy_newies_to_next_upper ~cancel t offset [@tail]))
-          else Lwt.return_unit
-      end
-
-      module CopyFromLower = struct
-        (* FIXME(samoht): copy/paste from iter_copy with s/copy/copy_from_lower *)
-        let iter_copy (contents, nodes, commits) ?(skip_commits = no_skip)
-            ?(cancel = always_false) ?(skip_nodes = no_skip)
-            ?(skip_contents = no_skip) t ?(min = []) cs =
-          (* if node or contents are already in dst then they are skipped by
-             Graph.iter; there is no need to check this again when the object is
-             copied *)
-          let commit k =
-            with_cancel cancel @@ fun () ->
-            X.Commit.CA.copy_from_lower ~dst:commits t.X.Repo.commit "Commit" k
-          in
-          let node k =
-            with_cancel cancel @@ fun () ->
-            X.Node.CA.copy_from_lower ~dst:nodes t.X.Repo.node k
-          in
-          let contents k =
-            with_cancel cancel @@ fun () ->
-            X.Contents.CA.copy_from_lower ~dst:contents t.X.Repo.contents
-              "Contents" k
-          in
-          let skip_node h = skip_with_stats ~skip:skip_nodes h in
-          let skip_contents h = skip_with_stats ~skip:skip_contents h in
-          let skip_commit h = skip_with_stats ~skip:skip_commits h in
-          let max = List.map (fun c -> `Commit c) cs in
-          let min = List.map (fun c -> `Commit c) min in
-          let+ () =
-            Repo.iter ~cache_size ~min ~max ~commit ~node ~contents ~skip_node
-              ~skip_contents ~pred_node ~skip_commit t
-          in
-          X.Repo.flush t
-
-        let on_current_upper t f =
-          let contents = X.Contents.CA.current_upper t.X.Repo.contents in
-          let nodes = X.Node.CA.current_upper t.X.Repo.node in
-          let commits = X.Commit.CA.current_upper t.X.Repo.commit in
-          f (contents, nodes, commits)
-
-        (** An object can be in either lower or upper or both. We can't skip an
-            object already in upper as some predecessors could still be in
-            lower. *)
-        let self_contained ?min ~max t =
-          let max = List.map (fun x -> Commit.hash x) max in
-          let min =
-            match min with
-            | None -> max (* if min is empty then copy only the max commits *)
-            | Some min -> List.map (fun x -> Commit.hash x) min
-          in
-          (* FIXME(samoht): do this in 2 steps: 1/ find the shallow
-             hashes in upper 2/ iterates with max=shallow
-
-             (ngoguey): we could stop at the uppers directly following a lower.
-          *)
-          Log.debug (fun l ->
-              l
-                "self_contained: copy commits min:%a; max:%a from lower into \
-                 upper to make the upper self contained"
-                (Fmt.list (Irmin.Type.pp H.t))
-                min
-                (Fmt.list (Irmin.Type.pp H.t))
-                max);
-          on_current_upper t (fun u -> iter_copy u ~min t max)
-      end
+           (ngoguey): we could stop at the uppers directly following a lower.
+        *)
+        Log.debug (fun l ->
+            l
+              "self_contained: copy commits min:%a; max:%a from lower into \
+               upper to make the upper self contained"
+              (Fmt.list (Irmin.Type.pp H.t))
+              min
+              (Fmt.list (Irmin.Type.pp H.t))
+              max);
+        on_current_upper t (fun u -> iter_copy u ~min t max)
     end
+  end
 
-    let copy ~cancel ~min_lower ~max_lower ~min_upper ~max_upper t =
-      (* Copy commits to lower.
-         In case cancellation of the freeze, copies to the lower layer will not
-         be reverted. Since the copying is performed in the [rev] order, the next
-         freeze will resume copying where the previous freeze stopped. *)
-      Irmin_layers.Stats.freeze_section "copy to lower";
-      (if t.X.Repo.with_lower then
-       Copy.CopyToLower.copy ~cancel t ~min:min_lower max_lower
+  let copy ~cancel ~min_lower ~max_lower ~min_upper ~max_upper t =
+    (* Copy commits to lower.
+       In case cancellation of the freeze, copies to the lower layer will not
+       be reverted. Since the copying is performed in the [rev] order, the next
+       freeze will resume copying where the previous freeze stopped. *)
+    Irmin_layers.Stats.freeze_section "copy to lower";
+    (if t.X.Repo.with_lower then
+     Copy.CopyToLower.copy ~cancel t ~min:min_lower max_lower
+    else Lwt.return_unit)
+    >>= fun () ->
+    (* Copy [min_upper, max_upper] to next_upper. In case of cancellation of the
+       freeze, the next upper will be cleared. *)
+    Irmin_layers.Stats.freeze_section "copy to next upper";
+    Copy.CopyToUpper.copy t ~cancel ~min:min_upper max_upper >>= fun () ->
+    Irmin_layers.Stats.freeze_section "copy branches";
+    (* Copy branches to both lower and next_upper *)
+    Copy.copy_branches t
+
+  module Field = struct
+    type t = F : 'a Fmt.t * string * 'a -> t | E
+
+    let pp ppf = function E -> () | F (pp, k, v) -> Fmt.pf ppf "%s=%a" k pp v
+
+    let pps ppf t =
+      Fmt.list ~sep:(Fmt.unit "; ") pp ppf (List.filter (fun x -> x <> E) t)
+
+    let commits k = function [] -> E | v -> F (pp_commits, k, v)
+  end
+
+  let pp_repo ppf t =
+    Fmt.pf ppf "%a" Layered_store.pp_current_upper t.X.Repo.flip
+
+  let unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t =
+    Log.info (fun l ->
+        l "[%a] freeze starts { %a }" pp_repo t Field.pps
+          [
+            Field.commits "min_lower" min_lower;
+            Field.commits "max_lower" max_lower;
+            Field.commits "min_upper" min_upper;
+            Field.commits "max_upper" max_upper;
+          ]);
+    let offset = X.Repo.offset t in
+    let lock_file = lock_path t.root in
+    (* We take a file lock here to signal that a freeze was in progess in
+       case of crash, to trigger the recovery path. *)
+    let* lock_file = Lock.v lock_file in
+    let cancel () = t.freeze.state = `Cancel in
+    let copy () =
+      may (fun f -> f `Before_Copy) hook >>= fun () ->
+      copy ~cancel ~min_lower ~max_lower ~min_upper ~max_upper t >>= fun () ->
+      Irmin_layers.Stats.freeze_section "flush lower";
+      X.Repo.flush_next_lower t;
+      may (fun f -> f `Before_Copy_Newies) hook >>= fun () ->
+      Irmin_layers.Stats.freeze_section "copy newies (loop)";
+      Copy.CopyToUpper.copy_newies_to_next_upper ~cancel:(Some cancel) t offset
+      >>= fun () ->
+      may (fun f -> f `Before_Copy_Last_Newies) hook >>= fun () ->
+      (* Let's finish the freeze under the batch lock so that no concurrent
+         modifications occur until the uppers are flipped. No more cancellations
+         from this point on. There are only a few newies left (less than
+         [newies_limit] bytes) so this lock should be quickly released. *)
+      Irmin_layers.Stats.freeze_section "wait for batch lock";
+      Irmin_layers.Stats.freeze_yield ();
+      Lwt_mutex.with_lock t.batch_lock (fun () ->
+          Irmin_layers.Stats.freeze_yield_end ();
+          Irmin_layers.Stats.freeze_section "copy newies (last)";
+          Copy.CopyToUpper.copy_newies ~cancel:None t >>= fun () ->
+          Irmin_layers.Stats.freeze_section "misc";
+          may (fun f -> f `Before_Flip) hook >>= fun () ->
+          X.Repo.flip_upper t;
+          may (fun f -> f `Before_Clear) hook >>= fun () ->
+          X.Repo.clear_previous_upper t)
+      >>= fun () ->
+      (* RO reads generation from pack file to detect a flip change, so it's
+         ok to write the flip file outside the lock *)
+      X.Repo.write_flip t
+    in
+    let finalize cancelled () =
+      Irmin_layers.Stats.freeze_section "finalize";
+      t.freeze.state <- `None;
+      (if cancelled then X.Repo.clear_previous_upper ~keep_generation:() t
       else Lwt.return_unit)
       >>= fun () ->
-      (* Copy [min_upper, max_upper] to next_upper. In case of cancellation of the
-         freeze, the next upper will be cleared. *)
-      Irmin_layers.Stats.freeze_section "copy to next upper";
-      Copy.CopyToUpper.copy t ~cancel ~min:min_upper max_upper >>= fun () ->
-      Irmin_layers.Stats.freeze_section "copy branches";
-      (* Copy branches to both lower and next_upper *)
-      Copy.copy_branches t
+      Lock.close lock_file >>= fun () ->
+      Lwt_mutex.unlock t.freeze.lock;
+      may (fun f -> f `After_Clear) hook >|= fun () ->
+      Irmin_layers.Stats.freeze_stop ();
+      (* Fmt.pr "\n%a%!" Irmin_layers.Stats.pp_latest (); *)
+      ()
+    in
+    let async () =
+      Lwt.try_bind copy (finalize false) (function
+        | Cancelled -> finalize true ()
+        | e -> Lwt.fail e)
+    in
+    Lwt.async async;
+    Lwt.return_unit
 
-    module Field = struct
-      type t = F : 'a Fmt.t * string * 'a -> t | E
-
-      let pp ppf = function
-        | E -> ()
-        | F (pp, k, v) -> Fmt.pf ppf "%s=%a" k pp v
-
-      let pps ppf t =
-        Fmt.list ~sep:(Fmt.unit "; ") pp ppf (List.filter (fun x -> x <> E) t)
-
-      let commits k = function [] -> E | v -> F (pp_commits, k, v)
-    end
-
-    let pp_repo ppf t =
-      Fmt.pf ppf "%a" Layered_store.pp_current_upper t.X.Repo.flip
-
-    let unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t =
-      Log.info (fun l ->
-          l "[%a] freeze starts { %a }" pp_repo t Field.pps
-            [
-              Field.commits "min_lower" min_lower;
-              Field.commits "max_lower" max_lower;
-              Field.commits "min_upper" min_upper;
-              Field.commits "max_upper" max_upper;
-            ]);
-      let offset = X.Repo.offset t in
-      let lock_file = lock_path t.root in
-      (* We take a file lock here to signal that a freeze was in progess in
-         case of crash, to trigger the recovery path. *)
-      let* lock_file = Lock.v lock_file in
-      let cancel () = t.freeze.state = `Cancel in
-      let copy () =
-        may (fun f -> f `Before_Copy) hook >>= fun () ->
-        copy ~cancel ~min_lower ~max_lower ~min_upper ~max_upper t >>= fun () ->
-        Irmin_layers.Stats.freeze_section "flush lower";
-        X.Repo.flush_next_lower t;
-        may (fun f -> f `Before_Copy_Newies) hook >>= fun () ->
-        Irmin_layers.Stats.freeze_section "copy newies (loop)";
-        Copy.CopyToUpper.copy_newies_to_next_upper ~cancel:(Some cancel) t
-          offset
-        >>= fun () ->
-        may (fun f -> f `Before_Copy_Last_Newies) hook >>= fun () ->
-        (* Let's finish the freeze under the batch lock so that no concurrent
-           modifications occur until the uppers are flipped. No more cancellations
-           from this point on. There are only a few newies left (less than
-           [newies_limit] bytes) so this lock should be quickly released. *)
-        Irmin_layers.Stats.freeze_section "wait for batch lock";
-        Irmin_layers.Stats.freeze_yield ();
-        Lwt_mutex.with_lock t.batch_lock (fun () ->
-            Irmin_layers.Stats.freeze_yield_end ();
-            Irmin_layers.Stats.freeze_section "copy newies (last)";
-            Copy.CopyToUpper.copy_newies ~cancel:None t >>= fun () ->
-            Irmin_layers.Stats.freeze_section "misc";
-            may (fun f -> f `Before_Flip) hook >>= fun () ->
-            X.Repo.flip_upper t;
-            may (fun f -> f `Before_Clear) hook >>= fun () ->
-            X.Repo.clear_previous_upper t)
-        >>= fun () ->
-        (* RO reads generation from pack file to detect a flip change, so it's
-           ok to write the flip file outside the lock *)
-        X.Repo.write_flip t
+  (** Main thread takes the [t.freeze.lock] at the begining of freeze and async
+      thread releases it at the end. This is to ensure that no two freezes can
+      run simultaneously. *)
+  let freeze' ?min_lower ?max_lower ?min_upper ?max_upper ?(recovery = false)
+      ?hook t =
+    let* () =
+      if recovery then X.Repo.clear_previous_upper ~keep_generation:() t
+      else Lwt.return_unit
+    in
+    let freeze () =
+      let t0 = Mtime_clock.now () in
+      Lwt_mutex.lock t.freeze.lock >>= fun () ->
+      t.freeze.state <- `Running;
+      Irmin_layers.Stats.freeze_start t0 "wait for freeze lock";
+      Irmin_layers.Stats.freeze_section "misc";
+      let min_lower = Option.value min_lower ~default:[] in
+      let* max_lower =
+        match max_lower with Some l -> Lwt.return l | None -> Repo.heads t
       in
-      let finalize cancelled () =
-        Irmin_layers.Stats.freeze_section "finalize";
-        t.freeze.state <- `None;
-        (if cancelled then X.Repo.clear_previous_upper ~keep_generation:() t
-        else Lwt.return_unit)
-        >>= fun () ->
-        Lock.close lock_file >>= fun () ->
-        Lwt_mutex.unlock t.freeze.lock;
-        may (fun f -> f `After_Clear) hook >|= fun () ->
-        Irmin_layers.Stats.freeze_stop ();
-        (* Fmt.pr "\n%a%!" Irmin_layers.Stats.pp_latest (); *)
-        ()
-      in
-      let async () =
-        Lwt.try_bind copy (finalize false) (function
-          | Cancelled -> finalize true ()
-          | e -> Lwt.fail e)
-      in
-      Lwt.async async;
+      let max_upper = Option.value max_upper ~default:max_lower in
+      let min_upper = Option.value min_upper ~default:max_upper in
+      unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t
+    in
+    if t.X.Repo.closed then Lwt.fail_with "store is closed"
+    else if t.readonly then raise Irmin_pack.RO_not_allowed
+    else
+      match (t.freeze.state, t.freeze.throttle) with
+      | `Running, `Overcommit_memory -> Lwt.return ()
+      | `Running, `Cancel_existing ->
+          t.freeze.state <- `Cancel;
+          freeze ()
+      | _ -> freeze ()
+
+  let layer_id = X.Repo.layer_id
+  let freeze = freeze' ?hook:None
+  let async_freeze (t : Repo.t) = Lock.test (lock_path t.X.Repo.root)
+  let upper_in_use = X.Repo.upper_in_use
+  let self_contained = Copy.CopyFromLower.self_contained
+  let needs_recovery t = Lock.test (lock_path t.X.Repo.root)
+
+  let check_self_contained ?heads t =
+    Log.debug (fun l -> l "Check that the upper layer is self contained");
+    let errors = ref 0 in
+    let none () =
+      incr errors;
       Lwt.return_unit
+    in
+    let node k = X.Node.CA.check t.X.Repo.node ~none k in
+    let contents k = X.Contents.CA.check t.X.Repo.contents ~none k in
+    let commit k = X.Commit.CA.check t.X.Repo.commit ~none k in
+    let* heads =
+      match heads with None -> Repo.heads t | Some m -> Lwt.return m
+    in
+    let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
+    let+ () =
+      Repo.iter ~cache_size ~min:[] ~max:hashes ~commit ~node ~contents t
+    in
+    let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
+    if !errors = 0 then
+      Fmt.kstrf
+        (fun x -> Ok (`Msg x))
+        "Upper layer is self contained for heads %a" pp_commits heads
+    else
+      Fmt.kstrf
+        (fun x -> Error (`Msg x))
+        "Upper layer is not self contained for heads %a: %n phantom objects \
+         detected"
+        pp_commits heads !errors
 
-    (** Main thread takes the [t.freeze.lock] at the begining of freeze and
-        async thread releases it at the end. This is to ensure that no two
-        freezes can run simultaneously. *)
-    let freeze' ?min_lower ?max_lower ?min_upper ?max_upper ?(recovery = false)
-        ?hook t =
-      let* () =
-        if recovery then X.Repo.clear_previous_upper ~keep_generation:() t
-        else Lwt.return_unit
-      in
-      let freeze () =
-        let t0 = Mtime_clock.now () in
-        Lwt_mutex.lock t.freeze.lock >>= fun () ->
-        t.freeze.state <- `Running;
-        Irmin_layers.Stats.freeze_start t0 "wait for freeze lock";
-        Irmin_layers.Stats.freeze_section "misc";
-        let min_lower = Option.value min_lower ~default:[] in
-        let* max_lower =
-          match max_lower with Some l -> Lwt.return l | None -> Repo.heads t
-        in
-        let max_upper = Option.value max_upper ~default:max_lower in
-        let min_upper = Option.value min_upper ~default:max_upper in
-        unsafe_freeze ~min_lower ~max_lower ~min_upper ~max_upper ?hook t
-      in
-      if t.X.Repo.closed then Lwt.fail_with "store is closed"
-      else if t.readonly then raise Irmin_pack.RO_not_allowed
-      else
-        match (t.freeze.state, t.freeze.throttle) with
-        | `Running, `Overcommit_memory -> Lwt.return ()
-        | `Running, `Cancel_existing ->
-            t.freeze.state <- `Cancel;
-            freeze ()
-        | _ -> freeze ()
+  module Private_layer = struct
+    module Hook = struct
+      type 'a t = 'a -> unit Lwt.t
 
-    let layer_id = X.Repo.layer_id
-    let freeze = freeze' ?hook:None
-    let async_freeze (t : Repo.t) = Lock.test (lock_path t.X.Repo.root)
-    let upper_in_use = X.Repo.upper_in_use
-    let self_contained = Copy.CopyFromLower.self_contained
-    let needs_recovery t = Lock.test (lock_path t.X.Repo.root)
-
-    let check_self_contained ?heads t =
-      Log.debug (fun l -> l "Check that the upper layer is self contained");
-      let errors = ref 0 in
-      let none () =
-        incr errors;
-        Lwt.return_unit
-      in
-      let node k = X.Node.CA.check t.X.Repo.node ~none k in
-      let contents k = X.Contents.CA.check t.X.Repo.contents ~none k in
-      let commit k = X.Commit.CA.check t.X.Repo.commit ~none k in
-      let* heads =
-        match heads with None -> Repo.heads t | Some m -> Lwt.return m
-      in
-      let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
-      let+ () =
-        Repo.iter ~cache_size ~min:[] ~max:hashes ~commit ~node ~contents t
-      in
-      let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
-      if !errors = 0 then
-        Fmt.kstrf
-          (fun x -> Ok (`Msg x))
-          "Upper layer is self contained for heads %a" pp_commits heads
-      else
-        Fmt.kstrf
-          (fun x -> Error (`Msg x))
-          "Upper layer is not self contained for heads %a: %n phantom objects \
-           detected"
-          pp_commits heads !errors
-
-    module Private_layer = struct
-      module Hook = struct
-        type 'a t = 'a -> unit Lwt.t
-
-        let v f = f
-      end
-
-      let wait_for_freeze (t : Repo.t) =
-        Lwt_mutex.with_lock t.freeze.lock (fun () -> Lwt.return_unit)
-
-      let freeze' = freeze'
-      let upper_in_use = upper_in_use
+      let v f = f
     end
+
+    let wait_for_freeze (t : Repo.t) =
+      Lwt_mutex.with_lock t.freeze.lock (fun () -> Lwt.return_unit)
+
+    let freeze' = freeze'
+    let upper_in_use = upper_in_use
   end
 end

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -21,7 +21,7 @@ module type S = S.Store
 module type Maker = S.Maker
 
 module Maker (Config : Irmin_pack.Conf.S) =
-  Maker_ext (Config) (Irmin.Private.Node) (Irmin.Private.Commit)
+  Maker_ext (Config) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
 
 module Checks = Checks
 

--- a/src/irmin-pack/layered/irmin_pack_layered.mli
+++ b/src/irmin-pack/layered/irmin_pack_layered.mli
@@ -40,10 +40,7 @@ module type S = sig
   (** @inline *)
 end
 
-module type Maker = sig
-  include S.Maker
-  (** @inline *)
-end
+module type Maker = S.Maker
 
 module Maker (_ : Irmin_pack.Conf.S) : Maker
 

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -32,21 +32,20 @@ module type Store = sig
     list
 end
 
-module type Maker = sig
-  module Make
-      (M : Irmin.Metadata.S)
-      (C : Irmin.Contents.S)
-      (P : Irmin.Path.S)
-      (B : Irmin.Branch.S)
-      (H : Irmin.Hash.S) :
-    Store
-      with type key = P.t
-       and type step = P.step
-       and type metadata = M.t
-       and type contents = C.t
-       and type branch = B.t
-       and type hash = H.t
-end
+module type Maker = functor
+  (M : Irmin.Metadata.S)
+  (C : Irmin.Contents.S)
+  (P : Irmin.Path.S)
+  (B : Irmin.Branch.S)
+  (H : Irmin.Hash.S)
+  ->
+  Store
+    with type key = P.t
+     and type step = P.step
+     and type metadata = M.t
+     and type contents = C.t
+     and type branch = B.t
+     and type hash = H.t
 
 module type Layered_general = sig
   type 'a t

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -64,8 +64,7 @@ let layered_store :
     (module Layered_store) =
  fun (module B) (module M) ->
   let module Layered_store =
-    B.Make (M) (Irmin.Contents.String) (Irmin.Path.String_list)
-      (Irmin.Branch.String)
+    B (M) (Irmin.Contents.String) (Irmin.Path.String_list) (Irmin.Branch.String)
       (Irmin.Hash.SHA1)
   in
   (module Layered_store)

--- a/src/irmin/append_only_intf.ml
+++ b/src/irmin/append_only_intf.ml
@@ -39,13 +39,11 @@ module type S = sig
   (** @inline *)
 end
 
-module type Maker = sig
-  module Make (K : Type.S) (V : Type.S) : sig
-    include S with type key = K.t and type value = V.t
+module type Maker = functor (K : Type.S) (V : Type.S) -> sig
+  include S with type key = K.t and type value = V.t
 
-    include Of_config with type 'a t := 'a t
-    (** @inline *)
-  end
+  include Of_config with type 'a t := 'a t
+  (** @inline *)
 end
 
 module type Sigs = sig

--- a/src/irmin/atomic_write.ml
+++ b/src/irmin/atomic_write.ml
@@ -17,66 +17,65 @@
 open Import
 include Atomic_write_intf
 
-module Check_closed (AW : Maker) = struct
-  module Make (K : Type.S) (V : Type.S) = struct
-    module S = AW.Make (K) (V)
+module Check_closed (Make_atomic_write : Maker) (K : Type.S) (V : Type.S) =
+struct
+  module S = Make_atomic_write (K) (V)
 
-    type t = { closed : bool ref; t : S.t }
-    type key = S.key
-    type value = S.value
+  type t = { closed : bool ref; t : S.t }
+  type key = S.key
+  type value = S.value
 
-    let check_not_closed t = if !(t.closed) then raise Store_properties.Closed
+  let check_not_closed t = if !(t.closed) then raise Store_properties.Closed
 
-    let mem t k =
-      check_not_closed t;
-      S.mem t.t k
+  let mem t k =
+    check_not_closed t;
+    S.mem t.t k
 
-    let find t k =
-      check_not_closed t;
-      S.find t.t k
+  let find t k =
+    check_not_closed t;
+    S.find t.t k
 
-    let set t k v =
-      check_not_closed t;
-      S.set t.t k v
+  let set t k v =
+    check_not_closed t;
+    S.set t.t k v
 
-    let test_and_set t k ~test ~set =
-      check_not_closed t;
-      S.test_and_set t.t k ~test ~set
+  let test_and_set t k ~test ~set =
+    check_not_closed t;
+    S.test_and_set t.t k ~test ~set
 
-    let remove t k =
-      check_not_closed t;
-      S.remove t.t k
+  let remove t k =
+    check_not_closed t;
+    S.remove t.t k
 
-    let list t =
-      check_not_closed t;
-      S.list t.t
+  let list t =
+    check_not_closed t;
+    S.list t.t
 
-    type watch = S.watch
+  type watch = S.watch
 
-    let watch t ?init f =
-      check_not_closed t;
-      S.watch t.t ?init f
+  let watch t ?init f =
+    check_not_closed t;
+    S.watch t.t ?init f
 
-    let watch_key t k ?init f =
-      check_not_closed t;
-      S.watch_key t.t k ?init f
+  let watch_key t k ?init f =
+    check_not_closed t;
+    S.watch_key t.t k ?init f
 
-    let unwatch t w =
-      check_not_closed t;
-      S.unwatch t.t w
+  let unwatch t w =
+    check_not_closed t;
+    S.unwatch t.t w
 
-    let v conf =
-      let+ t = S.v conf in
-      { closed = ref false; t }
+  let v conf =
+    let+ t = S.v conf in
+    { closed = ref false; t }
 
-    let close t =
-      if !(t.closed) then Lwt.return_unit
-      else (
-        t.closed := true;
-        S.close t.t)
+  let close t =
+    if !(t.closed) then Lwt.return_unit
+    else (
+      t.closed := true;
+      S.close t.t)
 
-    let clear t =
-      check_not_closed t;
-      S.clear t.t
-  end
+  let clear t =
+    check_not_closed t;
+    S.clear t.t
 end

--- a/src/irmin/atomic_write_intf.ml
+++ b/src/irmin/atomic_write_intf.ml
@@ -79,13 +79,11 @@ module type S = sig
   (** @inline *)
 end
 
-module type Maker = sig
-  module Make (K : Type.S) (V : Type.S) : sig
-    include S with type key = K.t and type value = V.t
+module type Maker = functor (K : Type.S) (V : Type.S) -> sig
+  include S with type key = K.t and type value = V.t
 
-    include Of_config with type _ t := t
-    (** @inline *)
-  end
+  include Of_config with type _ t := t
+  (** @inline *)
 end
 
 module type Sigs = sig

--- a/src/irmin/content_addressable.ml
+++ b/src/irmin/content_addressable.ml
@@ -17,76 +17,72 @@
 open Import
 include Content_addressable_intf
 
-module Make (AO : Append_only.Maker) = struct
-  module Make (K : Hash.S) (V : Type.S) = struct
-    include AO.Make (K) (V)
-    open Lwt.Infix
-    module H = Hash.Typed (K) (V)
+module Make (AO : Append_only.Maker) (K : Hash.S) (V : Type.S) = struct
+  include AO (K) (V)
+  open Lwt.Infix
+  module H = Hash.Typed (K) (V)
 
-    let hash = H.hash
-    let pp_key = Type.pp K.t
-    let equal_hash = Type.(unstage (equal K.t))
+  let hash = H.hash
+  let pp_key = Type.pp K.t
+  let equal_hash = Type.(unstage (equal K.t))
 
-    let find t k =
-      find t k >>= function
-      | None -> Lwt.return_none
-      | Some v as r ->
-          let k' = hash v in
-          if equal_hash k k' then Lwt.return r
-          else
-            Fmt.kstrf Lwt.fail_invalid_arg
-              "corrupted value: got %a, expecting %a" pp_key k' pp_key k
+  let find t k =
+    find t k >>= function
+    | None -> Lwt.return_none
+    | Some v as r ->
+        let k' = hash v in
+        if equal_hash k k' then Lwt.return r
+        else
+          Fmt.kstrf Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
+            pp_key k' pp_key k
 
-    let unsafe_add t k v = add t k v
+  let unsafe_add t k v = add t k v
 
-    let add t v =
-      let k = hash v in
-      add t k v >|= fun () -> k
-  end
+  let add t v =
+    let k = hash v in
+    add t k v >|= fun () -> k
 end
 
-module Check_closed (CA : Maker) = struct
-  module Make (K : Hash.S) (V : Type.S) = struct
-    module S = CA.Make (K) (V)
+module Check_closed (CA : Maker) (K : Hash.S) (V : Type.S) = struct
+  module S = CA (K) (V)
 
-    type 'a t = { closed : bool ref; t : 'a S.t }
-    type key = S.key
-    type value = S.value
+  type 'a t = { closed : bool ref; t : 'a S.t }
+  type key = S.key
+  type value = S.value
 
-    let check_not_closed t = if !(t.closed) then raise Store_properties.Closed
+  let check_not_closed t = if !(t.closed) then raise Store_properties.Closed
 
-    let mem t k =
-      check_not_closed t;
-      S.mem t.t k
+  let mem t k =
+    check_not_closed t;
+    S.mem t.t k
 
-    let find t k =
-      check_not_closed t;
-      S.find t.t k
+  let find t k =
+    check_not_closed t;
+    S.find t.t k
 
-    let add t v =
-      check_not_closed t;
-      S.add t.t v
+  let add t v =
+    check_not_closed t;
+    S.add t.t v
 
-    let unsafe_add t k v =
-      check_not_closed t;
-      S.unsafe_add t.t k v
+  let unsafe_add t k v =
+    check_not_closed t;
+    S.unsafe_add t.t k v
 
-    let batch t f =
-      check_not_closed t;
-      S.batch t.t (fun w -> f { t = w; closed = t.closed })
+  let batch t f =
+    check_not_closed t;
+    S.batch t.t (fun w -> f { t = w; closed = t.closed })
 
-    let v conf =
-      let+ t = S.v conf in
-      { closed = ref false; t }
+  let v conf =
+    let+ t = S.v conf in
+    { closed = ref false; t }
 
-    let close t =
-      if !(t.closed) then Lwt.return_unit
-      else (
-        t.closed := true;
-        S.close t.t)
+  let close t =
+    if !(t.closed) then Lwt.return_unit
+    else (
+      t.closed := true;
+      S.close t.t)
 
-    let clear t =
-      check_not_closed t;
-      S.clear t.t
-  end
+  let clear t =
+    check_not_closed t;
+    S.clear t.t
 end

--- a/src/irmin/content_addressable_intf.ml
+++ b/src/irmin/content_addressable_intf.ml
@@ -46,30 +46,23 @@ module type S = sig
   (** @inline *)
 end
 
-module type Maker = sig
-  module Make (K : Hash.S) (V : Type.S) : sig
-    include S with type key = K.t and type value = V.t
+module type Maker = functor (K : Hash.S) (V : Type.S) -> sig
+  include S with type key = K.t and type value = V.t
 
-    include Of_config with type 'a t := 'a t
-    (** @inline *)
-  end
+  include Of_config with type 'a t := 'a t
+  (** @inline *)
 end
 
 module type Sigs = sig
   module type S = S
   module type Maker = Maker
 
-  module Make (X : Append_only.Maker) : sig
-    module Make (K : Hash.S) (V : Type.S) : sig
-      include
-        S
-          with type 'a t = 'a X.Make(K)(V).t
-           and type key = K.t
-           and type value = V.t
+  module Make (F : Append_only.Maker) (K : Hash.S) (V : Type.S) : sig
+    include
+      S with type 'a t = 'a F(K)(V).t and type key = K.t and type value = V.t
 
-      include Of_config with type 'a t := 'a t
-      (** @inline *)
-    end
+    include Of_config with type 'a t := 'a t
+    (** @inline *)
   end
 
   module Check_closed (M : Maker) : Maker

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -56,26 +56,26 @@ struct
       module Hash = H
 
       module Contents = struct
-        module CA = CA.Make (H) (C)
+        module CA = CA (H) (C)
         include Contents.Store (CA) (H) (C)
       end
 
       module Node = struct
-        module V = N.Make (H) (P) (M)
-        module CA = CA.Make (H) (V)
+        module V = N (H) (P) (M)
+        module CA = CA (H) (V)
         include Node.Store (Contents) (CA) (H) (V) (M) (P)
       end
 
       module Commit = struct
         module C = CT.Make (H)
-        module CA = CA.Make (H) (C)
+        module CA = CA (H) (C)
         include Commit.Store (Info) (Node) (CA) (H) (C)
       end
 
       module Branch = struct
         module Key = B
         module Val = H
-        include AW.Make (Key) (Val)
+        include AW (Key) (Val)
       end
 
       module Slice = Slice.Make (Contents) (Node) (Commit)
@@ -125,7 +125,7 @@ struct
 end
 
 module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) =
-  Maker_ext (CA) (AW) (Node) (Commit)
+  Maker_ext (CA) (AW) (Node.Make) (Commit)
 
 module Of_private = Store.Make
 

--- a/src/irmin/mem/irmin_mem.ml
+++ b/src/irmin/mem/irmin_mem.ml
@@ -56,85 +56,81 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
     Lwt.return (KMap.mem key t)
 end
 
-module Append_only = struct
-  module Make (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
-    include Read_only (K) (V)
+module Append_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
+  include Read_only (K) (V)
 
-    let add t key value =
-      Log.debug (fun f -> f "add -> %a" pp_key key);
-      t.t <- KMap.add key value t.t;
-      Lwt.return_unit
-  end
+  let add t key value =
+    Log.debug (fun f -> f "add -> %a" pp_key key);
+    t.t <- KMap.add key value t.t;
+    Lwt.return_unit
 end
 
-module Atomic_write = struct
-  module Make (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
-    module RO = Read_only (K) (V)
-    module W = Irmin.Private.Watch.Make (K) (V)
-    module L = Irmin.Private.Lock.Make (K)
+module Atomic_write (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
+  module RO = Read_only (K) (V)
+  module W = Irmin.Private.Watch.Make (K) (V)
+  module L = Irmin.Private.Lock.Make (K)
 
-    type t = { t : unit RO.t; w : W.t; lock : L.t }
-    type key = RO.key
-    type value = RO.value
-    type watch = W.watch
+  type t = { t : unit RO.t; w : W.t; lock : L.t }
+  type key = RO.key
+  type value = RO.value
+  type watch = W.watch
 
-    let watches = W.v ()
-    let lock = L.v ()
+  let watches = W.v ()
+  let lock = L.v ()
 
-    let v config =
-      let* t = RO.v config in
-      Lwt.return { t; w = watches; lock }
+  let v config =
+    let* t = RO.v config in
+    Lwt.return { t; w = watches; lock }
 
-    let close t = W.clear t.w >>= fun () -> RO.close t.t
-    let find t = RO.find t.t
-    let mem t = RO.mem t.t
-    let watch_key t = W.watch_key t.w
-    let watch t = W.watch t.w
-    let unwatch t = W.unwatch t.w
+  let close t = W.clear t.w >>= fun () -> RO.close t.t
+  let find t = RO.find t.t
+  let mem t = RO.mem t.t
+  let watch_key t = W.watch_key t.w
+  let watch t = W.watch t.w
+  let unwatch t = W.unwatch t.w
 
-    let list t =
-      Log.debug (fun f -> f "list");
-      RO.KMap.fold (fun k _ acc -> k :: acc) t.t.RO.t [] |> Lwt.return
+  let list t =
+    Log.debug (fun f -> f "list");
+    RO.KMap.fold (fun k _ acc -> k :: acc) t.t.RO.t [] |> Lwt.return
 
-    let set t key value =
-      Log.debug (fun f -> f "update");
-      let* () =
-        L.with_lock t.lock key (fun () ->
-            t.t.RO.t <- RO.KMap.add key value t.t.RO.t;
-            Lwt.return_unit)
-      in
-      W.notify t.w key (Some value)
+  let set t key value =
+    Log.debug (fun f -> f "update");
+    let* () =
+      L.with_lock t.lock key (fun () ->
+          t.t.RO.t <- RO.KMap.add key value t.t.RO.t;
+          Lwt.return_unit)
+    in
+    W.notify t.w key (Some value)
 
-    let remove t key =
-      Log.debug (fun f -> f "remove");
-      let* () =
-        L.with_lock t.lock key (fun () ->
-            t.t.RO.t <- RO.KMap.remove key t.t.RO.t;
-            Lwt.return_unit)
-      in
-      W.notify t.w key None
+  let remove t key =
+    Log.debug (fun f -> f "remove");
+    let* () =
+      L.with_lock t.lock key (fun () ->
+          t.t.RO.t <- RO.KMap.remove key t.t.RO.t;
+          Lwt.return_unit)
+    in
+    W.notify t.w key None
 
-    let equal_v_opt = Irmin.Type.(unstage (equal (option V.t)))
+  let equal_v_opt = Irmin.Type.(unstage (equal (option V.t)))
 
-    let test_and_set t key ~test ~set =
-      Log.debug (fun f -> f "test_and_set");
-      let* updated =
-        L.with_lock t.lock key (fun () ->
-            let+ v = find t key in
-            if equal_v_opt test v then
-              let () =
-                match set with
-                | None -> t.t.RO.t <- RO.KMap.remove key t.t.RO.t
-                | Some v -> t.t.RO.t <- RO.KMap.add key v t.t.RO.t
-              in
-              true
-            else false)
-      in
-      let+ () = if updated then W.notify t.w key set else Lwt.return_unit in
-      updated
+  let test_and_set t key ~test ~set =
+    Log.debug (fun f -> f "test_and_set");
+    let* updated =
+      L.with_lock t.lock key (fun () ->
+          let+ v = find t key in
+          if equal_v_opt test v then
+            let () =
+              match set with
+              | None -> t.t.RO.t <- RO.KMap.remove key t.t.RO.t
+              | Some v -> t.t.RO.t <- RO.KMap.add key v t.t.RO.t
+            in
+            true
+          else false)
+    in
+    let+ () = if updated then W.notify t.w key set else Lwt.return_unit in
+    updated
 
-    let clear t = W.clear t.w >>= fun () -> RO.clear t.t
-  end
+  let clear t = W.clear t.w >>= fun () -> RO.clear t.t
 end
 
 let config () = Irmin.Private.Conf.empty

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -73,14 +73,13 @@ module type S = sig
   (** [default] is the default metadata value. *)
 end
 
-module type Maker = sig
-  module Make
-      (H : Hash.S) (P : sig
-        type step [@@deriving irmin]
-      end)
-      (M : Metadata.S) :
-    S with type metadata = M.t and type hash = H.t and type step = P.step
-end
+module type Maker = functor
+  (H : Hash.S)
+  (P : sig
+     type step [@@deriving irmin]
+   end)
+  (M : Metadata.S)
+  -> S with type metadata = M.t and type hash = H.t and type step = P.step
 
 module type Store = sig
   include Content_addressable.S
@@ -191,7 +190,7 @@ module type Sigs = sig
   module type S = S
   module type Maker = Maker
 
-  include Maker
+  module Make : Maker
   (** [Make] provides a simple node implementation, parameterized by the
       contents and notes keys [K], paths [P] and metadata [M]. *)
 

--- a/src/irmin/read_only_intf.ml
+++ b/src/irmin/read_only_intf.ml
@@ -44,13 +44,11 @@ module type S = sig
   (** @inline *)
 end
 
-module type Maker = sig
-  module Make (K : Type.S) (V : Type.S) : sig
-    include S with type key = K.t and type value = V.t
+module type Maker = functor (K : Type.S) (V : Type.S) -> sig
+  include S with type key = K.t and type value = V.t
 
-    include Of_config with type 'a t := 'a t
-    (** @inline *)
-  end
+  include Of_config with type 'a t := 'a t
+  (** @inline *)
 end
 
 module type Sigs = sig

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -46,16 +46,18 @@ module type S = sig
 end
 
 module Append_only = Irmin_mem.Append_only
-module Content_addressable = Irmin.Content_addressable.Make (Append_only)
+
+module Content_addressable =
+  Irmin.Content_addressable.Make (Append_only) (Key) (Value)
 
 module Mem = struct
-  include Content_addressable.Make (Key) (Value)
+  include Content_addressable
 
   let v () = v @@ Irmin_mem.config ()
 end
 
 module MemChunk = struct
-  include Content_addressable.Make (Key) (Value)
+  include Content_addressable
 
   let small_config = Irmin_chunk.config ~min_size:44 ~size:44 ()
   let v () = v small_config

--- a/test/irmin-containers/linked_log.ml
+++ b/test/irmin-containers/linked_log.ml
@@ -19,7 +19,7 @@ open! Import
 open Common
 
 module CAS = struct
-  include Irmin.Content_addressable.Make (Irmin_mem.Append_only)
+  module Make = Irmin.Content_addressable.Make (Irmin_mem.Append_only)
 
   let config = Irmin_mem.config ()
 end

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -30,10 +30,8 @@ module Conf = struct
   let stable_hash = 256
 end
 
-module Maker = Irmin_pack_layered.Maker (Conf)
-
 module Store =
-  Maker.Make (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack_layered.Maker (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Irmin.Hash.BLAKE2B)

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -17,7 +17,7 @@
 module Hash = Irmin.Hash.BLAKE2B
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
-module Node = Irmin.Private.Node
+module Node = Irmin.Private.Node.Make
 module Commit = Irmin.Private.Commit
 
 module Conf = struct
@@ -35,10 +35,11 @@ module Maker (V : Irmin_pack.Version.S) = struct
 end
 
 module Store = Irmin_pack.Checks.Make (Maker)
-module M = Irmin_pack_layered.Maker_ext (Conf) (Node) (Commit)
 
 module S =
-  M.Make (Irmin.Metadata.None) (Irmin.Contents.String) (Path)
+  Irmin_pack_layered.Maker_ext (Conf) (Node) (Commit) (Irmin.Metadata.None)
+    (Irmin.Contents.String)
+    (Path)
     (Irmin.Branch.String)
     (Hash)
 

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -41,10 +41,9 @@ module Conf = struct
 end
 
 module Hash = Irmin.Hash.SHA1
-module Maker = Irmin_pack_layered.Maker (Conf)
 
 module Store =
-  Maker.Make (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack_layered.Maker (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -38,7 +38,7 @@ end
 module S = struct
   module P = Irmin.Path.String_list
   module M = Irmin.Metadata.None
-  module XNode = Irmin.Private.Node
+  module XNode = Irmin.Private.Node.Make
   module XCommit = Irmin.Private.Commit
   module Maker = Irmin_pack.Maker_ext (V2) (Conf) (XNode) (XCommit)
 

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -287,10 +287,8 @@ module Config_layered_store = struct
     exec_cmd cmd
 end
 
-module Maker = Irmin_pack_layered.Maker (Conf)
-
 module Make_layered =
-  Maker.Make (Irmin.Metadata.None) (Irmin.Contents.String)
+  Irmin_pack_layered.Maker (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
     (Hash)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -29,7 +29,8 @@ end
 let test_dir = Filename.concat "_build" "test-db-pack"
 
 module Irmin_pack_maker =
-  Irmin_pack.Maker_ext (V2) (Config) (Irmin.Private.Node) (Irmin.Private.Commit)
+  Irmin_pack.Maker_ext (V2) (Config) (Irmin.Private.Node.Make)
+    (Irmin.Private.Commit)
 
 let suite =
   let store =


### PR DESCRIPTION
This partially reverts changes introduced by 046ec54f38103e00561fa71144e6466e977aa63c where they are not strictly necessary.  In particular, it avoids indirections of the following type:

```ocaml
module type Maker : sig
  module Make (...) = struct ... end
end
```

where they are not necessary (whenever the `Maker` type contains only a `Make` functor and no other types).

This introduces some inconsistency in the `Maker` convention: when the corresponding functor must perform a module substitution as part of application then the old convention is still necessary, but overall it reduces the boilerplate significantly in the common case.