### PR TITLE
irmin-bench: Upgrade progress library version

### DIFF
--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -74,17 +74,27 @@ let with_timer f =
   (t1, a)
 
 let with_progress_bar ~message ~n ~unit =
-  let bar =
-    let w =
-      if n = 0 then 1
-      else float_of_int n |> log10 |> floor |> int_of_float |> succ
-    in
-    let pp fmt i = Format.fprintf fmt "%*Ld/%*d %s" w i w n unit in
-    let pp f = f ~width:(w + 1 + w + 1 + String.length unit) pp in
-    Progress_unix.counter ~mode:`ASCII ~width:79 ~total:(Int64.of_int n)
-      ~message ~pp ()
+  let open Progress in
+  let config =
+    Config.v ~max_width:(Some 79) ~min_interval:(Some Duration.(of_sec 0.5)) ()
   in
-  Progress_unix.with_reporters bar
+  let bar =
+    Line.(
+      const message
+      ++ const " "
+      ++ count_to n
+      ++ const " "
+      ++ const unit
+      ++ const " "
+      ++ elapsed ()
+      ++ const " (ETA: "
+      ++ eta n
+      ++ const ") "
+      ++ bar n
+      ++ const " "
+      ++ percentage_of n)
+  in
+  with_reporter ~config bar
 
 module Conf = struct
   let entries = 32

--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -80,19 +80,16 @@ let with_progress_bar ~message ~n ~unit =
   in
   let bar =
     Line.(
-      const message
-      ++ const " "
-      ++ count_to n
-      ++ const " "
-      ++ const unit
-      ++ const " "
-      ++ elapsed ()
-      ++ const " (ETA: "
-      ++ eta n
-      ++ const ") "
-      ++ bar n
-      ++ const " "
-      ++ percentage_of n)
+      list
+        [
+          const message;
+          count_to n;
+          const unit;
+          elapsed ();
+          parens (const "ETA: " ++ eta n);
+          bar n;
+          percentage_of n;
+        ])
   in
   with_reporter ~config bar
 

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -22,7 +22,7 @@ val reset_stats : unit -> unit
 val with_timer : (unit -> 'a Lwt.t) -> (float * 'a) Lwt.t
 
 val with_progress_bar :
-  message:string -> n:int -> unit:string -> ((int64 -> unit) -> 'a) -> 'a
+  message:string -> n:int -> unit:string -> ((int -> unit) -> 'a) -> 'a
 
 val random_blob : unit -> bytes
 

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -11,7 +11,7 @@
 (library
  (name bench_common)
  (modules bench_common)
- (libraries irmin-pack unix progress progress.unix uuidm))
+ (libraries irmin-pack unix progress uuidm))
 
 (library
  (name irmin_traces)

--- a/bench/irmin-pack/trace_replay.ml
+++ b/bench/irmin-pack/trace_replay.ml
@@ -314,7 +314,7 @@ module Make (Store : Store) = struct
 
   let add_commits repo max_ncommits commit_seq on_commit on_end stats check_hash
       empty_blobs =
-    with_progress_bar ~message:"Replaying trace" ~n:max_ncommits ~unit:"commits"
+    with_progress_bar ~message:"Replaying trace" ~n:max_ncommits ~unit:"commit"
     @@ fun prog ->
     let t =
       {
@@ -338,7 +338,7 @@ module Make (Store : Store) = struct
             Logs.app (fun l ->
                 l "\nAfter commit %6d we have %d/%d history sizes" i len0 len1);
           let* () = on_commit i (Option.get t.latest_commit) in
-          prog Int64.one;
+          prog 1;
           aux commit_seq (i + 1)
     in
     aux commit_seq 0

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -89,14 +89,14 @@ module Bench_suite (Store : Store) = struct
         Store.Commit.v repo ~info:(Info.f ()) ~parents:[ prev_commit ] tree
 
   let add_commits ~message repo ncommits on_commit on_end f () =
-    with_progress_bar ~message ~n:ncommits ~unit:"commits" @@ fun prog ->
+    with_progress_bar ~message ~n:ncommits ~unit:"commit" @@ fun prog ->
     let* c = init_commit repo in
     let rec aux c i =
       if i >= ncommits then on_end ()
       else
         let* c' = checkout_and_commit repo (Store.Commit.hash c) f in
         let* () = on_commit i (Store.Commit.hash c') in
-        prog Int64.one;
+        prog 1;
         aux c' (i + 1)
     in
     aux c 0

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -26,7 +26,7 @@ depends: [
   "re"           {>= "1.9.0"}
   "fmt"
   "uuidm"
-  "progress"     {= "0.1.1"}
+  "progress"     {>="0.2.1"}
   "fpath"        {with-test}
   "bentov"       {with-test}
   "mtime"        {with-test}

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -33,7 +33,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "index.dev" "git+https://github.com/mirage/index#f3133b9104638ac6df6af8a2da433a68ccaadce5" ]
+  [ "index.dev" "git+https://github.com/mirage/index#aa8b812a373344642c3694d6ccd5475ea724c6b4" ]
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"


### PR DESCRIPTION
Let's wait for `progress=0.2.1` before merging