### PR TITLE
irmin-pack: refactor Index reconstruction implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,9 @@
     (#1377, @samoht)
   - Moved `Irmin_pack.Store.Atomic_write` into its own module (#1378, @samoht)
   - All the types in `inode.ml` are now derived automatically (#1451, @samoht, @mattiasdrp)
+  - `Checks.Reconstruct_index.run` now takes an optional `index_log_size`
+    parameter for customising the interval between merges during
+    reconstruction. (#1459, @CraigFe)
 
 ## 2.6.0 (2021-04-13)
 

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -34,6 +34,8 @@ depends: [
 
 pin-depends: [
   [ "index.dev" "git+https://github.com/mirage/index#f3133b9104638ac6df6af8a2da433a68ccaadce5" ]
+  [ "repr.dev" "git+https://github.com/mirage/repr#30e4a2e14ac0bbea297e104c7d328b9c2e7bf5d3" ]
+  [ "ppx_repr.dev" "git+https://github.com/mirage/repr#30e4a2e14ac0bbea297e104c7d328b9c2e7bf5d3" ]
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -114,7 +114,7 @@ module Make (G : Git.S) = struct
       | Ok _ -> failwith "wrong object kind"
       | Error _ -> failwith "wrong object kind"
 
-    let size_of = Irmin.Type.stage (fun _ -> None)
+    let size_of = Irmin.Type.Size.custom_dynamic ()
     let t = Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c
   end
 end

--- a/src/irmin-git/contents.ml
+++ b/src/irmin-git/contents.ml
@@ -56,7 +56,7 @@ module Make (G : Git.S) (C : Irmin.Contents.S) = struct
           | None -> failwith "wrong object kind")
       | Error (`Msg _) -> failwith "wrong object"
 
-    let size_of = Irmin.Type.stage (fun _ -> None)
+    let size_of = Irmin.Type.Size.custom_dynamic ()
     let t = Irmin.Type.like ~bin:(encode_bin, decode_bin, size_of) t
   end
 end

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -166,7 +166,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
       | Ok _ -> failwith "wrong object kind"
       | Error _ -> failwith "wrong object"
 
-    let size_of = Irmin.Type.stage (fun _ -> None)
+    let size_of = Irmin.Type.Size.custom_dynamic ()
     let t = Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
   end
 end

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -80,11 +80,12 @@ module Unix : S = struct
       let off = header t.version ++ off ++ len in
       off <= t.flushed)
 
-  let read t ~off buf =
+  let read_buffer t ~off ~buf ~len =
     let off = header t.version ++ off in
     assert (if not t.readonly then off <= t.flushed else true);
-    Raw.unsafe_read t.raw ~off ~len:(Bytes.length buf) buf
+    Raw.unsafe_read t.raw ~off ~len buf
 
+  let read t ~off buf = read_buffer t ~off ~buf ~len:(Bytes.length buf)
   let offset t = t.offset
 
   let force_offset t =
@@ -307,12 +308,6 @@ module Unix : S = struct
         Fmt.invalid_arg "[%s] Unsupported migration path: %a → %a"
           (Filename.basename src.file)
           Version.pp src_v Version.pp dst_v
-
-  let read_buffer ~chunk ~off src =
-    let off = header src.version ++ off in
-    let tmp = Bytes.create chunk in
-    let len = Raw.unsafe_read src.raw ~off ~len:chunk tmp in
-    Bytes.sub_string tmp 0 len
 end
 
 module Cache = struct

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -28,6 +28,7 @@ module type S = sig
   val append : t -> string -> unit
   val set : t -> off:int63 -> string -> unit
   val read : t -> off:int63 -> bytes -> int
+  val read_buffer : t -> off:int63 -> buf:bytes -> len:int -> int
   val offset : t -> int63
   val generation : t -> int63
   val force_headers : t -> headers
@@ -49,8 +50,6 @@ module type S = sig
     Version.t ->
     (unit, [> `Msg of string ]) result
   (** @raise Invalid_arg if the migration path is not supported. *)
-
-  val read_buffer : chunk:int -> off:int63 -> t -> string
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/checks_intf.ml
+++ b/src/irmin-pack/checks_intf.ml
@@ -61,7 +61,13 @@ module type S = sig
   end
 
   module Reconstruct_index :
-    Subcommand with type run := root:string -> output:string option -> unit
+    Subcommand
+      with type run :=
+            root:string ->
+            output:string option ->
+            ?index_log_size:int ->
+            unit ->
+            unit
   (** Rebuilds an index for an existing pack file *)
 
   (** Checks the integrity of a store *)

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -923,6 +923,11 @@ struct
     let encode_compress = Irmin.Type.(unstage (encode_bin Compress.t))
     let decode_compress = Irmin.Type.(unstage (decode_bin Compress.t))
 
+    let decode_compress_length =
+      match Irmin.Type.Size.of_encoding Compress.t with
+      | Unknown | Static _ -> assert false
+      | Dynamic f -> f
+
     let encode_bin ~dict ~offset (t : t) k =
       let step s : Compress.name =
         let str = step_to_bin s in
@@ -1000,6 +1005,8 @@ struct
       in
       let t = Bin.v ~stable:i.stable ~hash:(lazy i.hash) (t i.v) in
       (off, t)
+
+    let decode_bin_length = decode_compress_length
   end
 
   type hash = T.hash
@@ -1183,9 +1190,7 @@ struct
   let batch = Pack.batch
   let close = Pack.close
   let clear = Pack.clear
-
-  let decode_bin ~dict ~hash buff off =
-    Inter.Raw.decode_bin ~dict ~hash buff off |> fst
+  let decode_bin_length = Inter.Raw.decode_bin_length
 
   let integrity_check_inodes t k =
     find t k >|= function

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -27,8 +27,7 @@ module type S = sig
   module Key : Irmin.Hash.S with type t = key
   module Val : Value with type t = value and type hash = key
 
-  val decode_bin :
-    dict:(int -> string option) -> hash:(int63 -> key) -> string -> int -> int
+  val decode_bin_length : string -> int -> int
 end
 
 module type Persistent = sig

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -106,9 +106,6 @@ struct
     | Upper -> P.copy (Upper, dst) t "Node"
 
   let check = P.check
-
-  let decode_bin ~dict ~hash buff off =
-    Internal.Raw.decode_bin ~dict ~hash buff off |> fst
-
+  let decode_bin_length = Internal.Raw.decode_bin_length
   let integrity_check_inodes _ _ = failwith "TODO"
 end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -47,6 +47,14 @@ struct
     let len, t = decode_value s off in
     (len, t.v)
 
+  let decode_bin_length =
+    match Irmin.Type.(Size.of_encoding value) with
+    | Unknown ->
+        Fmt.failwith "Type must have a recoverable encoded length: %a"
+          Irmin.Type.pp_ty t
+    | Static n -> fun _ _ -> n
+    | Dynamic f -> f
+
   let kind _ = Config.selected_kind
 end
 

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -23,6 +23,8 @@ module type S = sig
     string ->
     int ->
     int * t
+
+  val decode_bin_length : string -> int -> int
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/reconstruct_index.ml
+++ b/src/irmin-pack/reconstruct_index.ml
@@ -88,8 +88,10 @@ end = struct
     let expand_and_refill_buffer ~from =
       let length = Bytes.length !buffer in
       if length > 1_000_000_000 (* 1 GB *) then
-        failwith
-          "Couldn't decode a value in %d of buffer space. Corrupted data file?"
+        Fmt.failwith
+          "Couldn't decode the value at offset %a in %d of buffer space. \
+           Corrupted data file?"
+          Int63.pp from length
       else (
         buffer := Bytes.create (2 * length);
         refill_buffer ~from)

--- a/src/irmin-pack/reconstruct_index.ml
+++ b/src/irmin-pack/reconstruct_index.ml
@@ -1,6 +1,37 @@
 open! Import
 module IO = IO.Unix
 
+module Stats : sig
+  type t
+
+  val empty : unit -> t
+  val add : t -> Pack_value.Kind.t -> unit
+  val pp : t Fmt.t
+end = struct
+  open Pack_value.Kind
+
+  type t = int array
+
+  let empty () = Array.make 4 0
+  let incr t n = t.(n) <- t.(n) + 1
+
+  let add t = function
+    | Contents -> incr t 0
+    | Commit -> incr t 1
+    | Node -> incr t 2
+    | Inode -> incr t 3
+
+  let pp =
+    let open Fmt.Dump in
+    record
+      [
+        field "Contents" (fun t -> t.(0)) Fmt.int;
+        field "Commit" (fun t -> t.(1)) Fmt.int;
+        field "Node" (fun t -> t.(2)) Fmt.int;
+        field "Inode" (fun t -> t.(3)) Fmt.int;
+      ]
+end
+
 module type Args = sig
   module Version : Version.S
   module Hash : Irmin.Hash.S
@@ -16,98 +47,121 @@ module Make (Args : Args) : sig
 end = struct
   open Args
 
-  let pp_hash = Irmin.Type.pp Hash.t
+  let pp_key = Irmin.Type.pp Hash.t
   let decode_key = Irmin.Type.(unstage (decode_bin Hash.t))
   let decode_kind = Irmin.Type.(unstage (decode_bin Pack_value.Kind.t))
 
-  let decode_buffer ~progress ~total pack dict index =
-    let decode_len buf (kind : Pack_value.Kind.t) =
-      try
-        let len =
-          match kind with
-          | Contents ->
-              fst
-                (Contents.decode_bin
-                   ~dict:(fun _ -> assert false)
-                   ~hash:(fun _ -> assert false)
-                   buf 0)
-          | Commit ->
-              fst
-                (Commit.decode_bin
-                   ~dict:(fun _ -> assert false)
-                   ~hash:(fun _ -> assert false)
-                   buf 0)
-          | Node | Inode ->
-              let hash off =
-                let buf = IO.read_buffer ~chunk:Hash.hash_size ~off pack in
-                decode_key buf 0 |> snd
-              in
-              let dict = Dict.find dict in
-              Inode.decode_bin ~hash ~dict buf 0
-        in
-        Some len
-      with
-      | Invalid_argument msg when msg = "index out of bounds" -> None
-      | Invalid_argument msg when msg = "String.blit / Bytes.blit_string" ->
-          None
+  (* [Repr] doesn't yet support buffered binary decoders, so we hack one
+     together by re-interpreting [Invalid_argument _] exceptions from [Repr]
+     as requests for more data. *)
+  exception Not_enough_buffer
+
+  type index_binding = { key : Hash.t; data : Index.value }
+
+  let decode_entry_length = function
+    | Pack_value.Kind.Contents -> Contents.decode_bin_length
+    | Commit -> Commit.decode_bin_length
+    | Node | Inode -> Inode.decode_bin_length
+
+  let decode_entry_exn ~off ~buffer ~buffer_off =
+    try
+      (* Decode the key and kind by hand *)
+      let off_after_key, key = decode_key buffer buffer_off in
+      assert (off_after_key = buffer_off + Hash.hash_size);
+      let off_after_kind, kind = decode_kind buffer off_after_key in
+      assert (off_after_kind = buffer_off + Hash.hash_size + 1);
+      (* Get the length of the entire entry *)
+      let entry_len = decode_entry_length kind buffer buffer_off in
+      { key; data = (off, entry_len, kind) }
+    with
+    | Invalid_argument msg when msg = "index out of bounds" ->
+        raise Not_enough_buffer
+    | Invalid_argument msg when msg = "String.blit / Bytes.blit_string" ->
+        raise Not_enough_buffer
+
+  let ingest_data_file ~progress ~total pack index =
+    let buffer = ref (Bytes.create 1024) in
+    let refill_buffer ~from =
+      let read = IO.read pack ~off:from !buffer in
+      assert (read = Bytes.length !buffer)
     in
-    let decode_entry buf off =
-      let off_k, k = decode_key buf 0 in
-      assert (off_k = Hash.hash_size);
-      let off_m, kind = decode_kind buf off_k in
-      assert (off_m = Hash.hash_size + 1);
-      match decode_len buf kind with
-      | Some len ->
-          let new_off = off ++ Int63.of_int len in
-          Log.debug (fun l ->
-              l "k = %a (off, len, kind) = (%a, %d, %a)" pp_hash k Int63.pp off
-                len Pack_value.Kind.pp kind);
-          Index.add index k (off, len, kind);
-          progress (Int63.of_int len);
-          Some new_off
-      | None -> None
+    let expand_and_refill_buffer ~from =
+      let length = Bytes.length !buffer in
+      if length > 1_000_000_000 (* 1 GB *) then
+        failwith
+          "Couldn't decode a value in %d of buffer space. Corrupted data file?"
+      else (
+        buffer := Bytes.create (2 * length);
+        refill_buffer ~from)
     in
-    let rec read_and_decode ?(retries = 1) off =
-      Log.debug (fun l ->
-          l "read_and_decode retries %d off %a" retries Int63.pp off);
-      let chunk = 64 * 10 * retries in
-      let buf = IO.read_buffer ~chunk ~off pack in
-      match decode_entry buf off with
-      | Some new_off -> new_off
-      | None ->
-          (* the biggest entry in a tezos store is a blob of 54801B *)
-          if retries > 90 then
-            failwith "too many retries to read data, buffer size = 57600B"
-          else (read_and_decode [@tailcall]) ~retries:(retries + 1) off
-    in
-    let rec read_buffer off =
-      if off >= total then ()
+    let stats = Stats.empty () in
+    let rec loop_entries ~buffer_off off =
+      if off >= total then stats
       else
-        let new_off = read_and_decode off in
-        (read_buffer [@tailcall]) new_off
+        let buffer_off, off =
+          match
+            decode_entry_exn ~off
+              ~buffer:(Bytes.unsafe_to_string !buffer)
+              ~buffer_off
+          with
+          | { key; data } ->
+              let off', entry_len, kind = data in
+              let entry_lenL = Int63.of_int entry_len in
+              assert (off = off');
+              Log.debug (fun l ->
+                  l "k = %a (off, len, kind) = (%a, %d, %a)" pp_key key Int63.pp
+                    off entry_len Pack_value.Kind.pp kind);
+              Stats.add stats kind;
+              Index.add index key data;
+              progress entry_lenL;
+              (buffer_off + entry_len, off ++ entry_lenL)
+          | exception Not_enough_buffer ->
+              let () =
+                if buffer_off > 0 then
+                  (* Try again with the value at the start of the buffer. *)
+                  refill_buffer ~from:off
+                else
+                  (* The entire buffer isn't enough to hold this value: expand it. *)
+                  expand_and_refill_buffer ~from:off
+              in
+              (0, off)
+        in
+        loop_entries ~buffer_off off
     in
-    read_buffer Int63.zero
+    refill_buffer ~from:Int63.zero;
+    loop_entries ~buffer_off:0 Int63.zero
 
   let run ?output config =
     if Conf.readonly config then raise S.RO_not_allowed;
-    Log.info (fun l -> l "[%s] reconstructing index" (Conf.root config));
+    let run_duration = Mtime_clock.counter () in
     let root = Conf.root config in
     let dest = match output with Some path -> path | None -> root in
     let log_size = Conf.index_log_size config in
+    Log.app (fun f ->
+        f "Beginning index reconstruction with parameters: { log_size = %d }"
+          log_size);
     let index = Index.v ~fresh:true ~readonly:false ~log_size dest in
     let pack_file = Filename.concat root "store.pack" in
     let pack =
       IO.v ~fresh:false ~readonly:true ~version:(Some Version.version) pack_file
     in
-    let dict = Dict.v ~fresh:false ~readonly:true root in
     let total = IO.offset pack in
     let bar, progress =
       Utils.Progress.counter ~total ~sampling_interval:100
         ~message:"Reconstructing index" ~pp_count:Utils.pp_bytes ()
     in
-    decode_buffer ~progress ~total pack dict index;
+    let stats = ingest_data_file ~progress ~total pack index in
+    Utils.Progress.finalise bar;
+    (* Ensure that the log file is empty, so that subsequent opens with a
+       smaller [log_size] don't immediately trigger a merge operation. *)
+    Log.app (fun f ->
+        f "Completed indexing of pack entries. Running a final merge ...");
+    Index.try_merge index;
     Index.close index;
     IO.close pack;
-    Dict.close dict;
-    Utils.Progress.finalise bar
+    let run_duration = Mtime_clock.count run_duration in
+    Log.app (fun f ->
+        f "%a in %a. Store statistics:@,  @[<v 0>%a@]"
+          Fmt.(styled `Green string)
+          "Success" Mtime.Span.pp run_duration Stats.pp stats)
 end

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -511,10 +511,7 @@ module V1 = struct
       let h = Type.string_of `Int64
       let hash_to_bin_string = Type.(unstage (to_bin_string X.t))
       let hash_of_bin_string = Type.(unstage (of_bin_string X.t))
-
-      let size_of =
-        let size_of = Type.(unstage (size_of h)) in
-        Type.stage (fun x -> size_of (hash_to_bin_string x))
+      let size_of = Type.Size.using hash_to_bin_string (Type.Size.t h)
 
       let encode_bin =
         let encode_bin = Type.(unstage (encode_bin h)) in

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -220,7 +220,7 @@ module V1 = struct
     include String
 
     let t = Type.(boxed (string_of `Int64))
-    let size_of = Type.size_of t
+    let size_of = Type.Size.t t
     let decode_bin = Type.decode_bin t
     let encode_bin = Type.encode_bin t
     let pre_hash = Type.pre_hash t

--- a/src/irmin/hash.ml
+++ b/src/irmin/hash.ml
@@ -76,10 +76,7 @@ module V1 (K : S) : S with type t = K.t = struct
   let h = Type.string_of `Int64
   let to_bin_key = Type.unstage (Type.to_bin_string K.t)
   let of_bin_key = Type.unstage (Type.of_bin_string K.t)
-
-  let size_of =
-    let size_of = Type.unstage (Type.size_of h) in
-    Type.stage (fun x -> size_of (to_bin_key x))
+  let size_of = Type.Size.using to_bin_key (Type.Size.t h)
 
   let encode_bin =
     let encode_bin = Type.unstage (Type.encode_bin h) in

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -362,10 +362,7 @@ module V1 (N : S with type step = string) = struct
     let h = Type.string_of `Int64
     let to_bin_string = Type.(unstage (to_bin_string N.hash_t))
     let of_bin_string = Type.(unstage (of_bin_string N.hash_t))
-
-    let size_of =
-      let size_of = Type.(unstage (size_of h)) in
-      Type.stage (fun x -> size_of (to_bin_string x))
+    let size_of = Type.Size.using to_bin_string (Type.Size.t h)
 
     let encode_bin =
       let encode_bin = Type.(unstage (encode_bin h)) in

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -55,6 +55,11 @@ module S = struct
   let decode_bin ~dict:_ ~hash:_ x off =
     let len, (_, v) = decode_pair x off in
     (len, v)
+
+  let decode_bin_length =
+    match Irmin.Type.(Size.of_encoding (pair H.t t)) with
+    | Dynamic f -> f
+    | _ -> assert false
 end
 
 module H = Irmin.Hash.SHA1


### PR DESCRIPTION
... using the improved `size_of` functions provided by https://github.com/mirage/repr/pull/69.

The new implementation avoids decoding Inode / Node values from the read buffer, which avoids needing to use the path dictionary and reduces the number of allocations significantly. (As a result, certain corruptions of the data file itself will no longer be noticed during index reconstruction, but we have other integrity checks for those.)

Also exposes an `index_log_size` parameter to allow the user to override the default. To compensate for using very large log sizes during reconstruction, we now attempt a manual merge at the end of the process.