### PR TITLE
irmin-pack: provide `Version.{V1,V2}` modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,13 @@
 
 ### Added
 
-- **irmin-graphql**
-  - Added `last_modified` field to GraphQL interface (#1393, @kluvin)
-
 - **irmin**
    - Added `Store.Tree.length`. (#1316, @Ngoguey42)
+  - Added `Read_only.S` and `Read_only.Maker` module types (#1343, @samoht)
+  - Append-only and content-addressable backend implementations have to
+    provide `close` and `batch` functions (#1345, @samoht)
+  - Atomic-write backend implementations have to provide a `close` function
+    (#1345, @samoht)
 
 - **irmin-bench**
   - Benchmarks for tree operations now support layered stores
@@ -27,12 +29,12 @@
     #1404, #1416, #1429, #1430, #1438 @Ngoguey42)
   - Check hash of commit in benchmarks for trees (#1328, @icristescu)
 
-- **irmin**
-  - Added `Read_only.S` and `Read_only.Maker` module types (#1343, @samoht)
-  - Append-only and content-addressable backend implementations have to
-    provide `close` and `batch` functions (#1345, @samoht)
-  - Atomic-write backend implementations have to provide a `close` function
-    (#1345, @samoht)
+- **irmin-pack**
+  - Added `Irmin_pack.Version.{V1,V2}` modules for convenience. (#TODO,
+    @CraigFe)
+
+- **irmin-graphql**
+  - Added `last_modified` field to GraphQL interface (#1393, @kluvin)
 
 - **irmin-mem**
   - Added `Irmin_mem.Content_addressable` (#1369, @samoht)

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -16,17 +16,13 @@
 
 let config ~root = Irmin_pack.config ~fresh:false root
 
-module V2 = struct
-  let version = `V2
-end
-
 module Config = struct
   let entries = 2
   let stable_hash = 3
 end
 
 module KV = struct
-  module Maker = Irmin_pack.KV (V2) (Config)
+  module Maker = Irmin_pack.KV (Irmin_pack.Version.V2) (Config)
   include Maker.Make (Irmin.Contents.String)
 end
 

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -211,11 +211,9 @@ struct
 
   open Tezos_context_hash_irmin.Encoding
 
-  module V1 = struct
-    let version = `V1
-  end
+  module Maker =
+    Irmin_pack.Maker_ext (Irmin_pack.Version.V1) (Conf) (Node) (Commit)
 
-  module Maker = Irmin_pack.Maker_ext (V1) (Conf) (Node) (Commit)
   module Store = Maker.Make (Metadata) (Contents) (Path) (Branch) (Hash)
 
   let create_repo config =

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -50,16 +50,8 @@ let path =
   @@ info ~doc:"Path to the Irmin store on disk" ~docv:"PATH" []
 
 module Make (M : Maker) = struct
-  module V1 = struct
-    let version = `V1
-  end
-
-  module V2 = struct
-    let version = `V2
-  end
-
-  module Store_V1 = M (V1)
-  module Store_V2 = M (V2)
+  module Store_V1 = M (Version.V1)
+  module Store_V2 = M (Version.V2)
   module Hash = Store_V1.Hash
   module Index = Pack_index.Make (Hash)
 

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -37,13 +37,8 @@ let migrate = Migrate.run
 module Maker (V : Version.S) (Config : Conf.S) =
   Maker_ext (V) (Config) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
 
-module V1 = Maker (struct
-  let version = `V1
-end)
-
-module V2 = Maker (struct
-  let version = `V2
-end)
+module V1 = Maker (Version.V1)
+module V2 = Maker (Version.V2)
 
 module KV (V : Version.S) (Config : Conf.S) = struct
   type endpoint = unit
@@ -63,10 +58,7 @@ module Checks = Checks
 module Inode = Inode
 module IO = IO
 module Utils = Utils
-
-module Vx = struct
-  let version = `V1
-end
+module Vx = Version.V1
 
 module Cx = struct
   let stable_hash = 0

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -18,10 +18,7 @@ open! Import
 
 (* TODO(craigfe): better namespacing of modules shared with [irmin-pack] *)
 module Layout_layered = Layout
-
-module V = struct
-  let version = `V2
-end
+module V = Irmin_pack.Version.V2
 
 let cache_size = 10_000
 

--- a/src/irmin-pack/version.ml
+++ b/src/irmin-pack/version.ml
@@ -25,6 +25,14 @@ module type S = sig
   val version : t
 end
 
+module V1 = struct
+  let version = `V1
+end
+
+module V2 = struct
+  let version = `V2
+end
+
 let enum = [ (`V1, "00000001"); (`V2, "00000002") ]
 let pp = Fmt.of_to_string (function `V1 -> "v1" | `V2 -> "v2")
 let to_bin v = List.assoc v enum

--- a/src/irmin-pack/version.mli
+++ b/src/irmin-pack/version.mli
@@ -36,3 +36,6 @@ exception Invalid of { expected : t; found : t }
 module type S = sig
   val version : t
 end
+
+module V1 : S
+module V2 : S

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -12,11 +12,9 @@ module Store = struct
 
   open Tezos_context_hash_irmin.Encoding
 
-  module V1 = struct
-    let version = `V1
-  end
+  module Maker =
+    Irmin_pack.Maker_ext (Irmin_pack.Version.V1) (Conf) (Node) (Commit)
 
-  module Maker = Irmin_pack.Maker_ext (V1) (Conf) (Node) (Commit)
   module Store = Maker.Make (Metadata) (Contents) (Path) (Branch) (Hash)
 
   let create_repo store_dir =

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -16,10 +16,7 @@
 
 open Irmin.Export_for_backends
 module Int63 = Optint.Int63
-
-module Dict = Irmin_pack.Dict.Make (struct
-  let version = `V2
-end)
+module Dict = Irmin_pack.Dict.Make (Irmin_pack.Version.V2)
 
 let get = function Some x -> x | None -> Alcotest.fail "None"
 let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
@@ -64,13 +61,13 @@ module H = Irmin.Hash.SHA1
 module I = Index
 module Index = Irmin_pack.Index.Make (H)
 
-module V2 = struct
-  let version = `V2
-end
+module P =
+  Irmin_pack.Content_addressable.Maker (Irmin_pack.Version.V2) (Index) (H)
 
-module P = Irmin_pack.Content_addressable.Maker (V2) (Index) (H)
 module Pack = P.Make (S)
-module Branch = Irmin_pack.Atomic_write.Make (V2) (Irmin.Branch.String) (H)
+
+module Branch =
+  Irmin_pack.Atomic_write.Make (Irmin_pack.Version.V2) (Irmin.Branch.String) (H)
 
 module Make_context (Config : sig
   val root : string

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -31,16 +31,14 @@ end
 
 module Hash = Irmin.Hash.SHA1
 
-module V2 = struct
-  let version = `V2
-end
-
 module S = struct
   module P = Irmin.Path.String_list
   module M = Irmin.Metadata.None
   module XNode = Irmin.Private.Node.Make
   module XCommit = Irmin.Private.Commit
-  module Maker = Irmin_pack.Maker_ext (V2) (Conf) (XNode) (XCommit)
+
+  module Maker =
+    Irmin_pack.Maker_ext (Irmin_pack.Version.V2) (Conf) (XNode) (XCommit)
 
   include
     Maker.Make (M) (Irmin.Contents.String) (P) (Irmin.Branch.String) (Hash)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -17,10 +17,6 @@
 open! Import
 open Common
 
-module V2 = struct
-  let version = `V2
-end
-
 module Config = struct
   let entries = 2
   let stable_hash = 3
@@ -29,7 +25,8 @@ end
 let test_dir = Filename.concat "_build" "test-db-pack"
 
 module Irmin_pack_maker =
-  Irmin_pack.Maker_ext (V2) (Config) (Irmin.Private.Node.Make)
+  Irmin_pack.Maker_ext (Irmin_pack.Version.V2) (Config)
+    (Irmin.Private.Node.Make)
     (Irmin.Private.Commit)
 
 let suite =
@@ -560,12 +557,9 @@ module Pack = struct
 end
 
 module Branch = struct
-  module V2 = struct
-    let version = `V2
-  end
-
   module Branch =
-    Irmin_pack.Atomic_write.Make (V2) (Irmin.Branch.String) (Irmin.Hash.SHA1)
+    Irmin_pack.Atomic_write.Make (Irmin_pack.Version.V2) (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
 
   let pp_hash = Irmin.Type.pp Irmin.Hash.SHA1.t
 


### PR DESCRIPTION
More refactoring from https://github.com/mirage/irmin/pull/1436.