### PR TITLE
irmin-unix: Add `config_path` argument to `Irmin_unix.Resolver.load_config`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,9 @@
     parameter for customising the interval between merges during
     reconstruction. (#1459, @CraigFe)
 
+- **irmin-unix**
+  - Allow config file to be specified when using `Irmin_unix.Resolver.load_config` (#1464, @zshipko)
+
 ## 2.6.0 (2021-04-13)
 
 ** Note: this release is based on 2.5.3, and does not contain 2.5.4. **

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -477,9 +477,13 @@ let from_config_file_with_defaults path (store, hash, contents) config branch :
       | None -> S ((module S), mk_master (), remote)
       | Some b -> S ((module S), mk_branch b, remote))
 
-let load_config ?(default = Irmin.Private.Conf.empty) ~store ~hash ~contents ()
-    =
-  let cfg = Irmin.Private.Conf.get default config_path_key in
+let load_config ?(default = Irmin.Private.Conf.empty) ?config_path ~store ~hash
+    ~contents () =
+  let cfg =
+    match config_path with
+    | Some _ as p -> p
+    | None -> Irmin.Private.Conf.get default config_path_key
+  in
   load_config_file_with_defaults cfg (store, hash, contents) default
 
 let branch =

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -78,11 +78,18 @@ val remote : Irmin.remote Lwt.t Cmdliner.Term.t
 
 val load_config :
   ?default:Irmin.config ->
+  ?config_path:string ->
   store:string option ->
   hash:hash option ->
   contents:string option ->
   unit ->
   Store.t * Irmin.config
+(** Load config file from disk
+
+    [config_path] can be used to specify the location of a configuration file.
+
+    The values provided for [store], [hash] and [contents] will be used by
+    default if no other value is found in the config file *)
 
 type store =
   | S :


### PR DESCRIPTION
Currently when using `Irmin_unix.Resolver.load_config` we're only searching in the default paths, this adds a `config_path` argument so a specific configuration file can be loaded. 