### PR TITLE
[RFC] Define custom `Irmin_pack.Schema` module type

### DIFF
--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -51,13 +51,10 @@ module Schema = struct
   module Node = Irmin.Node.Make (Hash) (Path) (Metadata)
   module Commit = Irmin.Commit.Make (Hash)
   module Info = Irmin.Info.Default
+  module Config = Conf
 end
 
-module Store = struct
-  open Irmin_pack_layered.Maker (Conf)
-  include Make (Schema)
-end
-
+module Store = Irmin_pack_layered.Make (Schema)
 module Info = Info (Store.Info)
 
 let configure_store root merge_throttle freeze_throttle =

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -21,10 +21,8 @@ module Config = struct
   let stable_hash = 3
 end
 
-module KV = struct
-  module Maker = Irmin_pack.KV (Irmin_pack.Version.V2) (Config)
-  include Maker.Make (Irmin.Contents.String)
-end
+module KV =
+  Irmin_pack.KV (Irmin_pack.Version.V2) (Config) (Irmin.Contents.String)
 
 module Bench = Irmin_bench.Make (KV)
 

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -17,226 +17,223 @@
 open! Import
 module IO = IO.Unix
 
-module Maker (V : Version.S) (Config : Conf.S) = struct
-  type endpoint = unit
-
-  module Make (Schema : Irmin.Schema.S) = struct
-    open struct
-      module H = Schema.Hash
-      module P = Schema.Path
-      module M = Schema.Metadata
-      module C = Schema.Contents
-      module B = Schema.Branch
-    end
-
-    module Index = Pack_index.Make (H)
-    module Pack = Pack_store.Maker (V) (Index) (H)
-    module Dict = Pack_dict.Make (V)
-
-    module X = struct
-      module Hash = H
-
-      type 'a value = { hash : H.t; kind : Pack_value.Kind.t; v : 'a }
-      [@@deriving irmin]
-
-      module Contents = struct
-        module Pack_value = Pack_value.Of_contents (H) (C)
-        module CA = Pack.Make (Pack_value)
-        include Irmin.Contents.Store (CA) (H) (C)
-      end
-
-      module Node = struct
-        module CA = struct
-          module Inter = Inode.Make_internal (Config) (H) (Schema.Node)
-          include Inode.Make_persistent (H) (Schema.Node) (Inter) (Pack)
-        end
-
-        include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
-      end
-
-      module Schema = struct
-        include Schema
-        module Node = Node
-      end
-
-      module Commit = struct
-        module Pack_value =
-          Pack_value.Of_commit
-            (H)
-            (struct
-              module Info = Schema.Info
-              include Schema.Commit
-            end)
-
-        module CA = Pack.Make (Pack_value)
-        include Irmin.Commit.Store (Schema.Info) (Node) (CA) (H) (Schema.Commit)
-      end
-
-      module Branch = struct
-        module Key = B
-        module Val = H
-        module AW = Atomic_write.Make_persistent (V) (Key) (Val)
-        include Atomic_write.Closeable (AW)
-
-        let v ?fresh ?readonly path =
-          AW.v ?fresh ?readonly path >|= make_closeable
-      end
-
-      module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
-      module Remote = Irmin.Private.Remote.None (H) (B)
-
-      module Repo = struct
-        type t = {
-          config : Irmin.Private.Conf.t;
-          contents : read Contents.CA.t;
-          node : read Node.CA.t;
-          commit : read Commit.CA.t;
-          branch : Branch.t;
-          index : Index.t;
-        }
-
-        let contents_t t : 'a Contents.t = t.contents
-        let node_t t : 'a Node.t = (contents_t t, t.node)
-        let commit_t t : 'a Commit.t = (node_t t, t.commit)
-        let branch_t t = t.branch
-
-        let batch t f =
-          Commit.CA.batch t.commit (fun commit ->
-              Node.CA.batch t.node (fun node ->
-                  Contents.CA.batch t.contents (fun contents ->
-                      let contents : 'a Contents.t = contents in
-                      let node : 'a Node.t = (contents, node) in
-                      let commit : 'a Commit.t = (node, commit) in
-                      f contents node commit)))
-
-        let unsafe_v config =
-          let root = Conf.root config in
-          let fresh = Conf.fresh config in
-          let lru_size = Conf.lru_size config in
-          let readonly = Conf.readonly config in
-          let log_size = Conf.index_log_size config in
-          let throttle = Conf.merge_throttle config in
-          let f = ref (fun () -> ()) in
-          let index =
-            Index.v
-              ~flush_callback:(fun () -> !f ())
-                (* backpatching to add pack flush before an index flush *)
-              ~fresh ~readonly ~throttle ~log_size root
-          in
-          let* contents =
-            Contents.CA.v ~fresh ~readonly ~lru_size ~index root
-          in
-          let* node = Node.CA.v ~fresh ~readonly ~lru_size ~index root in
-          let* commit = Commit.CA.v ~fresh ~readonly ~lru_size ~index root in
-          let+ branch = Branch.v ~fresh ~readonly root in
-          (* Stores share instances in memory, one flush is enough. In case of a
-             system crash, the flush_callback might not make with the disk. In
-             this case, when the store is reopened, [integrity_check] needs to be
-             called to repair the store. *)
-          (f := fun () -> Contents.CA.flush ~index:false contents);
-          { contents; node; commit; branch; config; index }
-
-        let close t =
-          Index.close t.index;
-          Contents.CA.close (contents_t t) >>= fun () ->
-          Node.CA.close (snd (node_t t)) >>= fun () ->
-          Commit.CA.close (snd (commit_t t)) >>= fun () -> Branch.close t.branch
-
-        let v config =
-          Lwt.catch
-            (fun () -> unsafe_v config)
-            (function
-              | Version.Invalid { expected; found } as e
-                when expected = V.version ->
-                  Log.err (fun m ->
-                      m "[%s] Attempted to open store of unsupported version %a"
-                        (Conf.root config) Version.pp found);
-                  Lwt.fail e
-              | e -> Lwt.fail e)
-
-        (** Stores share instances in memory, one sync is enough. However each
-            store has its own lru and all have to be cleared. *)
-        let sync t =
-          let on_generation_change () =
-            Node.CA.clear_caches (snd (node_t t));
-            Commit.CA.clear_caches (snd (commit_t t))
-          in
-          Contents.CA.sync ~on_generation_change (contents_t t)
-
-        (** Stores share instances so one clear is enough. *)
-        let clear t = Contents.CA.clear (contents_t t)
-
-        let flush t =
-          Contents.CA.flush (contents_t t);
-          Branch.flush t.branch
-      end
-    end
-
-    let integrity_check ?ppf ~auto_repair t =
-      let module Checks = Checks.Index (Index) in
-      let contents = X.Repo.contents_t t in
-      let nodes = X.Repo.node_t t |> snd in
-      let commits = X.Repo.commit_t t |> snd in
-      let check ~kind ~offset ~length k =
-        match kind with
-        | `Contents -> X.Contents.CA.integrity_check ~offset ~length k contents
-        | `Node -> X.Node.CA.integrity_check ~offset ~length k nodes
-        | `Commit -> X.Commit.CA.integrity_check ~offset ~length k commits
-      in
-      Checks.integrity_check ?ppf ~auto_repair ~check t.index
-
-    include Irmin.Of_private (X)
-
-    let integrity_check_inodes ?heads t =
-      Log.debug (fun l -> l "Check integrity for inodes");
-      let bar, (_, progress_nodes, progress_commits) =
-        Utils.Progress.increment ()
-      in
-      let errors = ref [] in
-      let nodes = X.Repo.node_t t |> snd in
-      let node k =
-        progress_nodes ();
-        X.Node.CA.integrity_check_inodes nodes k >|= function
-        | Ok () -> ()
-        | Error msg -> errors := msg :: !errors
-      in
-      let commit _ =
-        progress_commits ();
-        Lwt.return_unit
-      in
-      let* heads =
-        match heads with None -> Repo.heads t | Some m -> Lwt.return m
-      in
-      let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
-      let+ () =
-        Repo.iter ~cache_size:1_000_000 ~min:[] ~max:hashes ~node ~commit t
-      in
-      Utils.Progress.finalise bar;
-      let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
-      if !errors = [] then
-        Fmt.kstrf (fun x -> Ok (`Msg x)) "Ok for heads %a" pp_commits heads
-      else
-        Fmt.kstrf
-          (fun x -> Error (`Msg x))
-          "Inconsistent inodes found for heads %a: %a" pp_commits heads
-          Fmt.(list ~sep:comma string)
-          !errors
-
-    let sync = X.Repo.sync
-    let clear = X.Repo.clear
-    let migrate = Migrate.run
-    let flush = X.Repo.flush
-
-    module Reconstruct_index = Reconstruct_index.Make (struct
-      module Version = V
-      module Hash = H
-      module Index = Index
-      module Inode = X.Node.CA
-      module Dict = Dict
-      module Contents = X.Contents.Pack_value
-      module Commit = X.Commit.Pack_value
-    end)
-
-    let reconstruct_index = Reconstruct_index.run
+module Make (Schema : Schema.S) = struct
+  open struct
+    module H = Schema.Hash
+    module P = Schema.Path
+    module M = Schema.Metadata
+    module C = Schema.Contents
+    module B = Schema.Branch
+    module V = Schema.Version
   end
+
+  module Index = Pack_index.Make (H)
+  module Pack = Pack_store.Maker (V) (Index) (H)
+  module Dict = Pack_dict.Make (V)
+
+  module X = struct
+    module Hash = H
+
+    type 'a value = { hash : H.t; kind : Pack_value.Kind.t; v : 'a }
+    [@@deriving irmin]
+
+    module Contents = struct
+      module Pack_value = Pack_value.Of_contents (H) (C)
+      module CA = Pack.Make (Pack_value)
+      include Irmin.Contents.Store (CA) (H) (C)
+    end
+
+    module Node = struct
+      module CA = struct
+        module Inter = Inode.Make_internal (Schema.Config) (H) (Schema.Node)
+        include Inode.Make_persistent (H) (Schema.Node) (Inter) (Pack)
+      end
+
+      include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+    end
+
+    module Schema = struct
+      include Schema
+      module Node = Node
+    end
+
+    module Commit = struct
+      module Pack_value =
+        Pack_value.Of_commit
+          (H)
+          (struct
+            module Info = Schema.Info
+            include Schema.Commit
+          end)
+
+      module CA = Pack.Make (Pack_value)
+      include Irmin.Commit.Store (Schema.Info) (Node) (CA) (H) (Schema.Commit)
+    end
+
+    module Branch = struct
+      module Key = B
+      module Val = H
+      module AW = Atomic_write.Make_persistent (V) (Key) (Val)
+      include Atomic_write.Closeable (AW)
+
+      let v ?fresh ?readonly path =
+        AW.v ?fresh ?readonly path >|= make_closeable
+    end
+
+    module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
+    module Remote = Irmin.Private.Remote.None (H) (B)
+
+    module Repo = struct
+      type t = {
+        config : Irmin.Private.Conf.t;
+        contents : read Contents.CA.t;
+        node : read Node.CA.t;
+        commit : read Commit.CA.t;
+        branch : Branch.t;
+        index : Index.t;
+      }
+
+      let contents_t t : 'a Contents.t = t.contents
+      let node_t t : 'a Node.t = (contents_t t, t.node)
+      let commit_t t : 'a Commit.t = (node_t t, t.commit)
+      let branch_t t = t.branch
+
+      let batch t f =
+        Commit.CA.batch t.commit (fun commit ->
+            Node.CA.batch t.node (fun node ->
+                Contents.CA.batch t.contents (fun contents ->
+                    let contents : 'a Contents.t = contents in
+                    let node : 'a Node.t = (contents, node) in
+                    let commit : 'a Commit.t = (node, commit) in
+                    f contents node commit)))
+
+      let unsafe_v config =
+        let root = Conf.root config in
+        let fresh = Conf.fresh config in
+        let lru_size = Conf.lru_size config in
+        let readonly = Conf.readonly config in
+        let log_size = Conf.index_log_size config in
+        let throttle = Conf.merge_throttle config in
+        let f = ref (fun () -> ()) in
+        let index =
+          Index.v
+            ~flush_callback:(fun () -> !f ())
+              (* backpatching to add pack flush before an index flush *)
+            ~fresh ~readonly ~throttle ~log_size root
+        in
+        let* contents = Contents.CA.v ~fresh ~readonly ~lru_size ~index root in
+        let* node = Node.CA.v ~fresh ~readonly ~lru_size ~index root in
+        let* commit = Commit.CA.v ~fresh ~readonly ~lru_size ~index root in
+        let+ branch = Branch.v ~fresh ~readonly root in
+        (* Stores share instances in memory, one flush is enough. In case of a
+           system crash, the flush_callback might not make with the disk. In
+           this case, when the store is reopened, [integrity_check] needs to be
+           called to repair the store. *)
+        (f := fun () -> Contents.CA.flush ~index:false contents);
+        { contents; node; commit; branch; config; index }
+
+      let close t =
+        Index.close t.index;
+        Contents.CA.close (contents_t t) >>= fun () ->
+        Node.CA.close (snd (node_t t)) >>= fun () ->
+        Commit.CA.close (snd (commit_t t)) >>= fun () -> Branch.close t.branch
+
+      let v config =
+        Lwt.catch
+          (fun () -> unsafe_v config)
+          (function
+            | Version.Invalid { expected; found } as e when expected = V.version
+              ->
+                Log.err (fun m ->
+                    m "[%s] Attempted to open store of unsupported version %a"
+                      (Conf.root config) Version.pp found);
+                Lwt.fail e
+            | e -> Lwt.fail e)
+
+      (** Stores share instances in memory, one sync is enough. However each
+          store has its own lru and all have to be cleared. *)
+      let sync t =
+        let on_generation_change () =
+          Node.CA.clear_caches (snd (node_t t));
+          Commit.CA.clear_caches (snd (commit_t t))
+        in
+        Contents.CA.sync ~on_generation_change (contents_t t)
+
+      (** Stores share instances so one clear is enough. *)
+      let clear t = Contents.CA.clear (contents_t t)
+
+      let flush t =
+        Contents.CA.flush (contents_t t);
+        Branch.flush t.branch
+    end
+  end
+
+  let integrity_check ?ppf ~auto_repair t =
+    let module Checks = Checks.Index (Index) in
+    let contents = X.Repo.contents_t t in
+    let nodes = X.Repo.node_t t |> snd in
+    let commits = X.Repo.commit_t t |> snd in
+    let check ~kind ~offset ~length k =
+      match kind with
+      | `Contents -> X.Contents.CA.integrity_check ~offset ~length k contents
+      | `Node -> X.Node.CA.integrity_check ~offset ~length k nodes
+      | `Commit -> X.Commit.CA.integrity_check ~offset ~length k commits
+    in
+    Checks.integrity_check ?ppf ~auto_repair ~check t.index
+
+  module Schema' = Schema
+  include Irmin.Of_private (X)
+  module Schema = Schema'
+
+  let integrity_check_inodes ?heads t =
+    Log.debug (fun l -> l "Check integrity for inodes");
+    let bar, (_, progress_nodes, progress_commits) =
+      Utils.Progress.increment ()
+    in
+    let errors = ref [] in
+    let nodes = X.Repo.node_t t |> snd in
+    let node k =
+      progress_nodes ();
+      X.Node.CA.integrity_check_inodes nodes k >|= function
+      | Ok () -> ()
+      | Error msg -> errors := msg :: !errors
+    in
+    let commit _ =
+      progress_commits ();
+      Lwt.return_unit
+    in
+    let* heads =
+      match heads with None -> Repo.heads t | Some m -> Lwt.return m
+    in
+    let hashes = List.map (fun x -> `Commit (Commit.hash x)) heads in
+    let+ () =
+      Repo.iter ~cache_size:1_000_000 ~min:[] ~max:hashes ~node ~commit t
+    in
+    Utils.Progress.finalise bar;
+    let pp_commits = Fmt.list ~sep:Fmt.comma Commit.pp_hash in
+    if !errors = [] then
+      Fmt.kstrf (fun x -> Ok (`Msg x)) "Ok for heads %a" pp_commits heads
+    else
+      Fmt.kstrf
+        (fun x -> Error (`Msg x))
+        "Inconsistent inodes found for heads %a: %a" pp_commits heads
+        Fmt.(list ~sep:comma string)
+        !errors
+
+  let sync = X.Repo.sync
+  let clear = X.Repo.clear
+  let migrate = Migrate.run
+  let flush = X.Repo.flush
+
+  module Reconstruct_index = Reconstruct_index.Make (struct
+    module Version = V
+    module Hash = H
+    module Index = Index
+    module Inode = X.Node.CA
+    module Dict = Dict
+    module Contents = X.Contents.Pack_value
+    module Commit = X.Commit.Pack_value
+  end)
+
+  let reconstruct_index = Reconstruct_index.run
 end

--- a/src/irmin-pack/ext.mli
+++ b/src/irmin-pack/ext.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Maker (_ : Version.S) (_ : Conf.S) : S.Maker
+module Make : S.Maker

--- a/src/irmin-pack/layered/ext_layered.mli
+++ b/src/irmin-pack/layered/ext_layered.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Maker (_ : Irmin_pack.Conf.S) : S.Maker
+module Make : S.Maker

--- a/src/irmin-pack/layered/irmin_pack_layered.ml
+++ b/src/irmin-pack/layered/irmin_pack_layered.ml
@@ -19,7 +19,7 @@ include Ext_layered
 module type S = S.Store
 module type Maker = S.Maker
 
-module Maker = Ext_layered.Maker
+module Make = Ext_layered.Make
 module Checks = Checks
 
 let config = Conf.v

--- a/src/irmin-pack/layered/irmin_pack_layered.mli
+++ b/src/irmin-pack/layered/irmin_pack_layered.mli
@@ -42,5 +42,5 @@ end
 
 module type Maker = S.Maker
 
-module Maker (_ : Irmin_pack.Conf.S) : Maker
+module Make : Maker
 module Checks = Checks

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -32,16 +32,8 @@ module type Store = sig
     list
 end
 
-module type Maker = sig
-  type endpoint = unit
-
-  module Make (Schema : Irmin.Schema.S) :
-    Store
-      with module Schema = Schema
-       and type Private.Remote.endpoint = endpoint
-end
-
-module Maker_is_a_maker (X : Maker) : Irmin.Maker = X
+module type Maker = functor (Schema : Irmin_pack.Schema.Unversioned) ->
+  Store with module Schema = Schema and type Private.Remote.endpoint = unit
 
 module type Layered_general = sig
   type 'a t

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -36,123 +36,121 @@ struct
   let v x = CA_mem.v x >|= make_closeable
 end
 
-module Maker (Config : Irmin_pack.Conf.S) = struct
-  type endpoint = unit
+module Make (Schema : Irmin_pack.Schema.Unversioned) = struct
+  module H = Schema.Hash
+  module C = Schema.Contents
+  module P = Schema.Path
+  module M = Schema.Metadata
+  module B = Schema.Branch
+  module Pack = Content_addressable.Maker (H)
 
-  module Make (Schema : Irmin.Schema.S) = struct
-    module H = Schema.Hash
-    module C = Schema.Contents
-    module P = Schema.Path
-    module M = Schema.Metadata
-    module B = Schema.Branch
-    module Pack = Content_addressable.Maker (H)
+  module X = struct
+    module Schema = Schema
+    module Hash = H
+    module Info = Schema.Info
 
-    module X = struct
-      module Schema = Schema
-      module Hash = H
-      module Info = Schema.Info
-
-      module Contents = struct
-        module Pack_value = Irmin_pack.Pack_value.Of_contents (H) (C)
-        module CA = CA_mem (H) (Pack_value)
-        include Irmin.Contents.Store (CA) (H) (C)
-      end
-
-      module Node = struct
-        module CA = struct
-          module Inter =
-            Irmin_pack.Inode.Make_internal (Config) (H) (Schema.Node)
-
-          module CA = Pack.Make (Inter.Raw)
-          include Irmin_pack.Inode.Make (H) (Schema.Node) (Inter) (CA)
-
-          let v = CA.v
-        end
-
-        include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
-      end
-
-      module Commit = struct
-        module Pack_value =
-          Irmin_pack.Pack_value.Of_commit
-            (H)
-            (struct
-              module Info = Schema.Info
-              include Schema.Commit
-            end)
-
-        module CA = CA_mem (H) (Pack_value)
-        include Irmin.Commit.Store (Info) (Node) (CA) (H) (Schema.Commit)
-      end
-
-      module Branch = struct
-        module Key = B
-        module Val = H
-        module AW = Atomic_write (Key) (Val)
-        include Irmin_pack.Atomic_write.Closeable (AW)
-
-        let v () = AW.v () >|= make_closeable
-      end
-
-      module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
-      module Remote = Irmin.Private.Remote.None (H) (B)
-
-      module Repo = struct
-        type t = {
-          config : Irmin.Private.Conf.t;
-          contents : read Contents.CA.t;
-          node : read Node.CA.t;
-          commit : read Commit.CA.t;
-          branch : Branch.t;
-        }
-
-        let contents_t t : 'a Contents.t = t.contents
-        let node_t t : 'a Node.t = (contents_t t, t.node)
-        let commit_t t : 'a Commit.t = (node_t t, t.commit)
-        let branch_t t = t.branch
-
-        let batch t f =
-          Commit.CA.batch t.commit (fun commit ->
-              Node.CA.batch t.node (fun node ->
-                  Contents.CA.batch t.contents (fun contents ->
-                      let contents : 'a Contents.t = contents in
-                      let node : 'a Node.t = (contents, node) in
-                      let commit : 'a Commit.t = (node, commit) in
-                      f contents node commit)))
-
-        let v config =
-          let root = Irmin_pack.Conf.root config in
-          let* contents = Contents.CA.v root in
-          let* node = Node.CA.v root in
-          let* commit = Commit.CA.v root in
-          let+ branch = Branch.v () in
-          { contents; node; commit; branch; config }
-
-        let close t =
-          Contents.CA.close (contents_t t) >>= fun () ->
-          Node.CA.close (snd (node_t t)) >>= fun () ->
-          Commit.CA.close (snd (commit_t t)) >>= fun () -> Branch.close t.branch
-
-        (* An in-memory store is always in sync. *)
-        let sync _ = ()
-        let flush _ = ()
-
-        (* Stores share instances so one clear is enough. *)
-        let clear t = Contents.CA.clear (contents_t t)
-      end
+    module Contents = struct
+      module Pack_value = Irmin_pack.Pack_value.Of_contents (H) (C)
+      module CA = CA_mem (H) (Pack_value)
+      include Irmin.Contents.Store (CA) (H) (C)
     end
 
-    include Irmin.Of_private (X)
+    module Node = struct
+      module CA = struct
+        module Inter =
+          Irmin_pack.Inode.Make_internal (Schema.Config) (H) (Schema.Node)
 
-    let integrity_check_inodes ?heads:_ _ =
-      Lwt.return
-        (Error (`Msg "Not supported: integrity checking of in-memory inodes"))
+        module CA = Pack.Make (Inter.Raw)
+        include Irmin_pack.Inode.Make (H) (Schema.Node) (Inter) (CA)
 
-    let sync = X.Repo.sync
-    let clear = X.Repo.clear
-    let migrate = Irmin_pack.migrate
-    let flush = X.Repo.flush
-    let integrity_check ?ppf:_ ~auto_repair:_ _t = Ok `No_error
-    let reconstruct_index ?output:_ _ = ()
+        let v = CA.v
+      end
+
+      include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+    end
+
+    module Commit = struct
+      module Pack_value =
+        Irmin_pack.Pack_value.Of_commit
+          (H)
+          (struct
+            module Info = Schema.Info
+            include Schema.Commit
+          end)
+
+      module CA = CA_mem (H) (Pack_value)
+      include Irmin.Commit.Store (Info) (Node) (CA) (H) (Schema.Commit)
+    end
+
+    module Branch = struct
+      module Key = B
+      module Val = H
+      module AW = Atomic_write (Key) (Val)
+      include Irmin_pack.Atomic_write.Closeable (AW)
+
+      let v () = AW.v () >|= make_closeable
+    end
+
+    module Slice = Irmin.Private.Slice.Make (Contents) (Node) (Commit)
+    module Remote = Irmin.Private.Remote.None (H) (B)
+
+    module Repo = struct
+      type t = {
+        config : Irmin.Private.Conf.t;
+        contents : read Contents.CA.t;
+        node : read Node.CA.t;
+        commit : read Commit.CA.t;
+        branch : Branch.t;
+      }
+
+      let contents_t t : 'a Contents.t = t.contents
+      let node_t t : 'a Node.t = (contents_t t, t.node)
+      let commit_t t : 'a Commit.t = (node_t t, t.commit)
+      let branch_t t = t.branch
+
+      let batch t f =
+        Commit.CA.batch t.commit (fun commit ->
+            Node.CA.batch t.node (fun node ->
+                Contents.CA.batch t.contents (fun contents ->
+                    let contents : 'a Contents.t = contents in
+                    let node : 'a Node.t = (contents, node) in
+                    let commit : 'a Commit.t = (node, commit) in
+                    f contents node commit)))
+
+      let v config =
+        let root = Irmin_pack.Conf.root config in
+        let* contents = Contents.CA.v root in
+        let* node = Node.CA.v root in
+        let* commit = Commit.CA.v root in
+        let+ branch = Branch.v () in
+        { contents; node; commit; branch; config }
+
+      let close t =
+        Contents.CA.close (contents_t t) >>= fun () ->
+        Node.CA.close (snd (node_t t)) >>= fun () ->
+        Commit.CA.close (snd (commit_t t)) >>= fun () -> Branch.close t.branch
+
+      (* An in-memory store is always in sync. *)
+      let sync _ = ()
+      let flush _ = ()
+
+      (* Stores share instances so one clear is enough. *)
+      let clear t = Contents.CA.clear (contents_t t)
+    end
   end
+
+  module Schema' = Schema
+  include Irmin.Of_private (X)
+  module Schema = Schema'
+
+  let integrity_check_inodes ?heads:_ _ =
+    Lwt.return
+      (Error (`Msg "Not supported: integrity checking of in-memory inodes"))
+
+  let sync = X.Repo.sync
+  let clear = X.Repo.clear
+  let migrate = Irmin_pack.migrate
+  let flush = X.Repo.flush
+  let integrity_check ?ppf:_ ~auto_repair:_ _t = Ok `No_error
+  let reconstruct_index ?output:_ _ = ()
 end

--- a/src/irmin-pack/mem/irmin_pack_mem.mli
+++ b/src/irmin-pack/mem/irmin_pack_mem.mli
@@ -18,4 +18,4 @@
     backend, intended for users that must be interoperable with the
     idiosyncrasies of the persistent implementation. *)
 
-module Maker : Irmin_pack.Maker
+module Make : Irmin_pack.Maker_unversioned

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -83,11 +83,8 @@ end
 
 module S_is_a_store (X : S) : Irmin.S = X
 
-module type Maker = sig
-  type endpoint = unit
+module type Maker_unversioned = functor (Schema : Schema.Unversioned) ->
+  S with module Schema = Schema and type Private.Remote.endpoint = unit
 
-  module Make (Schema : Irmin.Schema.S) :
-    S with module Schema = Schema and type Private.Remote.endpoint = endpoint
-end
-
-module Maker_is_a_maker (X : Maker) : Irmin.Maker with type endpoint = unit = X
+module type Maker = functor (Schema : Schema.S) ->
+  S with module Schema = Schema and type Private.Remote.endpoint = unit

--- a/src/irmin-pack/schema.ml
+++ b/src/irmin-pack/schema.ml
@@ -1,0 +1,9 @@
+module type Unversioned = sig
+  include Irmin.Schema.S
+  module Config : Conf.S
+end
+
+module type S = sig
+  include Unversioned
+  module Version : Version.S
+end

--- a/src/irmin/schema.ml
+++ b/src/irmin/schema.ml
@@ -22,14 +22,13 @@ module type S = sig
   module Commit : Commit.S with type hash = Hash.t and module Info := Info
   module Metadata : Metadata.S
   module Path : Path.S
+  module Contents : Contents.S
 
   module Node :
     Node.S
       with type metadata = Metadata.t
        and type hash = Hash.t
        and type step = Path.step
-
-  module Contents : Contents.S
 end
 
 module type KV =

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -2,16 +2,10 @@ open! Import
 
 let test_dir = Filename.concat "_build" "test-pack-trace-replay"
 
-module Conf = struct
-  let entries = 32
-  let stable_hash = 256
-end
-
 module Store = struct
   type store_config = string
 
-  module Maker = Irmin_pack.V1 (Conf)
-  module Store = Maker.Make (Tezos_context_hash_irmin.Encoding)
+  module Store = Irmin_pack.V1 (Tezos_context_hash_irmin.Encoding)
 
   let create_repo store_dir =
     let conf = Irmin_pack.config ~readonly:false ~fresh:true store_dir in
@@ -65,7 +59,8 @@ let replay_1_commit () =
       ncommits_trace = 1;
       store_dir;
       path_conversion = `None;
