### PR TITLE
Add integrity-check-index command to irmin_fsck

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
 - **irmin-mem**
   - Added `Irmin_mem.Content_addressable` (#1369, @samoht)
 
+- **irmin-pack**
+   - Added `integrity-check-index` command in `irmin-fsck`. (#1480, @icristescu,
+     @samoht)
+
 - **irmin-unix**
   - Update `irmin` CLI to raise an exception when an invalid/non-existent
     config file is specified (#1413, @zshipko)

--- a/test/irmin-pack/cli/dune
+++ b/test/irmin-pack/cli/dune
@@ -1,9 +1,7 @@
 (executable
  (name irmin_fsck)
- (public_name irmin_fsck)
- (package irmin-pack)
  (modules irmin_fsck)
- (libraries irmin-pack irmin-pack.layered))
+ (libraries irmin-pack irmin-pack.layered tezos-context-hash-irmin))
 
 (executable
  (name generate)

--- a/test/irmin-pack/cli/irmin-fsck-help.txt
+++ b/test/irmin-pack/cli/irmin-fsck-help.txt
@@ -8,6 +8,9 @@ COMMANDS
        integrity-check
            Check integrity of an existing store.
 
+       integrity-check-index
+           Check index integrity.
+
        integrity-check-inodes
            Check integrity of inodes in an existing store.
 

--- a/test/irmin-pack/cli/stat.t/run.t
+++ b/test/irmin-pack/cli/stat.t/run.t
@@ -1,5 +1,5 @@
 Running stat on a layered store after a first freeze
-  $ PACK_LAYERED=true ../irmin_fsck.exe stat ../data/layered_pack_upper
+  $ PACK=layered ../irmin_fsck.exe stat ../data/layered_pack_upper
   >> Getting statistics for store: `../data/layered_pack_upper'
   
   	0k contents / 0k nodes / 0k commits	0k contents / 0k nodes / 0k commits
@@ -112,5 +112,5 @@ Running stat on a layered store after a first freeze
 
 Running check on a layered store that is not self contained
 
-  $ PACK_LAYERED=true ../irmin_fsck.exe check ../data/layered_pack_upper
+  $ PACK=layered ../irmin_fsck.exe check ../data/layered_pack_upper
   Error -- Upper layer is not self contained for heads 6a88b83f76c48b1b20a0d421c73de6e0e0e42553d44a40fccc07af074f304e0d9f10a7b5ab47b61205da0f2f599d2ebb1bf27452c05b926b0c7ef8f867778130: 2 phantom objects detected


### PR DESCRIPTION
- check a corrupted store
```
time PACK=tezos dune exec -- ./test/irmin-pack/cli/irmin_fsck.exe integrity-check-index ../store/pirbo-tezos-node_20210521/context/
>> Beginning index checking with parameters: { log_size = 500000 }
Reconstructing index     4.8 GiB  09:42  [###############################.]  97%irmin-fsck: internal error, uncaught exception:
            (Failure
              "Pack entry with idx=49_972_463 containing [5254590022,358,\"N\"] is bound to [5313859794,358,\"N\"] in index")
________________________________________________________
Executed in  522.20 secs
```
- reconstruct index 
```
time PACK=tezos dune exec -- ./test/irmin-pack/cli/irmin_fsck.exe reconstruct-index --index-log-size=10_000_000 ../store/pirbo-tezos-node_20210521/context/
>> Beginning index reconstruction with parameters: { log_size = 10000000 }
Reconstructing index   622.4 MiB  01:50  [###.............................]  12%Semaphore replace was blocked for 1.145s
Reconstructing index     2.6 GiB  02:17  [################................]  53%Semaphore merge { id=3 } was blocked for 21.293s
Reconstructing index     3.7 GiB  04:34  [########################........]  75%Semaphore merge { id=4 } was blocked for 21.235s
Reconstructing index     4.8 GiB  05:47  [###############################.]  97%Semaphore merge { id=5 } was blocked for 23.914s
Reconstructing index     5.0 GiB  05:25  [################################] 100%
>> Completed indexing of pack entries. Running a final merge ...
Semaphore merge { id=6 } was blocked for 14.723s
Semaphore close was blocked for 8.965s
>> Success in 5min48s. Store statistics:
  { "Contents" = 6952062;
    "Commit" = 30419;
    "Node" = 38251454;
    "Inode" = 5739746 }

________________________________________________________
Executed in  349.76 secs
```
- but then when rechecking the now repaired store, I still have the same error:
```
time PACK=tezos dune exec -- ./test/irmin-pack/cli/irmin_fsck.exe integrity-check-index ../store/pirbo-tezos-node_20210521/context/
>> Beginning index checking with parameters: { log_size = 500000 }
Reconstructing index     4.8 GiB  04:50  [###############################.]  97%irmin-fsck: internal error, uncaught exception:
            (Failure
              "Pack entry with idx=49_972_463 containing [5254590022,358,\"N\"] is bound to [5313859794,358,\"N\"] in index")


________________________________________________________
Executed in  233.98 secs
```

The duplicate entries from the pack file are added to the index twice and so they are still problematic as long as they are in the pack?

(draft for now because I'm not sure I can get irmin_fsck to compile with the dependence for tezos-context-hash. But it is easier to test the `reconstruct-index` and `integrity-check-index` directly from irmin.)
