### PR TITLE
Mandatory dependencies to install printbox.unicode

### DIFF
--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -22,7 +22,7 @@
  (preprocess
   (pps ppx_repr ppx_deriving.enum))
  (libraries irmin irmin-pack unix lwt repr ppx_repr bentov mtime printbox
-   printbox.unicode mtime.clock.os bench_common))
+   uucp uutf printbox.unicode mtime.clock.os bench_common))
 
 (executable
  (name tree)


### PR DESCRIPTION
As of now, if `uutf` or `uucp` are not installed, `printbox.unicode` won't be installed. This behaviour is silent making it really hard to know why dune is complaining about `printbox.unicode` being unavailable. Making `uutf` and `uucp` mandatory dependencies should make it easier:

```
> opam switch create . ocaml-base-compiler -y
# ...installing all immediate packages...
> dune external-lib-deps --missing @@default
# ...installing missing packages (including printbox.unicode since uutf and uucp will be installed)...
> dune build
# ...everything compiles smoothly...
```