### PR TITLE
Stable to kind

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,6 +133,9 @@
     `Irmin_pack.Pack.File` into `Irmin_pack.Content_addressable.Maker`
     (#1377, @samoht)
   - Moved `Irmin_pack.Store.Atomic_write` into its own module (#1378, @samoht)
+  - Replaced `stable` fields with `kind (= Node | Inode)` fields to allow having
+    more than two kinds (will become useful for #1440 where
+    `kind = Node of version | Inode of version`) (#1452, @samoht, @mattiasdrp)
 
 ## 2.6.0 (2021-04-13)
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -669,7 +669,7 @@ struct
       | Unsorted_pointers t -> Error (`Unsorted_pointers t)
 
     let hash t = Lazy.force t.hash
-    let is_node t = t.kind = Kind.Node
+    let is_node t = t.kind = Kind.Node [@@inline]
 
     let is_root t =
       match t.v with


### PR DESCRIPTION
Allowed me to find a bug [here](https://github.com/mirage/irmin/pull/1440/files#diff-032a7a23087d2e5ce953b0543a6183b1b5b12a66610f55dfef414ddb2d2a707cR716) since 

```ocaml
    let check_write_op_supported t =
      if not @@ is_root t then
        failwith "Cannot perform blah operation on non-root inode value."

```

and 

```ocaml
    let is_root t =
      match t.v with
      | Tree { depth; _ } -> depth = 0
      | Values _ -> is_node t
```

So a stabilized `inode` needs to have kind `Node` and not `Inode` or the above check will fail [(before it changed from `stable = false` to `stable = true`)](https://github.com/mirage/irmin/pull/1440/files#diff-032a7a23087d2e5ce953b0543a6183b1b5b12a66610f55dfef414ddb2d2a707cL700)