### PR TITLE
irmin-pack: extract `Pack_value` abstraction

### DIFF
--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -314,8 +314,8 @@ module Index (Index : Pack_index.S) = struct
     let bar, (progress_contents, progress_nodes, progress_commits) =
       Utils.Progress.increment ()
     in
-    let f (k, (offset, length, (m : Pack_value.Kind.t))) =
-      match m with
+    let f (k, (offset, length, (kind : Pack_value.Kind.t))) =
+      match kind with
       | Contents ->
           progress_contents ();
           check ~kind:`Contents ~offset ~length k

--- a/src/irmin-pack/content_addressable.ml
+++ b/src/irmin-pack/content_addressable.ml
@@ -255,7 +255,7 @@ struct
         let off = IO.offset t.pack.block in
         Val.encode_bin ~offset ~dict v k (IO.append t.pack.block);
         let len = Int63.to_int (IO.offset t.pack.block -- off) in
-        Index.add ~overcommit t.pack.index k (off, len, Val.magic v);
+        Index.add ~overcommit t.pack.index k (off, len, Val.kind v);
         if Tbl.length t.staging >= auto_flush then flush t
         else Tbl.add t.staging k v;
         Lru.add t.lru k v)

--- a/src/irmin-pack/content_addressable.ml
+++ b/src/irmin-pack/content_addressable.ml
@@ -76,7 +76,7 @@ struct
       IO.close t.block;
       Dict.close t.dict)
 
-  module Make (Val : Value with type hash := K.t) = struct
+  module Make (Val : Pack_value.S with type hash := K.t) = struct
     module H = struct
       include K
 

--- a/src/irmin-pack/content_addressable_intf.ml
+++ b/src/irmin-pack/content_addressable_intf.ml
@@ -16,26 +16,6 @@
 
 open! Import
 
-module type Value = sig
-  include Irmin.Type.S
-
-  type hash
-
-  val hash : t -> hash
-  val kind : t -> Pack_value.Kind.t
-
-  val encode_bin :
-    dict:(string -> int option) ->
-    offset:(hash -> int63 option) ->
-    t ->
-    hash ->
-    (string -> unit) ->
-    unit
-
-  val decode_bin :
-    dict:(int -> string option) -> hash:(int63 -> hash) -> string -> int -> t
-end
-
 module type S = sig
   include Irmin.Content_addressable.S
 
@@ -89,12 +69,11 @@ module type Maker = sig
 
   (** Save multiple kind of values in the same pack file. Values will be
       distinguished using [V.kind], so they have to all be different. *)
-  module Make (V : Value with type hash := key) :
+  module Make (V : Pack_value.S with type hash := key) :
     S with type key = key and type value = V.t and type index = index
 end
 
 module type Sigs = sig
-  module type Value = Value
   module type S = S
   module type Maker = Maker
 

--- a/src/irmin-pack/content_addressable_intf.ml
+++ b/src/irmin-pack/content_addressable_intf.ml
@@ -22,7 +22,7 @@ module type Value = sig
   type hash
 
   val hash : t -> hash
-  val magic : t -> char
+  val kind : t -> Pack_value.Kind.t
 
   val encode_bin :
     dict:(string -> int option) ->
@@ -88,7 +88,7 @@ module type Maker = sig
   type index
 
   (** Save multiple kind of values in the same pack file. Values will be
-      distinguished using [V.magic], so they have to all be different. *)
+      distinguished using [V.kind], so they have to all be different. *)
   module Make (V : Value with type hash := key) :
     S with type key = key and type value = V.t and type index = index
 end

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -41,7 +41,8 @@ struct
       module Hash = H
       module Info = Commit.Info
 
-      type 'a value = { hash : H.t; magic : char; v : 'a } [@@deriving irmin]
+      type 'a value = { hash : H.t; kind : Pack_value.Kind.t; v : 'a }
+      [@@deriving irmin]
 
       module Contents = struct
         module CA = struct
@@ -50,19 +51,19 @@ struct
             module H = Irmin.Hash.Typed (H) (C)
 
             let hash = H.hash
-            let magic = 'B'
+            let kind = Pack_value.Kind.Contents
             let value = value_t C.t
             let encode_value = Irmin.Type.(unstage (encode_bin value))
             let decode_value = Irmin.Type.(unstage (decode_bin value))
 
             let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { magic; hash; v }
+              encode_value { kind; hash; v }
 
             let decode_bin ~dict:_ ~hash:_ s off =
               let _, t = decode_value s off in
               t.v
 
-            let magic _ = magic
+            let kind _ = kind
           end)
 
           include Content_addressable.Closeable (CA_Pack)
@@ -87,18 +88,18 @@ struct
 
             let hash = H.hash
             let value = value_t Commit.t
-            let magic = 'C'
+            let kind = Pack_value.Kind.Commit
             let encode_value = Irmin.Type.(unstage (encode_bin value))
             let decode_value = Irmin.Type.(unstage (decode_bin value))
 
             let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { magic; hash; v }
+              encode_value { kind; hash; v }
 
             let decode_bin ~dict:_ ~hash:_ s off =
               let _, v = decode_value s off in
               v.v
 
-            let magic _ = magic
+            let kind _ = kind
           end)
 
           include Content_addressable.Closeable (CA_Pack)
@@ -212,16 +213,16 @@ struct
             Irmin.Type.(unstage (decode_bin (value_t Commit.Val.t)))
 
           let decode_key = Irmin.Type.(unstage (decode_bin Hash.t))
-          let decode_magic = Irmin.Type.(unstage (decode_bin char))
+          let decode_kind = Irmin.Type.(unstage (decode_bin Pack_value.Kind.t))
 
           let decode_buffer ~progress ~total pack dict index =
-            let decode_len buf magic =
+            let decode_len buf (kind : Pack_value.Kind.t) =
               try
                 let len =
-                  match magic with
-                  | 'B' -> decode_contents buf 0 |> fst
-                  | 'C' -> decode_commit buf 0 |> fst
-                  | 'N' | 'I' ->
+                  match kind with
+                  | Contents -> decode_contents buf 0 |> fst
+                  | Commit -> decode_commit buf 0 |> fst
+                  | Node | Inode ->
                       let hash off =
                         let buf =
                           IO.read_buffer ~chunk:Hash.hash_size ~off pack
@@ -230,7 +231,6 @@ struct
                       in
                       let dict = Dict.find dict in
                       Node.CA.decode_bin ~hash ~dict buf 0
-                  | _ -> failwith "unexpected magic char"
                 in
                 Some len
               with
@@ -242,15 +242,15 @@ struct
             let decode_entry buf off =
               let off_k, k = decode_key buf 0 in
               assert (off_k = Hash.hash_size);
-              let off_m, magic = decode_magic buf off_k in
+              let off_m, kind = decode_kind buf off_k in
               assert (off_m = Hash.hash_size + 1);
-              match decode_len buf magic with
+              match decode_len buf kind with
               | Some len ->
                   let new_off = off ++ Int63.of_int len in
                   Log.debug (fun l ->
-                      l "k = %a (off, len, magic) = (%a, %d, %c)" pp_hash k
-                        Int63.pp off len magic);
-                  Index.add index k (off, len, magic);
+                      l "k = %a (off, len, kind) = (%a, %d, %a)" pp_hash k
+                        Int63.pp off len Pack_value.Kind.pp kind);
+                  Index.add index k (off, len, kind);
                   progress (Int63.of_int len);
                   Some new_off
               | None -> None

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -45,27 +45,10 @@ struct
       [@@deriving irmin]
 
       module Contents = struct
+        module Pack_value = Pack_value.Of_contents (H) (C)
+
         module CA = struct
-          module CA_Pack = Pack.Make (struct
-            include C
-            module H = Irmin.Hash.Typed (H) (C)
-
-            let hash = H.hash
-            let kind = Pack_value.Kind.Contents
-            let value = value_t C.t
-            let encode_value = Irmin.Type.(unstage (encode_bin value))
-            let decode_value = Irmin.Type.(unstage (decode_bin value))
-
-            let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { kind; hash; v }
-
-            let decode_bin ~dict:_ ~hash:_ s off =
-              let _, t = decode_value s off in
-              t.v
-
-            let kind _ = kind
-          end)
-
+          module CA_Pack = Pack.Make (Pack_value)
           include Content_addressable.Closeable (CA_Pack)
         end
 
@@ -80,28 +63,10 @@ struct
 
       module Commit = struct
         module Commit = Commit.Make (H)
+        module Pack_value = Pack_value.Of_commit (H) (Commit)
 
         module CA = struct
-          module CA_Pack = Pack.Make (struct
-            include Commit
-            module H = Irmin.Hash.Typed (H) (Commit)
-
-            let hash = H.hash
-            let value = value_t Commit.t
-            let kind = Pack_value.Kind.Commit
-            let encode_value = Irmin.Type.(unstage (encode_bin value))
-            let decode_value = Irmin.Type.(unstage (decode_bin value))
-
-            let encode_bin ~dict:_ ~offset:_ v hash =
-              encode_value { kind; hash; v }
-
-            let decode_bin ~dict:_ ~hash:_ s off =
-              let _, v = decode_value s off in
-              v.v
-
-            let kind _ = kind
-          end)
-
+          module CA_Pack = Pack.Make (Pack_value)
           include Content_addressable.Closeable (CA_Pack)
         end
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -203,8 +203,10 @@ struct
     type t = { hash : H.t; stable : bool; v : v }
 
     let v ~stable ~hash v = { hash; stable; v }
-    let magic_node = 'N'
-    let magic_inode = 'I'
+    let kind_node = Pack_value.Kind.Node
+    let kind_inode = Pack_value.Kind.Inode
+    let magic_node = Pack_value.Kind.to_magic kind_node
+    let magic_inode = Pack_value.Kind.to_magic kind_inode
 
     let stable_t : bool Irmin.Type.t =
       Irmin.Type.(map char)
@@ -912,8 +914,8 @@ struct
 
     let t = Bin.t
 
-    let magic (t : t) =
-      if t.stable then Compress.magic_node else Compress.magic_inode
+    let kind (t : t) =
+      if t.stable then Compress.kind_node else Compress.kind_inode
 
     let hash t = Bin.hash t
     let step_to_bin = Irmin.Type.(unstage (to_bin_string T.step_t))

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -55,7 +55,7 @@ module type Internal = sig
 
   val pp_hash : hash Fmt.t
 
-  module Raw : Content_addressable.Value with type hash = hash
+  module Raw : Pack_value.S with type hash = hash
 
   val decode_raw :
     dict:(int -> string option) ->

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -58,6 +58,7 @@ module Checks = Checks
 module Inode = Inode
 module IO = IO
 module Utils = Utils
+module Pack_value = Pack_value
 module Vx = Version.V1
 
 module Cx = struct

--- a/src/irmin-pack/irmin_pack_intf.ml
+++ b/src/irmin-pack/irmin_pack_intf.ml
@@ -78,6 +78,7 @@ module type Sigs = sig
   module Atomic_write = Atomic_write
   module IO = IO
   module Utils = Utils
+  module Pack_value = Pack_value
 
   module type Maker = functor (_ : Conf.S) -> sig
     include S.Maker

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -53,13 +53,13 @@ struct
     module Hash = H
     module Info = Commit.Info
 
-    type 'a value = { magic : char; hash : H.t; v : 'a }
+    type 'a value = { kind : Irmin_pack.Pack_value.Kind.t; hash : H.t; v : 'a }
 
     let value a =
       let open Irmin.Type in
-      record "value" (fun hash magic v -> { magic; hash; v })
+      record "value" (fun hash kind v -> { kind; hash; v })
       |+ field "hash" H.t (fun v -> v.hash)
-      |+ field "magic" char (fun v -> v.magic)
+      |+ field "kind" Irmin_pack.Pack_value.Kind.t (fun v -> v.kind)
       |+ field "v" a (fun v -> v.v)
       |> sealr
 
@@ -71,19 +71,19 @@ struct
           module H = Irmin.Hash.Typed (H) (C)
 
           let hash = H.hash
-          let magic = 'B'
+          let kind = Irmin_pack.Pack_value.Kind.Contents
           let value = value C.t
           let encode_value = Irmin.Type.(unstage (encode_bin value))
           let decode_value = Irmin.Type.(unstage (decode_bin value))
 
           let encode_bin ~dict:_ ~offset:_ v hash =
-            encode_value { magic; hash; v }
+            encode_value { kind; hash; v }
 
           let decode_bin ~dict:_ ~hash:_ s off =
             let _, t = decode_value s off in
             t.v
 
-          let magic _ = magic
+          let kind _ = kind
         end)
 
         module CA = Irmin_pack.Content_addressable.Closeable (CA_Pack)
@@ -110,18 +110,18 @@ struct
 
           let hash = H.hash
           let value = value Commit.t
-          let magic = 'C'
+          let kind = Irmin_pack.Pack_value.Kind.Commit
           let encode_value = Irmin.Type.(unstage (encode_bin value))
           let decode_value = Irmin.Type.(unstage (decode_bin value))
 
           let encode_bin ~dict:_ ~offset:_ v hash =
-            encode_value { magic; hash; v }
+            encode_value { kind; hash; v }
 
           let decode_bin ~dict:_ ~hash:_ s off =
             let _, v = decode_value s off in
             v.v
 
-          let magic _ = magic
+          let kind _ = kind
         end)
 
         module CA = Irmin_pack.Content_addressable.Closeable (CA_Pack)

--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -324,8 +324,7 @@ struct
   type index = P.index
   type key = P.key
 
-  module Make (V : Irmin_pack.Content_addressable.Value with type hash := key) =
-  struct
+  module Make (V : Irmin_pack.Pack_value.S with type hash := key) = struct
     module Upper = Irmin_pack.Content_addressable.Closeable (P.Make (V))
     include Content_addressable (H) (Index) (Upper) (Upper)
   end

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -160,12 +160,10 @@ module type Content_addressable = sig
 end
 
 module type Content_addressable_maker = sig
-  open Irmin_pack.Content_addressable
-
   type key
   type index
 
-  module Make (V : Value with type hash := key) :
+  module Make (V : Irmin_pack.Pack_value.S with type hash := key) :
     Content_addressable
       with type key = key
        and type value = V.t

--- a/src/irmin-pack/pack_index.ml
+++ b/src/irmin-pack/pack_index.ml
@@ -34,15 +34,16 @@ module Make (K : Irmin.Hash.S) = struct
   end
 
   module Val = struct
-    type t = int63 * int * char [@@deriving irmin]
+    type t = int63 * int * Pack_value.Kind.t [@@deriving irmin]
 
     let to_bin_string =
-      Irmin.Type.(unstage (to_bin_string (triple int63_t int32 char)))
+      Irmin.Type.(
+        unstage (to_bin_string (triple int63_t int32 Pack_value.Kind.t)))
 
     let encode (off, len, kind) = to_bin_string (off, Int32.of_int len, kind)
 
     let decode_bin =
-      Irmin.Type.(unstage (decode_bin (triple int63_t int32 char)))
+      Irmin.Type.(unstage (decode_bin (triple int63_t int32 Pack_value.Kind.t)))
 
     let decode s off =
       let off, len, kind = snd (decode_bin s off) in

--- a/src/irmin-pack/pack_index_intf.ml
+++ b/src/irmin-pack/pack_index_intf.ml
@@ -17,7 +17,7 @@
 open! Import
 
 module type S = sig
-  include Index.S with type value = int63 * int * char
+  include Index.S with type value = int63 * int * Pack_value.Kind.t
 
   val v :
     ?flush_callback:(unit -> unit) ->

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -1,4 +1,5 @@
 open! Import
+include Pack_value_intf
 
 module Kind = struct
   type t = Commit | Contents | Inode | Node
@@ -19,3 +20,40 @@ module Kind = struct
   let t = Irmin.Type.(map char) of_magic to_magic
   let pp = Fmt.using to_magic Fmt.char
 end
+
+type ('h, 'a) value = { hash : 'h; kind : Kind.t; v : 'a } [@@deriving irmin]
+
+module type S = S with type kind := Kind.t
+
+module Make (Config : sig
+  val selected_kind : Kind.t
+end)
+(Hash : Irmin.Hash.S)
+(Data : Irmin.Type.S) =
+struct
+  module Hash = Irmin.Hash.Typed (Hash) (Data)
+
+  type t = Data.t [@@deriving irmin]
+  type hash = Hash.t
+
+  let hash = Hash.hash
+  let kind = Config.selected_kind
+  let value = [%typ: (Hash.t, Data.t) value]
+  let encode_value = Irmin.Type.(unstage (encode_bin value))
+  let decode_value = Irmin.Type.(unstage (decode_bin value))
+  let encode_bin ~dict:_ ~offset:_ v hash = encode_value { kind; hash; v }
+
+  let decode_bin ~dict:_ ~hash:_ s off =
+    let _, t = decode_value s off in
+    t.v
+
+  let kind _ = Config.selected_kind
+end
+
+module Of_contents = Make (struct
+  let selected_kind = Kind.Contents
+end)
+
+module Of_commit = Make (struct
+  let selected_kind = Kind.Commit
+end)

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -1,0 +1,21 @@
+open! Import
+
+module Kind = struct
+  type t = Commit | Contents | Inode | Node
+
+  let to_magic = function
+    | Commit -> 'C'
+    | Contents -> 'B'
+    | Inode -> 'I'
+    | Node -> 'N'
+
+  let of_magic = function
+    | 'C' -> Commit
+    | 'B' -> Contents
+    | 'I' -> Inode
+    | 'N' -> Node
+    | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
+
+  let t = Irmin.Type.(map char) of_magic to_magic
+  let pp = Fmt.using to_magic Fmt.char
+end

--- a/src/irmin-pack/pack_value.mli
+++ b/src/irmin-pack/pack_value.mli
@@ -1,6 +1,2 @@
-module Kind : sig
-  type t = Commit | Contents | Inode | Node [@@deriving irmin]
-
-  val to_magic : t -> char
-  val pp : t Fmt.t
-end
+include Pack_value_intf.Sigs
+(** @inline *)

--- a/src/irmin-pack/pack_value.mli
+++ b/src/irmin-pack/pack_value.mli
@@ -1,0 +1,6 @@
+module Kind : sig
+  type t = Commit | Contents | Inode | Node [@@deriving irmin]
+
+  val to_magic : t -> char
+  val pp : t Fmt.t
+end

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -1,0 +1,45 @@
+open! Import
+
+module type S = sig
+  include Irmin.Type.S
+
+  type hash
+  type kind
+
+  val hash : t -> hash
+  val kind : t -> kind
+
+  val encode_bin :
+    dict:(string -> int option) ->
+    offset:(hash -> int63 option) ->
+    t ->
+    hash ->
+    (string -> unit) ->
+    unit
+
+  val decode_bin :
+    dict:(int -> string option) -> hash:(int63 -> hash) -> string -> int -> t
+end
+
+module type Sigs = sig
+  module Kind : sig
+    type t = Commit | Contents | Inode | Node [@@deriving irmin]
+
+    val to_magic : t -> char
+    val pp : t Fmt.t
+  end
+
+  module type S = S with type kind := Kind.t
+
+  module Make (_ : sig
+    val selected_kind : Kind.t
+  end)
+  (Hash : Irmin.Hash.S)
+  (Data : Irmin.Type.S) : S with type hash = Hash.t
+
+  module Of_contents (Hash : Irmin.Hash.S) (Contents : Irmin.Contents.S) :
+    S with type t = Contents.t and type hash = Hash.t
+
+  module Of_commit (Hash : Irmin.Hash.S) (Commit : Irmin.Private.Commit.S) :
+    S with type t = Commit.t and type hash = Hash.t
+end

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -43,7 +43,7 @@ end
 module S = struct
   include Irmin.Contents.String
 
-  let magic _ = 'S'
+  let kind _ = Irmin_pack.Pack_value.Kind.Contents
 
   module H = Irmin.Hash.Typed (Irmin.Hash.SHA1) (Irmin.Contents.String)
 

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -226,6 +226,7 @@ module Test_reconstruct = struct
           cmd n
 
   let test_reconstruct () =
+    let module Kind = Irmin_pack.Pack_value.Kind in
     setup_test_env ();
     let conf = config ~readonly:false ~fresh:false Config_store.root_v1 in
     S.migrate conf;
@@ -238,15 +239,15 @@ module Test_reconstruct = struct
         Config_store.root_v1
     in
     Index.iter
-      (fun k (offset, length, magic) ->
+      (fun k (offset, length, kind) ->
         Log.debug (fun l ->
-            l "index find k = %a (off, len, magic) = (%a, %d, %c)"
-              (Irmin.Type.pp Hash.t) k Int63.pp offset length magic);
+            l "index find k = %a (off, len, kind) = (%a, %d, %a)"
+              (Irmin.Type.pp Hash.t) k Int63.pp offset length Kind.pp kind);
         match Index.find index_new k with
-        | Some (offset', length', magic') ->
+        | Some (offset', length', kind') ->
             Alcotest.(check int63) "check offset" offset offset';
             Alcotest.(check int) "check length" length length';
-            Alcotest.(check char) "check magic" magic magic'
+            Alcotest.(check_repr Kind.t) "check kind" kind kind'
         | None ->
             Alcotest.failf "expected to find hash %a" (Irmin.Type.pp Hash.t) k)
       index_old;


### PR DESCRIPTION
This is some refactoring extracted from #1436. Does two things:

- uses types for magic chars;
- provides functors for interacting with pack value triplets, avoiding some duplication in `irmin-pack.layered`.