### PR TITLE
Avoid implicit coercions of dangling hashes to empty nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Fixed
 
+- **irmin**
+  - `Tree` operations now raise a `Dangling_hash` exception when called with a
+    path that contains dangling hashes in the underlying store, rather than
+    interpreting such paths as ending with empty nodes (#1477, @CraigFe)
+
 - **irmin-pack**
   - Fix termination condition of reconstruct index (#1468, @Ngoguey42)
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1029,32 +1029,7 @@ module Make (S : S) = struct
       Alcotest.(check inspect) "inspect:3" (`Node `Hash) (S.Tree.inspect v);
       Alcotest.(check int) "val-v:3" 1 (S.Tree.counters ()).node_val_v;
       Alcotest.(check int) "val-list:3" 0 (S.Tree.counters ()).node_val_list;
-
-      (* Test caching (makesure that no tree is lying in scope) *)
-      let v0 = S.Tree.shallow repo (`Node (P.Contents.Key.hash "foo-x")) in
-      S.Tree.reset_counters ();
-      let foo = "foo-x" in
-      let* v0 = S.Tree.add v0 [ "foo" ] foo in
-      (* 2 calls to Node.find because v0 is a shallow tree *)
-      Alcotest.(check int) "1 Node.find" 2 (S.Tree.counters ()).node_find;
-
-      (* cache is filled whenever we hash something *)
-      let _ = S.Tree.hash v0 in
-      let* _v0 = S.Tree.add v0 [ "foo" ] foo in
-      let _k = S.Tree.hash v0 in
-      let v0 = S.Tree.shallow repo (`Node (P.Contents.Key.hash "bar-x")) in
-      let xxx = "xxx" in
-      let yyy = "yyy" in
-      let zzz = "zzz" in
-      let* v0 = S.Tree.add v0 [ "a" ] xxx in
-      S.set_tree_exn ~info t1 [] v0 >>= fun () ->
-      let* v0 = S.get_tree t1 [] in
-      let* v0 = S.Tree.add v0 [ "b" ] xxx in
-      S.set_tree_exn ~info t1 [] v0 >>= fun () ->
-      let* v0 = S.Tree.add v0 [ "c"; "d" ] yyy in
-      let* v0 = S.Tree.add v0 [ "c"; "e"; "f" ] zzz in
-      Alcotest.(check inspect) "inspect" (`Node `Value) (S.Tree.inspect v0);
-      S.set_tree_exn ~info t1 [] v0 >>= fun () -> P.Repo.close repo
+      P.Repo.close repo
     in
     run x test
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -75,6 +75,10 @@ module type S = sig
   (** Operations on lazy nodes can fail if the underlying store does not contain
       the expected hash. *)
 
+  exception Dangling_hash of { context : string; hash : hash }
+  (** The exception raised by functions that can force lazy tree nodes but do
+      not return an explicit {!or_error}. *)
+
   (** Operations on lazy tree contents. *)
   module Contents : sig
     type t

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -56,8 +56,10 @@ module Alcotest = struct
 
   let check_tree_lwt =
     let concrete_tree = gtestable Tree.concrete_t in
-    fun msg ~expected b_lwt ->
-      b_lwt >>= Tree.to_concrete >|= Alcotest.check concrete_tree msg expected
+    fun ?__POS__:pos msg ~expected b_lwt ->
+      b_lwt
+      >>= Tree.to_concrete
+      >|= Alcotest.check ?pos concrete_tree msg expected
 end
 
 let ( >> ) f g x = g (f x)
@@ -559,7 +561,75 @@ let test_shallow _ () =
        non-shallow contents"
       hash hash_shallow
   in
+  Lwt.return_unit
 
+let test_dangling_hash _ () =
+  let check_exn pos f =
+    Lwt.catch
+      (fun () ->
+        let* _ = f () in
+        Alcotest.failf ~pos
+          "Expected a `Dangling_hash` exception, but no exception was raised.")
+      (function Tree.Dangling_hash _ -> Lwt.return_unit | exn -> Lwt.fail exn)
+  in
+  let* shallow_leaf, shallow_node =
+    let+ repo = Store.Repo.v (Irmin_mem.config ()) in
+    (* Get hashes of valid nodes / contents, assumed absent from [repo]. *)
+    let rand = Irmin.Type.(unstage (random (string_of (`Fixed 32)))) () in
+    let c_hash = Tree.(hash @@ of_concrete (c rand)) in
+    let n_hash = Tree.(hash @@ of_concrete (`Tree [ ("k", c rand) ])) in
+    ( Tree.shallow repo (`Contents (c_hash, Metadata.default)),
+      Tree.shallow repo (`Node n_hash) )
+  in
+  let run_tests path =
+    Logs.app (fun f ->
+        f "Testing operations on a tree with a shallowed position at %a" pp_key
+          path);
+    let* shallow_leaf = Tree.(add_tree empty) path shallow_leaf in
+    let* shallow_node = Tree.(add_tree empty) path shallow_node in
+    let beneath = path @ [ "a"; "b"; "c" ] in
+    let blob = "v" in
+    let* singleton_at_path = Tree.(add empty path blob >>= to_concrete) in
+    let* singleton_beneath = Tree.(add empty beneath blob >>= to_concrete) in
+
+    (* [add] on shallow nodes/contents replaces the shallowed position. *)
+    let* () =
+      Tree.add shallow_leaf path blob
+      |> Alcotest.check_tree_lwt ~__POS__ "" ~expected:singleton_at_path
+    in
+    let* () =
+      Tree.add shallow_node path blob
+      |> Alcotest.check_tree_lwt ~__POS__ "" ~expected:singleton_at_path
+    in
+
+    (* [add] _beneath_ a shallow contents value also works fine, but on shallow
+       nodes an exception is raised. (We can't know what the node's contents are,
+       so there's no valid return tree.) *)
+    let* () =
+      Tree.add shallow_leaf beneath blob
+      |> Alcotest.check_tree_lwt ~__POS__ "" ~expected:singleton_beneath
+    in
+    let* () =
+      check_exn __POS__ (fun () -> Tree.add shallow_node beneath blob)
+    in
+
+    (* [find] on shallow contents raises an exception (can't recover contents),
+       but _beneath_ shallow contents it returns [None] (mismatched type). (The
+       behaviour is reversed for shallow nodes.) *)
+    let* () = check_exn __POS__ (fun () -> Tree.find shallow_leaf path) in
+    let* () = check_exn __POS__ (fun () -> Tree.find shallow_node beneath) in
+    let* () =
+      Tree.find shallow_leaf beneath
+      >|= Alcotest.(check ~pos:__POS__ (option reject)) "" None
+    in
+    let* () =
+      Store.Tree.find shallow_node path
+      >|= Alcotest.(check ~pos:__POS__ (option reject)) "" None
+    in
+    Lwt.return_unit
+  in
+  let* () = run_tests [] in
+  let* () = run_tests [ "k" ] in
   Lwt.return_unit
 
 let test_kind_empty_path _ () =
@@ -646,6 +716,7 @@ let suite =
     Alcotest_lwt.test_case "clear" `Quick test_clear;
     Alcotest_lwt.test_case "fold" `Quick test_fold_force;
     Alcotest_lwt.test_case "shallow" `Quick test_shallow;
+    Alcotest_lwt.test_case "dangling hash" `Quick test_dangling_hash;
     Alcotest_lwt.test_case "kind of empty path" `Quick test_kind_empty_path;
     Alcotest_lwt.test_case "generic equality" `Quick test_generic_equality;
     Alcotest_lwt.test_case "is_empty" `Quick test_is_empty;


### PR DESCRIPTION
The existing implementation of `Tree` contains several operations that consider "dangling" hashes (internal tree hashes that are `Not_found` in the underlying store) to be equivalent to empty nodes. For instance:

- `Tree.find` at a path that contains a dangling hash will return `None` (and similarly `Tree.mem` returns `false`).

- `Tree.update` at a path that contains a dangling hash will observe a false empty node at the end of the path (... with similar results for `add` / `remove` etc.)

This behaviour can be triggered by the user using `Tree.shallow`, but also arises when the underlying store is corrupt (and certain internal objects can't be found). In each case, silently coercing to an empty node is surprising, and so this commit changes these operations to raise a `Dangling_hash` exception when this happens instead.

This is a fix for https://github.com/mirage/irmin/issues/1475 that opts for not breaking the API over exposing a richer `result` type in each of the `Tree` operations where this case can occur. I tried the latter, and it produed a lot of churn in consumer code without adding much value. I think for the vast majority of use-cases it makes sense to interpret dangling hashes as unintentional (user error or store corruption) and raise an exception. I still think any future use of trees as proofs would be better served by a dedicated "blind" internal representation vs. overloading the existing "shallow" concept.