-      inode_config = (Conf.entries, Conf.stable_hash);
+      inode_config =
+        Tezos_context_hash_irmin.Encoding.Config.(entries, stable_hash);
       store_type = `Pack;
       commit_data_file = trace_path;
       artefacts_dir = test_dir;
@@ -82,8 +77,7 @@ let replay_1_commit () =
 module Store_mem = struct
   type store_config = string
 
-  module Maker = Irmin_pack_mem.Maker (Conf)
-  module Store = Maker.Make (Tezos_context_hash_irmin.Encoding)
+  module Store = Irmin_pack_mem.Make (Tezos_context_hash_irmin.Encoding)
 
   let create_repo store_dir =
     let conf = Irmin_pack.config ~readonly:false ~fresh:true store_dir in
@@ -118,7 +112,8 @@ let replay_1_commit_mem () =
       ncommits_trace = 1;
       store_dir;
       path_conversion = `None;
-      inode_config = (Conf.entries, Conf.stable_hash);
+      inode_config =
+        Tezos_context_hash_irmin.Encoding.Config.(entries, stable_hash);
       store_type = `Pack;
       commit_data_file = trace_path;
       artefacts_dir = test_dir;

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -25,17 +25,17 @@ let rm_dir () =
     let _ = Sys.command cmd in
     ())
 
-module Conf = struct
-  let entries = 32
-  let stable_hash = 256
+module Schema = struct
+  include Irmin.Schema.KV (Irmin.Contents.String)
+  module Version = Irmin_pack.Version.V2
+
+  module Config = struct
+    let entries = 32
+    let stable_hash = 256
+  end
 end
 
-module Schema = Irmin.Schema.KV (Irmin.Contents.String)
-
-module Store = struct
-  open Irmin_pack_layered.Maker (Conf)
-  include Make (Schema)
-end
+module Store = Irmin_pack_layered.Make (Schema)
 
 let config root =
   let conf = Irmin_pack.config ~readonly:false ~fresh:true root in

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -50,6 +50,12 @@ module Schema = struct
   module Node = Node.Make (Hash) (Path) (Metadata)
   module Commit = Commit.Make (Hash)
   module Info = Info.Default
+  module Version = Irmin_pack.Version.V2
+
+  module Config = struct
+    let entries = 32
+    let stable_hash = 256
+  end
 end
 
 module Contents = struct

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -21,7 +21,7 @@ module I = Index
 module Conf : Irmin_pack.Conf.S
 
 module Schema :
-  Irmin.Schema.S
+  Irmin_pack.Schema.S
     with type Hash.t = Irmin.Hash.SHA1.t
      and type Path.step = string
      and type Path.t = string list

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -41,13 +41,13 @@ module Conf = struct
   let with_lower = true
 end
 
-module Store = struct
-  open Irmin_pack_layered.Maker (Conf)
-  include Make (Schema)
+module Schema = struct
+  include Schema
+  module Config = Conf
 end
 
-module V2 = Irmin_pack.V2 (Conf)
-module StoreSimple = V2.Make (Schema)
+module Store = Irmin_pack_layered.Make (Schema)
+module StoreSimple = Irmin_pack.V2 (Schema)
 
 let config ?(readonly = false) ?(fresh = true) ?(lower_root = Conf.lower_root)
     ?(upper_root0 = Conf.upper0_root) ?(with_lower = Conf.with_lower) root =

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -21,18 +21,9 @@ let root = Filename.concat "_build" "test-instances"
 let src = Logs.Src.create "tests.instances" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
+module S = Irmin_pack.Make (Schema)
 
 let index_log_size = Some 1_000
-
-module Conf = struct
-  let entries = 32
-  let stable_hash = 256
-end
-
-module S = struct
-  module Maker = Irmin_pack.Maker (Irmin_pack.Version.V2) (Conf)
-  include Maker.Make (Schema)
-end
 
 let config ?(readonly = false) ?(fresh = true) root =
   Irmin_pack.config ~readonly ?index_log_size ~fresh root

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -161,15 +161,16 @@ module Config_store = struct
           cmd n
 end
 
-module Small_conf = struct
-  let entries = 2
-  let stable_hash = 3
-end
+module V1 () = Irmin_pack.V1 (struct
+  include (Schema : Irmin_pack.Schema.Unversioned)
 
-module V1_maker = Irmin_pack.V1 (Small_conf)
-module V2_maker = Irmin_pack.V2 (Conf)
-module V1 () = V1_maker.Make (Schema)
-module V2 () = V2_maker.Make (Schema)
+  module Config = struct
+    let entries = 2
+    let stable_hash = 3
+  end
+end)
+
+module V2 () = Irmin_pack.V2 ((Schema : Irmin_pack.Schema.Unversioned))
 
 module Test_store = struct
   module S = V2 ()
@@ -277,11 +278,7 @@ module Config_layered_store = struct
     exec_cmd cmd
 end
 
-module Make_layered = struct
-  open Irmin_pack_layered.Maker (Conf)
-  include Make (Schema)
-end
-
+module Make_layered = Irmin_pack_layered.Make (Schema)
 module Test_layered_store = Test (Make_layered) (Config_layered_store)
 
 module Test_corrupted_stores = struct

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -17,15 +17,34 @@
 open! Import
 open Common
 
-module Config = struct
-  let entries = 2
-  let stable_hash = 3
+module Schema = struct
+  include Schema
+
+  module Config = struct
+    let entries = 2
+    let stable_hash = 3
+  end
 end
 
 let test_dir = Filename.concat "_build" "test-db-pack"
 
-module Irmin_pack_maker = Irmin_pack.V2 (Config)
-module Irmin_pack_layered = Irmin_pack_layered.Maker (Config)
+module Irmin_pack_maker = struct
+  type endpoint = unit
+
+  module Make (S : Irmin.Schema.S) = Irmin_pack.V2 (struct
+    include S
+    module Config = Schema.Config
+  end)
+end
+
+module Irmin_pack_layered = struct
+  type endpoint = unit
+
+  module Make (S : Irmin.Schema.S) = Irmin_pack_layered.Make (struct
+    include S
+    module Config = Schema.Config
+  end)
+end
 
 let suite_pack =
   let store =
@@ -84,7 +103,14 @@ let suite_pack =
     layered_store = Some layered_store;
   }
 
-module Irmin_pack_mem_maker = Irmin_pack_mem.Maker (Config)
+module Irmin_pack_mem_maker = struct
+  type endpoint = unit
+
+  module Make (S : Irmin.Schema.S) = Irmin_pack_mem.Make (struct
+    include S
+    module Config = Schema.Config
+  end)
+end
 
 let suite_mem =
   let store =


### PR DESCRIPTION
CC @ngoguey42, here's a draft of the change you were considering [here](https://github.com/mirage/irmin/pull/1470#discussion_r663780658). I recommend hiding whitespace changes when viewing the diff.

I think this is slightly worse overall for two reasons:

- need to be generic over `Version` / `Config` specifically in a few places;
- no longer subtyping the the core Irmin store constructors.

My take-away from this is that the `Schema.S` abstraction works well for customisable types that propogate through to the `Irmin.S` API, but doesn't compose well with general backend configuration. Happy to hear arguments in favour / suggestions for improvements.