### PR TITLE
irmin: make Node and Commit non-private modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@
   - `Irmin.Sync` is now a namespace: use `Irmin.Sync.Make(S)` instead of
     `Irmin.Sync(S)` (#1338, @samoht)
   - `Store.Private.Sync` is now `Store.Private.Remote` (#1338, @samoht)
+  - `Irmin.Private.{Commit,Node}` are now `Irmin.{Node,Commit}`. (#1471,
+    @CraigFe)
   - All module types are now using snake-case and are not capitalized anymore.
     (#1341, @samoht)
   - Move signatures for backend stores into their own modules. All the

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -205,10 +205,8 @@ end
 
 open Tezos_context_hash_irmin.Encoding
 
-module type Impl = functor
-  (_ : Irmin.Private.Node.Maker)
-  (_ : Irmin.Private.Commit.Maker)
-  -> Irmin_pack.Maker
+module type Impl = functor (_ : Irmin.Node.Maker) (_ : Irmin.Commit.Maker) ->
+  Irmin_pack.Maker
 
 module Make_basic
     (Impl : Impl) (Conf : sig
@@ -237,8 +235,8 @@ module Make_store_mem = Make_basic (Irmin_pack_mem.Maker)
 module Make_store_pack =
   Make_basic
     ((functor
-       (Node : Irmin.Private.Node.Maker)
-       (Commit : Irmin.Private.Commit.Maker)
+       (Node : Irmin.Node.Maker)
+       (Commit : Irmin.Commit.Maker)
        (C : Irmin_pack.Conf.S)
        ->
        Irmin_pack.Maker_ext (Irmin_pack.Version.V1) (C) (Node) (Commit)))

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -91,7 +91,7 @@ module Make (G : Git.S) = struct
       let message = Option.value ~default:"" (G.Value.Commit.message g) in
       info_of_git author message
 
-    module C = Irmin.Private.Commit.Make (Key)
+    module C = Irmin.Commit.Make (Key)
 
     let of_c c = to_git (C.info c) (C.node c) (C.parents c)
 

--- a/src/irmin-git/commit.mli
+++ b/src/irmin-git/commit.mli
@@ -27,7 +27,7 @@ module Make (G : Git.S) : sig
   module Key : Irmin.Hash.S with type t = key
 
   module Val :
-    Irmin.Private.Commit.S
+    Irmin.Commit.S
       with type t = value
        and type hash = key
        and module Info = Info

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -240,15 +240,13 @@ struct
         module CA = CA (Hash) (V)
 
         include
-          Irmin.Private.Node.Store (Contents) (CA) (Hash) (V)
-            (Dummy.Node.Metadata)
-            (P)
+          Irmin.Node.Store (Contents) (CA) (Hash) (V) (Dummy.Node.Metadata) (P)
       end
 
       module Commit = struct
         module V = Dummy.Commit.Val
         module CA = CA (Hash) (V)
-        include Irmin.Private.Commit.Store (Info) (Node) (CA) (Hash) (V)
+        include Irmin.Commit.Store (Info) (Node) (CA) (Hash) (V)
       end
 
       module Branch = struct

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -147,7 +147,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
         [] (G.Value.Tree.to_list t)
       |> List.rev
 
-    module N = Irmin.Private.Node.Make (Key) (P) (Metadata)
+    module N = Irmin.Node.Make (Key) (P) (Metadata)
 
     let to_n t = N.v (alist t)
     let of_n n = v (N.list n)

--- a/src/irmin-git/node.mli
+++ b/src/irmin-git/node.mli
@@ -26,7 +26,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) : sig
   module Key : Irmin.Hash.S with type t = key
 
   module Val :
-    Irmin.Private.Node.S
+    Irmin.Node.S
       with type t = value
        and type hash = key
        and type step = P.step

--- a/src/irmin-git/private.ml
+++ b/src/irmin-git/private.ml
@@ -39,14 +39,12 @@ struct
 
   module Node = struct
     module S = Node.Make (G) (P)
-
-    include
-      Irmin.Private.Node.Store (Contents) (S) (S.Key) (S.Val) (Metadata) (P)
+    include Irmin.Node.Store (Contents) (S) (S.Key) (S.Val) (Metadata) (P)
   end
 
   module Commit = struct
     module S = Commit.Make (G)
-    include Irmin.Private.Commit.Store (Info) (Node) (S) (S.Key) (S.Val)
+    include Irmin.Commit.Store (Info) (Node) (S) (S.Key) (S.Val)
   end
 
   module Branch = struct

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -483,7 +483,7 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
         include Closeable.Content_addressable (CA)
       end
 
-      include Irmin.Private.Commit.Store (S.Info) (Node) (X) (X.Key) (X.Val)
+      include Irmin.Commit.Store (S.Info) (Node) (X) (X.Key) (X.Val)
 
       let v ?ctx config = X.v ?ctx config "commit" "commits"
     end

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -31,8 +31,8 @@ end
 module Maker_ext
     (CA : Irmin.Content_addressable.Maker)
     (AW : Irmin.Atomic_write.Maker)
-    (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker)
+    (N : Irmin.Node.Maker)
+    (CT : Irmin.Commit.Maker)
     (M : Irmin.Metadata.S)
     (C : Irmin.Contents.S)
     (P : Irmin.Path.S)
@@ -78,6 +78,6 @@ end
 module Maker
     (CA : Irmin.Content_addressable.Maker)
     (AW : Irmin.Atomic_write.Maker) =
-  Maker_ext (CA) (AW) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
+  Maker_ext (CA) (AW) (Irmin.Node.Make) (Irmin.Commit)
 
 module Stats = Stats

--- a/src/irmin-layers/irmin_layers_intf.ml
+++ b/src/irmin-layers/irmin_layers_intf.ml
@@ -155,8 +155,8 @@ module type Sigs = sig
   module Maker_ext
       (CA : Irmin.Content_addressable.Maker)
       (AW : Irmin.Atomic_write.Maker)
-      (Node : Irmin.Private.Node.Maker)
-      (Commit : Irmin.Private.Commit.Maker) : Maker
+      (Node : Irmin.Node.Maker)
+      (Commit : Irmin.Commit.Maker) : Maker
 
   module Maker
       (CA : Irmin.Content_addressable.Maker)

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -20,8 +20,8 @@ module IO = IO.Unix
 module Maker
     (V : Version.S)
     (Config : Conf.S)
-    (Node : Irmin.Private.Node.Maker)
-    (Commit : Irmin.Private.Commit.Maker) =
+    (Node : Irmin.Node.Maker)
+    (Commit : Irmin.Commit.Maker) =
 struct
   type endpoint = unit
   type info = Commit.Info.t
@@ -58,14 +58,14 @@ struct
           include Inode.Make_persistent (H) (Node) (Inter) (Pack)
         end
 
-        include Irmin.Private.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+        include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
       end
 
       module Commit = struct
         module Commit = Commit.Make (H)
         module Pack_value = Pack_value.Of_commit (H) (Commit)
         module CA = Pack.Make (Pack_value)
-        include Irmin.Private.Commit.Store (Info) (Node) (CA) (H) (Commit)
+        include Irmin.Commit.Store (Info) (Node) (CA) (H) (Commit)
       end
 
       module Branch = struct

--- a/src/irmin-pack/ext.mli
+++ b/src/irmin-pack/ext.mli
@@ -17,5 +17,5 @@
 module Maker
     (_ : Version.S)
     (_ : Conf.S)
-    (N : Irmin.Private.Node.Maker)
-    (CT : Irmin.Private.Commit.Maker) : S.Maker with type info = CT.Info.t
+    (N : Irmin.Node.Maker)
+    (CT : Irmin.Commit.Maker) : S.Maker with type info = CT.Info.t

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -20,7 +20,7 @@ include Inode_intf
 module Make_internal
     (Conf : Conf.S)
     (H : Irmin.Hash.S)
-    (Node : Irmin.Private.Node.S with type hash = H.t) =
+    (Node : Irmin.Node.S with type hash = H.t) =
 struct
   let () =
     if Conf.entries > Conf.stable_hash then
@@ -1136,7 +1136,7 @@ end
 
 module Make
     (H : Irmin.Hash.S)
-    (Node : Irmin.Private.Node.S with type hash = H.t)
+    (Node : Irmin.Node.S with type hash = H.t)
     (Inter : Internal
                with type hash = H.t
                 and type Val.metadata = Node.metadata
@@ -1208,7 +1208,7 @@ end
 
 module Make_persistent
     (H : Irmin.Hash.S)
-    (Node : Irmin.Private.Node.S with type hash = H.t)
+    (Node : Irmin.Node.S with type hash = H.t)
     (Inter : Internal
                with type hash = H.t
                 and type Val.metadata = Node.metadata

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -17,7 +17,7 @@
 open! Import
 
 module type Value = sig
-  include Irmin.Private.Node.S
+  include Irmin.Node.S
 
   val pred : t -> [ `Node of hash | `Inode of hash | `Contents of hash ] list
 end
@@ -128,7 +128,7 @@ module type Sigs = sig
   module Make_internal
       (Conf : Conf.S)
       (H : Irmin.Hash.S)
-      (Node : Irmin.Private.Node.S with type hash = H.t) :
+      (Node : Irmin.Node.S with type hash = H.t) :
     Internal
       with type hash = H.t
        and type Val.metadata = Node.metadata
@@ -136,7 +136,7 @@ module type Sigs = sig
 
   module Make
       (H : Irmin.Hash.S)
-      (Node : Irmin.Private.Node.S with type hash = H.t)
+      (Node : Irmin.Node.S with type hash = H.t)
       (Inter : Internal
                  with type hash = H.t
                   and type Val.metadata = Node.metadata
@@ -153,7 +153,7 @@ module type Sigs = sig
 
   module Make_persistent
       (H : Irmin.Hash.S)
-      (Node : Irmin.Private.Node.S with type hash = H.t)
+      (Node : Irmin.Node.S with type hash = H.t)
       (Inter : Internal
                  with type hash = H.t
                   and type Val.metadata = Node.metadata

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -37,7 +37,7 @@ module Conf = Conf
 let migrate = Migrate.run
 
 module Maker (V : Version.S) (Config : Conf.S) =
-  Maker_ext (V) (Config) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
+  Maker_ext (V) (Config) (Irmin.Node.Make) (Irmin.Commit)
 
 module V1 = Maker (Version.V1)
 module V2 = Maker (Version.V2)

--- a/src/irmin-pack/irmin_pack_intf.ml
+++ b/src/irmin-pack/irmin_pack_intf.ml
@@ -62,8 +62,8 @@ module type Sigs = sig
   module Maker_ext
       (_ : Version.S)
       (_ : Conf.S)
-      (N : Irmin.Private.Node.Maker)
-      (CT : Irmin.Private.Commit.Maker) : S.Maker with type info = CT.Info.t
+      (N : Irmin.Node.Maker)
+      (CT : Irmin.Commit.Maker) : S.Maker with type info = CT.Info.t
 
   module Stats = Stats
   module Layout = Layout

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -33,8 +33,8 @@ let lock_path root = Filename.concat root "lock"
 
 module Maker
     (Config : Conf.Pack.S)
-    (Node : Irmin.Private.Node.Maker)
-    (Commit : Irmin.Private.Commit.Maker)
+    (Node : Irmin.Node.Maker)
+    (Commit : Irmin.Commit.Maker)
     (M : Irmin.Metadata.S)
     (C : Irmin.Contents.S)
     (P : Irmin.Path.S)
@@ -69,7 +69,7 @@ struct
       module Pa = Layered_store.Pack_maker (H) (Index) (Pack)
       module Node = Node (H) (P) (M)
       module CA = Inode_layers.Make (Config) (H) (Pa) (Node)
-      include Irmin.Private.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+      include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
     end
 
     module Commit = struct
@@ -81,7 +81,7 @@ struct
         include Layered_store.Content_addressable (H) (Index) (CA) (CA)
       end
 
-      include Irmin.Private.Commit.Store (Info) (Node) (CA) (H) (Commit)
+      include Irmin.Commit.Store (Info) (Node) (CA) (H) (Commit)
     end
 
     module Branch = struct

--- a/src/irmin-pack/layered/ext_layered.mli
+++ b/src/irmin-pack/layered/ext_layered.mli
@@ -16,5 +16,5 @@
 
 module Maker
     (_ : Irmin_pack.Conf.S)
-    (_ : Irmin.Private.Node.Maker)
-    (_ : Irmin.Private.Commit.Maker) : S.Maker
+    (_ : Irmin.Node.Maker)
+    (_ : Irmin.Commit.Maker) : S.Maker

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -23,7 +23,7 @@ module Make
     (Maker : S.Content_addressable_maker
                with type key = H.t
                 and type index := Index.Make(H).t)
-    (Node : Irmin.Private.Node.S with type hash = H.t) =
+    (Node : Irmin.Node.S with type hash = H.t) =
 struct
   type index = Index.Make(H).t
 

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -83,7 +83,7 @@ module type Sigs = sig
       (_ : S.Content_addressable_maker
              with type key = H.t
               and type index = Index.Make(H).t)
-      (Node : Irmin.Private.Node.S with type hash = H.t) :
+      (Node : Irmin.Node.S with type hash = H.t) :
     S
       with type key = H.t
        and type Val.metadata = Node.metadata

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -21,7 +21,7 @@ module type S = S.Store
 module type Maker = S.Maker
 
 module Maker (Config : Irmin_pack.Conf.S) =
-  Maker_ext (Config) (Irmin.Private.Node.Make) (Irmin.Private.Commit)
+  Maker_ext (Config) (Irmin.Node.Make) (Irmin.Commit)
 
 module Checks = Checks
 

--- a/src/irmin-pack/layered/irmin_pack_layered.mli
+++ b/src/irmin-pack/layered/irmin_pack_layered.mli
@@ -46,7 +46,7 @@ module Maker (_ : Irmin_pack.Conf.S) : Maker
 
 module Maker_ext
     (_ : Irmin_pack.Conf.S)
-    (_ : Irmin.Private.Node.Maker)
-    (_ : Irmin.Private.Commit.Maker) : Maker
+    (_ : Irmin.Node.Maker)
+    (_ : Irmin.Commit.Maker) : Maker
 
 module Checks = Checks

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -37,8 +37,8 @@ struct
 end
 
 module Maker
-    (Node : Irmin.Private.Node.Maker)
-    (Commit : Irmin.Private.Commit.Maker)
+    (Node : Irmin.Node.Maker)
+    (Commit : Irmin.Commit.Maker)
     (Config : Irmin_pack.Conf.S) =
 struct
   type endpoint = unit
@@ -76,14 +76,14 @@ struct
           let v = CA.v
         end
 
-        include Irmin.Private.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+        include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
       end
 
       module Commit = struct
         module Commit = Commit.Make (H)
         module Pack_value = Irmin_pack.Pack_value.Of_commit (H) (Commit)
         module CA = CA_mem (H) (Pack_value)
-        include Irmin.Private.Commit.Store (Info) (Node) (CA) (H) (Commit)
+        include Irmin.Commit.Store (Info) (Node) (CA) (H) (Commit)
       end
 
       module Branch = struct

--- a/src/irmin-pack/mem/irmin_pack_mem.mli
+++ b/src/irmin-pack/mem/irmin_pack_mem.mli
@@ -18,5 +18,4 @@
     backend, intended for users that must be interoperable with the
     idiosyncrasies of the persistent implementation. *)
 
-module Maker (_ : Irmin.Private.Node.Maker) (_ : Irmin.Private.Commit.Maker) :
-  Irmin_pack.Maker
+module Maker (_ : Irmin.Node.Maker) (_ : Irmin.Commit.Maker) : Irmin_pack.Maker

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -46,6 +46,6 @@ module type Sigs = sig
   module Of_contents (Hash : Irmin.Hash.S) (Contents : Irmin.Contents.S) :
     S with type t = Contents.t and type hash = Hash.t
 
-  module Of_commit (Hash : Irmin.Hash.S) (Commit : Irmin.Private.Commit.S) :
+  module Of_commit (Hash : Irmin.Hash.S) (Commit : Irmin.Commit.S) :
     S with type t = Commit.t and type hash = Hash.t
 end

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -85,7 +85,7 @@ end
 
 module Make_helpers (S : S) = struct
   module P = S.Private
-  module Graph = Irmin.Private.Node.Graph (P.Node)
+  module Graph = Irmin.Node.Graph (P.Node)
 
   let info message =
     let date = Int64.of_float 0. in

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -23,8 +23,8 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make_Layered (S : Layered_store) = struct
   module P = S.Private
-  module Graph = Irmin.Private.Node.Graph (P.Node)
-  module History = Irmin.Private.Commit.History (P.Commit)
+  module Graph = Irmin.Node.Graph (P.Node)
+  module History = Irmin.Commit.History (P.Commit)
 
   let info message =
     let date = Int64.of_float 0. in

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -23,7 +23,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make (S : S) = struct
   include Common.Make_helpers (S)
-  module History = Irmin.Private.Commit.History (P.Commit)
+  module History = Irmin.Commit.History (P.Commit)
 
   let with_binding k v t = S.Tree.add t k v
   let random_value value = random_string value

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -29,6 +29,8 @@ module Dot = Dot.Make
 module Hash = Hash
 module Path = Path
 module Perms = Perms
+module Node = Node
+module Commit = Commit
 
 exception Closed = Store_properties.Closed
 
@@ -141,8 +143,6 @@ module type KV_maker = Store.KV_maker
 
 module Private = struct
   module Conf = Conf
-  module Node = Node
-  module Commit = Commit
   module Slice = Slice
   module Remote = Remote
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -120,6 +120,8 @@ module Contents = Contents
     {{!Contents.Json} JSON} contents are provided. *)
 
 module Branch = Branch
+module Node = Node
+module Commit = Commit
 
 type remote = Remote.t = ..
 (** The type for remote stores. *)
@@ -143,8 +145,6 @@ module Private : sig
   module Watch = Watch
   module Lock = Lock
   module Lru = Lru
-  module Node = Node
-  module Commit = Commit
   module Slice = Slice
   module Remote = Remote
 
@@ -450,8 +450,8 @@ module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
 module Maker_ext
     (CA : Content_addressable.Maker)
     (AW : Atomic_write.Maker)
-    (Node : Private.Node.Maker)
-    (Commit : Private.Commit.Maker) :
+    (Node : Node.Maker)
+    (Commit : Commit.Maker) :
   Maker with type endpoint = unit and type info = Commit.Info.t
 
 (** Advanced store creator. *)

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -17,8 +17,8 @@
 module Hash = Irmin.Hash.BLAKE2B
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
-module Node = Irmin.Private.Node.Make
-module Commit = Irmin.Private.Commit
+module Node = Irmin.Node.Make
+module Commit = Irmin.Commit
 
 module Conf = struct
   let entries = 32

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -34,8 +34,8 @@ module Hash = Irmin.Hash.SHA1
 module S = struct
   module P = Irmin.Path.String_list
   module M = Irmin.Metadata.None
-  module XNode = Irmin.Private.Node.Make
-  module XCommit = Irmin.Private.Commit
+  module XNode = Irmin.Node.Make
+  module XCommit = Irmin.Commit
 
   module Maker =
     Irmin_pack.Maker_ext (Irmin_pack.Version.V2) (Conf) (XNode) (XCommit)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -31,7 +31,7 @@ let log_size = 1000
 
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
-module Node = Irmin.Private.Node.Make (H) (Path) (Metadata)
+module Node = Irmin.Node.Make (H) (Path) (Metadata)
 module Index = Irmin_pack.Index.Make (H)
 module Inter = Irmin_pack.Inode.Make_internal (Conf) (H) (Node)
 module Inode = Irmin_pack.Inode.Make_persistent (H) (Node) (Inter) (P)

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -25,9 +25,8 @@ end
 let test_dir = Filename.concat "_build" "test-db-pack"
 
 module Irmin_pack_maker =
-  Irmin_pack.Maker_ext (Irmin_pack.Version.V2) (Config)
-    (Irmin.Private.Node.Make)
-    (Irmin.Private.Commit)
+  Irmin_pack.Maker_ext (Irmin_pack.Version.V2) (Config) (Irmin.Node.Make)
+    (Irmin.Commit)
 
 let suite_pack =
   let store =
@@ -87,7 +86,7 @@ let suite_pack =
   }
 
 module Irmin_pack_mem_maker =
-  Irmin_pack_mem.Maker (Irmin.Private.Node.Make) (Irmin.Private.Commit) (Config)
+  Irmin_pack_mem.Maker (Irmin.Node.Make) (Irmin.Commit) (Config)
 
 let suite_mem =
   let store =


### PR DESCRIPTION
Refactoring extracted from https://github.com/mirage/irmin/pull/1470/files.

These modules aren't "Private" in the sense of only being necessary for defining backends; they're just customised less often than the main user-definable objects (contents, hash, path, etc.).

This commit moves `Irmin.Private.Commit` to `Irmin.Commit` (and likewise for `Node`) to reflect this.