### PR TITLE
Add benchmarks for migration to flattened stores

### DIFF
--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -25,6 +25,7 @@ val with_progress_bar :
   message:string -> n:int -> unit:string -> ((int -> unit) -> 'a) -> 'a
 
 val random_blob : unit -> bytes
+val random_string : int -> string
 
 module Info (I : Irmin.Info.S) : sig
   val f : I.f
@@ -37,6 +38,7 @@ module FSHelper : sig
   val rm_dir : string -> unit
   val get_size : string -> int
   val print_size_layers : string -> unit
+  val cp_dir : string -> string -> unit
 end
 
 module Generate_trees (Store : Irmin.KV with type Schema.Contents.t = bytes) : sig
@@ -48,3 +50,13 @@ module Generate_trees (Store : Irmin.KV with type Schema.Contents.t = bytes) : s
   (** [add_large_trees width nb tree] adds [nb] random contents to [tree],
       breadthwise. *)
 end
+
+module Benchmark : sig
+  type result
+
+  val run : string -> (unit -> 'a Lwt.t) -> (result * 'a) Lwt.t
+  val pp_results : Format.formatter -> result -> unit
+end
+
+val get_maxrss : unit -> int
+val report_mem_stats : unit -> unit

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -1,7 +1,7 @@
 (executables
- (names main layers)
- (public_names bench-pack bench-pack-layers)
- (modules main layers import)
+ (names main layers migration)
+ (public_names bench-pack bench-pack-layers bench-migration)
+ (modules main layers import migration flatten)
  (package irmin-bench)
  (preprocess
   (pps ppx_repr))
@@ -11,7 +11,7 @@
 (library
  (name bench_common)
  (modules bench_common)
- (libraries irmin-pack unix progress uuidm))
+ (libraries irmin-pack unix progress uuidm rusage))
 
 (library
  (name irmin_traces)
@@ -42,5 +42,5 @@
 (rule
  (alias runtest)
  (package irmin-bench)
- (deps main.exe layers.exe tree.exe trace_stats.exe)
+ (deps main.exe layers.exe tree.exe trace_stats.exe migration.exe)
  (action (progn)))

--- a/bench/irmin-pack/flatten.ml
+++ b/bench/irmin-pack/flatten.ml
@@ -1,0 +1,147 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* Open Source License                                                       *)
+(* Copyright (c) 2018 Dynamic Ledger Solutions, Inc. <contact@tezos.com>     *)
+(* Copyright (c) 2019-2020 Nomadic Labs <contact@nomadic-labs.com>           *)
+(* Copyright (c) 2021 DaiLambda, Inc. <contact@dailambda.jp>                 *)
+(*                                                                           *)
+(* Permission is hereby granted, free of charge, to any person obtaining a   *)
+(* copy of this software and associated documentation files (the "Software"),*)
+(* to deal in the Software without restriction, including without limitation *)
+(* the rights to use, copy, modify, merge, publish, distribute, sublicense,  *)
+(* and/or sell copies of the Software, and to permit persons to whom the     *)
+(* Software is furnished to do so, subject to the following conditions:      *)
+(*                                                                           *)
+(* The above copyright notice and this permission notice shall be included   *)
+(* in all copies or substantial portions of the Software.                    *)
+(*                                                                           *)
+(* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR*)
+(* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  *)
+(* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL   *)
+(* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER*)
+(* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING   *)
+(* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER       *)
+(* DEALINGS IN THE SOFTWARE.                                                 *)
+(*                                                                           *)
+(*****************************************************************************)
+
+(* Extracted from https://gitlab.com/tezos/tezos. *)
+
+open Irmin.Export_for_backends
+open Bench_common
+
+module Make
+    (Store : Irmin.S
+               with type Schema.Path.t = string list
+                and type Schema.Branch.t = string) =
+struct
+  let current_data_key = [ "data" ]
+  let data_key key = current_data_key @ key
+
+  type index = { repo : Store.Repo.t }
+  type context = { index : index; tree : Store.tree }
+
+  let tree_fold ?depth t k ~init ~f =
+    Store.Tree.find_tree t k >>= function
+    | None -> Lwt.return init
+    | Some t ->
+        Store.Tree.fold ?depth ~force:`And_clear ~uniq:`False
+          ~node:(fun k v acc -> f k (Store.Tree.of_node v) acc)
+          ~contents:(fun k v acc ->
+            if k = [] then Lwt.return acc
+            else f k (Store.Tree.of_contents v) acc)
+          t init
+
+  let fold ?depth ctxt key ~init ~f =
+    tree_fold ?depth ctxt.tree (data_key key) ~init ~f
+
+  let add_tree ctxt key tree =
+    Store.Tree.add_tree ctxt.tree (data_key key) tree >|= fun tree ->
+    { ctxt with tree }
+
+  let counter = ref 0
+
+  module Flatten_storage_for_H = struct
+    (* /tree_abs_key/key/*/*/*/*/*
+       => /tree_abs_key/key/rename( */*/*/*/* )
+    *)
+    let flatten ~tree ~key ~depth ~rename ~init =
+      tree_fold tree key ~depth:(`Eq depth) ~init
+        ~f:(fun old_key tree dst_tree ->
+          let new_key = rename old_key in
+          Store.Tree.add_tree dst_tree new_key tree)
+      >>= fun dst_tree ->
+      (* rm -rf $index_key
+         mv $tmp_index_key $index_key *)
+      Store.Tree.add_tree tree key dst_tree
+
+    (* /abs_key/*(depth')/mid_key/*(depth)
+       => /abs_key/*(depth')/mid_key/rename( *(depth) )
+    *)
+    let fold_flatten ctxt abs_key depth' mid_key ~depth ~rename =
+      fold ~depth:(`Eq depth') ctxt abs_key ~init:ctxt ~f:(fun key tree ctxt ->
+          (* tree at /abs_key/*(depth') *)
+          flatten ~tree ~key:mid_key ~depth ~rename ~init:Store.Tree.empty
+          >>= fun tree ->
+          incr counter;
+          add_tree ctxt (abs_key @ key) tree)
+
+    let flatten_storage ctxt =
+      Logs.info (fun l ->
+          l "Flattening the context storage.  It takes several minutes.");
+      let rec drop n xs =
+        match (n, xs) with
+        | 0, _ -> xs
+        | _, [] -> assert false
+        | _, _ :: xs -> drop (n - 1) xs
+      in
+      report_mem_stats ();
+      counter := 0;
+      (* *)
+      (* /contracts/index/xx/xx/xx/xx/xx/xx/yyyyyyyyyy
+         => /contracts/index/yyyyyyyyyy
+      *)
+      fold_flatten ctxt [ "contracts"; "index" ] 0 [] ~depth:7 ~rename:(drop 6)
+      >>= fun ctxt ->
+      Logs.info (fun l -> l "flattened /contracts/index/ ");
+      report_mem_stats ();
+      (* *)
+      (* /contracts/index/yyyyyyyyyy/delegated/xx/xx/xx/xx/xx/xx/zzzzzzzzzz
+         => /contracts/index/yyyyyyyyyy/delegated/zzzzzzzzzz
+      *)
+      fold_flatten ctxt [ "contracts"; "index" ] 1 [ "delegated" ] ~depth:7
+        ~rename:(drop 6)
+      >>= fun ctxt ->
+      Logs.info (fun l -> l "flattened /contracts/index/delegated/");
+      report_mem_stats ();
+      (* *)
+      (* /rolls/owner/snapshot/n1/n2/x/y/n3
+         => /rolls/owner/snapshot/n1/n2/n3
+      *)
+      fold_flatten ctxt
+        [ "rolls"; "owner"; "snapshot" ]
+        2 [] ~depth:3 ~rename:(drop 2)
+      >|= fun ctxt ->
+      Logs.info (fun l -> l "flatten /rolls/owner/snapshot");
+      report_mem_stats ();
+      Logs.info (fun l -> l "Flattened the context storage.");
+      ctxt
+  end
+
+  let close { index; _ } = Store.Repo.close index.repo
+
+  let run_migration root =
+    let* repo =
+      Store.Repo.v (Irmin_pack.config ~readonly:false ~fresh:false root)
+    in
+    let index = { repo } in
+    let* commit =
+      Store.Branch.find repo "migrate" >>= function
+      | None -> Lwt.fail_with "branch migrate not found"
+      | Some commit -> Lwt.return commit
+    in
+    let tree = Store.Commit.tree commit in
+    let context = { index; tree } in
+    let* ctxt = Flatten_storage_for_H.flatten_storage context in
+    close ctxt
+end

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -98,11 +98,6 @@ let print_commit_stats config c i time =
         l "Commit %a %d in cycle completed in %f; objects created: %d"
           Store.Commit.pp_hash c i time num_objects)
 
-let get_maxrss () =
-  let usage = Rusage.(get Self) in
-  let ( / ) = Int64.div in
-  Int64.to_int (usage.maxrss / 1024L / 1024L)
-
 let print_stats () = Logs.app (fun l -> l "%t" Irmin_layers.Stats.pp_latest)
 
 let write_cycle config repo init_commit =

--- a/bench/irmin-pack/migration.ml
+++ b/bench/irmin-pack/migration.ml
@@ -1,0 +1,163 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Bench_common
+open Irmin.Export_for_backends
+
+type config = { store_dir : string }
+
+let config ~root = Irmin_pack.config ~fresh:false root
+
+module Store = struct
+  module Maker = Irmin_pack.KV (Irmin_pack.Version.V1) (Conf)
+  include Maker.Make (Irmin.Contents.String)
+end
+
+module Info = Info (Store.Info)
+
+module Generate_store = struct
+  let init root =
+    Store.Repo.v (Irmin_pack.config ~readonly:false ~fresh:true root)
+
+  let close repo = Store.Repo.close repo
+
+  type path = { length : int; repetition : int }
+
+  let generate_tree tree (a, b, c, d) nb_entries =
+    let path pattern =
+      let rec aux_path acc i =
+        if i >= pattern.repetition then acc
+        else aux_path (random_string pattern.length :: acc) (i + 1)
+      in
+      aux_path [] 0
+    in
+    let rec aux tree i =
+      if i >= nb_entries then Lwt.return tree
+      else
+        let key = a @ path b @ c @ path d in
+        let blob = random_string 2 in
+        let* tree = Store.Tree.add tree key blob in
+        aux tree (i + 1)
+    in
+    aux tree 0
+
+  let commit_init repo =
+    Store.Commit.v repo ~info:(Info.f ()) ~parents:[] Store.Tree.empty
+
+  let commit_tree repo parent pattern nb_entries =
+    let rec aux parent i =
+      if i * 100 >= nb_entries then Lwt.return parent
+      else
+        let tree = Store.Commit.tree parent in
+        let hash = Store.Commit.hash parent in
+        let* tree = generate_tree tree pattern 100 in
+        let* commit =
+          Store.Commit.v repo ~info:(Info.f ()) ~parents:[ hash ] tree
+        in
+        aux commit (i + 1)
+    in
+    aux parent 0
+
+  let commit repo =
+    let* init_commit = commit_init repo in
+    Logs.info (fun l ->
+        l "committing /contracts/index/xx/xx/xx/xx/xx/xx/yyyyyyyyyy");
+    report_mem_stats ();
+    let pattern =
+      ( [ "data"; "contracts"; "index" ],
+        { length = 2; repetition = 6 },
+        [],
+        { length = 10; repetition = 1 } )
+    in
+    let nb_entries = 100_000 in
+    let* commit = commit_tree repo init_commit pattern nb_entries in
+    Logs.info (fun l ->
+        l "committing /contracts/index/yyyyyyyyyy/delegated/xx/xx/xx/xx/xx/xx");
+    report_mem_stats ();
+    let pattern =
+      ( [ "data"; "contracts"; "index" ],
+        { length = 10; repetition = 1 },
+        [ "delegated" ],
+        { length = 2; repetition = 6 } )
+    in
+    let nb_entries = 1_000 in
+    (* let nb_entries = 104 in *)
+    let* commit = commit_tree repo commit pattern nb_entries in
+    Logs.info (fun l -> l "committing /rolls/owner/snapshot/n1/n2/x/y/n3");
+    report_mem_stats ();
+    let pattern =
+      ( [ "data"; "rolls"; "owner"; "snapshot" ],
+        { length = 8; repetition = 2 },
+        [],
+        { length = 2; repetition = 3 } )
+    in
+    let nb_entries = 3_000_000 in
+    (* let nb_entries = 3 in *)
+    let* commit = commit_tree repo commit pattern nb_entries in
+    report_mem_stats ();
+    Lwt.return commit
+
+  let v root =
+    let* repo = init root in
+    let* head = commit repo in
+    let* () = Store.Branch.set repo "migrate" head in
+    close repo
+end
+
+include Flatten.Make (Store)
+
+let run_migration config =
+  let run () = run_migration config.store_dir in
+  let+ result, () = Benchmark.run config.store_dir run in
+  Format.printf "%a\n@." Benchmark.pp_results result
+
+let main () store_dir =
+  Printexc.record_backtrace true;
+  let tmp_store_dir = Filename.concat "_build" "migration" in
+  let run =
+    let* () =
+      if Sys.file_exists store_dir then (
+        FSHelper.cp_dir store_dir tmp_store_dir;
+        Lwt.return_unit)
+      else
+        let* () = Generate_store.v store_dir in
+        FSHelper.cp_dir store_dir tmp_store_dir;
+        Lwt.return_unit
+    in
+    let config = { store_dir = tmp_store_dir } in
+    run_migration config
+  in
+  Lwt_main.run run
+
+open Cmdliner
+
+let default_store_dir = Filename.concat "test-bench" "migration"
+
+let store_dir =
+  let doc =
+    Arg.info ~docv:"PATH" ~doc:"Destination of the store before flattening."
+      [ "store" ]
+  in
+  Arg.(value @@ opt string default_store_dir doc)
+
+let setup_log =
+  Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
+
+let main_term = Term.(const main $ setup_log $ store_dir)
+
+let () =
+  let info = Term.info "Benchmarks for migration to flattened store" in
+  Term.exit @@ Term.eval (main_term, info)

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -58,19 +58,6 @@ let pp_store_type ppf = function
   | `Pack_layered -> Format.fprintf ppf "[pack-layered store]"
   | `Pack_mem -> Format.fprintf ppf "[pack-mem store]"
 
-module Benchmark = struct
-  type result = { time : float; size : int }
-
-  let run config f =
-    let+ time, res = with_timer f in
-    let size = FSHelper.get_size config.store_dir in
-    ({ time; size }, res)
-
-  let pp_results ppf result =
-    Format.fprintf ppf "Total time: %f@\nSize on disk: %d M" result.time
-      result.size
-end
-
 module Bench_suite (Store : Store) = struct
   module Info = Info (Store.Info)
 
@@ -108,7 +95,7 @@ module Bench_suite (Store : Store) = struct
       Trees.add_large_trees config.width config.nlarge_trees
       |> add_commits ~message:"Playing large mode" repo config.ncommits
            on_commit on_end
-      |> Benchmark.run config
+      |> Benchmark.run config.store_dir
     in
     let+ () = Store.Repo.close repo in
     fun ppf ->
@@ -128,7 +115,7 @@ module Bench_suite (Store : Store) = struct
       Trees.add_chain_trees config.depth config.nchain_trees
       |> add_commits ~message:"Playing chain mode" repo config.ncommits
            on_commit on_end
-      |> Benchmark.run config
+      |> Benchmark.run config.store_dir
     in
     let+ () = Store.Repo.close repo in
     fun ppf ->


### PR DESCRIPTION
With these benchmarks it takes around 25 minutes to construct the store (which once constructed, we can reuse) and 21 minutes to run the flattening on my mac. So maybe I’m setting up something wrong. 

But we can see that `Gc.heap_words = 822_203_392` in 21 minutes with irmin#master and `Gc.heap_words = 740_809_216` in 34 minutes with https://github.com/mirage/irmin/pull/1508.  