### PR TITLE
irmin: use sequences instead of list for node constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
     provide `close` and `batch` functions (#1345, @samoht)
   - Atomic-write backend implementations have to provide a `close` function
     (#1345, @samoht)
+  - `Node.seq` and `Node.of_seq` are added to avoid allocating intermediate
+    lists when it is not necessary (#1506, @samoht)
 
 - **irmin-bench**
   - Many improvements to the actions trace replay:
@@ -83,6 +85,7 @@
   - Add `Irmin.Private.Conf.Schema` for grouping configuration keys. Now
     `Irmin.Private.Conf.key` takes an additional `~spec` parameter.
     (#1492, @zshipko)
+  - `Node.v` is renamed to `Node.of_list` (#1506, @samoht)
 
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -995,7 +995,9 @@ struct
             (name, `Node hash)
       in
       let t : Compress.v -> Bin.v = function
-        | Values vs -> Values (List.rev_map value (List.rev vs))
+        | Values vs ->
+           (* List.map is fine here as the number of entries is small *)
+           Values (List.map value vs)
         | Tree { depth; length; entries } ->
             let entries = List.map ptr entries in
             Tree { depth; length; entries }

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -144,7 +144,7 @@ module Make (S : S) = struct
         check_val "find xx" None (P.Node.Val.find u "xx")
       in
       check_values u;
-      let w = P.Node.Val.v [ ("y", k); ("z", k); ("x", k) ] in
+      let w = P.Node.Val.of_list [ ("y", k); ("z", k); ("x", k) ] in
       check P.Node.Val.t "v" u w;
       let l = P.Node.Val.list u in
       check_list "list all" [ ("x", k); ("y", k); ("z", k) ] l;
@@ -1902,7 +1902,7 @@ module Make (S : S) = struct
       let tree_1 = S.Tree.shallow repo (`Node foo_k) in
       let tree_2 = S.Tree.shallow repo (`Node bar_k) in
       let node_3 =
-        S.Private.Node.Val.v
+        S.Private.Node.Val.of_list
           [
             ("foo", `Contents (foo_k, S.Metadata.default)); ("bar", `Node bar_k);
           ]

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -74,18 +74,23 @@ module Seq = struct
     | Nil -> Nil
     | Cons (_, l') -> drop (n - 1) l' ()
 
-  let take : type a. int -> a t -> a list =
-    let rec aux acc n l =
-      if n = 0 then acc
-      else
-        match l () with Nil -> acc | Cons (x, l') -> aux (x :: acc) (n - 1) l'
-    in
-    fun n s -> List.rev (aux [] n s)
-
   let exists : type a. (a -> bool) -> a Seq.t -> bool =
    fun f s ->
     let rec aux s =
       match s () with Seq.Nil -> false | Seq.Cons (v, s) -> f v || aux s
     in
     aux s
+
+  let rec take n (l : 'a t) () =
+    if n = 0 then Nil
+    else match l () with Nil -> Nil | Cons (x, l') -> Cons (x, take (n - 1) l')
+
+  let nil () = Nil
+  let singleton x () = Cons (x, nil)
+  let length l = Seq.fold_left (fun acc _ -> acc + 1) 0 l
+
+  let rec snoc l1 x () =
+    match l1 () with
+    | Nil -> singleton x ()
+    | Cons (x, l1') -> Cons (x, snoc l1' x)
 end

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -37,12 +37,19 @@ module type S = sig
   (** The type for either (node) keys or (contents) keys combined with their
       metadata. *)
 
-  val v : (step * value) list -> t
-  (** [create l] is a new node. *)
+  val of_list : (step * value) list -> t
+  (** [of_list l] is the node [n] such that [list n = l]. *)
 
   val list : ?offset:int -> ?length:int -> t -> (step * value) list
   (** [list t] is the contents of [t]. [offset] and [length] are used to
       paginate results.*)
+
+  val of_seq : (step * value) Seq.t -> t
+  (** [of_seq s] is a new node. *)
+
+  val seq : ?offset:int -> ?length:int -> t -> (step * value) Seq.t
+  (** [seq t] is the contents of [t]. [offset] and [length] are used to paginate
+      results.*)
 
   val empty : t
   (** [empty] is the empty node. *)


### PR DESCRIPTION
This avoids allocating large intermediate lists.