### PR TITLE
Add support for non-content-addressed backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,11 +109,13 @@
     depends on whether the node is in memory or on disk (#1525, @icristescu,
     @Ngoguey42, @CraigFe)
 
-  - Add support for non-content-addressed ("generic key") backend stores. This includes:
-    - New functions: `Store.{Commit,Contents,Tree}.of_key`
-    - Adds `Irmin.Generic_key` and `Irmin.Node.Generic_key` modules.
+  - Add support for non-content-addressed ("generic key") backend stores. This
+    allows Irmin to work with backends in which not all values are addressed by
+    their hash. In particular, this includes:
+    - New functions: `Store.{Commit,Contents,Tree}.of_key`.
+    - Adds `Irmin.{Node,Commit}.Generic_key` modules.
+    - Adds a new type that must be provided by backends: `Node.Portable`.
     - Adds a new type of backend store: `Irmin.Indexable.S`.
-    - ... TODO(craigfe)
 
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,7 +110,7 @@
     @Ngoguey42, @CraigFe)
 
   - Add support for non-content-addressed ("generic key") backend stores. This includes:
-    - `Store.Commit.of_hash` is now `Store.Commit.of_key`.
+    - New functions: `Store.{Commit,Contents,Tree}.of_key`
     - Adds `Irmin.Generic_key` and `Irmin.Node.Generic_key` modules.
     - Adds a new type of backend store: `Irmin.Indexable.S`.
     - ... TODO(craigfe)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,12 @@
     depends on whether the node is in memory or on disk (#1525, @icristescu,
     @Ngoguey42, @CraigFe)
 
+  - Add support for non-content-addressed ("generic key") backend stores. This includes:
+    - `Store.Commit.of_hash` is now `Store.Commit.of_key`.
+    - Adds `Irmin.Generic_key` and `Irmin.Node.Generic_key` modules.
+    - Adds a new type of backend store: `Irmin.Indexable.S`.
+    - ... TODO(craigfe)
+
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to
     `Irmin.Content_addressable.S` (#1369, @samoht)

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -49,7 +49,7 @@ module Schema = struct
   module Branch = Irmin.Branch.String
   module Hash = Irmin.Hash.SHA1
   module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
-  module Commit = Irmin.Commit.Make (Hash)
+  module Commit = Irmin.Commit.Generic_key.Make (Hash)
   module Info = Irmin.Info.Default
 end
 

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -48,7 +48,7 @@ module Schema = struct
   module Path = Irmin.Path.String_list
   module Branch = Irmin.Branch.String
   module Hash = Irmin.Hash.SHA1
-  module Node = Irmin.Node.Make (Hash) (Path) (Metadata)
+  module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
   module Commit = Irmin.Commit.Make (Hash)
   module Info = Irmin.Info.Default
 end

--- a/irmin.opam
+++ b/irmin.opam
@@ -31,6 +31,7 @@ depends: [
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
+  "vector" {with-test}
 ]
 
 conflicts: [

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -81,7 +81,7 @@ module Make (G : Git.S) = struct
     let message = Option.value ~default:"" (G.Value.Commit.message g) in
     info_of_git author message
 
-  module C = Irmin.Commit.Make (Hash) (Key) (Key)
+  module C = Irmin.Commit.Make (Hash)
 
   let of_c c = to_git (C.info c) (C.node c) (C.parents c)
 

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -19,10 +19,13 @@ open Import
 module Make (G : Git.S) = struct
   module Info = Irmin.Info.Default
   module Raw = Git.Value.Make (G.Hash)
-  module Key = Irmin.Hash.Make (G.Hash)
+  module Hash = Irmin.Hash.Make (G.Hash)
+  module Key = Irmin.Key.Of_hash (Hash)
 
   type t = G.Value.Commit.t
-  type hash = Key.t [@@deriving irmin]
+  type commit_key = Key.t [@@deriving irmin]
+  type node_key = Key.t [@@deriving irmin]
+  type hash = Hash.t [@@deriving irmin]
 
   let info_of_git author message =
     let id = author.Git.User.name in
@@ -78,7 +81,7 @@ module Make (G : Git.S) = struct
     let message = Option.value ~default:"" (G.Value.Commit.message g) in
     info_of_git author message
 
-  module C = Irmin.Commit.Make (Key)
+  module C = Irmin.Commit.Make (Hash) (Key) (Key)
 
   let of_c c = to_git (C.info c) (C.node c) (C.parents c)
 
@@ -107,7 +110,7 @@ end
 
 module Store (G : Git.S) = struct
   module Info = Irmin.Info.Default
-  module Key = Irmin.Hash.Make (G.Hash)
+  module Hash = Irmin.Hash.Make (G.Hash)
   module Val = Make (G)
 
   module V = struct

--- a/src/irmin-git/commit.mli
+++ b/src/irmin-git/commit.mli
@@ -19,7 +19,8 @@
 module Make (G : Git.S) :
   Irmin.Commit.S
     with type t = G.Value.Commit.t
-     and type hash = G.hash
+     and type node_key = G.hash
+     and type commit_key = G.hash
      and module Info = Irmin.Info.Default
 
 module Store (G : Git.S) : sig
@@ -30,11 +31,12 @@ module Store (G : Git.S) : sig
        and type value = G.Value.Commit.t
 
   module Info = Irmin.Info.Default
-  module Key : Irmin.Hash.S with type t = key
+  module Hash : Irmin.Hash.S with type t = key
 
   module Val :
     Irmin.Commit.S
       with type t = value
-       and type hash = key
+       and type node_key = key
+       and type commit_key = key
        and module Info = Info
 end

--- a/src/irmin-git/commit.mli
+++ b/src/irmin-git/commit.mli
@@ -19,8 +19,7 @@
 module Make (G : Git.S) :
   Irmin.Commit.S
     with type t = G.Value.Commit.t
-     and type node_key = G.hash
-     and type commit_key = G.hash
+     and type hash = G.hash
      and module Info = Irmin.Info.Default
 
 module Store (G : Git.S) : sig
@@ -36,7 +35,6 @@ module Store (G : Git.S) : sig
   module Val :
     Irmin.Commit.S
       with type t = value
-       and type node_key = key
-       and type commit_key = key
+       and type hash = key
        and module Info = Info
 end

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -276,7 +276,12 @@ struct
       end
 
       module Commit = struct
-        module V = Dummy.Commit.Val
+        module V = struct
+          include Dummy.Commit.Val
+
+          type hash = Hash.t [@@deriving irmin]
+        end
+
         module CA = CA (Hash) (V)
         include Irmin.Commit.Store (Info) (Node) (CA) (Hash) (V)
       end

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -185,10 +185,12 @@ module KV
 struct
   module Maker = Maker (G) (S)
   module Branch = Branch.Make (Irmin.Branch.String)
+  include Irmin.Key.Store_spec.Hash_keyed
 
   type endpoint = Maker.endpoint
   type metadata = Metadata.t
   type branch = Branch.t
+  type hash = G.hash
 
   module Make (C : Irmin.Contents.S) = Maker.Make (Schema.Make (G) (C) (Branch))
 end
@@ -216,6 +218,9 @@ struct
 
   type endpoint = unit
   type metadata = Metadata.t
+  type hash = G.hash
+
+  include Irmin.Key.Store_spec.Hash_keyed
 
   module Schema (C : Irmin.Contents.S) = struct
     module Metadata = Metadata
@@ -247,6 +252,7 @@ struct
       module Schema = Sc
       module Hash = Dummy.Hash
       module Info = Irmin.Info.Default
+      module Key = Irmin.Key.Of_hash (Hash)
 
       module Contents = struct
         module V = Dummy.Contents.Val
@@ -261,6 +267,12 @@ struct
         include
           Irmin.Node.Store (Contents) (CA) (Hash) (V) (Dummy.Node.Metadata)
             (Schema.Path)
+      end
+
+      module Node_portable = struct
+        include Node.Val
+
+        let of_node x = x
       end
 
       module Commit = struct

--- a/src/irmin-git/irmin_git_intf.ml
+++ b/src/irmin-git/irmin_git_intf.ml
@@ -32,7 +32,7 @@ module type S = sig
   module Schema :
     Irmin.Schema.S with type Metadata.t = Metadata.t and type Hash.t = Git.hash
 
-  include Irmin.S with module Schema := Schema
+  include Irmin.S with type hash = Schema.Hash.t and module Schema := Schema
 
   val git_commit : Repo.t -> commit -> Git.Value.Commit.t option Lwt.t
   (** [git_commit repo h] is the commit corresponding to [h] in the repository

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -17,15 +17,18 @@
 open Import
 
 module Make (G : Git.S) (P : Irmin.Path.S) = struct
-  module Key = Irmin.Hash.Make (G.Hash)
+  module Hash = Irmin.Hash.Make (G.Hash)
+  module Key = Irmin.Key.Of_hash (Hash)
   module Raw = Git.Value.Make (G.Hash)
   module Path = P
   module Metadata = Metadata
 
   type t = G.Value.Tree.t
   type metadata = Metadata.t [@@deriving irmin]
-  type hash = Key.t [@@deriving irmin]
+  type hash = Hash.t [@@deriving irmin]
   type step = Path.step [@@deriving irmin]
+  type node_key = hash [@@deriving irmin]
+  type contents_key = hash [@@deriving irmin]
 
   type value = [ `Node of hash | `Contents of hash * metadata ]
   [@@deriving irmin]
@@ -135,7 +138,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
       [] (G.Value.Tree.to_list t)
     |> List.rev
 
-  module N = Irmin.Node.Make (Key) (P) (Metadata)
+  module N = Irmin.Node.Make (Hash) (P) (Metadata)
 
   let to_n t = N.of_list (alist t)
   let of_n n = v (N.list n)

--- a/src/irmin-git/private.ml
+++ b/src/irmin-git/private.ml
@@ -32,6 +32,9 @@ module Make
 struct
   module Hash = Irmin.Hash.Make (G.Hash)
   module Schema = Schema
+  module Key = Irmin.Key.Of_hash (Hash)
+  module Commit_key = Key
+  module Node_key = Key
 
   module Contents = struct
     module S = Contents.Make (G) (Schema.Contents)
@@ -45,14 +48,20 @@ struct
       Irmin.Node.Store (Contents) (S) (S.Key) (S.Val) (Metadata) (Schema.Path)
   end
 
+  module Node_portable = struct
+    include Node.Val
+
+    let of_node x = x
+  end
+
   module Commit = struct
     module S = Commit.Store (G)
-    include Irmin.Commit.Store (Schema.Info) (Node) (S) (S.Key) (S.Val)
+    include Irmin.Commit.Store (Schema.Info) (Node) (S) (S.Hash) (S.Val)
   end
 
   module Branch = struct
     module Key = Schema.Branch
-    module Val = Hash
+    module Val = Commit_key
     module S = Atomic_write.Make (Schema.Branch) (G)
     include Atomic_write.Check_closed (S)
 

--- a/src/irmin-git/private.mli
+++ b/src/irmin-git/private.mli
@@ -35,6 +35,9 @@ module Make
       with type 'a Contents.t = t
        and type 'a Node.t = t * t
        and type 'a Commit.t = (t * t) * t
+       and type Contents.key = G.hash
+       and type Node.key = G.hash
+       and type Commit.key = G.hash
        and type Remote.endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   val git_of_repo : Repo.t -> G.t

--- a/src/irmin-git/schema.ml
+++ b/src/irmin-git/schema.ml
@@ -31,11 +31,7 @@ module type S = sig
        and type step = Path.step
        and type hash = Hash.t
 
-  module Commit :
-    Irmin.Commit.S
-      with module Info := Info
-       and type node_key = Hash.t
-       and type commit_key = Hash.t
+  module Commit : Irmin.Commit.S with module Info := Info and type hash = Hash.t
 end
 
 module Make (G : Git.S) (V : Irmin.Contents.S) (B : Branch.S) :

--- a/src/irmin-git/schema.ml
+++ b/src/irmin-git/schema.ml
@@ -24,6 +24,18 @@ module type S = sig
        and type Info.t = Irmin.Info.default
        and type Path.step = string
        and type Path.t = string list
+
+  module Node :
+    Irmin.Node.S
+      with type metadata = Metadata.t
+       and type step = Path.step
+       and type hash = Hash.t
+
+  module Commit :
+    Irmin.Commit.S
+      with module Info := Info
+       and type node_key = Hash.t
+       and type commit_key = Hash.t
 end
 
 module Make (G : Git.S) (V : Irmin.Contents.S) (B : Branch.S) :

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -495,7 +495,13 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
     module Commit = struct
       module X = struct
         module Key = S.Hash
-        module Val = S.Private.Commit.Val
+
+        module Val = struct
+          include S.Private.Commit.Val
+
+          type hash = S.Hash.t [@@deriving irmin]
+        end
+
         module CA = CA (Client) (Key) (Val)
         include Closeable.Content_addressable (CA)
       end

--- a/src/irmin-http/irmin_http.mli
+++ b/src/irmin-http/irmin_http.mli
@@ -35,7 +35,10 @@ module type HTTP_CLIENT = sig
 end
 
 module Client (C : HTTP_CLIENT) (S : Irmin.S) :
-  Irmin.S with module Schema = S.Schema and type Private.Remote.endpoint = unit
+  Irmin.S
+    with type hash = S.hash
+     and module Schema = S.Schema
+     and type Private.Remote.endpoint = unit
 
 (** HTTP server *)
 

--- a/src/irmin-http/irmin_http_server.ml
+++ b/src/irmin-http/irmin_http_server.ml
@@ -346,6 +346,7 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
       (struct
         include P.Contents
 
+        let unsafe_add t k v = unsafe_add t k v >|= fun _ -> ()
         let batch t f = P.Repo.batch t @@ fun x _ _ -> f x
       end)
       (P.Contents.Key)
@@ -356,6 +357,7 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
       (struct
         include P.Node
 
+        let unsafe_add t k v = unsafe_add t k v >|= fun _ -> ()
         let batch t f = P.Repo.batch t @@ fun _ x _ -> f x
       end)
       (P.Node.Key)
@@ -366,6 +368,7 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
       (struct
         include P.Commit
 
+        let unsafe_add t k v = unsafe_add t k v >|= fun _ -> ()
         let batch t f = P.Repo.batch t @@ fun _ _ x -> f x
       end)
       (P.Commit.Key)

--- a/src/irmin-layers/irmin_layers.ml
+++ b/src/irmin-layers/irmin_layers.ml
@@ -33,8 +33,7 @@ module Maker
     (AW : Irmin.Atomic_write.Maker) =
 struct
   module Maker = Irmin.Maker (CA) (AW)
-
-  type endpoint = Maker.endpoint
+  include Maker
 
   module Make (Schema : Irmin.Schema.S) = struct
     include Maker.Make (Schema)
@@ -43,10 +42,10 @@ struct
         _repo =
       Lwt.fail_with "not implemented"
 
-    type store_handle =
-      | Commit_t : hash -> store_handle
-      | Node_t : hash -> store_handle
-      | Content_t : hash -> store_handle
+    type kinded_key =
+      | Commit_t of commit_key
+      | Node_t of node_key
+      | Content_t of contents_key
 
     let layer_id _repo _store_handle = Lwt.fail_with "not implemented"
     let async_freeze _ = failwith "not implemented"

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -20,7 +20,9 @@ module IO = IO.Unix
 module Maker (V : Version.S) (Config : Conf.S) = struct
   type endpoint = unit
 
-  module Make (Schema : Irmin.Schema.S) = struct
+  include Irmin.Key.Store_spec.Hash_keyed
+
+  module Make (Schema : Irmin.Schema.Extended) = struct
     open struct
       module H = Schema.Hash
       module P = Schema.Path
@@ -32,6 +34,7 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
     module Index = Pack_index.Make (H)
     module Pack = Pack_store.Maker (V) (Index) (H)
     module Dict = Pack_dict.Make (V)
+    module XKey = Irmin.Key.Of_hash (H)
 
     module X = struct
       module Hash = H
@@ -46,13 +49,18 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
       end
 
       module Node = struct
+        module Value = Schema.Node (XKey) (XKey)
+
         module CA = struct
-          module Inter = Inode.Make_internal (Config) (H) (Schema.Node)
-          include Inode.Make_persistent (H) (Schema.Node) (Inter) (Pack)
+          module Inter = Inode.Make_internal (Config) (H) (Value)
+          include Inode.Make_persistent (H) (Value) (Inter) (Pack)
         end
 
-        include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+        include
+          Irmin.Node.Generic_key.Store (Contents) (CA) (H) (CA.Val) (M) (P)
       end
+
+      module Node_portable = Node.CA.Val.Portable
 
       module Schema = struct
         include Schema
@@ -60,21 +68,27 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
       end
 
       module Commit = struct
+        module Value = Schema.Commit (Node.Key) (XKey)
+
         module Pack_value =
           Pack_value.Of_commit
             (H)
             (struct
               module Info = Schema.Info
-              include Schema.Commit
+              include Value
             end)
 
         module CA = Pack.Make (Pack_value)
-        include Irmin.Commit.Store (Schema.Info) (Node) (CA) (H) (Schema.Commit)
+        include Irmin.Commit.Store (Schema.Info) (Node) (CA) (H) (Value)
       end
 
       module Branch = struct
         module Key = B
-        module Val = H
+
+        module Val = struct
+          include H
+          include Commit.Key
+        end
 
         module AW =
           Atomic_write.Make_persistent (V) (Key)

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -68,7 +68,11 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
       end
 
       module Commit = struct
-        module Value = Schema.Commit (Node.Key) (XKey)
+        module Value = struct
+          include Schema.Commit (Node.Key) (XKey)
+
+          type hash = Hash.t [@@deriving irmin]
+        end
 
         module Pack_value =
           Pack_value.Of_commit

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -42,7 +42,9 @@ module V2 = Maker (Version.V2)
 
 module KV (V : Version.S) (Config : Conf.S) = struct
   type endpoint = unit
+  type hash = Irmin.Schema.default_hash
 
+  include Irmin.Key.Store_spec.Hash_keyed
   module Maker = Maker (V) (Config)
 
   type metadata = Metadata.t
@@ -67,6 +69,3 @@ end
 
 (* Enforce that {!KV} is a sub-type of {!Irmin.KV_maker}. *)
 module KV_is_a_KV_maker : Irmin.KV_maker = KV (Vx) (Cx)
-
-(* Enforce that {!Maker} is a sub-type of {!Irmin.Maker}. *)
-module Maker_is_a_maker : Irmin.Maker = Maker (Vx) (Cx)

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -79,7 +79,11 @@ module Maker' (Config : Conf.Pack.S) (Schema : Irmin.Schema.Extended) = struct
     module Node_portable = Node.CA.Val.Portable
 
     module Commit = struct
-      module Value = Schema.Commit (Node.Key) (XKey)
+      module Value = struct
+        include Schema.Commit (Node.Key) (XKey)
+
+        type hash = Hash.t [@@deriving irmin]
+      end
 
       module Pack_value =
         Irmin_pack.Pack_value.Of_commit

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -30,13 +30,16 @@ struct
   module Internal = Irmin_pack.Inode.Make_internal (Conf) (H) (Node)
   module P = Maker.Make (Internal.Raw)
   module Val = Internal.Val
-  module Key = H
+  module Hash = H
+  module Key = Irmin.Key.Of_hash (H)
 
   type 'a t = 'a P.t
   type key = Key.t
   type value = Val.t
+  type hash = Hash.t
 
   let mem t k = P.mem t k
+  let index _ h = Lwt.return_some h
   let unsafe_find = P.unsafe_find
 
   let find t k =
@@ -75,7 +78,7 @@ struct
   let unsafe_add t k v =
     check_hash k (hash v);
     save t v;
-    Lwt.return ()
+    Lwt.return k
 
   let clear_caches_next_upper = P.clear_caches_next_upper
 

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -86,6 +86,7 @@ module type Sigs = sig
       (Node : Irmin.Node.S with type hash = H.t) :
     S
       with type key = H.t
+       and type hash = H.t
        and type Val.metadata = Node.metadata
        and type Val.step = Node.step
        and type index = Index.Make(H).t

--- a/src/irmin-pack/layered/s.ml
+++ b/src/irmin-pack/layered/s.ml
@@ -35,13 +35,19 @@ end
 module type Maker = sig
   type endpoint = unit
 
-  module Make (Schema : Irmin.Schema.S) :
+  include Irmin.Key.Store_spec.Hash_keyed
+
+  module Make (Schema : Irmin.Schema.Extended) :
     Store
-      with module Schema = Schema
+      with type hash = Schema.Hash.t
+       and type Schema.Branch.t = Schema.Branch.t
+       and type Schema.Metadata.t = Schema.Metadata.t
+       and type Schema.Path.t = Schema.Path.t
+       and type Schema.Path.step = Schema.Path.step
+       and type Schema.Contents.t = Schema.Contents.t
+       and type Schema.Info.t = Schema.Info.t
        and type Private.Remote.endpoint = endpoint
 end
-
-module Maker_is_a_maker (X : Maker) : Irmin.Maker = X
 
 module type Layered_general = sig
   type 'a t

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -79,7 +79,11 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
       module Node_portable = Node.CA.Val.Portable
 
       module Commit = struct
-        module Value = Schema.Commit (Node.Key) (XKey)
+        module Value = struct
+          include Schema.Commit (Node.Key) (XKey)
+
+          type hash = Hash.t [@@deriving irmin]
+        end
 
         module Pack_value =
           Irmin_pack.Pack_value.Of_commit

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -39,13 +39,16 @@ end
 module Maker (Config : Irmin_pack.Conf.S) = struct
   type endpoint = unit
 
-  module Make (Schema : Irmin.Schema.S) = struct
+  include Irmin.Key.Store_spec.Hash_keyed
+
+  module Make (Schema : Irmin.Schema.Extended) = struct
     module H = Schema.Hash
     module C = Schema.Contents
     module P = Schema.Path
     module M = Schema.Metadata
     module B = Schema.Branch
     module Pack = Content_addressable.Maker (H)
+    module XKey = Irmin.Key.Of_hash (H)
 
     module X = struct
       module Schema = Schema
@@ -59,35 +62,45 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
       end
 
       module Node = struct
-        module CA = struct
-          module Inter =
-            Irmin_pack.Inode.Make_internal (Config) (H) (Schema.Node)
+        module Value = Schema.Node (XKey) (XKey)
 
+        module CA = struct
+          module Inter = Irmin_pack.Inode.Make_internal (Config) (H) (Value)
           module CA = Pack.Make (Inter.Raw)
-          include Irmin_pack.Inode.Make (H) (Schema.Node) (Inter) (CA)
+          include Irmin_pack.Inode.Make (H) (Value) (Inter) (CA)
 
           let v = CA.v
         end
 
-        include Irmin.Node.Store (Contents) (CA) (H) (CA.Val) (M) (P)
+        include
+          Irmin.Node.Generic_key.Store (Contents) (CA) (H) (CA.Val) (M) (P)
       end
 
+      module Node_portable = Node.CA.Val.Portable
+
       module Commit = struct
+        module Value = Schema.Commit (Node.Key) (XKey)
+
         module Pack_value =
           Irmin_pack.Pack_value.Of_commit
             (H)
             (struct
               module Info = Schema.Info
-              include Schema.Commit
+              include Value
             end)
 
         module CA = CA_mem (H) (Pack_value)
-        include Irmin.Commit.Store (Info) (Node) (CA) (H) (Schema.Commit)
+        include Irmin.Commit.Store (Info) (Node) (CA) (H) (Value)
       end
 
       module Branch = struct
         module Key = B
-        module Val = H
+
+        module Val = struct
+          include H
+          include Commit.Key
+        end
+
         module AW = Atomic_write (Key) (Val)
         include Irmin_pack.Atomic_write.Closeable (AW)
 

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -54,7 +54,7 @@ module Schema (M : Irmin.Metadata.S) = struct
   module Commit = Irmin.Commit.Make (Hash)
   module Path = Irmin.Path.String_list
   module Metadata = M
-  module Node = Irmin.Node.Make (Hash) (Path) (Metadata)
+  module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
   module Branch = Irmin.Branch.String
   module Info = Irmin.Info.Default
   module Contents = Irmin.Contents.String
@@ -110,6 +110,17 @@ module Make_helpers (S : S) = struct
     S.Info.v ~author ~message date
 
   let infof fmt = Fmt.kstrf (fun str () -> info str) fmt
+
+  let get_contents_key = function
+    | `Contents key -> key
+    | _ -> Alcotest.fail "expecting contents_key"
+
+  let get_node_key = function
+    | `Node key -> key
+    | _ -> Alcotest.fail "expecting node_key"
+
+  type x = int [@@deriving irmin]
+
   let v repo = P.Repo.contents_t repo
   let n repo = P.Repo.node_t repo
   let ct repo = P.Repo.commit_t repo
@@ -121,6 +132,7 @@ module Make_helpers (S : S) = struct
   let with_contents repo f = P.Repo.batch repo (fun t _ _ -> f t)
   let with_node repo f = P.Repo.batch repo (fun _ t _ -> f t)
   let with_commit repo f = P.Repo.batch repo (fun _ _ t -> f t)
+  let with_info repo n f = with_commit repo (fun h -> f h ~info:(info n))
   let kv1 ~repo = with_contents repo (fun t -> P.Contents.add t v1)
   let kv2 ~repo = with_contents repo (fun t -> P.Contents.add t v2)
   let normal x = `Contents (x, S.Metadata.default)
@@ -150,7 +162,7 @@ module Make_helpers (S : S) = struct
 
   let r1 ~repo =
     let* kn2 = n2 ~repo in
-    S.Tree.of_hash repo (`Node kn2) >>= function
+    S.Tree.of_key repo (`Node kn2) >>= function
     | None -> Alcotest.fail "r1"
     | Some tree ->
         S.Commit.v repo ~info:S.Info.empty ~parents:[] (tree :> S.tree)
@@ -158,10 +170,10 @@ module Make_helpers (S : S) = struct
   let r2 ~repo =
     let* kn3 = n3 ~repo in
     let* kr1 = r1 ~repo in
-    S.Tree.of_hash repo (`Node kn3) >>= function
+    S.Tree.of_key repo (`Node kn3) >>= function
     | None -> Alcotest.fail "r2"
     | Some t3 ->
-        S.Commit.v repo ~info:S.Info.empty ~parents:[ S.Commit.hash kr1 ]
+        S.Commit.v repo ~info:S.Info.empty ~parents:[ S.Commit.key kr1 ]
           (t3 :> S.tree)
 
   let run (x : Suite.t) test =

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -90,18 +90,37 @@ type t = {
   store : store;
   layered_store : (module Layered_store) option;
   stats : (unit -> int * int) option;
+  (* Certain store implementations currently don't support implementing
+     repository state from a slice, because their slice formats contain
+     non-portable objects. For now, we disable the tests require this feature
+     for such backends.
+
+     TODO: fix slices to always contain portable objects, and extend
+     [Store.import] to re-hydrate the keys in these slices (by tracking keys of
+     added objects), then require all backends to run thee tests. *)
+  import_supported : bool;
 }
 
 module Suite = struct
   type nonrec t = t
 
-  let create ~name ~init ~clean ~config ~store ~layered_store ~stats =
-    { name; init; clean; config; store = S store; layered_store; stats }
+  let create ~name ~init ~clean ~config ~store ~layered_store ~stats
+      ?(import_supported = true) () =
+    {
+      name;
+      init;
+      clean;
+      config;
+      store = S store;
+      layered_store;
+      stats;
+      import_supported;
+    }
 
   let create_generic_key ~name ~init ~clean ~config ~store ~layered_store ~stats
-      =
+      ?(import_supported = true) () =
     let store = Generic_key store in
-    { name; init; clean; config; store; layered_store; stats }
+    { name; init; clean; config; store; layered_store; stats; import_supported }
 
   let name t = t.name
   let config t = t.config

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -1,7 +1,7 @@
 (library
  (name irmin_test)
  (public_name irmin-test)
- (modules Irmin_test Store Store_graph Store_watch Common Layered_store
+ (modules Irmin_test Node Store Store_graph Store_watch Common Layered_store
    Import)
  (preprocess
   (pps ppx_irmin))

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -98,7 +98,8 @@ let t =
     $ clear
     $ gc)
 
-module Make (Store : Irmin.KV with type Schema.Contents.t = string) = struct
+module Make (Store : Irmin.Generic_key.KV with type Schema.Contents.t = string) =
+struct
   let info () = Store.Info.v ~author:"author" ~message:"commit message" 0L
 
   let times ~n ~init f =

--- a/src/irmin-test/irmin_bench.mli
+++ b/src/irmin-test/irmin_bench.mli
@@ -15,7 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (S : Irmin.KV with type Schema.Contents.t = string) : sig
+module Make (S : Irmin.Generic_key.KV with type Schema.Contents.t = string) : sig
   val run :
     config:(root:string -> Irmin.config) -> size:(root:string -> int) -> unit
 end

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -15,6 +15,7 @@
  *)
 
 module type S = Common.S
+module type Generic_key = Common.Generic_key
 module type Layered_store = Common.Layered_store
 
 val reporter : ?prefix:string -> unit -> Logs.reporter
@@ -32,9 +33,19 @@ module Suite : sig
     stats:(unit -> int * int) option ->
     t
 
+  val create_generic_key :
+    name:string ->
+    init:(unit -> unit Lwt.t) ->
+    clean:(unit -> unit Lwt.t) ->
+    config:Irmin.config ->
+    store:(module Generic_key) ->
+    layered_store:(module Layered_store) option ->
+    stats:(unit -> int * int) option ->
+    t
+
   val name : t -> string
   val config : t -> Irmin.config
-  val store : t -> (module S)
+  val store : t -> (module S) option
   val init : t -> unit -> unit Lwt.t
   val clean : t -> unit -> unit Lwt.t
 end

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -25,24 +25,24 @@ module Suite : sig
 
   val create :
     name:string ->
-    init:(unit -> unit Lwt.t) ->
-    clean:(unit -> unit Lwt.t) ->
+    ?init:(unit -> unit Lwt.t) ->
+    ?clean:(unit -> unit Lwt.t) ->
     config:Irmin.config ->
     store:(module S) ->
     layered_store:(module Layered_store) option ->
-    stats:(unit -> int * int) option ->
+    ?stats:(unit -> int * int) ->
     ?import_supported:bool ->
     unit ->
     t
 
   val create_generic_key :
     name:string ->
-    init:(unit -> unit Lwt.t) ->
-    clean:(unit -> unit Lwt.t) ->
+    ?init:(unit -> unit Lwt.t) ->
+    ?clean:(unit -> unit Lwt.t) ->
     config:Irmin.config ->
     store:(module Generic_key) ->
     layered_store:(module Layered_store) option ->
-    stats:(unit -> int * int) option ->
+    ?stats:(unit -> int * int) ->
     ?import_supported:bool ->
     unit ->
     t

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -31,6 +31,8 @@ module Suite : sig
     store:(module S) ->
     layered_store:(module Layered_store) option ->
     stats:(unit -> int * int) option ->
+    ?import_supported:bool ->
+    unit ->
     t
 
   val create_generic_key :
@@ -41,6 +43,8 @@ module Suite : sig
     store:(module Generic_key) ->
     layered_store:(module Layered_store) option ->
     stats:(unit -> int * int) option ->
+    ?import_supported:bool ->
+    unit ->
     t
 
   val name : t -> string

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -14,19 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type S =
-  Irmin.S
-    with type Schema.Path.step = string
-     and type Schema.Path.t = string list
-     and type Schema.Contents.t = string
-     and type Schema.Branch.t = string
-
-module type Layered_store =
-  Irmin_layers.S
-    with type Schema.Path.step = string
-     and type Schema.Path.t = string list
-     and type Schema.Contents.t = string
-     and type Schema.Branch.t = string
+module type S = Common.S
+module type Layered_store = Common.Layered_store
 
 val reporter : ?prefix:string -> unit -> Logs.reporter
 
@@ -70,3 +59,5 @@ module Store : sig
     (Alcotest.speed_level * Suite.t) list ->
     unit
 end
+
+module Node = Node

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -25,6 +25,7 @@ module Make_Layered (S : Layered_store) = struct
   module P = S.Private
   module Graph = Irmin.Node.Graph (P.Node)
   module History = Irmin.Commit.History (P.Commit)
+  open Common.Make_helpers (S)
 
   let info message =
     let date = Int64.of_float 0. in
@@ -40,13 +41,6 @@ module Make_Layered (S : Layered_store) = struct
   let v6 = "X6"
   let b1 = "foo"
   let b2 = "bar/toto"
-  let with_contents repo f = P.Repo.batch repo (fun t _ _ -> f t)
-  let with_node repo f = P.Repo.batch repo (fun _ t _ -> f t)
-  let with_commit repo f = P.Repo.batch repo (fun _ _ t -> f t)
-  let with_info repo n f = with_commit repo (fun h -> f h ~info:(info n))
-  let normal x = `Contents (x, S.Metadata.default)
-  let h repo = P.Repo.commit_t repo
-  let n repo = P.Repo.node_t repo
 
   let n1 ~repo =
     let* kv1 = with_contents repo (fun t -> P.Contents.add t v1) in
@@ -55,7 +49,7 @@ module Make_Layered (S : Layered_store) = struct
 
   let r1 ~repo =
     let* kn2 = n1 ~repo in
-    S.Tree.of_hash repo (`Node kn2) >>= function
+    S.Tree.of_key repo (`Node kn2) >>= function
     | None -> Alcotest.fail "r1"
     | Some tree ->
         S.Commit.v repo ~info:(info "r1") ~parents:[] (tree :> S.tree)
@@ -64,21 +58,11 @@ module Make_Layered (S : Layered_store) = struct
     let* kn2 = n1 ~repo in
     let* kn3 = with_node repo (fun t -> Graph.v t [ ("a", `Node kn2) ]) in
     let* kr1 = r1 ~repo in
-    S.Tree.of_hash repo (`Node kn3) >>= function
+    S.Tree.of_key repo (`Node kn3) >>= function
     | None -> Alcotest.fail "r2"
     | Some t3 ->
-        S.Commit.v repo ~info:(info "r2") ~parents:[ S.Commit.hash kr1 ]
+        S.Commit.v repo ~info:(info "r2") ~parents:[ S.Commit.key kr1 ]
           (t3 :> S.tree)
-
-  let run x test =
-    try
-      Lwt_main.run
-        (let* () = x.init () in
-         let* repo = S.Repo.v x.config in
-         test repo >>= x.clean)
-    with e ->
-      Lwt_main.run (x.clean ());
-      raise e
 
   let fail_with_none f msg =
     f >>= function None -> Alcotest.fail msg | Some c -> Lwt.return c
@@ -109,7 +93,7 @@ module Make_Layered (S : Layered_store) = struct
       in
       let* t1 = P.Commit.find (h repo) kr1 in
       let* commit =
-        fail_with_none (S.Commit.of_hash repo kr1) "of_hash commit"
+        fail_with_none (S.Commit.of_key repo kr1) "of_hash commit"
       in
       S.freeze repo ~max_lower:[ commit ] ~max_upper:[] >>= fun () ->
       let* t1' = P.Commit.find (h repo) kr1 in
@@ -133,7 +117,7 @@ module Make_Layered (S : Layered_store) = struct
       check_keys "closure over upper and lower" [ kr1; kr2 ] kr2s;
       let* t2 = P.Commit.find (h repo) kr2' in
       let* commit =
-        fail_with_none (S.Commit.of_hash repo kr2') "of_hash commit"
+        fail_with_none (S.Commit.of_key repo kr2') "of_key commit"
       in
       S.freeze repo ~max_lower:[ commit ] ~max_upper:[] >>= fun () ->
       let* t1' = P.Commit.find (h repo) kr1 in
@@ -165,11 +149,11 @@ module Make_Layered (S : Layered_store) = struct
       let* tree = S.Tree.add tree [ "c"; "b"; "a" ] "x" in
       let* c0 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b"; "a1" ] "x1" in
-      let* c1 = S.Commit.v repo ~info ~parents:[ S.Commit.hash c0 ] tree in
+      let* c1 = S.Commit.v repo ~info ~parents:[ S.Commit.key c0 ] tree in
       let* tree = S.Tree.add tree [ "c"; "b"; "a2" ] "x2" in
-      let* c2 = S.Commit.v repo ~info ~parents:[ S.Commit.hash c1 ] tree in
+      let* c2 = S.Commit.v repo ~info ~parents:[ S.Commit.key c1 ] tree in
       let* tree = S.Tree.add tree [ "c"; "b"; "a3" ] "x3" in
-      let* c3 = S.Commit.v repo ~info ~parents:[ S.Commit.hash c1 ] tree in
+      let* c3 = S.Commit.v repo ~info ~parents:[ S.Commit.key c1 ] tree in
       Lwt.return (c2, c3)
     in
     (*
@@ -183,18 +167,18 @@ module Make_Layered (S : Layered_store) = struct
       let* tree = S.Tree.add tree [ "c"; "b2" ] "x5" in
       let* c5 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b1"; "a" ] "x6" in
-      let* c6 = S.Commit.v repo ~info ~parents:[ S.Commit.hash c5 ] tree in
+      let* c6 = S.Commit.v repo ~info ~parents:[ S.Commit.key c5 ] tree in
       let* tree = S.Tree.add tree [ "c"; "e" ] "x7" in
-      let* c7 = S.Commit.v repo ~info ~parents:[ S.Commit.hash c6 ] tree in
+      let* c7 = S.Commit.v repo ~info ~parents:[ S.Commit.key c6 ] tree in
       let* tree = S.Tree.add tree [ "c"; "d" ] "x8" in
-      let* c8 = S.Commit.v repo ~info ~parents:[ S.Commit.hash c6 ] tree in
+      let* c8 = S.Commit.v repo ~info ~parents:[ S.Commit.key c6 ] tree in
       Lwt.return (c4, c5, c7, c8)
     in
     let test repo =
       let* c2, c3 = tree1 repo in
-      let* t2 = P.Commit.find (h repo) (S.Commit.hash c2) in
+      let* t2 = P.Commit.find (h repo) (S.Commit.key c2) in
       S.freeze repo ~max_lower:[ c2 ] ~max_upper:[] >>= fun () ->
-      let* t2' = P.Commit.find (h repo) (S.Commit.hash c2) in
+      let* t2' = P.Commit.find (h repo) (S.Commit.key c2) in
       check_val "c2" t2 t2';
       let tree = S.Commit.tree c2 in
       let* x1 = S.Tree.find tree [ "c"; "b"; "a1" ] in
@@ -205,7 +189,7 @@ module Make_Layered (S : Layered_store) = struct
       Alcotest.(check (option string)) "x2" (Some "x2") x2;
       let* () =
         if not (S.async_freeze repo) then (
-          let* t3 = P.Commit.find (h repo) (S.Commit.hash c3) in
+          let* t3 = P.Commit.find (h repo) (S.Commit.key c3) in
           check_val "c3" None t3;
           let* x3 = S.Tree.find tree [ "c"; "b"; "a3" ] in
           Alcotest.(check (option string)) "x3" None x3;
@@ -214,29 +198,27 @@ module Make_Layered (S : Layered_store) = struct
         else Lwt.return_unit
       in
       let* c4, c5, c7, c8 = tree2 repo in
-      let* t5 = P.Commit.find (h repo) (S.Commit.hash c5) in
-      let* t7 = P.Commit.find (h repo) (S.Commit.hash c7) in
+      let* t5 = P.Commit.find (h repo) (S.Commit.key c5) in
+      let* t7 = P.Commit.find (h repo) (S.Commit.key c7) in
       S.freeze repo ~max_lower:[ c7 ] ~max_upper:[] >>= fun () ->
-      let* t5' = P.Commit.find (h repo) (S.Commit.hash c5) in
+      let* t5' = P.Commit.find (h repo) (S.Commit.key c5) in
       check_val "c5" t5 t5';
-      let* t7' = P.Commit.find (h repo) (S.Commit.hash c7) in
+      let* t7' = P.Commit.find (h repo) (S.Commit.key c7) in
       check_val "c7" t7 t7';
       let* c7 =
-        fail_with_none
-          (S.Commit.of_hash repo (S.Commit.hash c7))
-          "of_hash commit"
+        fail_with_none (S.Commit.of_key repo (S.Commit.key c7)) "of_key commit"
       in
       let tree = S.Commit.tree c7 in
       let* x7 = S.Tree.find tree [ "c"; "e" ] in
       Alcotest.(check (option string)) "x7" (Some "x7") x7;
       let* () =
         if not (S.async_freeze repo) then (
-          let* t4 = P.Commit.find (h repo) (S.Commit.hash c4) in
+          let* t4 = P.Commit.find (h repo) (S.Commit.key c4) in
           check_val "c4" None t4;
-          let* t8 = P.Commit.find (h repo) (S.Commit.hash c8) in
+          let* t8 = P.Commit.find (h repo) (S.Commit.key c8) in
           check_val "c8" None t8;
           fail_with_some
-            (S.Commit.of_hash repo (S.Commit.hash c8))
+            (S.Commit.of_key repo (S.Commit.key c8))
             "should not find c8")
         else Lwt.return_unit
       in
@@ -266,11 +248,11 @@ module Make_Layered (S : Layered_store) = struct
     S.layer_id repo handler >|= check Irmin_layers.Layer_id.t msg exp
 
   let check_layer_for_commits repo commit msg exp =
-    check_layer repo (S.Commit_t (S.Commit.hash commit)) msg exp
+    check_layer repo (S.Commit_t (S.Commit.key commit)) msg exp
 
   let test_set x () =
     let check_list = checks T.(pair S.Key.step_t S.tree_t) in
-    let check_parents = checks S.Hash.t in
+    let check_parents = checks P.Commit.Key.t in
     let contents v = S.Tree.v (`Contents (v, S.Metadata.default)) in
     let test repo =
       let* t = S.master repo in
@@ -289,7 +271,7 @@ module Make_Layered (S : Layered_store) = struct
       check_layer_for_commits repo c2 "layer id of commit 2" `Upper0
       >>= fun () ->
       let parents = S.Commit.parents c2 in
-      check_parents "parents of c2" [ S.Commit.hash c1 ] parents;
+      check_parents "parents of c2" [ S.Commit.key c1 ] parents;
       let* s = S.get t [ "a"; "b"; "c" ] in
       (* read value from lower layers *)
       Alcotest.(check string) "commit 1" s v1;
@@ -412,22 +394,22 @@ module Make_Layered (S : Layered_store) = struct
         if not (S.async_freeze repo) then
           let* () =
             fail_with_some
-              (S.Commit.of_hash repo (S.Commit.hash c))
+              (S.Commit.of_key repo (S.Commit.key c))
               "should not find c"
           in
           let* () =
             fail_with_some
-              (S.Commit.of_hash repo (S.Commit.hash c1))
+              (S.Commit.of_key repo (S.Commit.key c1))
               "should not find c1"
           in
           let* () =
             fail_with_some
-              (S.Commit.of_hash repo (S.Commit.hash c2))
+              (S.Commit.of_key repo (S.Commit.key c2))
               "should not find c2"
           in
           let* _ =
             fail_with_none
-              (S.Commit.of_hash repo (S.Commit.hash c3))
+              (S.Commit.of_key repo (S.Commit.key c3))
               "should find c3"
           in
           Lwt.return_unit
@@ -477,7 +459,7 @@ module Make_Layered (S : Layered_store) = struct
         S.freeze repo ~min_lower:heads ~max_lower:heads ~max_upper:[]
       in
       let* () =
-        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.hash c1) >>= function
+        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.key c1) >>= function
         | true ->
             if not (S.async_freeze repo) then
               check_layer_for_commits repo c1 "layer id commit 1" `Lower
@@ -486,7 +468,7 @@ module Make_Layered (S : Layered_store) = struct
             Alcotest.failf "did not copy commit %a to dst" S.Commit.pp_hash c1
       in
       let* () =
-        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.hash c2) >>= function
+        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.key c2) >>= function
         | true ->
             if not (S.async_freeze repo) then
               check_layer_for_commits repo c2 "layer id commit 2" `Lower
@@ -509,14 +491,14 @@ module Make_Layered (S : Layered_store) = struct
       >>= fun () ->
       S.Private_layer.wait_for_freeze repo >>= fun () ->
       let* () =
-        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.hash c1) >|= function
+        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.key c1) >|= function
         | true ->
             Alcotest.failf "should not copy commit %a to dst" S.Commit.pp_hash
               c1
         | false -> ()
       in
       let* () =
-        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.hash c2) >>= function
+        P.Commit.mem (P.Repo.commit_t repo) (S.Commit.key c2) >>= function
         | true -> check_layer_for_commits repo c2 "layer id commit 2" `Lower
         | false ->
             Alcotest.failf "should copy commit %a to dst" S.Commit.pp_hash c2
@@ -610,7 +592,7 @@ module Make_Layered (S : Layered_store) = struct
       S.Tree.clear tree;
       let* commit =
         fail_with_none
-          (S.Commit.of_hash repo (S.Commit.hash h))
+          (S.Commit.of_key repo (S.Commit.key h))
           "commit not found"
       in
       let tree = S.Commit.tree commit in
@@ -648,7 +630,7 @@ module Make_Layered (S : Layered_store) = struct
       in
       (* Test that commit c1 and all its objects are preserved in upper after a
          freeze. *)
-      let* c1 = fail_with_none (S.Commit.of_hash repo kr1) "of_hash commit" in
+      let* c1 = fail_with_none (S.Commit.of_key repo kr1) "of_key commit" in
       (* copy in upper too *)
       S.freeze repo ~max_lower:[ c1 ] >>= fun () ->
       S.Private_layer.wait_for_freeze repo >>= fun () ->
@@ -674,7 +656,7 @@ module Make_Layered (S : Layered_store) = struct
       in
       (* Test that commits c1 and c2 are preserved in upper during and after a
          freeze. *)
-      let* c2 = fail_with_none (S.Commit.of_hash repo kr2) "of_hash commit" in
+      let* c2 = fail_with_none (S.Commit.of_key repo kr2) "of_key commit" in
       let* () =
         (* copy in upper too *)
         S.freeze repo ~min_upper:[ c1 ] ~max_lower:[ c2 ]
@@ -701,12 +683,13 @@ module Make_Layered (S : Layered_store) = struct
          a freeze. *)
       (* copy in upper too *)
       S.freeze repo ~max_lower:[ c1 ] >>= fun () ->
-      let* hv1 = fail_with_none (S.hash foo [ "a"; "b"; "c" ]) "hash of v1'" in
+      let* hv1 = fail_with_none (S.key foo [ "a"; "b"; "c" ]) "hash of v1'" in
+      let hv1 = get_contents_key hv1 in
       check_layer_id repo (S.Content_t hv1) "layer id of v1" `Upper
       >>= fun () ->
       S.set_exn foo [ "a"; "d" ] v2 ~info:(infof "commit 2") >>= fun () ->
       let* c2 = S.Head.get foo in
-      let hc2 = S.Commit.hash c2 in
+      let hc2 = S.Commit.key c2 in
       check_layer_id repo (S.Commit_t hc2) "layer_id commit 2" `Upper
       >>= fun () ->
       S.Private_layer.wait_for_freeze repo >>= fun () ->
@@ -720,11 +703,12 @@ module Make_Layered (S : Layered_store) = struct
       >>= fun () ->
       check_layer_id repo (S.Content_t hv1) "layer id of v1" `Upper
       >>= fun () ->
-      let* hv2 = fail_with_none (S.hash foo [ "a"; "d" ]) "hash of v2'" in
+      let* hv2 = fail_with_none (S.key foo [ "a"; "d" ]) "hash of v2'" in
+      let hv2 = get_contents_key hv2 in
       check_layer_id repo (S.Content_t hv2) "layer id of v2" `Upper
       >>= fun () ->
       S.Private_layer.wait_for_freeze repo >>= fun () ->
-      let hc1 = S.Commit.hash c1 in
+      let hc1 = S.Commit.key c1 in
       check_layer_id repo (S.Commit_t hc1) "layer_id commit 1" `Lower
       >>= fun () ->
       check_layer_id repo (S.Commit_t hc2) "layer_id commit 2" `Upper
@@ -768,14 +752,14 @@ module Make_Layered (S : Layered_store) = struct
           | 1 ->
               let* c1 =
                 S.Commit.v repo ~info
-                  ~parents:[ S.Commit.hash (List.nth commits 0) ]
+                  ~parents:[ S.Commit.key (List.nth commits 0) ]
                   tree'
               in
               setup (i + 1) tree' (commits @ [ c1 ]) contents
           | 2 ->
               let* c =
                 S.Commit.v repo ~info
-                  ~parents:[ S.Commit.hash (List.nth commits 1) ]
+                  ~parents:[ S.Commit.key (List.nth commits 1) ]
                   tree'
               in
               S.Branch.set repo b c >>= fun () ->
@@ -783,7 +767,7 @@ module Make_Layered (S : Layered_store) = struct
           | 3 ->
               let* c =
                 S.Commit.v repo ~info
-                  ~parents:[ S.Commit.hash (List.nth commits 1) ]
+                  ~parents:[ S.Commit.key (List.nth commits 1) ]
                   tree'
               in
               S.Branch.set repo b c >>= fun () ->
@@ -791,14 +775,14 @@ module Make_Layered (S : Layered_store) = struct
           | 4 ->
               let* c =
                 S.Commit.v repo ~info
-                  ~parents:[ S.Commit.hash (List.nth commits 3) ]
+                  ~parents:[ S.Commit.key (List.nth commits 3) ]
                   tree'
               in
               setup (i + 1) tree (commits @ [ c ]) contents
           | 5 | 6 ->
               let* c =
                 S.Commit.v repo ~info
-                  ~parents:[ S.Commit.hash (List.nth commits 3) ]
+                  ~parents:[ S.Commit.key (List.nth commits 3) ]
                   tree'
               in
               S.Branch.set repo b c >>= fun () ->
@@ -822,7 +806,7 @@ module Make_Layered (S : Layered_store) = struct
         Lwt_list.iter_p
           (fun i ->
             let+ t =
-              P.Commit.find (h repo) (S.Commit.hash (List.nth commits i))
+              P.Commit.find (h repo) (S.Commit.key (List.nth commits i))
             in
             check_commit "deleted commit" None t)
           [ 0; 2; 4 ]
@@ -838,14 +822,14 @@ module Make_Layered (S : Layered_store) = struct
 
       let* () =
         check_layer_id repo
-          (S.Commit_t (S.Commit.hash (List.nth commits 1)))
+          (S.Commit_t (S.Commit.key (List.nth commits 1)))
           "layer id of c1" `Lower
       in
       let* () =
         Lwt_list.iter_p
           (fun i ->
             check_layer_id repo
-              (S.Commit_t (S.Commit.hash (List.nth commits i)))
+              (S.Commit_t (S.Commit.key (List.nth commits i)))
               ("layer id of c" ^ string_of_int i)
               `Upper)
           [ 3; 5; 6 ]
@@ -969,7 +953,7 @@ module Make_Layered (S : Layered_store) = struct
       let find_commit c v () =
         let* commit =
           fail_with_none
-            (S.Commit.of_hash repo (S.Commit.hash c))
+            (S.Commit.of_key repo (S.Commit.key c))
             "no hash found in repo"
         in
         let tree = S.Commit.tree commit in
@@ -1001,7 +985,7 @@ module Make_Layered (S : Layered_store) = struct
         let* c = S.Head.get t in
         let* commit =
           fail_with_none
-            (S.Commit.of_hash repo (S.Commit.hash c))
+            (S.Commit.of_key repo (S.Commit.key c))
             "no hash found in repo"
         in
         let tree = S.Commit.tree commit in
@@ -1056,7 +1040,7 @@ module Make_Layered (S : Layered_store) = struct
       let* c = S.Head.get t in
       let* commit =
         fail_with_none
-          (S.Commit.of_hash repo (S.Commit.hash c))
+          (S.Commit.of_key repo (S.Commit.key c))
           "no hash found in repo"
       in
       let tree = S.Commit.tree commit in

--- a/src/irmin-test/node.ml
+++ b/src/irmin-test/node.ml
@@ -1,0 +1,50 @@
+let check pos typ ~expected actual =
+  let typ =
+    Alcotest.testable Irmin.Type.(pp_dump typ) Irmin.Type.(unstage (equal typ))
+  in
+  Alcotest.(check ~pos typ) "" expected actual
+
+module Make (Make_node : Irmin.Node.Generic_key.Maker) : sig
+  val suite : unit Alcotest.test_case list
+end = struct
+  module Schema = Irmin.Schema.KV (Irmin.Contents.String)
+  module Hash = Schema.Hash
+  module Key = Irmin.Key.Of_hash (Hash)
+  module X = Make_node (Hash) (Schema.Path) (Schema.Metadata) (Key) (Key)
+
+  type key = Key.t [@@deriving irmin]
+
+  let random_key =
+    let hash_of_string = Irmin.Type.(unstage (of_bin_string Hash.t)) in
+    let random_string =
+      Irmin.Type.(unstage (random (string_of (`Fixed Hash.hash_size))))
+    in
+    fun () ->
+      match hash_of_string (random_string ()) with
+      | Ok x -> x
+      | Error _ -> assert false
+
+  let test_empty () =
+    check __POS__ [%typ: bool] ~expected:true X.(is_empty empty);
+    check __POS__ [%typ: int] ~expected:0 X.(length empty);
+    check __POS__ [%typ: (X.step * X.value) list] ~expected:[] X.(list empty)
+
+  let test_add () =
+    let with_binding k v t = X.add t k v in
+    let k1 = random_key () and k2 = random_key () in
+    let a =
+      X.empty |> with_binding "a" (`Node k1) |> with_binding "b" (`Node k2)
+    in
+    check __POS__ [%typ: int] ~expected:2 (X.length a)
+
+  let test_remove () =
+    (* Remove is a no-op on an empty node *)
+    check __POS__ [%typ: X.t] ~expected:X.empty X.(remove empty "foo")
+
+  let suite =
+    [
+      Alcotest.test_case "empty" `Quick test_empty;
+      Alcotest.test_case "add" `Quick test_add;
+      Alcotest.test_case "remove" `Quick test_remove;
+    ]
+end

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1439,8 +1439,6 @@ module Make (S : Generic_key) = struct
       | `Contents _ -> Alcotest.fail "got `Contents, expected `Node"
       | `Node node -> (
           let* v = S.to_private_node node in
-          let module PNode = P.Node_portable in
-          let module PNode_hash = Irmin.Hash.Typed (P.Hash) (P.Node_portable) in
           let () =
             let ls = P.Node.Val.list v in
             Alcotest.(check int) "list wide node" size (List.length ls)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2042,6 +2042,8 @@ let suite' l ?(prefix = "") (_, x) =
   let module T = Make (S) in
   (prefix ^ x.name, l)
 
+let when_ b x = if b then x else []
+
 let suite (speed, x) =
   let (module S) = Suite.store_generic_key x in
   let module T = Make (S) in
@@ -2056,14 +2058,12 @@ let suite (speed, x) =
        ("Basic operations on branches", speed, T.test_branches x);
        ("Hash operations on trees", speed, T.test_tree_hashes x);
        ("Basic merge operations", speed, T.test_simple_merges x);
-       ("Basic operations on slices", speed, T.test_slice x);
        ("Test merges on tree updates", speed, T.test_merge_outdated_tree x);
        ("Tree caches and hashconsing", speed, T.test_tree_caches x);
        ("Complex histories", speed, T.test_history x);
        ("Empty stores", speed, T.test_empty x);
        ("Private node manipulation", speed, T.test_private_nodes x);
        ("High-level store operations", speed, T.test_stores x);
-       ("High-level store synchronisation", speed, T.test_sync x);
        ("High-level store merges", speed, T.test_merge x);
        ("Unrelated merges", speed, T.test_merge_unrelated x);
        ("Low-level concurrency", speed, T.test_concurrent_low x);
@@ -2075,6 +2075,11 @@ let suite (speed, x) =
        ("Closure with disconnected commits", speed, T.test_closure x);
        ("Clear", speed, T.test_clear x);
      ]
+    @ when_ x.import_supported
+        [
+          ("Basic operations on slices", speed, T.test_slice x);
+          ("High-level store synchronisation", speed, T.test_sync x);
+        ]
     @ List.map (fun (n, test) -> ("Graph." ^ n, speed, test x)) T_graph.tests
     @ List.map (fun (n, test) -> ("Watch." ^ n, speed, test x)) T_watch.tests)
     (speed, x)
@@ -2103,7 +2108,6 @@ let layered_suite (speed, x) =
           ("Basic merge operations", speed, T.test_simple_merges ~hook x);
           ("Complex histories", speed, T.test_history ~hook x);
           ("Empty stores", speed, T.test_empty ~hook x);
-          ("Basic operations on slices", speed, T.test_slice ~hook x);
           ("Private node manipulation", speed, T.test_private_nodes ~hook x);
           ("High-level store merges", speed, T.test_merge ~hook x);
           ("Unrelated merges", speed, T.test_merge_unrelated ~hook x);
@@ -2127,7 +2131,9 @@ let layered_suite (speed, x) =
           ("Test find during freeze", speed, TL.test_find_during_freeze x);
           ("Test add during freeze", speed, TL.test_add_during_freeze x);
           ("Adds again objects deleted by freeze", speed, TL.test_add_again x);
-        ] )
+        ]
+        @ when_ x.import_supported
+            [ ("Basic operations on slices", speed, T.test_slice ~hook x) ] )
 
 let run name ?(slow = false) ~misc tl =
   Printexc.record_backtrace true;

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -49,16 +49,16 @@ module Make (S : S) = struct
     | None -> Lwt.return_unit
     | Some f -> f repo commits
 
-  let may_get_hashes repo hashes = function
+  let may_get_keys repo keys = function
     | None -> Lwt.return_unit
     | Some f ->
         let* commits =
           Lwt_list.map_p
-            (fun hash ->
-              S.Commit.of_hash repo hash >|= function
+            (fun key ->
+              S.Commit.of_key repo key >|= function
               | None -> Alcotest.fail "Cannot read commit hash"
               | Some c -> c)
-            hashes
+            keys
         in
         f repo commits
 
@@ -117,14 +117,15 @@ module Make (S : S) = struct
   let test_nodes x () =
     let test repo =
       let g = g repo and n = n repo in
-      let k = normal (P.Contents.Key.hash "foo") in
+      let k = normal (P.Contents.Hash.hash "foo") in
+      let check_hash = check P.Hash.t in
       let check_key = check P.Node.Key.t in
       let check_val = check [%typ: Graph.value option] in
       let check_list = checks [%typ: S.step * P.Node.Val.value] in
       let check_node msg v =
-        let h' = H_node.hash v in
-        let+ h = with_node repo (fun n -> P.Node.add n v) in
-        check_key (msg ^ ": hash(v) = add(v)") h h'
+        let h' = P.Node.Hash.hash v in
+        let+ key = with_node repo (fun n -> P.Node.add n v) in
+        check_hash (msg ^ ": hash(v) = add(v)") (P.Node.Key.to_hash key) h'
       in
       let v = P.Node.Val.empty in
       check_node "empty node" v >>= fun () ->
@@ -162,9 +163,9 @@ module Make (S : S) = struct
       check_node "node: x+y+z+a" u >>= fun () ->
       let u = P.Node.Val.add u "b" k in
       check_node "node: x+y+z+a+b" u >>= fun () ->
-      let h = H_node.hash u in
+      let h = P.Node.Hash.hash u in
       let* k = with_node repo (fun n -> P.Node.add n u) in
-      check_key "hash(v) = add(v)" h k;
+      check_hash "hash(v) = add(v)" h (P.Node.Key.to_hash k);
       let* w = P.Node.find n k in
       check_values (get w);
       let* kv1 = kv1 ~repo in
@@ -291,7 +292,7 @@ module Make (S : S) = struct
       let* kr2s = History.closure h ~min:[] ~max:[ kr2 ] in
       check_keys "g2" [ kr1; kr2 ] kr2s;
       let* () =
-        S.Commit.of_hash repo kr1 >|= function
+        S.Commit.of_key repo kr1 >|= function
         | None -> Alcotest.fail "Cannot read commit hash"
         | Some c ->
             Alcotest.(check string)
@@ -314,6 +315,7 @@ module Make (S : S) = struct
         S.Info.v ~author:"test" ~message (Int64.of_int date)
       in
       let check_keys = checks P.Commit.Key.t in
+      let equal_key = Irmin.Type.(unstage (equal P.Commit.Key.t)) in
       let h = h repo in
       let initialise_nodes =
         Lwt_list.map_p
@@ -403,7 +405,7 @@ module Make (S : S) = struct
       in
       let* () =
         let+ ls = History.closure h ~min:[ commits.(7) ] ~max:[ commits.(6) ] in
-        if List.mem ~equal:H_node.equal commits.(7) ls then
+        if List.mem ~equal:equal_key commits.(7) ls then
           Alcotest.fail "disconnected node should not be in closure"
       in
       let* krs =
@@ -418,7 +420,7 @@ module Make (S : S) = struct
             ~min:[ commits.(4); commits.(0) ]
             ~max:[ commits.(4); commits.(6) ]
         in
-        if List.mem ~equal:H_node.equal commits.(0) ls then
+        if List.mem ~equal:equal_key commits.(0) ls then
           Alcotest.fail "disconnected node should not be in closure"
       in
       S.Repo.close repo
@@ -478,7 +480,7 @@ module Make (S : S) = struct
       let check_hash msg bindings =
         let* node = node bindings in
         let+ tree = tree bindings in
-        check S.Hash.t msg node (S.Tree.hash tree)
+        check P.Hash.t msg (P.Node.Key.to_hash node) (S.Tree.hash tree)
       in
       check_hash "empty" [] >>= fun () ->
       let bindings1 = [ ([ "a" ], "x"); ([ "b" ], "y") ] in
@@ -569,7 +571,7 @@ module Make (S : S) = struct
       let* kr0, _ = with_info 0 (History.v ~node:k0 ~parents:[]) in
       let* kr1, _ = with_info 1 (History.v ~node:k2 ~parents:[ kr0 ]) in
       let* kr2, _ = with_info 2 (History.v ~node:k3 ~parents:[ kr0 ]) in
-      may_get_hashes repo [ kr1; kr2 ] hook >>= fun () ->
+      may_get_keys repo [ kr1; kr2 ] hook >>= fun () ->
       let* kr3 =
         with_info 3 (fun h ~info ->
             Irmin.Merge.f
@@ -577,28 +579,29 @@ module Make (S : S) = struct
               ~old:(old kr0) kr1 kr2)
       in
       let* kr3 = merge_exn "kr3" kr3 in
-      may_get_hashes repo [ kr3 ] hook >>= fun () ->
-      let* kr3_id' =
+      may_get_keys repo [ kr3 ] hook >>= fun () ->
+      let* kr3_key' =
         with_info 4 (fun h ~info ->
             Irmin.Merge.f
               (History.merge h ~info:(fun () -> info))
               ~old:(old kr2) kr2 kr3)
       in
-      let* kr3_id' = merge_exn "kr3_id'" kr3_id' in
-      check S.Hash.t "kr3 id with immediate parent'" kr3 kr3_id';
-      let* kr3_id =
+      let* kr3_key' = merge_exn "kr3_key'" kr3_key' in
+      let check_key = check P.Commit.Key.t in
+      check_key "kr3 id with immediate parent'" kr3 kr3_key';
+      let* kr3_key =
         with_info 5 (fun h ~info ->
             Irmin.Merge.f
               (History.merge h ~info:(fun () -> info))
               ~old:(old kr0) kr0 kr3)
       in
-      let* kr3_id = merge_exn "kr3_id" kr3_id in
-      check S.Hash.t "kr3 id with old parent" kr3 kr3_id;
+      let* kr3_key = merge_exn "kr3_key" kr3_key in
+      check_key "kr3 key with old parent" kr3 kr3_key;
       let* kr3', _ = with_info 3 @@ History.v ~node:k4 ~parents:[ kr1; kr2 ] in
       let* r3 = P.Commit.find c kr3 in
       let* r3' = P.Commit.find c kr3' in
       check T.(option P.Commit.Val.t) "r3" r3 r3';
-      check S.Hash.t "kr3" kr3 kr3';
+      check_key "kr3" kr3 kr3';
       P.Repo.close repo
     in
     run x test
@@ -670,22 +673,22 @@ module Make (S : S) = struct
       assert_history_empty "nonempty 1 commit" c0 false >>= fun () ->
       let* tree = S.Tree.add tree k1 (random_value 1024) in
       let* c1 =
-        S.Commit.v repo ~info:(info 1) ~parents:[ S.Commit.hash c0 ] tree
+        S.Commit.v repo ~info:(info 1) ~parents:[ S.Commit.key c0 ] tree
       in
       assert_history_empty "nonempty 2 commits" c0 false >>= fun () ->
       let* tree = S.Tree.add tree k0 (random_value 1024) in
       let* c2 =
-        S.Commit.v repo ~info:(info 2) ~parents:[ S.Commit.hash c1 ] tree
+        S.Commit.v repo ~info:(info 2) ~parents:[ S.Commit.key c1 ] tree
       in
       let* tree = S.Tree.add tree k0 (random_value 1024) in
       let* tree = S.Tree.add tree k1 (random_value 1024) in
       let* c3 =
-        S.Commit.v repo ~info:(info 3) ~parents:[ S.Commit.hash c2 ] tree
+        S.Commit.v repo ~info:(info 3) ~parents:[ S.Commit.key c2 ] tree
       in
       may repo [ c3 ] hook >>= fun () ->
       let* tree = S.Tree.add tree k1 (random_value 1024) in
       let* c4 =
-        S.Commit.v repo ~info:(info 4) ~parents:[ S.Commit.hash c3 ] tree
+        S.Commit.v repo ~info:(info 4) ~parents:[ S.Commit.key c3 ] tree
       in
       assert_lcas "line lcas 1" ~max_depth:0 3 c3 c4 [ c3 ] >>= fun () ->
       assert_lcas "line lcas 2" ~max_depth:1 3 c2 c4 [ c2 ] >>= fun () ->
@@ -718,41 +721,41 @@ module Make (S : S) = struct
       *)
       let* tree = S.Tree.add tree k2 (random_value 1024) in
       let* c10 =
-        S.Commit.v repo ~info:(info 10) ~parents:[ S.Commit.hash c4 ] tree
+        S.Commit.v repo ~info:(info 10) ~parents:[ S.Commit.key c4 ] tree
       in
       let* tree_up = S.Tree.add tree k0 (random_value 1024) in
       let* tree_up = S.Tree.add tree_up k2 (random_value 1024) in
       let* c11 =
-        S.Commit.v repo ~info:(info 11) ~parents:[ S.Commit.hash c10 ] tree_up
+        S.Commit.v repo ~info:(info 11) ~parents:[ S.Commit.key c10 ] tree_up
       in
       let* tree_down = S.Tree.add tree k0 (random_value 1024) in
       let* tree_12 = S.Tree.add tree_down k1 (random_value 1024) in
       let* c12 =
-        S.Commit.v repo ~info:(info 12) ~parents:[ S.Commit.hash c10 ] tree_12
+        S.Commit.v repo ~info:(info 12) ~parents:[ S.Commit.key c10 ] tree_12
       in
       let* tree_up = S.Tree.add tree_up k1 (random_value 1024) in
       let* c13 =
-        S.Commit.v repo ~info:(info 13) ~parents:[ S.Commit.hash c11 ] tree_up
+        S.Commit.v repo ~info:(info 13) ~parents:[ S.Commit.key c11 ] tree_up
       in
       let* tree_down = S.Tree.add tree_12 k2 (random_value 1024) in
       let* c14 =
-        S.Commit.v repo ~info:(info 14) ~parents:[ S.Commit.hash c12 ] tree_down
+        S.Commit.v repo ~info:(info 14) ~parents:[ S.Commit.key c12 ] tree_down
       in
       let* tree_up = S.Tree.add tree_12 k1 (random_value 1024) in
       let* tree_up = S.Tree.add tree_up k2 (random_value 1024) in
       let* c15 =
         S.Commit.v repo ~info:(info 15)
-          ~parents:[ S.Commit.hash c12; S.Commit.hash c13 ]
+          ~parents:[ S.Commit.key c12; S.Commit.key c13 ]
           tree_up
       in
       let* tree_down = S.Tree.add tree_down k2 (random_value 1024) in
       let* c16 =
-        S.Commit.v repo ~info:(info 16) ~parents:[ S.Commit.hash c14 ] tree_down
+        S.Commit.v repo ~info:(info 16) ~parents:[ S.Commit.key c14 ] tree_down
       in
       let* tree_down = S.Tree.add tree_down k0 (random_value 1024) in
       let* c17 =
         S.Commit.v repo ~info:(info 17)
-          ~parents:[ S.Commit.hash c11; S.Commit.hash c16 ]
+          ~parents:[ S.Commit.key c11; S.Commit.key c16 ]
           tree_down
       in
       assert_lcas "x lcas 0" ~max_depth:0 5 c10 c10 [ c10 ] >>= fun () ->
@@ -790,29 +793,29 @@ module Make (S : S) = struct
                  \-----------/
       *)
       let* c10 =
-        S.Commit.v repo ~info:(info 10) ~parents:[ S.Commit.hash c4 ] tree
+        S.Commit.v repo ~info:(info 10) ~parents:[ S.Commit.key c4 ] tree
       in
       let* c11 =
-        S.Commit.v repo ~info:(info 11) ~parents:[ S.Commit.hash c10 ] tree
+        S.Commit.v repo ~info:(info 11) ~parents:[ S.Commit.key c10 ] tree
       in
       let* c12 =
-        S.Commit.v repo ~info:(info 12) ~parents:[ S.Commit.hash c11 ] tree
+        S.Commit.v repo ~info:(info 12) ~parents:[ S.Commit.key c11 ] tree
       in
       let* c13 =
-        S.Commit.v repo ~info:(info 13) ~parents:[ S.Commit.hash c12 ] tree
+        S.Commit.v repo ~info:(info 13) ~parents:[ S.Commit.key c12 ] tree
       in
       let* c14 =
         S.Commit.v repo ~info:(info 14)
-          ~parents:[ S.Commit.hash c11; S.Commit.hash c13 ]
+          ~parents:[ S.Commit.key c11; S.Commit.key c13 ]
           tree
       in
       let* c15 =
         S.Commit.v repo ~info:(info 15)
-          ~parents:[ S.Commit.hash c13; S.Commit.hash c14 ]
+          ~parents:[ S.Commit.key c13; S.Commit.key c14 ]
           tree
       in
       let* c16 =
-        S.Commit.v repo ~info:(info 16) ~parents:[ S.Commit.hash c11 ] tree
+        S.Commit.v repo ~info:(info 16) ~parents:[ S.Commit.key c11 ] tree
       in
       assert_lcas "weird lcas 1" ~max_depth:0 3 c14 c15 [ c14 ] >>= fun () ->
       assert_lcas "weird lcas 2" ~max_depth:0 3 c13 c15 [ c13 ] >>= fun () ->
@@ -1005,7 +1008,7 @@ module Make (S : S) = struct
     Alcotest.testable
       (fun ppf -> function
         | `Contents -> Fmt.string ppf "contents"
-        | `Node `Hash -> Fmt.string ppf "hash"
+        | `Node `Key -> Fmt.string ppf "key"
         | `Node `Map -> Fmt.string ppf "map"
         | `Node `Value -> Fmt.string ppf "value")
       ( = )
@@ -1018,7 +1021,7 @@ module Make (S : S) = struct
       (* Testing cache *)
       S.Tree.reset_counters ();
       let* v = S.get_tree t1 [] in
-      Alcotest.(check inspect) "inspect" (`Node `Hash) (S.Tree.inspect v);
+      Alcotest.(check inspect) "inspect" (`Node `Key) (S.Tree.inspect v);
       let* v = S.Tree.add v [ "foo" ] "foo" in
       Alcotest.(check inspect) "inspect:0" (`Node `Value) (S.Tree.inspect v);
       Alcotest.(check int) "val-v:0" 0 (S.Tree.counters ()).node_val_v;
@@ -1031,7 +1034,7 @@ module Make (S : S) = struct
       Alcotest.(check int) "val-v:2" 1 (S.Tree.counters ()).node_val_v;
       Alcotest.(check int) "val-list:2" 0 (S.Tree.counters ()).node_val_list;
       S.set_tree_exn t1 ~info [] v >>= fun () ->
-      Alcotest.(check inspect) "inspect:3" (`Node `Hash) (S.Tree.inspect v);
+      Alcotest.(check inspect) "inspect:3" (`Node `Key) (S.Tree.inspect v);
       Alcotest.(check int) "val-v:3" 1 (S.Tree.counters ()).node_val_v;
       Alcotest.(check int) "val-list:3" 0 (S.Tree.counters ()).node_val_list;
       P.Repo.close repo
@@ -1047,13 +1050,15 @@ module Make (S : S) = struct
       let nodes = random_nodes 100 in
       let foo1 = random_value 10 in
       let foo2 = random_value 10 in
-      S.Tree.empty |> fun v1 ->
-      let* v1 = S.Tree.add v1 [ "foo"; "toto" ] foo1 in
-      let* v1 = S.Tree.add v1 [ "foo"; "bar"; "toto" ] foo2 in
+      let* v1 =
+        S.Tree.empty
+        |> with_binding [ "foo"; "bar"; "toto" ] foo2
+        >>= with_binding [ "foo"; "toto" ] foo1
+      in
       S.Tree.clear v1;
       let* () =
         let dont_skip k =
-          Alcotest.failf "should not have skipped %a" pp_key k
+          Alcotest.failf "should not have skipped: '%a'" pp_key k
         in
         S.Tree.fold ~depth:(`Eq 1) ~force:(`False dont_skip) v1 ()
       in
@@ -1125,7 +1130,7 @@ module Make (S : S) = struct
       Alcotest.(check stats_t) "empty stats" empty_stats s;
       S.set_tree_exn t ~info:(infof "empty tree") [] v1 >>= fun () ->
       let* head = S.Head.get t in
-      S.Commit.hash head |> fun head ->
+      S.Commit.key head |> fun head ->
       let* commit = P.Commit.find (ct repo) head in
       let node = P.Commit.Val.node (get commit) in
       let* node = P.Node.find (n repo) node in
@@ -1224,11 +1229,13 @@ module Make (S : S) = struct
         Alcotest.(check int) "size l2" 0 (List.length l2);
         check_ls "5 paginated list" ls (l1 @ l2)
       in
-      let c0 = S.Tree.empty in
-      let* c0 = S.Tree.add c0 [ "foo"; "a" ] "1" in
-      let* c0 = S.Tree.add c0 [ "foo"; "b"; "c" ] "2" in
-      let* c0 = S.Tree.add c0 [ "foo"; "c" ] "3" in
-      let* c0 = S.Tree.add c0 [ "foo"; "d" ] "4" in
+      let* c0 =
+        S.Tree.empty
+        |> with_binding [ "foo"; "a" ] "1"
+        >>= with_binding [ "foo"; "b"; "c" ] "2"
+        >>= with_binding [ "foo"; "c" ] "3"
+        >>= with_binding [ "foo"; "d" ] "4"
+      in
       let* b = S.Tree.get_tree c0 [ "foo"; "b" ] in
       let* ls = S.Tree.list c0 [ "foo" ] in
       check_ls "list all"
@@ -1349,7 +1356,7 @@ module Make (S : S) = struct
       let i0 = S.Info.empty in
       let* c =
         S.Commit.v repo ~info:S.Info.empty
-          ~parents:[ S.Commit.hash r1; S.Commit.hash r2 ]
+          ~parents:[ S.Commit.key r1; S.Commit.key r2 ]
           v3
       in
       S.Head.set t c >>= fun () ->
@@ -1422,37 +1429,52 @@ module Make (S : S) = struct
       let h' = S.Tree.hash c' in
       let h = S.Tree.hash c in
       check S.Hash.t "same tree" h h';
-      S.Tree.get_tree c [ "foo" ] >>= fun c1 ->
+      let* c1 = S.Tree.get_tree c [ "foo" ] in
+      let* _ =
+        S.Private.Repo.batch repo (fun c n _ -> S.save_tree repo c n c1)
+      in
       (match S.Tree.destruct c1 with
       | `Contents _ -> Alcotest.fail "got `Contents, expected `Node"
       | `Node node -> (
-          S.to_private_node node >>= function
-          | Ok v -> (
-              let ls = P.Node.Val.list v in
-              Alcotest.(check int) "list wide node" size (List.length ls);
-              let k = normal (P.Contents.Key.hash "bar") in
-              let v1 = P.Node.Val.add v "x" k in
-              let h' = H_node.hash v1 in
-              with_node repo (fun n -> P.Node.add n v1) >>= fun h ->
-              check H_node.t "wide node + x: hash(v) = add(v)" h h';
-              let v2 = P.Node.Val.add v "x" k in
-              check P.Node.Val.t "add x" v1 v2;
-              let v0 = P.Node.Val.remove v1 "x" in
-              check P.Node.Val.t "remove x" v v0;
-              let v3 = P.Node.Val.remove v "1" in
-              let h' = H_node.hash v3 in
-              with_node repo (fun n -> P.Node.add n v3) >|= fun h ->
-              check H_node.t "wide node - 1 : hash(v) = add(v)" h h';
-              (match P.Node.Val.find v "499999" with
-              | None -> Alcotest.fail "value 499999 not found"
-              | Some x ->
-                  let x' = normal (P.Contents.Key.hash "499999") in
-                  check P.Node.Val.value_t "find 499999" x x');
-              match P.Node.Val.find v "500000" with
-              | None -> ()
-              | Some _ -> Alcotest.fail "value 500000 should not be found")
-          | Error (`Dangling_hash _) ->
-              Alcotest.fail "unexpected dangling hash in wide node"))
+          let* v = S.to_private_node node in
+          let module PNode = P.Node_portable in
+          let module PNode_hash = Irmin.Hash.Typed (P.Hash) (P.Node_portable) in
+          let () =
+            let ls = P.Node.Val.list v in
+            Alcotest.(check int) "list wide node" size (List.length ls)
+          in
+          let* bar_key = with_contents repo (fun t -> P.Contents.add t "bar") in
+          let k = normal bar_key in
+          let v1 = P.Node.Val.add v "x" k in
+          let* () =
+            let h' = P.Node.Hash.hash v1 in
+            let+ h = with_node repo (fun n -> P.Node.add n v1) in
+            check P.Node.Hash.t "wide node + x: hash(v) = add(v)"
+              (P.Node.Key.to_hash h) h'
+          in
+          let () =
+            let v2 = P.Node.Val.add v "x" k in
+            check P.Node.Val.t "add x" v1 v2
+          in
+          let () =
+            let v0 = P.Node.Val.remove v1 "x" in
+            check P.Node.Val.t "remove x" v v0
+          in
+          let* () =
+            let v3 = P.Node.Val.remove v "1" in
+            let h' = P.Node.Hash.hash v3 in
+            with_node repo (fun n -> P.Node.add n v3) >|= fun h ->
+            check P.Node.Hash.t "wide node - 1 : hash(v) = add(v)"
+              (P.Node.Key.to_hash h) h'
+          in
+          (match P.Node.Val.find v "499999" with
+          | None | Some (`Node _) -> Alcotest.fail "value 499999 not found"
+          | Some (`Contents (x, _)) ->
+              let x' = P.Contents.Hash.hash "499999" in
+              check P.Contents.Hash.t "find 499999" x x');
+          match P.Node.Val.find v "500000" with
+          | None -> Lwt.return_unit
+          | Some _ -> Alcotest.fail "value 500000 should not be found"))
       >>= fun () -> P.Repo.close repo
     in
     run x test
@@ -1612,13 +1634,13 @@ module Make (S : S) = struct
           Irmin.Merge.f
             (P.Commit.merge commit_t ~info)
             ~old
-            (Some (S.Commit.hash c3))
-            (Some (S.Commit.hash c2)))
+            (Some (S.Commit.key c3))
+            (Some (S.Commit.key c2)))
       >>= merge_exn "commit"
       >>= function
       | None -> Lwt.return_unit
       | Some c4 ->
-          let* k = none_fail (S.Commit.of_hash repo c4) "of hash" in
+          let* k = none_fail (S.Commit.of_key repo c4) "of hash" in
           S.Branch.set repo "foo" k >>= fun () ->
           let* t = S.of_branch repo "foo" in
           let* vy' = S.find t [ "u"; "x"; "y" ] in
@@ -1902,27 +1924,36 @@ module Make (S : S) = struct
 
   let test_shallow_objects x () =
     let test repo =
-      let foo_k = S.Private.Contents.Key.hash "foo" in
-      let bar_k = S.Private.Contents.Key.hash "bar" in
+      let contents s = P.Contents.Hash.hash s in
+      let node s = P.Contents.Hash.hash s in
+      let commit s = P.Contents.Hash.hash s in
+      let foo_k = node "foo" in
+      let bar_k = node "bar" in
       let tree_1 = S.Tree.shallow repo (`Node foo_k) in
       let tree_2 = S.Tree.shallow repo (`Node bar_k) in
       let node_3 =
         S.Private.Node.Val.of_list
           [
-            ("foo", `Contents (foo_k, S.Metadata.default)); ("bar", `Node bar_k);
+            ("foo", `Contents (contents "foo", S.Metadata.default));
+            ("bar", `Node bar_k);
           ]
       in
       let tree_3 = S.Tree.of_node (S.of_private_node repo node_3) in
+      let* _ =
+        S.Private.Repo.batch repo (fun c n _ -> S.save_tree repo c n tree_3)
+      in
+      let key_3 = get_node_key (Option.get (S.Tree.key tree_3)) in
       let info () = info "shallow" in
       let* t = S.master repo in
       S.set_tree_exn t [ "1" ] tree_1 ~info >>= fun () ->
       S.set_tree_exn t [ "2" ] tree_2 ~info >>= fun () ->
       let* h = S.Head.get t in
-      let commit =
-        S.of_private_commit repo
-        @@ S.Private.Commit.Val.v ~info:(info ()) ~node:(S.Tree.hash tree_3)
-             ~parents:[ S.Commit.hash h; foo_k ]
+      let commit_v =
+        S.Private.Commit.Val.v ~info:(info ()) ~node:key_3
+          ~parents:[ S.Commit.key h; commit "foo" ]
       in
+      let commit_key = P.Commit.Hash.hash commit_v in
+      let commit = S.of_private_commit repo commit_key commit_v in
       S.set_tree_exn t [ "3" ] ~parents:[ commit ] tree_3 ~info >>= fun () ->
       let* t1 = S.find_tree t [ "1" ] in
       Alcotest.(check (option tree_t)) "shallow tree" (Some tree_1) t1;
@@ -1963,7 +1994,7 @@ module Make (S : S) = struct
         >|= check_commit "r1 after clear is not found" None
       in
       let* () =
-        P.Commit.find ct (S.Commit.hash h1)
+        P.Commit.find ct (S.Commit.key h1)
         >|= check_none "after clear commit is not found"
       in
       let* () =
@@ -1996,6 +2027,7 @@ let suite (speed, x) =
   let module T_watch = Store_watch.Make (Log) (S) in
   suite'
     ([
+       ("High-level operations on trees", speed, T.test_trees x);
        ("Basic operations on contents", speed, T.test_contents x);
        ("Basic operations on nodes", speed, T.test_nodes x);
        ("Basic operations on commits", speed, T.test_commits x);
@@ -2009,7 +2041,6 @@ let suite (speed, x) =
        ("Empty stores", speed, T.test_empty x);
        ("Private node manipulation", speed, T.test_private_nodes x);
        ("High-level store operations", speed, T.test_stores x);
-       ("High-level operations on trees", speed, T.test_trees x);
        ("High-level store synchronisation", speed, T.test_sync x);
        ("High-level store merges", speed, T.test_merge x);
        ("Unrelated merges", speed, T.test_merge_unrelated x);
@@ -2083,4 +2114,4 @@ let run name ?(slow = false) ~misc tl =
   let tl1 = List.map suite tl in
   let tl1 = if slow then tl1 @ List.map slow_suite tl else tl1 in
   let tl2 = List.map layered_suite tl in
-  Alcotest.run name (tl1 @ tl2 @ misc)
+  Alcotest.run name (misc @ tl1 @ tl2)

--- a/src/irmin-test/store_graph.ml
+++ b/src/irmin-test/store_graph.ml
@@ -17,7 +17,7 @@
 open! Import
 open Common
 
-module Make (S : S) = struct
+module Make (S : Generic_key) = struct
   include Common.Make_helpers (S)
 
   let test_iter x () =
@@ -111,7 +111,7 @@ module Make (S : S) = struct
           nodes
       in
       let test1 () =
-        let foo = P.Contents.Hash.hash "foo" in
+        let* foo = with_contents repo (fun c -> P.Contents.add c "foo") in
         let foo_k = (foo, S.Metadata.default) in
         let* k1 = with_node repo (fun g -> Graph.v g [ ("b", normal foo) ]) in
         let* k2 = with_node repo (fun g -> Graph.v g [ ("a", `Node k1) ]) in
@@ -137,7 +137,7 @@ module Make (S : S) = struct
       let test2 () =
         (* Graph.iter requires a node as max, we cannot test a graph with only
            contents. *)
-        let foo = P.Contents.Hash.hash "foo" in
+        let* foo = with_contents repo (fun c -> P.Contents.add c "foo") in
         let foo_k = (foo, S.Metadata.default) in
         let* k1 = with_node repo (fun g -> Graph.v g [ ("b", normal foo) ]) in
         visited := [];
@@ -149,7 +149,7 @@ module Make (S : S) = struct
           ~not_visited:[ `Contents foo_k ]
       in
       let test3 () =
-        let foo = P.Contents.Hash.hash "foo" in
+        let* foo = with_contents repo (fun c -> P.Contents.add c "foo") in
         let foo_k = (foo, S.Metadata.default) in
         let* kb1 = with_node repo (fun g -> Graph.v g [ ("b1", normal foo) ]) in
         let* ka1 = with_node repo (fun g -> Graph.v g [ ("a1", `Node kb1) ]) in

--- a/src/irmin-test/store_graph.ml
+++ b/src/irmin-test/store_graph.ml
@@ -22,29 +22,33 @@ module Make (S : S) = struct
 
   let test_iter x () =
     let test repo =
-      let eq = Irmin.Type.(unstage (equal P.Hash.t)) in
-      let mem k ls = List.exists (fun k' -> eq k k') ls in
+      let pp_id = Irmin.Type.pp S.Tree.kinded_key_t in
+      let eq_id = Irmin.Type.(unstage (equal S.Tree.kinded_key_t)) in
+      let mem k ls = List.exists (fun k' -> eq_id k k') ls in
       let visited = ref [] in
       let skipped = ref [] in
       let rev_order oldest k =
-        if !visited = [] && not (eq k oldest) then
+        if !visited = [] && not (eq_id k oldest) then
           Alcotest.fail "traversal should start with oldest node"
       in
       let in_order oldest k =
-        if !visited = [] && eq k oldest then
+        if !visited = [] && eq_id k oldest then
           Alcotest.fail "traversal shouldn't start with oldest node"
       in
       let node k =
-        if mem k !visited then
-          Alcotest.failf "node %a visited twice" (Irmin.Type.pp P.Hash.t) k;
-        visited := k :: !visited;
+        if mem (`Node k) !visited then
+          Alcotest.failf "node %a visited twice" (Irmin.Type.pp P.Node.Key.t) k;
+        visited := `Node k :: !visited;
         Lwt.return_unit
       in
       let contents ?order k =
-        if mem k !visited then
-          Alcotest.failf "contents %a visited twice" (Irmin.Type.pp P.Hash.t) k;
-        (match order with None -> () | Some f -> f k);
-        visited := k :: !visited;
+        let e = `Contents (k, S.Metadata.default) in
+        if mem e !visited then
+          Alcotest.failf "contents %a visited twice"
+            (Irmin.Type.pp P.Contents.Key.t)
+            k;
+        (match order with None -> () | Some f -> f e);
+        visited := e :: !visited;
         Lwt.return_unit
       in
       let test_rev_order ~nodes ~max =
@@ -56,7 +60,9 @@ module Make (S : S) = struct
         List.iter
           (fun k ->
             if not (mem k !visited) then
-              Alcotest.failf "%a should be visited" (Irmin.Type.pp P.Hash.t) k)
+              Alcotest.failf "%a should be visited"
+                (Irmin.Type.pp S.Tree.kinded_key_t)
+                k)
           nodes
       in
       let test_in_order ~nodes ~max =
@@ -68,13 +74,13 @@ module Make (S : S) = struct
         List.iter
           (fun k ->
             if not (mem k !visited) then
-              Alcotest.failf "%a should be visited" (Irmin.Type.pp P.Hash.t) k)
+              Alcotest.failf "%a should be visited" pp_id k)
           nodes
       in
       let test_skip ~max ~to_skip ~not_visited =
         let skip_node k =
-          if mem k to_skip then (
-            skipped := k :: !skipped;
+          if mem (`Node k) to_skip then (
+            skipped := `Node k :: !skipped;
             Lwt.return_true)
           else Lwt.return_false
         in
@@ -85,13 +91,12 @@ module Make (S : S) = struct
         List.iter
           (fun k ->
             if mem k !visited || not (mem k !skipped) then
-              Alcotest.failf "%a should be skipped" (Irmin.Type.pp P.Hash.t) k)
+              Alcotest.failf "%a should be skipped" pp_id k)
           to_skip;
         List.iter
           (fun k ->
             if mem k !visited || mem k !skipped then
-              Alcotest.failf "%a should not be skipped nor visited"
-                (Irmin.Type.pp P.Hash.t) k)
+              Alcotest.failf "%a should not be skipped nor visited" pp_id k)
           not_visited
       in
       let test_min_max ~nodes ~min ~max ~not_visited =
@@ -100,47 +105,52 @@ module Make (S : S) = struct
         List.iter
           (fun k ->
             if mem k not_visited && mem k !visited then
-              Alcotest.failf "%a should not be visited" (Irmin.Type.pp P.Hash.t)
-                k;
+              Alcotest.failf "%a should not be visited" pp_id k;
             if (not (mem k not_visited)) && not (mem k !visited) then
-              Alcotest.failf "%a should not be visited" (Irmin.Type.pp P.Hash.t)
-                k)
+              Alcotest.failf "%a should not be visited" pp_id k)
           nodes
       in
       let test1 () =
-        let foo = P.Contents.Key.hash "foo" in
+        let foo = P.Contents.Hash.hash "foo" in
+        let foo_k = (foo, S.Metadata.default) in
         let* k1 = with_node repo (fun g -> Graph.v g [ ("b", normal foo) ]) in
         let* k2 = with_node repo (fun g -> Graph.v g [ ("a", `Node k1) ]) in
         let* k3 = with_node repo (fun g -> Graph.v g [ ("c", `Node k1) ]) in
-        let nodes = [ foo; k1; k2; k3 ] in
+        let nodes = [ `Contents foo_k; `Node k1; `Node k2; `Node k3 ] in
         visited := [];
         test_rev_order ~nodes ~max:[ k2; k3 ] >>= fun () ->
         visited := [];
         test_in_order ~nodes ~max:[ k2; k3 ] >>= fun () ->
         visited := [];
         skipped := [];
-        test_skip ~max:[ k2; k3 ] ~to_skip:[ k1 ] ~not_visited:[] >>= fun () ->
+        test_skip ~max:[ k2; k3 ] ~to_skip:[ `Node k1 ] ~not_visited:[]
+        >>= fun () ->
         visited := [];
         let* () =
-          test_min_max ~nodes ~min:[ k1 ] ~max:[ k2 ] ~not_visited:[ foo; k3 ]
+          test_min_max ~nodes ~min:[ k1 ] ~max:[ k2 ]
+            ~not_visited:[ `Contents foo_k; `Node k3 ]
         in
         visited := [];
         test_min_max ~nodes ~min:[ k2; k3 ] ~max:[ k2; k3 ]
-          ~not_visited:[ foo; k1 ]
+          ~not_visited:[ `Contents foo_k; `Node k1 ]
       in
       let test2 () =
         (* Graph.iter requires a node as max, we cannot test a graph with only
            contents. *)
-        let foo = P.Contents.Key.hash "foo" in
+        let foo = P.Contents.Hash.hash "foo" in
+        let foo_k = (foo, S.Metadata.default) in
         let* k1 = with_node repo (fun g -> Graph.v g [ ("b", normal foo) ]) in
         visited := [];
-        test_rev_order ~nodes:[ foo; k1 ] ~max:[ k1 ] >>= fun () ->
+        test_rev_order ~nodes:[ `Contents foo_k; `Node k1 ] ~max:[ k1 ]
+        >>= fun () ->
         visited := [];
         skipped := [];
-        test_skip ~max:[ k1 ] ~to_skip:[ k1 ] ~not_visited:[ foo ]
+        test_skip ~max:[ k1 ] ~to_skip:[ `Node k1 ]
+          ~not_visited:[ `Contents foo_k ]
       in
       let test3 () =
-        let foo = P.Contents.Key.hash "foo" in
+        let foo = P.Contents.Hash.hash "foo" in
+        let foo_k = (foo, S.Metadata.default) in
         let* kb1 = with_node repo (fun g -> Graph.v g [ ("b1", normal foo) ]) in
         let* ka1 = with_node repo (fun g -> Graph.v g [ ("a1", `Node kb1) ]) in
         let* ka2 = with_node repo (fun g -> Graph.v g [ ("a2", `Node kb1) ]) in
@@ -150,7 +160,16 @@ module Make (S : S) = struct
               Graph.v g
                 [ ("c1", `Node ka1); ("c2", `Node ka2); ("c3", `Node kb2) ])
         in
-        let nodes = [ foo; kb1; ka1; ka2; kb2; kc ] in
+        let nodes =
+          [
+            `Contents foo_k;
+            `Node kb1;
+            `Node ka1;
+            `Node ka2;
+            `Node kb2;
+            `Node kc;
+          ]
+        in
         visited := [];
         test_rev_order ~nodes ~max:[ kc ] >>= fun () ->
         visited := [];
@@ -158,22 +177,25 @@ module Make (S : S) = struct
         visited := [];
         skipped := [];
         let* () =
-          test_skip ~max:[ kc ] ~to_skip:[ ka1; ka2 ] ~not_visited:[ kb1 ]
+          test_skip ~max:[ kc ] ~to_skip:[ `Node ka1; `Node ka2 ]
+            ~not_visited:[ `Node kb1 ]
         in
         visited := [];
         skipped := [];
         let* () =
-          test_skip ~max:[ kc ] ~to_skip:[ ka1; ka2; kb2 ]
-            ~not_visited:[ kb1; foo ]
+          test_skip ~max:[ kc ]
+            ~to_skip:[ `Node ka1; `Node ka2; `Node kb2 ]
+            ~not_visited:[ `Node kb1; `Contents foo_k ]
         in
         visited := [];
         let* () =
           test_min_max ~nodes ~min:[ kb1 ] ~max:[ ka1 ]
-            ~not_visited:[ foo; ka2; kb2; kc ]
+            ~not_visited:[ `Contents foo_k; `Node ka2; `Node kb2; `Node kc ]
         in
         visited := [];
         test_min_max ~nodes ~min:[ kc ] ~max:[ kc ]
-          ~not_visited:[ foo; kb1; ka1; ka2; kb2 ]
+          ~not_visited:
+            [ `Contents foo_k; `Node kb1; `Node ka1; `Node ka2; `Node kb2 ]
       in
       test1 () >>= fun () ->
       test2 () >>= fun () ->

--- a/src/irmin-test/store_watch.ml
+++ b/src/irmin-test/store_watch.ml
@@ -17,7 +17,7 @@
 open! Import
 open Common
 
-module Make (Log : Logs.LOG) (S : S) = struct
+module Make (Log : Logs.LOG) (S : Generic_key) = struct
   include Common.Make_helpers (S)
 
   let sleep ?(sleep_t = 0.01) () =

--- a/src/irmin-unix/http.mli
+++ b/src/irmin-unix/http.mli
@@ -15,7 +15,10 @@
  *)
 
 module Client (S : Irmin.S) :
-  Irmin.S with module Schema = S.Schema and type Private.Remote.endpoint = unit
+  Irmin.S
+    with type hash = S.Hash.t
+     and module Schema = S.Schema
+     and type Private.Remote.endpoint = unit
 
 module Server (S : Irmin.S) :
   Irmin_http.SERVER

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -96,7 +96,8 @@ module Http : sig
       operation might take multiple RTTs. *)
   module Client (S : Irmin.S) :
     Irmin.S
-      with module Schema = S.Schema
+      with type hash = S.Hash.t
+       and module Schema = S.Schema
        and type Private.Remote.endpoint = unit
 
   (** {1 HTTP server} *)

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -282,12 +282,21 @@ module Store = struct
   let git (module C : Irmin.Contents.S) = v_git (module Xgit.FS.KV (C))
   let git_mem (module C : Irmin.Contents.S) = v_git (module Xgit.Mem.KV (C))
 
-  module Inode_config = struct
-    let entries = 32
-    let stable_hash = 256
+  module Irmin_pack_maker : Irmin.Maker = struct
+    include Irmin_pack.V1 (struct
+      let entries = 32
+      let stable_hash = 256
+    end)
+
+    module Make (Schema : Irmin.Schema.S) = Make (struct
+      include Schema
+      module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
+      module Commit_maker = Irmin.Commit.Maker (Info)
+      module Commit = Commit_maker.Make (Hash)
+    end)
   end
 
-  let pack = create Irmin_pack.Conf.spec (module Irmin_pack.V1 (Inode_config))
+  let pack = create Irmin_pack.Conf.spec (module Irmin_pack_maker)
 
   let all =
     ref

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -291,7 +291,7 @@ module Store = struct
     module Make (Schema : Irmin.Schema.S) = Make (struct
       include Schema
       module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
-      module Commit_maker = Irmin.Commit.Maker (Info)
+      module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
       module Commit = Commit_maker.Make (Hash)
     end)
   end

--- a/src/irmin/append_only_intf.ml
+++ b/src/irmin/append_only_intf.ml
@@ -39,6 +39,8 @@ module type S = sig
   (** @inline *)
 end
 
+module Append_only_is_a_read_only (X : S) : Read_only.S = X
+
 module type Maker = functor (K : Type.S) (V : Type.S) -> sig
   include S with type key = K.t and type value = V.t
 

--- a/src/irmin/branch_intf.ml
+++ b/src/irmin/branch_intf.ml
@@ -27,6 +27,8 @@ module type S = sig
   (** Check if the branch is valid. *)
 end
 
+module Irmin_key = Key
+
 module type Store = sig
   (** {1 Branch Store} *)
 
@@ -35,7 +37,7 @@ module type Store = sig
   module Key : S with type t = key
   (** Base functions on keys. *)
 
-  module Val : Hash.S with type t = value
+  module Val : Irmin_key.S with type t = value
   (** Base functions on values. *)
 end
 

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -25,43 +25,57 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Maker (Info : Info.S) = struct
   module Info = Info
 
-  module Make (H : Type.S) = struct
+  module Make
+      (H : Type.S)
+      (N : Key.S with type hash = H.t)
+      (C : Key.S with type hash = H.t) =
+  struct
     module Info = Info
 
-    type hash = H.t [@@deriving irmin ~compare]
+    type node_key = N.t [@@deriving irmin ~compare]
+    type commit_key = C.t [@@deriving irmin]
 
-    type t = { node : hash; parents : hash list; info : Info.t }
+    type t = { node : node_key; parents : commit_key list; info : Info.t }
     [@@deriving irmin]
 
     let parents t = t.parents
     let node t = t.node
     let info t = t.info
+    let compare_hash = Type.(unstage (compare H.t))
+    let compare_commit x y = compare_hash (C.to_hash x) (C.to_hash y)
 
     let v ~info ~node ~parents =
-      let parents = List.fast_sort compare_hash parents in
+      let parents = List.fast_sort compare_commit parents in
       { node; parents; info }
   end
 end
 
-module Store
+module Store_indexable
     (I : Info.S)
     (N : Node.Store)
-    (S : Content_addressable.S with type key = N.key)
-    (K : Hash.S with type t = S.key)
-    (V : S with type hash = S.key and type t = S.value and module Info := I) =
+    (S : Indexable.S)
+    (H : Hash.S with type t = S.hash)
+    (V : S
+           with type node_key = N.Key.t
+            and type commit_key = S.Key.t
+            and type t = S.value
+            and module Info := I) =
 struct
   module Node = N
   module Val = V
+  module Key = S.Key
+  module Hash = Hash.Typed (H) (V)
   module Info = I
-  module Key = Hash.Typed (K) (Val)
 
   type 'a t = 'a N.t * 'a S.t
   type key = Key.t [@@deriving irmin ~equal]
   type value = S.value
+  type hash = S.hash
 
   let add (_, t) = S.add t
   let unsafe_add (_, t) = S.unsafe_add t
   let mem (_, t) = S.mem t
+  let index (_, t) = S.index t
   let find (_, t) = S.find t
   let clear (_, t) = S.clear t
   let batch (n, s) f = N.batch n (fun n -> S.batch s (fun s -> f (n, s)))
@@ -84,9 +98,11 @@ struct
     | None -> N.add n N.Val.empty
     | Some node -> Lwt.return node
 
+  let equal_key = Type.(unstage (equal Key.t))
   let equal_opt_keys = Type.(unstage (equal (option Key.t)))
 
   let merge_commit info t ~old k1 k2 =
+    Log.debug (fun l -> l "Commit.merge %a %a" pp_key k1 pp_key k2);
     let* v1 = get t k1 in
     let* v2 = get t k2 in
     if List.mem ~equal:equal_key k1 (Val.parents v2) then Merge.ok k2
@@ -124,9 +140,21 @@ struct
   let merge t ~info = Merge.(option (v Key.t (merge_commit info t)))
 end
 
+module Store
+    (I : Info.S)
+    (N : Node.Store)
+    (S : Content_addressable.S with type key = N.key)
+    (K : Hash.S with type t = S.key)
+    (V : S
+           with type node_key = S.key
+            and type commit_key = S.key
+            and type t = S.value
+            and module Info := I) =
+  Store_indexable (I) (N) (Indexable.Of_content_addressable (K) (S)) (K) (V)
+
 module History (S : Store) = struct
-  type commit = S.Key.t [@@deriving irmin]
-  type node = S.Key.t [@@deriving irmin]
+  type commit_key = S.Key.t [@@deriving irmin]
+  type node_key = S.Val.node_key [@@deriving irmin]
   type v = S.Val.t [@@deriving irmin]
   type info = S.Info.t [@@deriving irmin]
   type 'a t = 'a S.t
@@ -156,7 +184,7 @@ module History (S : Store) = struct
     type t = unit [@@deriving irmin]
   end
 
-  module Graph = Object_graph.Make (S.Key) (U)
+  module Graph = Object_graph.Make (U) (S.Node.Key) (S.Key) (U)
 
   let edges t =
     Log.debug (fun f -> f "edges");
@@ -201,7 +229,7 @@ module History (S : Store) = struct
     type t = S.Key.t
 
     let compare = Type.(unstage (compare S.Key.t))
-    let hash = S.Key.short_hash
+    let hash k = S.Hash.short_hash (S.Key.to_hash k)
     let equal = Type.(unstage (equal S.Key.t))
   end
 
@@ -504,10 +532,10 @@ module V1 = struct
   end
 
   module Make (C : S with module Info := Info) = struct
-    module Mk (X : Type.S) = struct
+    module K (K : Type.S) = struct
       let h = Type.string_of `Int64
-      let hash_to_bin_string = Type.(unstage (to_bin_string X.t))
-      let hash_of_bin_string = Type.(unstage (of_bin_string X.t))
+      let hash_to_bin_string = Type.(unstage (to_bin_string K.t))
+      let hash_of_bin_string = Type.(unstage (of_bin_string K.t))
       let size_of = Type.Size.using hash_to_bin_string (Type.Size.t h)
 
       let encode_bin =
@@ -523,11 +551,22 @@ module V1 = struct
           | Ok v -> v
           | Error (`Msg e) -> Fmt.failwith "decode_bin: %s" e )
 
-      let t = Type.like X.t ~bin:(encode_bin, decode_bin, size_of)
+      type t = K.t
+
+      let t = Type.like K.t ~bin:(encode_bin, decode_bin, size_of)
     end
 
-    type hash = C.hash [@@deriving irmin]
-    type t = { parents : hash list; c : C.t }
+    module Node_key = K (struct
+      type t = C.node_key [@@deriving irmin]
+    end)
+
+    module Commit_key = K (struct
+      type t = C.commit_key [@@deriving irmin]
+    end)
+
+    type node_key = Node_key.t [@@deriving irmin]
+    type commit_key = Commit_key.t [@@deriving irmin]
+    type t = { parents : commit_key list; c : C.t }
 
     module Info = Info
 
@@ -539,15 +578,11 @@ module V1 = struct
     let v ~info ~node ~parents = { parents; c = C.v ~node ~parents ~info }
     let make = v
 
-    module Hash = Mk (struct
-      type t = C.hash [@@deriving irmin]
-    end)
-
     let t : t Type.t =
       let open Type in
       record "commit" (fun node parents info -> make ~info ~node ~parents)
-      |+ field "node" Hash.t node
-      |+ field "parents" (list ~len:`Int64 Hash.t) parents
+      |+ field "node" Node_key.t node
+      |+ field "parents" (list ~len:`Int64 Commit_key.t) parents
       |+ field "info" Info.t info
       |> sealr
   end

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -22,19 +22,22 @@ module type S = sig
   type t [@@deriving irmin]
   (** The type for commit values. *)
 
-  type hash [@@deriving irmin]
-  (** Type for keys. *)
+  type node_key [@@deriving irmin]
+  (** Type for node keys. *)
+
+  type commit_key [@@deriving irmin]
+  (** Type for commit keys. *)
 
   module Info : Info.S
   (** The type for commit info. *)
 
-  val v : info:Info.t -> node:hash -> parents:hash list -> t
+  val v : info:Info.t -> node:node_key -> parents:commit_key list -> t
   (** Create a commit. *)
 
-  val node : t -> hash
-  (** The underlying node. *)
+  val node : t -> node_key
+  (** The underlying node key. *)
 
-  val parents : t -> hash list
+  val parents : t -> commit_key list
   (** The commit parents. *)
 
   val info : t -> Info.t
@@ -43,24 +46,29 @@ end
 
 module type Maker = sig
   module Info : Info.S
-  module Make (H : Type.S) : S with type hash = H.t and module Info = Info
+
+  module Make
+      (H : Type.S)
+      (N : Key.S with type hash = H.t)
+      (C : Key.S with type hash = H.t) :
+    S with type node_key = N.t and type commit_key = C.t and module Info = Info
 end
 
 module type Store = sig
   (** {1 Commit Store} *)
 
-  include Content_addressable.S
+  include Indexable.S
 
   module Info : Info.S
   (** Commit info. *)
 
-  (** [Key] provides base functions for commit keys. *)
-  module Key : Hash.Typed with type t = key and type value = value
-
   (** [Val] provides functions for commit values. *)
-  module Val : S with type t = value and type hash = key and module Info := Info
+  module Val :
+    S with type t = value and type commit_key = key and module Info := Info
 
-  module Node : Node.Store with type key = Val.hash
+  module Hash : Hash.Typed with type t = hash and type value = value
+
+  module Node : Node.Store with type key = Val.node_key
   (** [Node] is the underlying node store. *)
 
   val merge : [> read_write ] t -> info:Info.f -> key option Merge.t
@@ -73,11 +81,11 @@ module type History = sig
   type 'a t
   (** The type for store handles. *)
 
-  type node [@@deriving irmin]
-  (** The type for node values. *)
+  type node_key [@@deriving irmin]
+  (** The type for node keys. *)
 
-  type commit [@@deriving irmin]
-  (** The type for commit values. *)
+  type commit_key [@@deriving irmin]
+  (** The type for commit keys. *)
 
   type v [@@deriving irmin]
   (** The type for commit objects. *)
@@ -87,29 +95,29 @@ module type History = sig
 
   val v :
     [> write ] t ->
-    node:node ->
-    parents:commit list ->
+    node:node_key ->
+    parents:commit_key list ->
     info:info ->
-    (commit * v) Lwt.t
+    (commit_key * v) Lwt.t
   (** Create a new commit. *)
 
-  val parents : [> read ] t -> commit -> commit list Lwt.t
+  val parents : [> read ] t -> commit_key -> commit_key list Lwt.t
   (** Get the commit parents.
 
       Commits form a append-only, fully functional, partial-order
       data-structure: every commit carries the list of its immediate
       predecessors. *)
 
-  val merge : [> read_write ] t -> info:(unit -> info) -> commit Merge.t
+  val merge : [> read_write ] t -> info:(unit -> info) -> commit_key Merge.t
   (** [merge t] is the 3-way merge function for commit. *)
 
   val lcas :
     [> read ] t ->
     ?max_depth:int ->
     ?n:int ->
-    commit ->
-    commit ->
-    (commit list, [ `Max_depth_reached | `Too_many_lcas ]) result Lwt.t
+    commit_key ->
+    commit_key ->
+    (commit_key list, [ `Max_depth_reached | `Too_many_lcas ]) result Lwt.t
   (** Find the lowest common ancestors
       {{:http://en.wikipedia.org/wiki/Lowest_common_ancestor} lca} between two
       commits. *)
@@ -119,8 +127,8 @@ module type History = sig
     info:(unit -> info) ->
     ?max_depth:int ->
     ?n:int ->
-    commit list ->
-    (commit option, Merge.conflict) result Lwt.t
+    commit_key list ->
+    (commit_key option, Merge.conflict) result Lwt.t
   (** Compute the lowest common ancestors ancestor of a list of commits by
       recursively calling {!lcas} and merging the results.
 
@@ -133,23 +141,26 @@ module type History = sig
     info:(unit -> info) ->
     ?max_depth:int ->
     ?n:int ->
-    commit ->
-    commit ->
-    (commit, Merge.conflict) result Lwt.t
+    commit_key ->
+    commit_key ->
+    (commit_key, Merge.conflict) result Lwt.t
   (** Compute the {!lcas} of the two commit and 3-way merge the result. *)
 
   val closure :
-    [> read ] t -> min:commit list -> max:commit list -> commit list Lwt.t
+    [> read ] t ->
+    min:commit_key list ->
+    max:commit_key list ->
+    commit_key list Lwt.t
   (** Same as {{!Node.Graph.closure} Node.Graph.closure} but for the history
       graph. *)
 
   val iter :
     [> read ] t ->
-    min:commit list ->
-    max:commit list ->
-    ?commit:(commit -> unit Lwt.t) ->
-    ?edge:(commit -> node -> unit Lwt.t) ->
-    ?skip:(commit -> bool Lwt.t) ->
+    min:commit_key list ->
+    max:commit_key list ->
+    ?commit:(commit_key -> unit Lwt.t) ->
+    ?edge:(commit_key -> commit_key -> unit Lwt.t) ->
+    ?skip:(commit_key -> bool Lwt.t) ->
     ?rev:bool ->
     unit ->
     unit Lwt.t
@@ -171,7 +182,11 @@ module type Sigs = sig
     (** Serialisation format for V1 info. *)
 
     module Make (C : S with module Info := Info) : sig
-      include S with module Info = Info and type hash = C.hash
+      include
+        S
+          with module Info = Info
+           and type node_key = C.node_key
+           and type commit_key = C.commit_key
 
       val import : C.t -> t
       val export : t -> C.t
@@ -187,12 +202,37 @@ module type Sigs = sig
       (N : Node.Store)
       (S : Content_addressable.S with type key = N.key)
       (K : Hash.S with type t = S.key)
-      (V : S with type hash = S.key and type t = S.value and module Info := I) :
+      (V : S
+             with type node_key = S.key
+              and type commit_key = S.key
+              and type t = S.value
+              and module Info := I) :
+    Store
+      with type 'a t = 'a N.t * 'a S.t
+       and type key = S.key
+       and type hash = S.key
+       and type value = S.value
+       and module Info = I
+       and module Val = V
+
+  (** [Store_indexable] is like {!Store} but uses an indexable store as a
+      backend (rather than a content-addressable one). *)
+  module Store_indexable
+      (I : Info.S)
+      (N : Node.Store)
+      (S : Indexable.S)
+      (H : Hash.S with type t = S.hash)
+      (V : S
+             with type node_key = N.key
+              and type commit_key = S.key
+              and type t = S.value
+              and module Info := I) :
     Store
       with type 'a t = 'a N.t * 'a S.t
        and type key = S.key
        and type value = S.value
        and module Info = I
+       and type hash = S.hash
        and module Val = V
 
   module type History = History
@@ -208,8 +248,8 @@ module type Sigs = sig
     History
       with type 'a t = 'a C.t
        and type v = C.Val.t
-       and type node = C.Node.key
-       and type commit = C.key
+       and type node_key = C.Node.key
+       and type commit_key = C.key
        and type info = C.Info.t
 
   include Maker with module Info = Info.Default

--- a/src/irmin/dot.ml
+++ b/src/irmin/dot.ml
@@ -55,7 +55,7 @@ module Make (S : Store.Generic_key.S) = struct
   module Slice = S.Private.Slice
 
   module Graph =
-    Object_graph.Make (Contents.Key) (Node.Key) (Commit.Key) (Branch.Key)
+    Object_graph.Make (Contents.Hash) (Node.Hash) (Commit.Hash) (Branch.Key)
 
   module Info = S.Info
 
@@ -76,7 +76,7 @@ module Make (S : Store.Generic_key.S) = struct
     let add_edge v1 l v2 =
       if mem_vertex v1 && mem_vertex v2 then edges := (v1, l, v2) :: !edges
     in
-    let string_of_key t k =
+    let string_of_hash t k =
       let s = Type.to_string t k in
       if String.length s <= 8 then s else String.with_range s ~len:8
     in
@@ -92,7 +92,7 @@ module Make (S : Store.Generic_key.S) = struct
         (if html then
          sprintf "<div class='node'><div class='sha1'>%s</div></div>"
         else fun x -> x)
-          (string_of_key Node.Key.t k)
+          (string_of_hash Node.Hash.t k)
       in
       `Label s
     in
@@ -105,7 +105,7 @@ module Make (S : Store.Generic_key.S) = struct
       `Label s
     in
     let label_of_commit k c =
-      let k = string_of_key Commit.Key.t k in
+      let k = string_of_hash Commit.Hash.t k in
       let o = Commit.Val.info c in
       let s =
         if html then
@@ -126,7 +126,7 @@ module Make (S : Store.Generic_key.S) = struct
       `Label s
     in
     let label_of_contents k v =
-      let k = string_of_key Contents.Key.t k in
+      let k = string_of_hash Contents.Hash.t k in
       let s =
         if html then
           sprintf
@@ -183,19 +183,24 @@ module Make (S : Store.Generic_key.S) = struct
           (fun (l, v) ->
             match v with
             | `Contents (v, _meta) ->
+                let v = Contents.Key.to_hash v in
                 add_edge (`Node k)
                   [ `Style `Dotted; label_of_step l ]
                   (`Contents v)
             | `Node n ->
+                let n = Node.Key.to_hash n in
                 add_edge (`Node k) [ `Style `Solid; label_of_step l ] (`Node n))
           (Node.Val.list t))
       !nodes;
     List.iter
       (fun (k, r) ->
         List.iter
-          (fun c -> add_edge (`Commit k) [ `Style `Bold ] (`Commit c))
+          (fun c ->
+            let c = Commit.Key.to_hash c in
+            add_edge (`Commit k) [ `Style `Bold ] (`Commit c))
           (Commit.Val.parents r);
-        add_edge (`Commit k) [ `Style `Dashed ] (`Node (Commit.Val.node r)))
+        let node_hash = Commit.Val.node r |> Node.Key.to_hash in
+        add_edge (`Commit k) [ `Style `Dashed ] (`Node node_hash))
       !commits;
     let branch_t = S.Private.Repo.branch_t (S.repo t) in
     let* bs = Branch.list branch_t in
@@ -205,6 +210,7 @@ module Make (S : Store.Generic_key.S) = struct
           Branch.find branch_t r >|= function
           | None -> ()
           | Some k ->
+              let k = Commit.Key.to_hash k in
               add_vertex (`Branch r)
                 [ `Shape `Plaintext; label_of_tag r; `Style `Filled ];
               add_edge (`Branch r) [ `Style `Bold ] (`Commit k))

--- a/src/irmin/dot.ml
+++ b/src/irmin/dot.ml
@@ -45,7 +45,7 @@ let is_valid_utf8 str =
     true
   with Utf8_failure -> false
 
-module Make (S : Store.S) = struct
+module Make (S : Store.Generic_key.S) = struct
   type db = S.t
 
   module Branch = S.Private.Branch
@@ -53,7 +53,10 @@ module Make (S : Store.S) = struct
   module Node = S.Private.Node
   module Commit = S.Private.Commit
   module Slice = S.Private.Slice
-  module Graph = Object_graph.Make (S.Hash) (Branch.Key)
+
+  module Graph =
+    Object_graph.Make (Contents.Key) (Node.Key) (Commit.Key) (Branch.Key)
+
   module Info = S.Info
 
   let pp_author = Type.pp Info.author_t

--- a/src/irmin/dot.mli
+++ b/src/irmin/dot.mli
@@ -42,4 +42,4 @@ module type S = sig
       only. *)
 end
 
-module Make (S : Store.S) : S with type db = S.t
+module Make (S : Store.Generic_key.S) : S with type db = S.t

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -66,6 +66,10 @@ module List = struct
    fun ~equal y -> function
     | [] -> false
     | x :: xs -> equal x y || mem ~equal y xs
+
+  let rec rev_append_map : type a b. (a -> b) -> a list -> b list -> b list =
+   fun f xs ys ->
+    match xs with [] -> ys | x :: xs -> rev_append_map f xs (f x :: ys)
 end
 
 module Seq = struct

--- a/src/irmin/indexable.ml
+++ b/src/irmin/indexable.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,46 +15,45 @@
  *)
 
 open! Import
-include Content_addressable_intf
+include Indexable_intf
 
-module Make (AO : Append_only.Maker) (K : Hash.S) (V : Type.S) = struct
-  include AO (K) (V)
-  open Lwt.Infix
-  module H = Hash.Typed (K) (V)
+module Of_content_addressable (Key : Type.S) (S : Content_addressable.S) =
+struct
+  include S
 
-  let hash = H.hash
-  let pp_key = Type.pp K.t
-  let equal_hash = Type.(unstage (equal K.t))
+  type hash = key
+  type key = Key.t
 
-  let find t k =
-    find t k >>= function
-    | None -> Lwt.return_none
-    | Some v as r ->
-        let k' = hash v in
-        if equal_hash k k' then Lwt.return r
-        else
-          Fmt.kstrf Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
-            pp_key k' pp_key k
+  module Key = struct
+    include Key
 
-  let unsafe_add t k v = add t k v
+    type nonrec hash = hash
 
-  let add t v =
-    let k = hash v in
-    add t k v >|= fun () -> k
+    let to_hash x = x
+  end
+
+  let index _ h = Lwt.return_some h
+  let unsafe_add t h v = unsafe_add t h v >|= fun () -> h
 end
 
-module Check_closed (CA : Maker) (K : Hash.S) (V : Type.S) = struct
-  module S = CA (K) (V)
+module Check_closed (CA : Maker) (Hash : Hash.S) (Value : Type.S) = struct
+  module S = CA (Hash) (Value)
+  module Key = S.Key
 
   type 'a t = { closed : bool ref; t : 'a S.t }
-  type key = S.key
   type value = S.value
+  type key = S.key
+  type hash = S.hash
 
   let check_not_closed t = if !(t.closed) then raise Store_properties.Closed
 
   let mem t k =
     check_not_closed t;
     S.mem t.t k
+
+  let index t h =
+    check_not_closed t;
+    S.index t.t h
 
   let find t k =
     check_not_closed t;

--- a/src/irmin/indexable.ml
+++ b/src/irmin/indexable.ml
@@ -17,6 +17,13 @@
 open! Import
 include Indexable_intf
 
+module Maker_concrete_key2_of_1 (X : Maker_concrete_key1) = struct
+  type ('h, _) key = 'h X.key
+
+  module Key (H : Hash.S) (_ : Type.S) = X.Key (H)
+  module Make = X.Make
+end
+
 module Of_content_addressable (Key : Type.S) (S : Content_addressable.S) =
 struct
   include S

--- a/src/irmin/indexable.mli
+++ b/src/irmin/indexable.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,7 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Common
-module Store = Store
-module Common = Common
-module Node = Node
+include Indexable_intf.Sigs
+(** @inline *)

--- a/src/irmin/indexable_intf.ml
+++ b/src/irmin/indexable_intf.ml
@@ -76,10 +76,31 @@ module type Maker = functor (Hash : Hash.S) (Value : Type.S) -> sig
   (** @inline *)
 end
 
+(** A {!Maker_concrete_key} is an indexable store in which the key type is
+    uniquely determined by the hash type and is stated up-front. *)
+module type Maker_concrete_key = sig
+  type 'h key
+
+  module Key : functor (Hash : Hash.S) ->
+    Key.S with type t = Hash.t key and type hash = Hash.t
+
+  module Make : functor (Hash : Hash.S) (Value : Type.S) -> sig
+    include
+      S
+        with type value = Value.t
+         and type hash = Hash.t
+         and type key = Hash.t key
+
+    include Of_config with type 'a t := 'a t
+    (** @inline *)
+  end
+end
+
 module type Sigs = sig
   module type S = S
   module type S_without_key_impl = S_without_key_impl
   module type Maker = Maker
+  module type Maker_concrete_key = Maker_concrete_key
 
   module Of_content_addressable
       (Key : Type.S)

--- a/src/irmin/indexable_intf.ml
+++ b/src/irmin/indexable_intf.ml
@@ -1,0 +1,94 @@
+(*
+ * Copyright (c) 2021 Craig Ferguson <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+open Store_properties
+
+module type S_without_key_impl = sig
+  include Read_only.S
+  (** @inline *)
+
+  type hash
+  (** The type of hashes of [value]. *)
+
+  val add : [> write ] t -> value -> key Lwt.t
+  (** Write the contents of a value to the store, and obtain its key. *)
+
+  val unsafe_add : [> write ] t -> hash -> value -> key Lwt.t
+  (** Same as {!add} but allows specifying the value's hash directly. The
+      backend might choose to discard that hash and/or can be corrupt if the
+      hash is not consistent. *)
+
+  val index : [> read ] t -> hash -> key option Lwt.t
+  (** Indexing maps the hash of a value to a corresponding key of that value in
+      the store. For stores that are addressed by hashes directly, this is
+      typically [fun _t h -> Lwt.return (Key.of_hash h)]; for stores with more
+      complex addressing schemes, [index] may attempt a lookup operation in the
+      store.
+
+      In general, indexing is best-effort and reveals no information about the
+      membership of the value in the store. In particular:
+
+      - [index t hash = Some key] doesn't guarantee [mem t key]: the value with
+        hash [hash] may still be absent from the store;
+
+      - [index t hash = None] doesn't guarantee that there is no [key] such that
+        [mem t key] and [Key.to_hash key = hash]: the value may still be present
+        in the store under a key that is not indexed. *)
+
+  include Clearable with type 'a t := 'a t
+  (** @inline *)
+
+  include Batch with type 'a t := 'a t
+  (** @inline *)
+end
+
+module type S = sig
+  (** An {i indexable} store is a read-write store in which values can be added
+      and later found via their keys.
+
+      Keys are not necessarily portable between different stores, so each store
+      provides an {!index} mechanism to find keys by the hashes of the values
+      they reference. *)
+
+  include S_without_key_impl (* @inline *)
+
+  module Key : Key.S with type t = key and type hash = hash
+end
+
+module type Maker = functor (Hash : Hash.S) (Value : Type.S) -> sig
+  include S with type value = Value.t and type hash = Hash.t
+
+  include Of_config with type 'a t := 'a t
+  (** @inline *)
+end
+
+module type Sigs = sig
+  module type S = S
+  module type S_without_key_impl = S_without_key_impl
+  module type Maker = Maker
+
+  module Of_content_addressable
+      (Key : Type.S)
+      (S : Content_addressable.S with type key = Key.t) :
+    S
+      with type 'a t = 'a S.t
+       and type key = Key.t
+       and type hash = Key.t
+       and type value = S.value
+
+  module Check_closed (M : Maker) : Maker
+end

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -80,10 +80,10 @@ module Maker_generic_key (Backend : Maker_generic_key_args) = struct
       module Node_portable = Node.Value.Portable
 
       module Commit = struct
-        module Commit_maker = Commit.Maker (Schema.Info)
+        module Commit_maker = Commit.Generic_key.Maker (Schema.Info)
         module C = Commit_maker.Make (S.Hash) (Node_key) (Commit_key)
         module Backend = Backend.Commit_store.Make (S.Hash) (C)
-        include Commit.Store_indexable (S.Info) (Node) (Backend) (S.Hash) (C)
+        include Commit.Generic_key.Store (S.Info) (Node) (Backend) (S.Hash) (C)
       end
 
       module Branch = struct

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -39,15 +39,15 @@ module Irmin_node = Node
 exception Closed = Store_properties.Closed
 
 module type Maker_generic_key_args = sig
-  module Contents_store : Indexable.Maker_concrete_key
-  module Node_store : Indexable.Maker_concrete_key
-  module Commit_store : Indexable.Maker_concrete_key
+  module Contents_store : Indexable.Maker_concrete_key2
+  module Node_store : Indexable.Maker_concrete_key1
+  module Commit_store : Indexable.Maker_concrete_key1
   module Branch_store : Atomic_write.Maker
 end
 
 module Maker_generic_key (Backend : Maker_generic_key_args) = struct
   type endpoint = unit
-  type 'h contents_key = 'h Backend.Contents_store.key
+  type ('h, 'v) contents_key = ('h, 'v) Backend.Contents_store.key
   type 'h node_key = 'h Backend.Node_store.key
   type 'h commit_key = 'h Backend.Commit_store.key
 
@@ -55,7 +55,7 @@ module Maker_generic_key (Backend : Maker_generic_key_args) = struct
     module X = struct
       module Schema = S
       module Hash = S.Hash
-      module Contents_key = Backend.Contents_store.Key (S.Hash)
+      module Contents_key = Backend.Contents_store.Key (S.Hash) (S.Contents)
       module Node_key = Backend.Node_store.Key (S.Hash)
       module Commit_key = Backend.Commit_store.Key (S.Hash)
 
@@ -140,7 +140,7 @@ module Maker_generic_key (Backend : Maker_generic_key_args) = struct
 end
 
 module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) = struct
-  module Indexable = struct
+  module Indexable_store = struct
     type 'h key = 'h
 
     module Key = Key.Of_hash
@@ -154,9 +154,9 @@ module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) = struct
   end
 
   module Maker_args = struct
-    module Contents_store = Indexable
-    module Node_store = Indexable
-    module Commit_store = Indexable
+    module Contents_store = Indexable.Maker_concrete_key2_of_1 (Indexable_store)
+    module Node_store = Indexable_store
+    module Commit_store = Indexable_store
     module Branch_store = Atomic_write.Check_closed (AW)
   end
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -212,9 +212,25 @@ module type KV_maker = sig
   (** @inline *)
 end
 
-module Generic_key = Store.Generic_key
 (** "Generic key" stores are Irmin stores in which the backend may not be keyed
     directly by the hashes of stored values. See {!Key} for more details. *)
+module Generic_key : sig
+  include module type of Store.Generic_key
+  (** @inline *)
+
+  module type Maker_args = sig
+    module Contents_store : Indexable.Maker_concrete_key
+    module Node_store : Indexable.Maker_concrete_key
+    module Commit_store : Indexable.Maker_concrete_key
+    module Branch_store : Atomic_write.Maker
+  end
+
+  module Maker (X : Maker_args) :
+    Maker
+      with type 'h contents_key = 'h X.Contents_store.key
+       and type 'h node_key = 'h X.Node_store.key
+       and type 'h commit_key = 'h X.Commit_store.key
+end
 
 (** {2 Synchronization} *)
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -219,15 +219,15 @@ module Generic_key : sig
   (** @inline *)
 
   module type Maker_args = sig
-    module Contents_store : Indexable.Maker_concrete_key
-    module Node_store : Indexable.Maker_concrete_key
-    module Commit_store : Indexable.Maker_concrete_key
+    module Contents_store : Indexable.Maker_concrete_key2
+    module Node_store : Indexable.Maker_concrete_key1
+    module Commit_store : Indexable.Maker_concrete_key1
     module Branch_store : Atomic_write.Maker
   end
 
   module Maker (X : Maker_args) :
     Maker
-      with type 'h contents_key = 'h X.Contents_store.key
+      with type ('h, 'v) contents_key = ('h, 'v) X.Contents_store.key
        and type 'h node_key = 'h X.Node_store.key
        and type 'h commit_key = 'h X.Commit_store.key
 end

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -73,6 +73,9 @@ module Read_only = Read_only
 module Append_only = Append_only
 (** Append-only backend backends. *)
 
+module Indexable = Indexable
+(** Indexable backend backends. *)
+
 module Content_addressable = Content_addressable
 (** Content-addressable backends. *)
 
@@ -152,6 +155,8 @@ module Private : sig
   (** The complete collection of private implementations. *)
 end
 
+module Key = Key
+
 (** {1 High-level Stores}
 
     An Irmin store is a branch-consistent store where keys are lists of steps.
@@ -207,9 +212,13 @@ module type KV_maker = sig
   (** @inline *)
 end
 
+module Generic_key = Store.Generic_key
+(** "Generic key" stores are Irmin stores in which the backend may not be keyed
+    directly by the hashes of stored values. See {!Key} for more details. *)
+
 (** {2 Synchronization} *)
 
-val remote_store : (module S with type t = 'a) -> 'a -> remote
+val remote_store : (module Generic_key.S with type t = 'a) -> 'a -> remote
 (** [remote_store t] is the remote corresponding to the local store [t].
     Synchronization is done by importing and exporting store {{!BC.slice}
     slices}, so this is usually much slower than native synchronization using
@@ -426,7 +435,7 @@ module Sync = Sync
 (** {1 Helpers} *)
 
 (** [Dot] provides functions to export a store to the Graphviz `dot` format. *)
-module Dot (S : S) : Dot.S with type db = S.t
+module Dot (S : Generic_key.S) : Dot.S with type db = S.t
 
 (** {1:backend Backends}
 
@@ -455,10 +464,13 @@ module KV_maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
 
 (** Advanced store creator. *)
 module Of_private (P : Private.S) :
-  S
+  Generic_key.S
     with module Schema = P.Schema
      and type repo = P.Repo.t
      and type slice = P.Slice.t
+     and type contents_key = P.Contents.Key.t
+     and type node_key = P.Node.Key.t
+     and type commit_key = P.Commit.Key.t
      and module Private = P
 
 module Export_for_backends = Export_for_backends

--- a/src/irmin/key.ml
+++ b/src/irmin/key.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,7 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Common
-module Store = Store
-module Common = Common
-module Node = Node
+include Key_intf
+
+module Of_hash (Hash : Type.S) = struct
+  type t = Hash.t [@@deriving irmin]
+  type hash = Hash.t
+
+  let to_hash x = x [@@inline]
+  let of_hash x = x [@@inline]
+end

--- a/src/irmin/key.mli
+++ b/src/irmin/key.mli
@@ -1,0 +1,92 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Module types for {i keys} into an arbitrary store.
+
+    {2 Choices of key representation}
+
+    {3 Hash-like keys}
+
+    Most Irmin stores are keyed directly by a {i hash} of the values that they
+    store. This results in a so-called "content-addressable" store, in which all
+    possible contents values have exactly one key. The key is derived from the
+    value via [hash] and, given a key, the corresponding value can be retrieved
+    from the store via [find]:
+
+    {[
+                      ┌───────────────────────────────┐
+                      │                               │
+      ┌───────┐       v    find   ┌───────┐  hash   ┌─────┐
+      │ Store │ ──>  (+)  ──────> │ Value │ ──────> │ Key │
+      └───────┘                   └───────┘         └─────┘
+    ]}
+
+    Keys built this way – with a 1:1 correspondence between the key and the
+    hash, are known as {!Hash_like}. This class of key representation has some
+    important properties:
+
+    - {b irredundant storage}: given that an object's key is derived directly
+      from its representation, there can be at most one copy of any content
+      value in the store at one time – the store is naturally free of
+      duplicates.
+
+    - {b reproducibility}: again, because keys are derived directly from values,
+      multiple parties are guaranteed to compute the same store keys for a given
+      set of stored values.
+
+    However, it also has some disadvantages. Implementing a hash-keyed store
+    requires some mechanism for mapping hashes to their physical location (e.g.
+    their offset on disk), called an "index". This auxiliary index occupies
+    space, and must be queried for each pointer in the store (even for internal
+    pointers between nodes along a path).
+
+    {3 Non-hash-like keys}
+
+    For this reason, Irmin allows backends to supply custom key representations
+    that do not satisfy the above properties (i.e. not irredundant, and not
+    reproducible). This leads to the following more complex set of relationships
+    between the values:
+
+    {[
+                     ┌────────────────────────────────────────────────────────┐
+                     │                                                        │
+        ┌············┼··········································┐             │
+        :            │                                          :             │
+      ┌───────┐      v    find  ┌───────┐  hash   ┌──────┐      v   index   ┌─────┐
+      │ Store │ ──> (+) ──────> │ Value │ ──────> │ Hash │ ··> (+) ·······> │ Key │
+      └───────┘                 └───────┘         └──────┘                  └─────┘
+        │                          v                 ∧        to_hash         │ ^
+        └───────────────────────> (+)                └────────────────────────┘ │
+                                   │       add                                  │
+                                   └────────────────────────────────────────────┘
+    ]}
+
+    In general, the key of a value isn't known until it has been added to a
+    particular store, and keys need not be portable between different stores.
+    It's still required that keys be convertible to hashes, as this ensures the
+    consistency of Irmin's Merkle tree structure.
+
+    Stores that use non-hash-like keys are not content-addressable, since the
+    user can't compute the key of a value given the value itself (and perhaps a
+    value has more than one possible key).
+
+    Implementer's note: all key implementations must have a pre-hash
+    implementation derived in terms of [Key.to_hash]. That is, for all keys [k],
+    given [h = Key.to_hash k] then [Irmin.Type.pre_hash key_t k] must equal
+    [Irmin.Type.pre_hash hash_t h]. *)
+
+include Key_intf.Sigs
+(** @inline *)

--- a/src/irmin/key_intf.ml
+++ b/src/irmin/key_intf.ml
@@ -1,0 +1,62 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module type S = sig
+  type t [@@deriving irmin]
+  (** The type for keys. *)
+
+  type hash
+
+  val to_hash : t -> hash
+end
+
+module type Hash_like = sig
+  include S
+
+  val of_hash : hash -> t
+end
+
+module Store_spec = struct
+  module type S = sig
+    type 'h contents_key
+    type 'h node_key
+    type 'h commit_key
+  end
+
+  module type Hash_keyed =
+    S
+      with type 'h contents_key = 'h
+       and type 'h node_key = 'h
+       and type 'h commit_key = 'h
+
+  module rec Hash_keyed : Hash_keyed = Hash_keyed
+end
+
+module type Sigs = sig
+  module type S = S
+  module type Hash_like = Hash_like
+
+  (** The simplest possible [Key] implementation is just a hash of the
+      corresponding value, attaching no additional metadata about the value. *)
+  module Of_hash (H : Type.S) : Hash_like with type t = H.t and type hash = H.t
+
+  module Store_spec : sig
+    module type S = Store_spec.S
+    module type Hash_keyed = Store_spec.Hash_keyed
+
+    module Hash_keyed : Hash_keyed
+  end
+end

--- a/src/irmin/key_intf.ml
+++ b/src/irmin/key_intf.ml
@@ -31,14 +31,14 @@ end
 
 module Store_spec = struct
   module type S = sig
-    type 'h contents_key
+    type ('h, 'v) contents_key
     type 'h node_key
     type 'h commit_key
   end
 
   module type Hash_keyed =
     S
-      with type 'h contents_key = 'h
+      with type ('h, _) contents_key = 'h
        and type 'h node_key = 'h
        and type 'h commit_key = 'h
 

--- a/src/irmin/mem/dune
+++ b/src/irmin/mem/dune
@@ -1,4 +1,6 @@
 (library
  (name irmin_mem)
  (public_name irmin.mem)
- (libraries irmin logs lwt))
+ (libraries irmin logs lwt)
+ (preprocess
+  (pps ppx_irmin)))

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -58,7 +58,7 @@ struct
     | Node of node_key node_entry
     | Contents of contents_key contents_entry
     | Contents_m of contents_key contents_m_entry
-    (* NOTE: the [_hash] cases are only externally reachable via
+    (* Invariant: the [_hash] cases are only externally reachable via
        [Portable.of_node]. *)
     | Node_hash of Hash.t node_entry
     | Contents_hash of Hash.t contents_entry
@@ -95,7 +95,7 @@ struct
     | Contents c -> (c.name, `Contents (c.contents, Metadata.default))
     | Contents_m c -> (c.name, `Contents (c.contents, c.metadata))
     | Node_hash _ | Contents_hash _ | Contents_m_hash _ ->
-        (* Not reachable after [Portable.of_node] *)
+        (* Not reachable after [Portable.of_node]. See invariant on {!entry}. *)
         assert false
 
   let of_seq l =

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -158,13 +158,22 @@ module type Maker_generic_key = functor
   (Metadata : Metadata.S)
   (Contents_key : Key.S with type hash = Hash.t)
   (Node_key : Key.S with type hash = Hash.t)
-  ->
-  S_generic_key
-    with type metadata = Metadata.t
-     and type step = Path.step
-     and type hash = Hash.t
-     and type contents_key = Contents_key.t
-     and type node_key = Node_key.t
+  -> sig
+  include
+    S_generic_key
+      with type metadata = Metadata.t
+       and type step = Path.step
+       and type hash = Hash.t
+       and type contents_key = Contents_key.t
+       and type node_key = Node_key.t
+
+  module Portable :
+    Portable
+      with type node := t
+       and type step := step
+       and type metadata := metadata
+       and type hash := hash
+end
 
 module type Store = sig
   include Indexable.S

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -31,26 +31,34 @@ let list_partition_map f t =
   in
   aux [] [] t
 
-module Make (Hash : HASH) (Branch : Type.S) = struct
+module Make
+    (Contents_key : Type.S)
+    (Node_key : Type.S)
+    (Commit_key : Type.S)
+    (Branch : Type.S) =
+struct
   module X = struct
     type t =
-      [ `Contents of Hash.t
-      | `Node of Hash.t
-      | `Commit of Hash.t
+      [ `Contents of Contents_key.t
+      | `Node of Node_key.t
+      | `Commit of Commit_key.t
       | `Branch of Branch.t ]
     [@@deriving irmin]
 
     let equal = Type.(unstage (equal t))
     let compare = Type.(unstage (compare t))
+    let hash_contents = Type.(unstage (short_hash Contents_key.t))
+    let hash_commit = Type.(unstage (short_hash Commit_key.t))
+    let hash_node = Type.(unstage (short_hash Node_key.t))
     let hash_branch = Type.(unstage (short_hash Branch.t))
 
     (* we are using cryptographic hashes here, so the first bytes
        are good enough to be used as short hashes. *)
     let hash (t : t) : int =
       match t with
-      | `Contents c -> Hash.short_hash c
-      | `Node n -> Hash.short_hash n
-      | `Commit c -> Hash.short_hash c
+      | `Contents c -> hash_contents c
+      | `Node n -> hash_node n
+      | `Commit c -> hash_commit c
       | `Branch b -> hash_branch b
   end
 
@@ -236,9 +244,9 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
     let vertex_name k =
       let str t v = "\"" ^ Type.to_string t v ^ "\"" in
       match k with
-      | `Node n -> str Hash.t n
-      | `Commit c -> str Hash.t c
-      | `Contents c -> str Hash.t c
+      | `Node n -> str Node_key.t n
+      | `Commit c -> str Commit_key.t c
+      | `Contents c -> str Contents_key.t c
       | `Branch b -> str Branch.t b
 
     let vertex_attributes k = !vertex_attributes k

--- a/src/irmin/object_graph_intf.ml
+++ b/src/irmin/object_graph_intf.ml
@@ -125,11 +125,15 @@ module type Sigs = sig
   module type HASH = HASH
 
   (** Build a graph. *)
-  module Make (Hash : HASH) (Branch : Type.S) :
+  module Make
+      (Contents_key : Type.S)
+      (Node_key : Type.S)
+      (Commit_key : Type.S)
+      (Branch : Type.S) :
     S
       with type V.t =
-            [ `Contents of Hash.t
-            | `Node of Hash.t
-            | `Commit of Hash.t
+            [ `Contents of Contents_key.t
+            | `Node of Node_key.t
+            | `Commit of Commit_key.t
             | `Branch of Branch.t ]
 end

--- a/src/irmin/private.ml
+++ b/src/irmin/private.ml
@@ -17,6 +17,10 @@
 open! Import
 open Store_properties
 
+open struct
+  module type Node_portable = Node.Portable.S
+end
+
 module type S = sig
   module Schema : Schema.S
 
@@ -24,26 +28,37 @@ module type S = sig
   (** Internal hashes. *)
 
   (** Private content store. *)
+
   module Contents :
-    Contents.Store with type key = Hash.t and type value = Schema.Contents.t
+    Contents.Store with type hash = Hash.t and type value = Schema.Contents.t
 
   (** Private node store. *)
+
   module Node :
     Node.Store
-      with type key = Hash.t
+      with type hash = Hash.t
+       and type Val.contents_key = Contents.key
        and module Path = Schema.Path
        and module Metadata = Schema.Metadata
 
+  module Node_portable :
+    Node_portable
+      with type node := Node.value
+       and type hash := Hash.t
+       and type metadata := Schema.Metadata.t
+       and type step := Schema.Path.step
+
   (** Private commit store. *)
+
   module Commit :
     Commit.Store
-      with type key = Hash.t
-       and type value = Schema.Commit.t
+      with type hash = Hash.t
+       and type Val.node_key = Node.key
        and module Info = Schema.Info
 
   (** Private branch store. *)
   module Branch :
-    Branch.Store with type key = Schema.Branch.t and type value = Hash.t
+    Branch.Store with type key = Schema.Branch.t and type value = Commit.key
 
   (** Private slices. *)
   module Slice :

--- a/src/irmin/private.ml
+++ b/src/irmin/private.ml
@@ -63,9 +63,9 @@ module type S = sig
   (** Private slices. *)
   module Slice :
     Slice.S
-      with type contents = Contents.key * Contents.value
-       and type node = Node.key * Node.value
-       and type commit = Commit.key * Commit.value
+      with type contents = Contents.hash * Contents.value
+       and type node = Node.hash * Node.value
+       and type commit = Commit.hash * Commit.value
 
   (** Private repositories. *)
   module Repo : sig

--- a/src/irmin/read_only_intf.ml
+++ b/src/irmin/read_only_intf.ml
@@ -44,8 +44,8 @@ module type S = sig
   (** @inline *)
 end
 
-module type Maker = functor (K : Type.S) (V : Type.S) -> sig
-  include S with type key = K.t and type value = V.t
+module type Maker = functor (Key : Type.S) (Value : Type.S) -> sig
+  include S with type key = Key.t and type value = Value.t
 
   include Of_config with type 'a t := 'a t
   (** @inline *)

--- a/src/irmin/schema.ml
+++ b/src/irmin/schema.ml
@@ -27,14 +27,6 @@ end
 module type Extended = sig
   include S
 
-  module Commit
-      (Node_key : Key.S with type hash = Hash.t)
-      (Commit_key : Key.S with type hash = Hash.t) :
-    Commit.S
-      with module Info := Info
-       and type node_key = Node_key.t
-       and type commit_key = Commit_key.t
-
   module Node
       (Contents_key : Key.S with type hash = Hash.t)
       (Node_key : Key.S with type hash = Hash.t) :
@@ -44,6 +36,14 @@ module type Extended = sig
        and type hash = Hash.t
        and type contents_key = Contents_key.t
        and type node_key = Node_key.t
+
+  module Commit
+      (Node_key : Key.S with type hash = Hash.t)
+      (Commit_key : Key.S with type hash = Hash.t) :
+    Commit.Generic_key.S
+      with module Info := Info
+       and type node_key = Node_key.t
+       and type commit_key = Commit_key.t
 end
 
 open struct
@@ -65,9 +65,9 @@ module KV (C : Contents.S) : KV with module Contents = C = struct
   module Hash = Hash.BLAKE2B
   module Info = Info.Default
   module Branch = Branch.String
-  module Commit = Commit.Make (Hash)
   module Path = Path.String_list
   module Metadata = Metadata.None
-  module Node = Node.Generic_key.Make (Hash) (Path) (Metadata)
   module Contents = C
+  module Node = Node.Generic_key.Make (Hash) (Path) (Metadata)
+  module Commit = Commit.Generic_key.Make (Hash)
 end

--- a/src/irmin/slice.ml
+++ b/src/irmin/slice.ml
@@ -21,9 +21,9 @@ module Make
     (Node : Node.Store)
     (Commit : Commit.Store) =
 struct
-  type contents = Contents.Key.t * Contents.Val.t [@@deriving irmin]
-  type node = Node.Key.t * Node.Val.t [@@deriving irmin]
-  type commit = Commit.Key.t * Commit.Val.t [@@deriving irmin]
+  type contents = Contents.Hash.t * Contents.Val.t [@@deriving irmin]
+  type node = Node.Hash.t * Node.Val.t [@@deriving irmin]
+  type commit = Commit.Hash.t * Commit.Val.t [@@deriving irmin]
 
   type value = [ `Contents of contents | `Node of node | `Commit of commit ]
   [@@deriving irmin]

--- a/src/irmin/slice_intf.ml
+++ b/src/irmin/slice_intf.ml
@@ -50,7 +50,7 @@ module type Sigs = sig
   (** Build simple slices. *)
   module Make (C : Contents.Store) (N : Node.Store) (H : Commit.Store) :
     S
-      with type contents = C.key * C.value
-       and type node = N.key * N.value
-       and type commit = H.key * H.value
+      with type contents = C.Key.t * C.value
+       and type node = N.Key.t * N.value
+       and type commit = H.Key.t * H.value
 end

--- a/src/irmin/slice_intf.ml
+++ b/src/irmin/slice_intf.ml
@@ -50,7 +50,7 @@ module type Sigs = sig
   (** Build simple slices. *)
   module Make (C : Contents.Store) (N : Node.Store) (H : Commit.Store) :
     S
-      with type contents = C.Key.t * C.value
-       and type node = N.Key.t * N.value
-       and type commit = H.Key.t * H.value
+      with type contents = C.hash * C.value
+       and type node = N.hash * N.value
+       and type commit = H.hash * H.value
 end

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -22,30 +22,40 @@ let src = Logs.Src.create "irmin" ~doc:"Irmin branch-consistent store"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+module Generic_key = struct
+  module type S = S_generic_key
+  module type KV = KV_generic_key
+  module type Maker = Maker_generic_key
+  module type KV_maker = KV_maker_generic_key
+end
+
 module Make (P : Private.S) = struct
   module Schema = P.Schema
+  module Contents_key = P.Contents.Key
+  module Commit_key = P.Commit.Key
   module Metadata = P.Node.Metadata
+  module Typed = Hash.Typed (P.Hash)
   module Hash = P.Hash
   module Branch_store = P.Branch
   module Key = P.Node.Path
-  module OCamlGraph = Graph
-  module Nodes = Node.Graph (P.Node)
   module Commits = Commit.History (P.Commit)
-  module Graph = Object_graph.Make (Hash) (Branch_store.Key)
   module Private = P
   module Info = P.Commit.Info
+  module H = Commit.History (P.Commit)
+  module T = Tree.Make (P)
 
   module Contents = struct
     include P.Contents.Val
+    module H = Typed (P.Contents.Val)
 
-    let of_hash r h = P.Contents.find (P.Repo.contents_t r) h
-    let hash c = P.Contents.Key.hash c
+    let of_key r k = P.Contents.find (P.Repo.contents_t r) k
+    let hash c = H.hash c
   end
 
   module Tree = struct
-    include Tree.Make (P)
+    include T
 
-    let of_hash r h = import r h
+    let of_key r k = import r k
     let shallow r h = import_no_check r h
 
     let hash : ?cache:bool -> t -> hash =
@@ -53,20 +63,20 @@ module Make (P : Private.S) = struct
       match hash ?cache tr with `Node h -> h | `Contents (h, _) -> h
   end
 
-  type branch = P.Branch.Key.t [@@deriving irmin]
-  type hash = Hash.t [@@deriving irmin]
+  type branch = Branch_store.Key.t [@@deriving irmin ~equal ~pp]
+  type contents_key = P.Contents.Key.t [@@deriving irmin ~pp ~equal]
+  type node_key = P.Node.Key.t [@@deriving irmin ~pp ~equal]
+  type commit_key = P.Commit.Key.t [@@deriving irmin ~pp ~equal]
+  type repo = P.Repo.t
+  type commit = { r : repo; key : commit_key; v : P.Commit.value }
+  type hash = Hash.t [@@deriving irmin ~pp ~compare]
   type node = Tree.node [@@deriving irmin]
-  type contents = Contents.t [@@deriving irmin]
+  type contents = Contents.t [@@deriving irmin ~equal]
   type metadata = Metadata.t [@@deriving irmin]
-  type tree = Tree.t [@@deriving irmin]
-  type key = Key.t [@@deriving irmin]
-  type slice = P.Slice.t [@@deriving irmin]
+  type tree = Tree.t [@@deriving irmin ~pp]
+  type key = Key.t [@@deriving irmin ~pp]
   type step = Key.step [@@deriving irmin]
   type info = P.Commit.Info.t [@@deriving irmin]
-  type repo = P.Repo.t
-  type commit = { r : repo; h : Hash.t; v : P.Commit.value }
-  type head_ref = [ `Branch of branch | `Head of commit option ref ]
-  type watch = unit -> unit Lwt.t
   type Remote.t += E of P.Remote.endpoint
   type lca_error = [ `Max_depth_reached | `Too_many_lcas ] [@@deriving irmin]
   type ff_error = [ `Rejected | `No_change | lca_error ]
@@ -96,28 +106,21 @@ module Make (P : Private.S) = struct
         ("rejected", `Rejected);
       ]
 
-  let equal_hash = Type.(unstage (equal Hash.t))
-  let equal_contents = Type.(unstage (equal Contents.t))
-  let equal_branch = Type.(unstage (equal Branch_store.Key.t))
-  let pp_key = Type.pp Key.t
-  let pp_hash = Type.pp Hash.t
-  let pp_branch = Type.pp Branch_store.Key.t
   let pp_int = Type.pp Type.int
-  let pp_tree = Type.(pp Tree.t)
-  let compare_hash = Type.(unstage (compare P.Hash.t))
   let save_contents b c = P.Contents.add b c
 
   let save_tree ?(clear = true) r x y (tr : Tree.t) =
     match Tree.destruct tr with
     | `Contents (c, _) ->
         let* c = Tree.Contents.force_exn c in
-        save_contents x c
-    | `Node n -> Tree.export ~clear r x y n
+        let+ k = save_contents x c in
+        `Contents k
+    | `Node n ->
+        let+ k = Tree.export ~clear r x y n in
+        `Node k
 
-  module Hashes = Set.Make (struct
-    type t = P.Hash.t
-
-    let compare = compare_hash
+  module Contents_keys = Set.Make (struct
+    type t = Contents_key.t [@@deriving irmin ~compare]
   end)
 
   module Commit = struct
@@ -125,8 +128,8 @@ module Make (P : Private.S) = struct
 
     let t r =
       let open Type in
-      record "commit" (fun h v -> { r; h; v })
-      |+ field "hash" Hash.t (fun t -> t.h)
+      record "commit" (fun key v -> { r; key; v })
+      |+ field "key" P.Commit.Key.t (fun t -> t.key)
       |+ field "value" P.Commit.Val.t (fun t -> t.v)
       |> sealr
 
@@ -138,27 +141,33 @@ module Make (P : Private.S) = struct
         | `Contents _ -> Lwt.fail_invalid_arg "cannot add contents at the root"
       in
       let v = P.Commit.Val.v ~info ~node ~parents in
-      let+ h = P.Commit.add commit_t v in
-      { r; h; v }
+      let+ key = P.Commit.add commit_t v in
+      { r; key; v }
 
     let node t = P.Commit.Val.node t.v
     let tree t = Tree.import_no_check t.r (`Node (node t))
-    let equal x y = equal_hash x.h y.h
-    let hash t = t.h
+    let equal x y = equal_commit_key x.key y.key
+    let key t = t.key
+    let hash t = P.Commit.Key.to_hash t.key
     let info t = P.Commit.Val.info t.v
     let parents t = P.Commit.Val.parents t.v
-    let pp_hash ppf t = pp_hash ppf t.h
+    let pp_hash ppf t = Type.pp Hash.t ppf (hash t)
+    let pp_key ppf t = Type.pp P.Commit.Key.t ppf t.key
 
-    let of_hash r h =
-      P.Commit.find (P.Repo.commit_t r) h >|= function
+    let of_key r key =
+      P.Commit.find (P.Repo.commit_t r) key >|= function
       | None -> None
-      | Some v -> Some { r; h; v }
+      | Some v -> Some { r; key; v }
+
+    let of_hash r hash =
+      P.Commit.index (P.Repo.commit_t r) hash >>= function
+      | None -> Lwt.return_none
+      | Some key -> of_key r key
+
+    module H = Typed (P.Commit.Val)
 
     let to_private_commit t = t.v
-
-    let of_private_commit r v =
-      let h = P.Commit.Key.hash v in
-      { r; h; v }
+    let of_private_commit r key v = { r; key; v }
 
     let equal_opt x y =
       match (x, y) with
@@ -167,21 +176,28 @@ module Make (P : Private.S) = struct
       | _ -> false
   end
 
+  let to_private_portable_node = Tree.to_private_portable_node
   let to_private_node = Tree.to_private_node
   let of_private_node = Tree.of_private_node
   let to_private_commit = Commit.to_private_commit
   let of_private_commit = Commit.of_private_commit
+
+  type head_ref = [ `Branch of branch | `Head of commit option ref ]
+
+  module OCamlGraph = Graph
+  module Graph = Node.Graph (P.Node)
+
+  module KGraph =
+    Object_graph.Make (P.Contents.Key) (P.Node.Key) (P.Commit.Key)
+      (Branch_store.Key)
+
+  type slice = P.Slice.t [@@deriving irmin]
+  type watch = unit -> unit Lwt.t
+
   let unwatch w = w ()
 
   module Repo = struct
     type t = repo
-
-    type elt =
-      [ `Commit of Hash.t
-      | `Node of Hash.t
-      | `Contents of Hash.t
-      | `Branch of P.Branch.Key.t ]
-    [@@deriving irmin]
 
     let v = P.Repo.v
     let close = P.Repo.close
@@ -198,8 +214,8 @@ module Make (P : Private.S) = struct
         (fun acc r ->
           Branch_store.find t r >>= function
           | None -> Lwt.return acc
-          | Some h -> (
-              Commit.of_hash repo h >|= function
+          | Some k -> (
+              Commit.of_key repo k >|= function
               | None -> acc
               | Some h -> h :: acc))
         [] bs
@@ -214,19 +230,19 @@ module Make (P : Private.S) = struct
             | `Max m -> string_of_int (List.length m)));
       let* max = match max with `Head -> heads t | `Max m -> Lwt.return m in
       let* slice = P.Slice.empty () in
-      let max = List.map (fun x -> `Commit x.h) max in
-      let min = List.map (fun x -> `Commit x.h) min in
+      let max = List.map (fun x -> `Commit x.key) max in
+      let min = List.map (fun x -> `Commit x.key) min in
       let pred = function
         | `Commit k ->
             let+ parents = Commits.parents (commit_t t) k in
             List.map (fun x -> `Commit x) parents
         | _ -> Lwt.return_nil
       in
-      let* g = Graph.closure ?depth ~pred ~min ~max () in
+      let* g = KGraph.closure ?depth ~pred ~min ~max () in
       let keys =
         List.fold_left
           (fun acc -> function `Commit c -> c :: acc | _ -> acc)
-          [] (Graph.vertex g)
+          [] (KGraph.vertex g)
       in
       let root_nodes = ref [] in
       let* () =
@@ -242,8 +258,8 @@ module Make (P : Private.S) = struct
       if not full then Lwt.return slice
       else
         (* XXX: we can compute a [min] if needed *)
-        let* nodes = Nodes.closure (node_t t) ~min:[] ~max:!root_nodes in
-        let contents = ref Hashes.empty in
+        let* nodes = Graph.closure (node_t t) ~min:[] ~max:!root_nodes in
+        let contents = ref Contents_keys.empty in
         let* () =
           Lwt_list.iter_p
             (fun k ->
@@ -253,7 +269,7 @@ module Make (P : Private.S) = struct
                   List.iter
                     (function
                       | _, `Contents (c, _) ->
-                          contents := Hashes.add c !contents
+                          contents := Contents_keys.add c !contents
                       | _ -> ())
                     (P.Node.Val.list v);
                   P.Slice.add slice (`Node (k, v)))
@@ -265,7 +281,7 @@ module Make (P : Private.S) = struct
               P.Contents.find (contents_t t) k >>= function
               | None -> Lwt.return_unit
               | Some m -> P.Slice.add slice (`Contents (k, m)))
-            (Hashes.elements !contents)
+            (Contents_keys.elements !contents)
         in
         slice
 
@@ -274,11 +290,10 @@ module Make (P : Private.S) = struct
     let import_error fmt = Fmt.kstrf (fun x -> Lwt.fail (Import_error x)) fmt
 
     let import t s =
-      let aux name add (k, v) =
+      let aux name equal pp add (k, v) =
         let* k' = add v in
-        if not (equal_hash k k') then
-          import_error "%s import error: expected %a, got %a" name pp_hash k
-            pp_hash k'
+        if not (equal k k') then
+          import_error "%s import error: expected %a, got %a" name pp k pp k'
         else Lwt.return_unit
       in
       let contents = ref [] in
@@ -301,17 +316,31 @@ module Make (P : Private.S) = struct
         (fun () ->
           let* () =
             Lwt_list.iter_p
-              (aux "Contents" (P.Contents.add contents_t))
+              (aux "Contents" equal_contents_key pp_contents_key
+                 (P.Contents.add contents_t))
               !contents
           in
-          Lwt_list.iter_p (aux "Node" (P.Node.add node_t)) !nodes >>= fun () ->
+          Lwt_list.iter_p
+            (aux "Node" equal_node_key pp_node_key (P.Node.add node_t))
+            !nodes
+          >>= fun () ->
           let+ () =
-            Lwt_list.iter_p (aux "Commit" (P.Commit.add commit_t)) !commits
+            Lwt_list.iter_p
+              (aux "Commit" equal_commit_key pp_commit_key
+                 (P.Commit.add commit_t))
+              !commits
           in
           Ok ())
         (function
           | Import_error e -> Lwt.return (Error (`Msg e))
           | e -> Fmt.kstrf Lwt.fail_invalid_arg "impot error: %a" Fmt.exn e)
+
+    type elt =
+      [ `Commit of commit_key
+      | `Node of node_key
+      | `Contents of contents_key
+      | `Branch of P.Branch.Key.t ]
+    [@@deriving irmin]
 
     let ignore_lwt _ = Lwt.return_unit
     let return_false _ = Lwt.return false
@@ -329,7 +358,7 @@ module Make (P : Private.S) = struct
     let default_pred_commit t c =
       P.Commit.find (commit_t t) c >|= function
       | None ->
-          Log.debug (fun l -> l "%a: not found" pp_hash c);
+          Log.debug (fun l -> l "%a: not found" pp_commit_key c);
           []
       | Some c ->
           let node = P.Commit.Val.node c in
@@ -368,7 +397,7 @@ module Make (P : Private.S) = struct
         | `Contents x -> pred_contents t x
         | `Branch x -> pred_branch t x
       in
-      Graph.iter ?cache_size ~pred ~min ~max ~node ?edge ~skip ~rev ()
+      KGraph.iter ?cache_size ~pred ~min ~max ~node ?edge ~skip ~rev ()
 
     let breadth_first_traversal ?cache_size ~max ?(branch = ignore_lwt)
         ?(commit = ignore_lwt) ?(node = ignore_lwt) ?(contents = ignore_lwt)
@@ -387,7 +416,7 @@ module Make (P : Private.S) = struct
         | `Contents x -> pred_contents t x
         | `Branch x -> pred_branch t x
       in
-      Graph.breadth_first_traversal ?cache_size ~pred ~max ~node ()
+      KGraph.breadth_first_traversal ?cache_size ~pred ~max ~node ()
   end
 
   type t = {
@@ -438,9 +467,9 @@ module Make (P : Private.S) = struct
     let err = Fmt.strf "%a is not a valid branch name." pp_branch t in
     Lwt.fail (Invalid_argument err)
 
-  let of_branch repo id =
-    if Branch_store.Key.is_valid id then of_ref repo (`Branch id)
-    else err_invalid_branch id
+  let of_branch repo key =
+    if Branch_store.Key.is_valid key then of_ref repo (`Branch key)
+    else err_invalid_branch key
 
   let master repo = of_branch repo Branch_store.Key.master
   let empty repo = of_ref repo (`Head (ref None))
@@ -500,10 +529,10 @@ module Make (P : Private.S) = struct
       | `Branch name -> (
           Branch_store.find (branch_store t) name >>= function
           | None -> Lwt.return_none
-          | Some h -> Commit.of_hash t.repo h)
+          | Some k -> Commit.of_key t.repo k)
     in
     let+ h = h in
-    Log.debug (fun f -> f "Head.find -> %a" Fmt.(option Commit.pp_hash) h);
+    Log.debug (fun f -> f "Head.find -> %a" Fmt.(option Commit.pp_key) h);
     h
 
   let tree_and_head t =
@@ -527,19 +556,19 @@ module Make (P : Private.S) = struct
 
   let lift_head_diff repo fn = function
     | `Removed x -> (
-        Commit.of_hash repo x >>= function
+        Commit.of_key repo x >>= function
         | None -> Lwt.return_unit
         | Some x -> fn (`Removed x))
     | `Updated (x, y) -> (
-        let* x = Commit.of_hash repo x in
-        let* y = Commit.of_hash repo y in
+        let* x = Commit.of_key repo x in
+        let* y = Commit.of_key repo y in
         match (x, y) with
         | None, None -> Lwt.return_unit
         | Some x, None -> fn (`Removed x)
         | None, Some y -> fn (`Added y)
         | Some x, Some y -> fn (`Updated (x, y)))
     | `Added x -> (
-        Commit.of_hash repo x >>= function
+        Commit.of_key repo x >>= function
         | None -> Lwt.return_unit
         | Some x -> fn (`Added x))
 
@@ -550,14 +579,14 @@ module Make (P : Private.S) = struct
         let init =
           match init with
           | None -> None
-          | Some head0 -> Some [ (name0, head0.h) ]
+          | Some head0 -> Some [ (name0, head0.key) ]
         in
-        let+ id =
+        let+ key =
           Branch_store.watch (branch_store t) ?init (fun name head ->
               if equal_branch name0 name then lift_head_diff t.repo fn head
               else Lwt.return_unit)
         in
-        fun () -> Branch_store.unwatch (branch_store t) id
+        fun () -> Branch_store.unwatch (branch_store t) key
 
   let watch_key t key ?init fn =
     Log.debug (fun f -> f "watch-key %a" pp_key key);
@@ -576,7 +605,7 @@ module Make (P : Private.S) = struct
       | `Head h ->
           h := Some c;
           Lwt.return_unit
-      | `Branch name -> Branch_store.set (branch_store t) name c.h
+      | `Branch name -> Branch_store.set (branch_store t) name c.key
 
     let test_and_set_unsafe t ~test ~set =
       match t.head_ref with
@@ -587,7 +616,7 @@ module Make (P : Private.S) = struct
             Lwt.return_true)
           else Lwt.return_false
       | `Branch name ->
-          let h = function None -> None | Some c -> Some c.h in
+          let h = function None -> None | Some c -> Some c.key in
           Branch_store.test_and_set (branch_store t) name ~test:(h test)
             ~set:(h set)
 
@@ -606,9 +635,10 @@ module Make (P : Private.S) = struct
             (* we only update if there is a change *)
             Lwt.return (Error `No_change)
           else
-            Commits.lcas (commit_store t) ?max_depth ?n new_head.h old_head.h
+            Commits.lcas (commit_store t) ?max_depth ?n new_head.key
+              old_head.key
             >>= function
-            | Ok [ x ] when equal_hash x old_head.h ->
+            | Ok [ x ] when equal_commit_key x old_head.key ->
                 (* we only update if new_head > old_head *)
                 test_and_set t ~test:(Some old_head) ~set:(Some new_head)
                 >|= return
@@ -620,7 +650,7 @@ module Make (P : Private.S) = struct
        - Perform recursive 3-way merges *)
     let three_way_merge t ?max_depth ?n ~info c1 c2 =
       P.Repo.batch (repo t) @@ fun _ _ commit_t ->
-      Commits.three_way_merge commit_t ?max_depth ?n ~info c1.h c2.h
+      Commits.three_way_merge commit_t ?max_depth ?n ~info c1.key c2.key
 
     (* FIXME: we might want to keep the new commit in case of conflict,
          and use it as a base for the next merge. *)
@@ -632,7 +662,7 @@ module Make (P : Private.S) = struct
         | None -> test_and_set_unsafe t ~test:head ~set:(Some c1) >>= Merge.ok
         | Some c2 ->
             three_way_merge t ~info ?max_depth ?n c1 c2 >>=* fun c3 ->
-            let* c3 = Commit.of_hash t.repo c3 in
+            let* c3 = Commit.of_key t.repo c3 in
             test_and_set_unsafe t ~test:head ~set:c3 >>= Merge.ok
       in
       Lwt_mutex.with_lock t.lock (fun () -> retry_merge "merge_head" aux)
@@ -673,8 +703,8 @@ module Make (P : Private.S) = struct
         (* concurrent handlers and/or process can modify the
            branch. Need to check that we are still working on the same
            head. *)
-        let test = match old_head with None -> None | Some c -> Some c.h in
-        let set = Some c.h in
+        let test = match old_head with None -> None | Some c -> Some c.key in
+        let set = Some c.key in
         let+ r = Branch_store.test_and_set (branch_store t) name ~test ~set in
         if r then t.tree <- Some tree;
         r
@@ -731,7 +761,7 @@ module Make (P : Private.S) = struct
       | Ok root ->
           let info = info () in
           let parents = match parents with None -> s.parents | Some p -> p in
-          let parents = List.map Commit.hash parents in
+          let parents = List.map Commit.key parents in
           let* c = Commit.v (repo t) ~info ~parents root in
           let* r = add_commit t s.head (c, root_tree (Tree.destruct root)) in
           Lwt.return (Ok r)
@@ -833,6 +863,15 @@ module Make (P : Private.S) = struct
   let find_tree t k = tree t >>= fun tree -> Tree.find_tree tree k
   let get_tree t k = tree t >>= fun tree -> Tree.get_tree tree k
 
+  let key t k =
+    find_tree t k >|= function
+    | None -> None
+    | Some tree -> (
+        match Tree.key tree with
+        | Some (`Contents (key, _)) -> Some (`Contents key)
+        | Some (`Node key) -> Some (`Node key)
+        | None -> None)
+
   let hash t k =
     find_tree t k >|= function
     | None -> None
@@ -890,29 +929,30 @@ module Make (P : Private.S) = struct
     let* () =
       Head.find src >>= function
       | None -> Branch_store.remove (branch_store src) dst
-      | Some h -> Branch_store.set (branch_store src) dst h.h
+      | Some h -> Branch_store.set (branch_store src) dst h.key
     in
     of_branch (repo src) dst
 
   let return_lcas r = function
     | Error _ as e -> Lwt.return e
     | Ok commits ->
-        Lwt_list.filter_map_p (Commit.of_hash r) commits >|= Result.ok
+        Lwt_list.filter_map_p (Commit.of_key r) commits >|= Result.ok
 
   let lcas ?max_depth ?n t1 t2 =
     let* h1 = Head.get t1 in
     let* h2 = Head.get t2 in
-    Commits.lcas (commit_store t1) ?max_depth ?n h1.h h2.h
+    Commits.lcas (commit_store t1) ?max_depth ?n h1.key h2.key
     >>= return_lcas t1.repo
 
   let lcas_with_commit t ?max_depth ?n c =
     let* h = Head.get t in
-    Commits.lcas (commit_store t) ?max_depth ?n h.h c.h >>= return_lcas t.repo
+    Commits.lcas (commit_store t) ?max_depth ?n h.key c.key
+    >>= return_lcas t.repo
 
   let lcas_with_branch t ?max_depth ?n b =
     let* h = Head.get t in
     let* head = Head.get { t with head_ref = `Branch b } in
-    Commits.lcas (commit_store t) ?max_depth ?n h.h head.h
+    Commits.lcas (commit_store t) ?max_depth ?n h.key head.key
     >>= return_lcas t.repo
 
   type 'a merge =
@@ -929,7 +969,7 @@ module Make (P : Private.S) = struct
         Fmt.kstrf Lwt.fail_invalid_arg
           "merge_with_branch: %a is not a valid branch ID" pp_branch other
     | Some c -> (
-        Commit.of_hash t.repo c >>= function
+        Commit.of_key t.repo c >>= function
         | None -> Lwt.fail_invalid_arg "invalid commit"
         | Some c -> Head.merge ~into:t ~info ?max_depth ?n c)
 
@@ -946,47 +986,58 @@ module Make (P : Private.S) = struct
   module History = OCamlGraph.Persistent.Digraph.ConcreteBidirectional (struct
     type t = commit
 
-    let hash h = P.Commit.Key.short_hash h.h
-    let compare x y = compare_hash x.h y.h
-    let equal x y = equal_hash x.h y.h
+    let hash h = P.Hash.short_hash (Commit.hash h)
+    let compare_key = Type.(unstage (compare P.Commit.Key.t))
+    let compare x y = compare_key x.key y.key
+    let equal x y = equal_commit_key x.key y.key
   end)
 
-  let filter_graph f g =
-    let t = History.empty in
-    if Graph.nb_vertex g = 1 then
-      match Graph.vertex g with
-      | [ v ] -> (
-          f v >|= function Some v -> History.add_vertex t v | None -> t)
-      | _ -> assert false
-    else
-      Graph.fold_edges
-        (fun x y t ->
-          let* t = t in
-          let* x = f x in
-          let+ y = f y in
-          match (x, y) with
-          | Some x, Some y ->
-              let t = History.add_vertex t x in
-              let t = History.add_vertex t y in
-              History.add_edge t x y
-          | _ -> t)
-        g (Lwt.return t)
+  module Gmap = struct
+    module Src = KGraph
+
+    module Dst = struct
+      include History
+
+      let empty () = empty
+    end
+
+    let filter_map f g =
+      let t = Dst.empty () in
+      if Src.nb_vertex g = 1 then
+        match Src.vertex g with
+        | [ v ] -> (
+            f v >|= function Some v -> Dst.add_vertex t v | None -> t)
+        | _ -> assert false
+      else
+        Src.fold_edges
+          (fun x y t ->
+            let* t = t in
+            let* x = f x in
+            let+ y = f y in
+            match (x, y) with
+            | Some x, Some y ->
+                let t = Dst.add_vertex t x in
+                let t = Dst.add_vertex t y in
+                Dst.add_edge t x y
+            | _ -> t)
+          g (Lwt.return t)
+  end
 
   let history ?depth ?(min = []) ?(max = []) t =
     Log.debug (fun f -> f "history");
     let pred = function
       | `Commit k ->
           Commits.parents (commit_store t) k
-          >>= Lwt_list.filter_map_p (Commit.of_hash t.repo)
-          >|= fun parents -> List.map (fun x -> `Commit x.h) parents
+          >>= Lwt_list.filter_map_p (Commit.of_key t.repo)
+          >|= fun parents -> List.map (fun x -> `Commit x.key) parents
       | _ -> Lwt.return_nil
     in
     let* max = Head.find t >|= function Some h -> [ h ] | None -> max in
-    let max = List.map (fun k -> `Commit k.h) max in
-    let min = List.map (fun k -> `Commit k.h) min in
-    let* g = Graph.closure ?depth ~min ~max ~pred () in
-    filter_graph
-      (function `Commit k -> Commit.of_hash t.repo k | _ -> Lwt.return_none)
+    let max = List.map (fun k -> `Commit k.key) max in
+    let min = List.map (fun k -> `Commit k.key) min in
+    let* g = Gmap.Src.closure ?depth ~min ~max ~pred () in
+    Gmap.filter_map
+      (function `Commit k -> Commit.of_key t.repo k | _ -> Lwt.return_none)
       g
 
   module Heap = Binary_heap.Make (struct
@@ -1027,7 +1078,7 @@ module Make (P : Private.S) = struct
           let* found =
             Lwt_list.for_all_p
               (fun hash ->
-                Commit.of_hash repo hash >>= function
+                Commit.of_key repo hash >>= function
                 | Some commit -> (
                     let () =
                       if not max_depth then
@@ -1055,14 +1106,14 @@ module Make (P : Private.S) = struct
     let find t br =
       P.Branch.find (Repo.branch_t t) br >>= function
       | None -> Lwt.return_none
-      | Some h -> Commit.of_hash t h
+      | Some h -> Commit.of_key t h
 
-    let set t br h = P.Branch.set (P.Repo.branch_t t) br h.h
+    let set t br h = P.Branch.set (P.Repo.branch_t t) br h.key
     let remove t = P.Branch.remove (P.Repo.branch_t t)
     let list = Repo.branches
 
     let watch t k ?init f =
-      let init = match init with None -> None | Some h -> Some h.h in
+      let init = match init with None -> None | Some h -> Some h.key in
       let+ w =
         P.Branch.watch_key (Repo.branch_t t) k ?init (lift_head_diff t f)
       in
@@ -1072,7 +1123,7 @@ module Make (P : Private.S) = struct
       let init =
         match init with
         | None -> None
-        | Some i -> Some (List.map (fun (k, v) -> (k, v.h)) i)
+        | Some i -> Some (List.map (fun (k, v) -> (k, v.key)) i)
       in
       let f k v = lift_head_diff t (f k) v in
       let+ w = P.Branch.watch (Repo.branch_t t) ?init f in
@@ -1100,7 +1151,7 @@ module Make (P : Private.S) = struct
     let pp ppf = function
       | `Empty -> Fmt.string ppf "empty"
       | `Branch b -> pp_branch ppf b
-      | `Commit c -> pp_hash ppf c.h
+      | `Commit c -> pp_hash ppf (Commit_key.to_hash c.key)
   end
 
   let commit_t = Commit.t
@@ -1157,4 +1208,5 @@ struct
     get_tree tree Store.Key.empty
 end
 
-type Remote.t += Store : (module S with type t = 'a) * 'a -> Remote.t
+type Remote.t +=
+  | Store : (module Generic_key.S with type t = 'a) * 'a -> Remote.t

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -63,6 +63,20 @@ module Make (P : Private.S) = struct
   module Tree = struct
     include T
 
+    let find_key r t =
+      match key t with
+      | Some k -> Lwt.return (Some k)
+      | None -> (
+          match hash t with
+          | `Node h -> (
+              P.Node.index (P.Repo.node_t r) h >|= function
+              | None -> None
+              | Some k -> Some (`Node k))
+          | `Contents (h, m) -> (
+              P.Contents.index (P.Repo.contents_t r) h >|= function
+              | None -> None
+              | Some k -> Some (`Contents (k, m))))
+
     let of_key r k = import r k
 
     let of_hash r = function

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -414,15 +414,26 @@ module type S_generic_key = sig
         reference (either {!contents} or {!node}). In the [contents] case, the
         key is paired with corresponding {!metadata}. *)
 
-    val hash : ?cache:bool -> tree -> hash
-    (** [hash c] is [c]'s hash. *)
-
     val key : tree -> kinded_key option
-    (** [id r c] is [c]'s ID. *)
+    (** [key t] is the key of tree [t] in the underlying repository, if it
+        exists. Tree objects that exist entirely in memory (such as those built
+        with {!of_concrete}) have no backend key until they are exported to a
+        repository, and so will return [None]. *)
+
+    val find_key : Repo.t -> tree -> kinded_key option Lwt.t
+    (** [find_key r t] is the key of a tree object with the same hash as [t] in
+        [r], if such a key exists and is indexed. *)
 
     val of_key : Repo.t -> kinded_key -> tree option Lwt.t
     (** [of_key r h] is the the tree object in [r] having [h] as key, or [None]
         is no such tree object exists. *)
+
+    val shallow : Repo.t -> kinded_key -> tree
+    (** [shallow r h] is the shallow tree object with the key [h]. No check is
+        performed to verify if [h] actually exists in [r]. *)
+
+    val hash : ?cache:bool -> tree -> hash
+    (** [hash t] is the hash of tree [t]. *)
 
     type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
     (** Like {!kinded_key}, but with hashes as value references rather than
@@ -434,10 +445,6 @@ module type S_generic_key = sig
 
         {b Note:} in stores for which {!node_key} = {!contents_key} = {!hash},
         this function has identical behaviour to {!of_key}. *)
-
-    val shallow : Repo.t -> kinded_key -> tree
-    (** [shallow r h] is the shallow tree object with the key [h]. No check is
-        performed to verify if [h] actually exists in [r]. *)
   end
 
   (** {1 Reads} *)

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -17,7 +17,7 @@
 open! Import
 open Store_properties
 
-module type S = sig
+module type S_generic_key = sig
   (** {1 Irmin stores}
 
       Irmin stores are tree-like read-write stores with extended capabilities.
@@ -63,7 +63,7 @@ module type S = sig
   (** The type for object hashes. *)
 
   type commit
-  (** Type for commit identifiers. Similar to Git's commit SHA1s. *)
+  (** Type for [`Commit] identifiers. Similar to Git's commit SHA1s. *)
 
   val commit_t : repo -> commit Type.t
   (** [commit_t r] is the value type for {!commit}. *)
@@ -89,6 +89,10 @@ module type S = sig
     include Info.S with type t = info
     (** @inline *)
   end
+
+  type contents_key [@@deriving irmin]
+  type node_key [@@deriving irmin]
+  type commit_key [@@deriving irmin]
 
   (** Repositories. *)
   module Repo : sig
@@ -137,7 +141,10 @@ module type S = sig
         modify branches. *)
 
     type elt =
-      [ `Commit of hash | `Node of hash | `Contents of hash | `Branch of branch ]
+      [ `Commit of commit_key
+      | `Node of node_key
+      | `Contents of contents_key
+      | `Branch of branch ]
     [@@deriving irmin]
     (** The type for elements iterated over by {!iter}. *)
 
@@ -147,17 +154,17 @@ module type S = sig
       max:elt list ->
       ?edge:(elt -> elt -> unit Lwt.t) ->
       ?branch:(branch -> unit Lwt.t) ->
-      ?commit:(hash -> unit Lwt.t) ->
-      ?node:(hash -> unit Lwt.t) ->
-      ?contents:(hash -> unit Lwt.t) ->
+      ?commit:(commit_key -> unit Lwt.t) ->
+      ?node:(node_key -> unit Lwt.t) ->
+      ?contents:(contents_key -> unit Lwt.t) ->
       ?skip_branch:(branch -> bool Lwt.t) ->
-      ?skip_commit:(hash -> bool Lwt.t) ->
-      ?skip_node:(hash -> bool Lwt.t) ->
-      ?skip_contents:(hash -> bool Lwt.t) ->
+      ?skip_commit:(commit_key -> bool Lwt.t) ->
+      ?skip_node:(node_key -> bool Lwt.t) ->
+      ?skip_contents:(contents_key -> bool Lwt.t) ->
       ?pred_branch:(t -> branch -> elt list Lwt.t) ->
-      ?pred_commit:(t -> hash -> elt list Lwt.t) ->
-      ?pred_node:(t -> hash -> elt list Lwt.t) ->
-      ?pred_contents:(t -> hash -> elt list Lwt.t) ->
+      ?pred_commit:(t -> commit_key -> elt list Lwt.t) ->
+      ?pred_node:(t -> node_key -> elt list Lwt.t) ->
+      ?pred_contents:(t -> contents_key -> elt list Lwt.t) ->
       ?rev:bool ->
       t ->
       unit Lwt.t
@@ -202,13 +209,13 @@ module type S = sig
       ?cache_size:int ->
       max:elt list ->
       ?branch:(branch -> unit Lwt.t) ->
-      ?commit:(hash -> unit Lwt.t) ->
-      ?node:(hash -> unit Lwt.t) ->
-      ?contents:(hash -> unit Lwt.t) ->
+      ?commit:(commit_key -> unit Lwt.t) ->
+      ?node:(node_key -> unit Lwt.t) ->
+      ?contents:(contents_key -> unit Lwt.t) ->
       ?pred_branch:(t -> branch -> elt list Lwt.t) ->
-      ?pred_commit:(t -> hash -> elt list Lwt.t) ->
-      ?pred_node:(t -> hash -> elt list Lwt.t) ->
-      ?pred_contents:(t -> hash -> elt list Lwt.t) ->
+      ?pred_commit:(t -> commit_key -> elt list Lwt.t) ->
+      ?pred_node:(t -> node_key -> elt list Lwt.t) ->
+      ?pred_contents:(t -> contents_key -> elt list Lwt.t) ->
       t ->
       unit Lwt.t
   end
@@ -328,7 +335,7 @@ module type S = sig
     val pp_hash : t Fmt.t
     (** [pp] is the pretty-printer for commit. Display only the hash. *)
 
-    val v : repo -> info:info -> parents:hash list -> tree -> commit Lwt.t
+    val v : repo -> info:info -> parents:commit_key list -> tree -> commit Lwt.t
     (** [v r i ~parents:p t] is the commit [c] such that:
 
         - [info c = i]
@@ -338,20 +345,30 @@ module type S = sig
     val tree : commit -> tree
     (** [tree c] is [c]'s root tree. *)
 
-    val parents : commit -> hash list
+    val parents : commit -> commit_key list
     (** [parents c] are [c]'s parents. *)
 
     val info : commit -> info
     (** [info c] is [c]'s info. *)
 
+    val hash : commit -> hash
+    (** [hash c] is [c]'s hash. *)
+
     (** {1 Import/Export} *)
 
-    val hash : commit -> hash
-    (** [hash c] it [c]'s hash. *)
+    val key : commit -> commit_key
+    (** [key c] is [c]'s key. *)
+
+    val of_key : repo -> commit_key -> commit option Lwt.t
+    (** [of_key r k] is the the commit object in [r] with key [k], or [None] if
+        no such commit object exists. *)
 
     val of_hash : repo -> hash -> commit option Lwt.t
-    (** [of_hash r h] is the the commit object in [r] having [h] as hash, or
-        [None] is no such commit object exists. *)
+    (** [of_hash r k] is the commit object in [r] with hash [h], or [None] if no
+        such commit object is indexed in [r].
+
+        {b Note:} in stores for which {!commit_key} = {!hash}, this function has
+        identical behaviour to {!of_key}. *)
   end
 
   (** [Contents] provides base functions for the store's contents. *)
@@ -361,10 +378,10 @@ module type S = sig
     (** {1 Import/Export} *)
 
     val hash : contents -> hash
-    (** [hash c] it [c]'s hash in the repository [r]. *)
+    (** [hash c] it [c]'s hash. *)
 
-    val of_hash : repo -> hash -> contents option Lwt.t
-    (** [of_hash r h] is the the contents object in [r] having [h] as hash, or
+    val of_key : repo -> contents_key -> contents option Lwt.t
+    (** [of_key r k] is the the contents object in [r] having [k] as ID, or
         [None] is no such contents object exists. *)
   end
 
@@ -377,25 +394,31 @@ module type S = sig
          and type key := key
          and type metadata := metadata
          and type contents := contents
+         and type contents_key := contents_key
          and type node := node
          and type hash := hash
 
     (** {1 Import/Export} *)
 
-    val hash : ?cache:bool -> tree -> hash
-    (** [hash r c] it [c]'s hash in the repository [r]. *)
-
-    type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]
+    type kinded_key =
+      [ `Contents of contents_key * metadata | `Node of node_key ]
+    [@@deriving irmin]
     (** Hashes in the Irmin store are tagged with the type of the value they
         reference (either {!contents} or {!node}). In the [contents] case, the
         hash is paired with corresponding {!metadata}. *)
 
-    val of_hash : Repo.t -> kinded_hash -> tree option Lwt.t
-    (** [of_hash r h] is the the tree object in [r] having [h] as hash, or
-        [None] is no such tree object exists. *)
+    val hash : ?cache:bool -> tree -> hash
+    (** [hash c] is [c]'s hash. *)
 
-    val shallow : Repo.t -> kinded_hash -> tree
-    (** [shallow r h] is the shallow tree object with the hash [h]. No check is
+    val key : tree -> kinded_key option
+    (** [id r c] is [c]'s ID. *)
+
+    val of_key : Repo.t -> kinded_key -> tree option Lwt.t
+    (** [of_key r h] is the the tree object in [r] having [h] as key, or [None]
+        is no such tree object exists. *)
+
+    val shallow : Repo.t -> kinded_key -> tree
+    (** [shallow r h] is the shallow tree object with the key [h]. No check is
         performed to verify if [h] actually exists in [r]. *)
   end
 
@@ -430,6 +453,11 @@ module type S = sig
 
   val get_tree : t -> key -> tree Lwt.t
   (** [get_tree t k] is {!Tree.get_tree} applied to [t]'s root tree. *)
+
+  type kinded_key := [ `Contents of contents_key | `Node of node_key ]
+
+  val key : t -> key -> kinded_key option Lwt.t
+  (** [id t k] *)
 
   val hash : t -> key -> hash option Lwt.t
   (** [hash t k] *)
@@ -741,7 +769,7 @@ module type S = sig
   (** Same as {!merge} but with a branch ID. *)
 
   val merge_with_commit : t -> commit merge
-  (** Same as {!merge} but with a commit ID. *)
+  (** Same as {!merge} but with a commit_id. *)
 
   val lcas :
     ?max_depth:int -> ?n:int -> t -> t -> (commit list, lca_error) result Lwt.t
@@ -768,7 +796,7 @@ module type S = sig
     ?n:int ->
     commit ->
     (commit list, lca_error) result Lwt.t
-  (** Same as {!lcas} but takes a commit ID as argument. *)
+  (** Same as {!lcas} but takes a commmit as argument. *)
 
   (** {1 History} *)
 
@@ -841,13 +869,16 @@ module type S = sig
   (** [Metadata] provides base functions for node metadata. *)
 
   (** Private functions, which might be used by the backends. *)
-  module Private : sig
-    include
-      Private.S
-        with module Schema = Schema
-         and type Slice.t = slice
-         and type Repo.t = repo
-  end
+  module Private :
+    Private.S
+      with module Schema = Schema
+      with type Slice.t = slice
+       and type Repo.t = repo
+       and module Hash = Hash
+       and module Node.Path = Key
+       and type Contents.key = contents_key
+       and type Node.key = node_key
+       and type Commit.key = commit_key
 
   type Remote.t +=
     | E of Private.Remote.endpoint
@@ -855,18 +886,21 @@ module type S = sig
 
   (** {2 Converters to private types} *)
 
-  val to_private_node : node -> Private.Node.value Tree.or_error Lwt.t
   val of_private_node : repo -> Private.Node.value -> node
+  val to_private_node : node -> Private.Node.value Lwt.t
+  val to_private_portable_node : node -> Private.Node_portable.t Lwt.t
 
   val to_private_commit : commit -> Private.Commit.value
   (** [to_private_commit c] is the private commit object associated with the
       commit [c]. *)
 
-  val of_private_commit : repo -> Private.Commit.value -> commit
-  (** [of_private_commit r c] is the commit associated with the private commit
-      object [c]. *)
+  val of_private_commit :
+    repo -> Private.Commit.Key.t -> Private.Commit.value -> commit
+  (** [of_private_commit r k c] is the commit associated with the private commit
+      object [c] that hash key [k] in [r]. *)
 
-  val save_contents : [> write ] Private.Contents.t -> contents -> hash Lwt.t
+  val save_contents :
+    [> write ] Private.Contents.t -> contents -> contents_key Lwt.t
   (** Save a content into the database *)
 
   val save_tree :
@@ -875,17 +909,45 @@ module type S = sig
     [> write ] Private.Contents.t ->
     [> read_write ] Private.Node.t ->
     tree ->
-    hash Lwt.t
+    kinded_key Lwt.t
   (** Save a tree into the database. Does not do any reads. If [clear] is set
       (it is by default), the tree cache will be cleared after the save. *)
 end
 
-module type Maker = sig
+module type S = sig
+  type hash
+
+  (** @inline *)
+  include
+    S_generic_key
+      with type Schema.Hash.t = hash
+       and type hash := hash
+       and type contents_key = hash
+       and type node_key = hash
+       and type commit_key = hash
+end
+
+module S_is_a_generic_keyed (X : S) : S_generic_key = X
+
+module type Maker_generic_key = sig
   type endpoint
 
+  include Key.Store_spec.S
+
   module Make (Schema : Schema.S) :
-    S with module Schema = Schema and type Private.Remote.endpoint = endpoint
+    S_generic_key
+      with module Schema = Schema
+       and type Private.Remote.endpoint = endpoint
+       and type contents_key = Schema.Hash.t contents_key
+       and type node_key = Schema.Hash.t node_key
+       and type commit_key = Schema.Hash.t commit_key
 end
+
+module type Maker =
+  Maker_generic_key
+    with type 'h contents_key = 'h
+     and type 'h node_key = 'h
+     and type 'h commit_key = 'h
 
 module type Json_tree = functor
   (Store : S with type Schema.Contents.t = Contents.json)
@@ -908,22 +970,42 @@ module type Json_tree = functor
   (** Project a [json] value onto a store at the given key. *)
 end
 
+module type KV_generic_key =
+  S_generic_key
+    with type Schema.Path.step = string
+     and type Schema.Path.t = string list
+     and type Schema.Branch.t = string
+
 module type KV =
   S
     with type Schema.Path.step = string
      and type Schema.Path.t = string list
      and type Schema.Branch.t = string
 
-module type KV_maker = sig
+module type KV_maker_generic_key = sig
   type endpoint
   type metadata
+  type hash
+  type 'h contents_key
+  type 'h node_key
+  type 'h commit_key
 
   module Make (C : Contents.S) :
-    KV
+    KV_generic_key
       with module Schema.Contents = C
        and type Schema.Metadata.t = metadata
        and type Private.Remote.endpoint = endpoint
+       and type Schema.Hash.t = hash
+       and type contents_key = hash contents_key
+       and type node_key = hash node_key
+       and type commit_key = hash commit_key
 end
+
+module type KV_maker =
+  KV_maker_generic_key
+    with type 'h contents_key = 'h
+     and type 'h node_key = 'h
+     and type 'h commit_key = 'h
 
 module type Sigs = sig
   module type S = S
@@ -932,13 +1014,24 @@ module type Sigs = sig
   module type KV = KV
   module type KV_maker = KV_maker
 
-  type Remote.t += Store : (module S with type t = 'a) * 'a -> Remote.t
+  module Generic_key : sig
+    module type S = S_generic_key
+    module type KV = KV_generic_key
+    module type Maker = Maker_generic_key
+    module type KV_maker = KV_maker_generic_key
+  end
+
+  type Remote.t +=
+    | Store : (module Generic_key.S with type t = 'a) * 'a -> Remote.t
 
   module Make (P : Private.S) :
-    S
+    Generic_key.S
       with module Schema = P.Schema
        and type slice = P.Slice.t
        and type repo = P.Repo.t
+       and type contents_key = P.Contents.key
+       and type node_key = P.Node.key
+       and type commit_key = P.Commit.key
        and module Private = P
 
   module Json_tree : Json_tree

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -956,14 +956,14 @@ module type Maker_generic_key = sig
     S_generic_key
       with module Schema = Schema
        and type Private.Remote.endpoint = endpoint
-       and type contents_key = Schema.Hash.t contents_key
+       and type contents_key = (Schema.Hash.t, Schema.Contents.t) contents_key
        and type node_key = Schema.Hash.t node_key
        and type commit_key = Schema.Hash.t commit_key
 end
 
 module type Maker =
   Maker_generic_key
-    with type 'h contents_key = 'h
+    with type ('h, _) contents_key = 'h
      and type 'h node_key = 'h
      and type 'h commit_key = 'h
 
@@ -1004,9 +1004,8 @@ module type KV_maker_generic_key = sig
   type endpoint
   type metadata
   type hash
-  type 'h contents_key
-  type 'h node_key
-  type 'h commit_key
+
+  include Key.Store_spec.S
 
   module Make (C : Contents.S) :
     KV_generic_key
@@ -1014,14 +1013,14 @@ module type KV_maker_generic_key = sig
        and type Schema.Metadata.t = metadata
        and type Private.Remote.endpoint = endpoint
        and type Schema.Hash.t = hash
-       and type contents_key = hash contents_key
+       and type contents_key = (hash, C.t) contents_key
        and type node_key = hash node_key
        and type commit_key = hash commit_key
 end
 
 module type KV_maker =
   KV_maker_generic_key
-    with type 'h contents_key = 'h
+    with type ('h, _) contents_key = 'h
      and type 'h node_key = 'h
      and type 'h commit_key = 'h
 

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -364,7 +364,7 @@ module type S_generic_key = sig
         no such commit object exists. *)
 
     val of_hash : repo -> hash -> commit option Lwt.t
-    (** [of_hash r k] is the commit object in [r] with hash [h], or [None] if no
+    (** [of_hash r h] is the commit object in [r] with hash [h], or [None] if no
         such commit object is indexed in [r].
 
         {b Note:} in stores for which {!commit_key} = {!hash}, this function has
@@ -381,8 +381,15 @@ module type S_generic_key = sig
     (** [hash c] it [c]'s hash. *)
 
     val of_key : repo -> contents_key -> contents option Lwt.t
-    (** [of_key r k] is the the contents object in [r] having [k] as ID, or
-        [None] is no such contents object exists. *)
+    (** [of_key r k] is the contents object in [r] with key [k], or [None] if no
+        such contents object exists. *)
+
+    val of_hash : repo -> hash -> contents option Lwt.t
+    (** [of_hash r h] is the contents object in [r] with hash [h], or [None] if
+        no such contents object is indexed in [r].
+
+        {b Note:} in stores for which {!contents_key} = {!hash}, this function
+        has identical behaviour to {!of_key}. *)
   end
 
   (** Managing store's trees. *)
@@ -403,9 +410,9 @@ module type S_generic_key = sig
     type kinded_key =
       [ `Contents of contents_key * metadata | `Node of node_key ]
     [@@deriving irmin]
-    (** Hashes in the Irmin store are tagged with the type of the value they
+    (** Keys in the Irmin store are tagged with the type of the value they
         reference (either {!contents} or {!node}). In the [contents] case, the
-        hash is paired with corresponding {!metadata}. *)
+        key is paired with corresponding {!metadata}. *)
 
     val hash : ?cache:bool -> tree -> hash
     (** [hash c] is [c]'s hash. *)
@@ -416,6 +423,17 @@ module type S_generic_key = sig
     val of_key : Repo.t -> kinded_key -> tree option Lwt.t
     (** [of_key r h] is the the tree object in [r] having [h] as key, or [None]
         is no such tree object exists. *)
+
+    type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
+    (** Like {!kinded_key}, but with hashes as value references rather than
+        keys. *)
+
+    val of_hash : Repo.t -> kinded_hash -> tree option Lwt.t
+    (** [of_hash r h] is the tree object in [r] with hash [h], or [None] if no
+        such tree object is indexed in [r].
+
+        {b Note:} in stores for which {!node_key} = {!contents_key} = {!hash},
+        this function has identical behaviour to {!of_key}. *)
 
     val shallow : Repo.t -> kinded_key -> tree
     (** [shallow r h] is the shallow tree object with the key [h]. No check is

--- a/src/irmin/sync.ml
+++ b/src/irmin/sync.ml
@@ -26,11 +26,12 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let remote_store m x = Store.Store (m, x)
 
-module Make (S : Store.S) = struct
+module Make (S : Store.Generic_key.S) = struct
   module B = S.Private.Remote
 
   type db = S.t
   type commit = S.commit
+  type commit_key = S.commit_key [@@deriving irmin ~pp]
   type info = S.info
 
   let conv dx dy =
@@ -81,13 +82,12 @@ module Make (S : Store.S) = struct
       [] l
 
   let pp_branch = Type.pp S.Branch.t
-  let pp_hash = Type.pp S.Hash.t
 
   type status = [ `Empty | `Head of commit ]
 
   let pp_status ppf = function
     | `Empty -> Fmt.string ppf "empty"
-    | `Head c -> Type.pp S.Hash.t ppf (S.Commit.hash c)
+    | `Head c -> S.Commit.pp_hash ppf c
 
   let status_t t =
     let open Type in
@@ -129,9 +129,9 @@ module Make (S : Store.S) = struct
             let* g = B.v (S.repo t) in
             B.fetch g ?depth e br >>= function
             | Error _ as e -> Lwt.return e
-            | Ok (Some c) -> (
-                Log.debug (fun l -> l "Fetched %a" pp_hash c);
-                S.Commit.of_hash (S.repo t) c >|= function
+            | Ok (Some key) -> (
+                Log.debug (fun l -> l "Fetched %a" pp_commit_key key);
+                S.Commit.of_key (S.repo t) key >|= function
                 | None -> Ok `Empty
                 | Some x -> Ok (`Head x))
             | Ok None -> (

--- a/src/irmin/sync.ml
+++ b/src/irmin/sync.ml
@@ -42,14 +42,14 @@ module Make (S : Store.Generic_key.S) = struct
   let convert_slice (type r s) (module RP : Private.S with type Slice.t = r)
       (module SP : Private.S with type Slice.t = s) r =
     let conv_contents_k =
-      Type.unstage (conv RP.Contents.Key.t SP.Contents.Key.t)
+      Type.unstage (conv RP.Contents.Hash.t SP.Contents.Hash.t)
     in
     let conv_contents_v =
       Type.unstage (conv RP.Contents.Val.t SP.Contents.Val.t)
     in
-    let conv_node_k = Type.unstage (conv RP.Node.Key.t SP.Node.Key.t) in
+    let conv_node_k = Type.unstage (conv RP.Node.Hash.t SP.Node.Hash.t) in
     let conv_node_v = Type.unstage (conv RP.Node.Val.t SP.Node.Val.t) in
-    let conv_commit_k = Type.unstage (conv RP.Commit.Key.t SP.Commit.Key.t) in
+    let conv_commit_k = Type.unstage (conv RP.Commit.Hash.t SP.Commit.Hash.t) in
     let conv_commit_v = Type.unstage (conv RP.Commit.Val.t SP.Commit.Val.t) in
     let* s = SP.Slice.empty () in
     let* () =

--- a/src/irmin/sync_intf.ml
+++ b/src/irmin/sync_intf.ml
@@ -94,8 +94,9 @@ end
 module type Sigs = sig
   module type S = S
 
-  val remote_store : (module Store.S with type t = 'a) -> 'a -> Remote.t
+  val remote_store :
+    (module Store.Generic_key.S with type t = 'a) -> 'a -> Remote.t
 
-  module Make (X : Store.S) :
+  module Make (X : Store.Generic_key.S) :
     S with type db = X.t and type commit = X.commit and type info = X.info
 end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -55,6 +55,14 @@ let alist_iter2_lwt compare_k f l1 l2 =
   alist_iter2 compare_k (fun left right -> l3 := f left right :: !l3) l1 l2;
   Lwt_list.iter_s (fun b -> b >>= fun () -> Lwt.return_unit) (List.rev !l3)
 
+exception Backend_invariant_violation of string
+exception Assertion_failure of string
+
+let backend_invariant_violation fmt =
+  Fmt.kstr (fun s -> raise (Backend_invariant_violation s)) fmt
+
+let assertion_failure fmt = Fmt.kstr (fun s -> raise (Assertion_failure s)) fmt
+
 module Make (P : Private.S) = struct
   type counters = {
     mutable contents_hash : int;
@@ -62,6 +70,7 @@ module Make (P : Private.S) = struct
     mutable contents_add : int;
     mutable node_hash : int;
     mutable node_mem : int;
+    mutable node_index : int;
     mutable node_add : int;
     mutable node_find : int;
     mutable node_val_v : int;
@@ -79,6 +88,7 @@ module Make (P : Private.S) = struct
       contents_find = 0;
       node_hash = 0;
       node_mem = 0;
+      node_index = 0;
       node_add = 0;
       node_find = 0;
       node_val_v = 0;
@@ -92,6 +102,7 @@ module Make (P : Private.S) = struct
     t.contents_find <- 0;
     t.node_hash <- 0;
     t.node_mem <- 0;
+    t.node_index <- 0;
     t.node_add <- 0;
     t.node_find <- 0;
     t.node_val_v <- 0;
@@ -106,7 +117,7 @@ module Make (P : Private.S) = struct
   module Hashes = Hashtbl.Make (struct
     type t = P.Hash.t
 
-    let hash = P.Hash.short_hash
+    let hash x = P.Hash.short_hash x
     let equal = Type.(unstage (equal P.Hash.t))
   end)
 
@@ -126,7 +137,7 @@ module Make (P : Private.S) = struct
   type key = Path.t [@@deriving irmin ~pp]
   type hash = P.Hash.t [@@deriving irmin ~pp ~equal ~compare]
   type step = Path.step [@@deriving irmin ~pp ~compare]
-  type contents = P.Contents.Val.t [@@deriving irmin ~equal]
+  type contents = P.Contents.Val.t [@@deriving irmin ~equal ~pp]
   type repo = P.Repo.t
   type marks = unit Hashes.t
   type 'a or_error = ('a, [ `Dangling_hash of hash ]) result
@@ -155,54 +166,73 @@ module Make (P : Private.S) = struct
     | Ok x -> x
     | Error (`Dangling_hash hash) -> raise (Dangling_hash { context; hash })
 
+  type 'key ptr_option = Key of 'key | Hash of hash | Ptr_none
+  (* NOTE: given the choice, we prefer caching [Key] over [Hash] as it can
+     be used to avoid storing duplicate contents values on export. *)
+
   module Contents = struct
-    type v = Hash of repo * hash | Value of contents
-    type info = { mutable hash : hash option; mutable value : contents option }
+    type key = P.Contents.Key.t [@@deriving irmin]
+    type v = Key of repo * key | Value of contents
+    type nonrec ptr_option = key ptr_option
+    type info = { mutable ptr : ptr_option; mutable value : contents option }
     type t = { mutable v : v; info : info }
 
-    let info_is_empty i = i.hash = None && i.value = None
+    let info_is_empty i = i.ptr = Ptr_none && i.value = None
 
     let v =
       let open Type in
-      variant "Node.Contents.v" (fun hash value -> function
-        | Hash (_, x) -> hash x | Value v -> value v)
-      |~ case1 "hash" P.Hash.t (fun _ -> assert false)
+      variant "Node.Contents.v" (fun key value (v : v) ->
+          match v with Key (_, x) -> key x | Value v -> value v)
+      |~ case1 "key" P.Contents.Key.t (fun _ -> assert false)
       |~ case1 "value" P.Contents.Val.t (fun v -> Value v)
       |> sealv
 
     let clear_info i =
       if not (info_is_empty i) then (
         i.value <- None;
-        i.hash <- None)
+        i.ptr <- Ptr_none)
 
     let clear t = clear_info t.info
 
-    let of_v v =
-      let hash, value =
-        match v with Hash (_, k) -> (Some k, None) | Value v -> (None, Some v)
+    let of_v (v : v) =
+      let ptr, value =
+        match v with
+        | Key (_, k) -> ((Key k : ptr_option), None)
+        | Value v -> (Ptr_none, Some v)
       in
-      let info = { hash; value } in
+      let info = { ptr; value } in
       { v; info }
 
     let export ?clear:(c = true) repo t k =
-      let hash = t.info.hash in
+      let ptr = t.info.ptr in
       if c then clear t;
-      match (t.v, hash) with
-      | Hash (repo', _), _ when repo == repo' -> ()
-      | Hash (_, k), _ -> t.v <- Hash (repo, k)
-      | Value _, None -> t.v <- Hash (repo, k)
-      | Value _, Some k -> t.v <- Hash (repo, k)
+      match (t.v, ptr) with
+      | Key (repo', _), (Ptr_none | Hash _) ->
+          if repo != repo' then t.v <- Key (repo, k)
+      | Key (repo', _), Key k -> if repo != repo' then t.v <- Key (repo, k)
+      | Value _, (Ptr_none | Hash _) -> t.v <- Key (repo, k)
+      | Value _, Key k -> t.v <- Key (repo, k)
 
     let of_value c = of_v (Value c)
-    let of_hash repo k = of_v (Hash (repo, k))
+    let of_key repo k = of_v (Key (repo, k))
 
     let cached_hash t =
-      match (t.v, t.info.hash) with
-      | Hash (_, k), None ->
-          let h = Some k in
-          t.info.hash <- h;
+      match (t.v, t.info.ptr) with
+      | Key (_, k), Ptr_none ->
+          let h = Some (P.Contents.Key.to_hash k) in
+          t.info.ptr <- Key k;
           h
-      | _, h -> h
+      | _, Key k -> Some (P.Contents.Key.to_hash k)
+      | _, Hash h -> Some h
+      | _, Ptr_none -> None
+
+    let cached_key t =
+      match (t.v, t.info.ptr) with
+      | Key (_, k), (Hash _ | Ptr_none) ->
+          t.info.ptr <- Key k;
+          Some k
+      | _, Key k -> Some k
+      | Value _, (Hash _ | Ptr_none) -> None
 
     let cached_value t =
       match (t.v, t.info.value) with
@@ -220,14 +250,17 @@ module Make (P : Private.S) = struct
           | None -> assert false
           | Some v ->
               cnt.contents_hash <- cnt.contents_hash + 1;
-              let k = P.Contents.Key.hash v in
-              if cache then c.info.hash <- Some k;
-              k)
+              let h = P.Contents.Hash.hash v in
+              assert (c.info.ptr = Ptr_none);
+              if cache then c.info.ptr <- Hash h;
+              h)
 
-    let value_of_hash ~cache t repo k =
+    let key t = match t.v with Key (_, k) -> Some k | _ -> None
+
+    let value_of_key ~cache t repo k =
       cnt.contents_find <- cnt.contents_find + 1;
       P.Contents.find (P.Repo.contents_t repo) k >|= function
-      | None -> Error (`Dangling_hash k)
+      | None -> Error (`Dangling_hash (P.Contents.Key.to_hash k))
       | Some v as some_v ->
           if cache then t.info.value <- some_v;
           Ok v
@@ -238,7 +271,7 @@ module Make (P : Private.S) = struct
       | None -> (
           match t.v with
           | Value v -> Lwt.return (Ok v)
-          | Hash (repo, k) -> value_of_hash ~cache t repo k)
+          | Key (repo, k) -> value_of_key ~cache t repo k)
 
     let force = to_value ~cache:true
 
@@ -292,7 +325,9 @@ module Make (P : Private.S) = struct
   end
 
   module Node = struct
-    type value = P.Node.Val.t [@@deriving irmin ~equal]
+    type value = P.Node.Val.t [@@deriving irmin ~equal ~pp]
+    type key = P.Node.Key.t [@@deriving irmin]
+    type nonrec ptr_option = key ptr_option
 
     type elt = [ `Node of t | `Contents of Contents.t * Metadata.t ]
 
@@ -305,13 +340,13 @@ module Make (P : Private.S) = struct
     and info = {
       mutable value : value option;
       mutable map : map option;
-      mutable hash : hash option;
+      mutable ptr : ptr_option;
       mutable findv_cache : map option;
     }
 
     and v =
       | Map of map
-      | Hash of repo * hash
+      | Key of repo * key
       | Value of repo * value * updatemap option
 
     and t = { mutable v : v; info : info }
@@ -320,7 +355,7 @@ module Make (P : Private.S) = struct
         - A [Map], only after a [Tree.of_concrete] operation.
         - A [Value], only after an add, a remove, temporarily during an export
           or at the end of a merge.
-        - It is otherwise a [Hash].
+        - It is otherwise a [Key].
 
         [t.info.map] is only populated during a call to [Node.to_map]. *)
 
@@ -357,63 +392,37 @@ module Make (P : Private.S) = struct
       let m = stepmap_t elt in
       let um = stepmap_t (update_t elt) in
       let open Type in
-      variant "Node.node" (fun map hash value -> function
-        | Map m -> map m
-        | Hash (_, y) -> hash y
-        | Value (_, v, m) -> value (v, m))
+      variant "Node.node" (fun map key value -> function
+        | Map m -> map m | Key (_, y) -> key y | Value (_, v, m) -> value (v, m))
       |~ case1 "map" m (fun m -> Map m)
-      |~ case1 "hash" P.Hash.t (fun _ -> assert false)
+      |~ case1 "key" P.Node.Key.t (fun _ -> assert false)
       |~ case1 "value" (pair P.Node.Val.t (option um)) (fun _ -> assert false)
       |> sealv
 
     let of_v v =
-      let hash, map, value =
+      let ptr, map, value =
         match v with
-        | Map m -> (None, Some m, None)
-        | Hash (_, k) -> (Some k, None, None)
-        | Value (_, v, None) -> (None, None, Some v)
-        | Value _ -> (None, None, None)
+        | Map m -> (Ptr_none, Some m, None)
+        | Key (_, k) -> (Key k, None, None)
+        | Value (_, v, None) -> (Ptr_none, None, Some v)
+        | Value _ -> (Ptr_none, None, None)
       in
       let findv_cache = None in
-      let info = { hash; map; value; findv_cache } in
+      let info = { ptr; map; value; findv_cache } in
       { v; info }
 
     let of_map m = of_v (Map m)
-    let of_hash repo k = of_v (Hash (repo, k))
+    let of_key repo k = of_v (Key (repo, k))
     let of_value ?updates repo v = of_v (Value (repo, v, updates))
 
-    let cached_hash t =
-      match (t.v, t.info.hash) with
-      | Hash (_, h), None ->
-          let h = Some h in
-          t.info.hash <- h;
-          h
-      | _, h -> h
-
-    let cached_map t =
-      match (t.v, t.info.map) with
-      | Map m, None ->
-          let m = Some m in
-          t.info.map <- m;
-          m
-      | _, m -> m
-
-    let cached_value t =
-      match (t.v, t.info.value) with
-      | Value (_, v, None), None ->
-          let v = Some v in
-          t.info.value <- v;
-          v
-      | _, v -> v
-
     let info_is_empty i =
-      i.map = None && i.value = None && i.findv_cache = None && i.hash = None
+      i.map = None && i.value = None && i.findv_cache = None && i.ptr = Ptr_none
 
     let clear_info_fields i =
       if not (info_is_empty i) then (
         i.value <- None;
         i.map <- None;
-        i.hash <- None;
+        i.ptr <- Ptr_none;
         i.findv_cache <- None)
 
     let rec clear_elt ~max_depth depth v =
@@ -445,97 +454,155 @@ module Make (P : Private.S) = struct
 
     (* export t to the given repo and clear the cache *)
     let export ?clear:(c = true) repo t k =
-      let hash = t.info.hash in
+      let ptr = t.info.ptr in
       if c then clear_info_fields t.info;
       match t.v with
-      | Hash (repo', _) when repo' == repo -> ()
-      | Hash (_, k) -> t.v <- Hash (repo, k)
-      | Value (_, v, None) when P.Node.Val.is_empty v -> ()
-      | Map m when StepMap.is_empty m -> ()
+      | Key (repo', k) -> if repo != repo' then t.v <- Key (repo, k)
+      | Value (_, v, None) when P.Node.Val.is_empty v -> t.info.ptr <- Key k
+      | Map m when StepMap.is_empty m -> t.info.ptr <- Key k
       | _ -> (
-          match hash with
-          | None -> t.v <- Hash (repo, k)
-          | Some k -> t.v <- Hash (repo, k))
+          match ptr with
+          | Ptr_none | Hash _ -> t.v <- Key (repo, k)
+          | Key k -> t.v <- Key (repo, k))
 
     let map_of_value ~cache repo (n : value) : map =
       cnt.node_val_list <- cnt.node_val_list + 1;
       let entries = P.Node.Val.seq ~cache n in
       let aux = function
-        | `Node h -> `Node (of_hash repo h)
-        | `Contents (c, m) -> `Contents (Contents.of_hash repo c, m)
+        | `Node h -> `Node (of_key repo h)
+        | `Contents (c, m) -> `Contents (Contents.of_key repo c, m)
       in
       Seq.fold_left
         (fun acc (k, v) -> StepMap.add k (aux v) acc)
         StepMap.empty entries
+
+    let cached_hash t =
+      match (t.v, t.info.ptr) with
+      | Key (_, k), Ptr_none ->
+          let h = Some (P.Node.Key.to_hash k) in
+          t.info.ptr <- Key k;
+          h
+      | _, Key k -> Some (P.Node.Key.to_hash k)
+      | _, Hash h -> Some h
+      | _, Ptr_none -> None
+
+    let cached_key t =
+      match (t.v, t.info.ptr) with
+      | Key (_, k), (Hash _ | Ptr_none) ->
+          t.info.ptr <- Key k;
+          Some k
+      | _, Key k -> Some k
+      | (Map _ | Value _), (Hash _ | Ptr_none) -> None
+
+    let cached_map t =
+      match (t.v, t.info.map) with
+      | Map m, None ->
+          let m = Some m in
+          t.info.map <- m;
+          m
+      | _, m -> m
+
+    let cached_value t =
+      match (t.v, t.info.value) with
+      | Value (_, v, None), None ->
+          let v = Some v in
+          t.info.value <- v;
+          v
+      | _, v -> v
+
+    let key t = match t.v with Key (_, k) -> Some k | _ -> None
+    let unsafe_cache_key t k = t.info.ptr <- Key k
+
+    open struct
+      module Portable = P.Node_portable
+      module Portable_hash = Hash.Typed (P.Hash) (P.Node_portable)
+    end
 
     let rec hash : type a. cache:bool -> t -> (hash -> a) -> a =
      fun ~cache t k ->
       match cached_hash t with
       | Some h -> k h
       | None -> (
-          let a_of_value v =
+          let a_of_hashable hash v =
             cnt.node_hash <- cnt.node_hash + 1;
-            let h = P.Node.Key.hash v in
-            if cache then t.info.hash <- Some h;
-            k h
+            let hash = hash v in
+            assert (t.info.ptr = Ptr_none);
+            if cache then t.info.ptr <- Hash hash;
+            k hash
           in
           match cached_value t with
-          | Some v -> a_of_value v
+          | Some v -> a_of_hashable P.Node.Hash.hash v
           | None -> (
               match t.v with
-              | Hash (_, h) -> k h
-              | Value (_, v, None) -> a_of_value v
+              | Key (_, h) -> k (P.Node.Key.to_hash h)
+              | Value (_, v, None) -> a_of_hashable P.Node.Hash.hash v
               | Value (_, v, Some um) ->
-                  value_of_updates ~cache t v um a_of_value
-              | Map m -> value_of_map ~cache t m a_of_value))
+                  portable_value_of_updates ~cache t v um (fun v ->
+                      a_of_hashable Portable_hash.hash v)
+              | Map m ->
+                  portable_value_of_map ~cache t m (fun v ->
+                      a_of_hashable Portable_hash.hash v)))
 
-    and value_of_map : type r. cache:bool -> t -> map -> (value, r) cont =
+    and portable_value_of_map :
+        type r. cache:bool -> t -> map -> (Portable.t, r) cont =
      fun ~cache t map k ->
       if StepMap.is_empty map then (
-        t.info.value <- Some P.Node.Val.empty;
-        k P.Node.Val.empty)
+        if cache then t.info.value <- Some P.Node.Val.empty;
+        k (Portable.of_node P.Node.Val.empty))
       else (
         cnt.node_val_v <- cnt.node_val_v + 1;
         let v =
+          (* NOTE: here we build a backend node in order to compute its hash,
+             but can't cache it as it may contain unkeyed hashes. *)
           StepMap.to_seq map
           |> Seq.map (function
                | step, `Contents (c, m) ->
-                   (step, `Contents (Contents.hash ~cache c, m))
-               | step, `Node n -> (step, hash ~cache n (fun h -> `Node h)))
-          |> P.Node.Val.of_seq
+                   let hash =
+                     match Contents.key c with
+                     | Some key -> P.Contents.Key.to_hash key
+                     | None -> Contents.hash c
+                   in
+                   (step, `Contents (hash, m))
+               | step, `Node n -> (
+                   match key n with
+                   | Some key -> (step, `Node (P.Node.Key.to_hash key))
+                   | None -> hash ~cache n (fun k -> (step, `Node k))))
+          |> Portable.of_seq
         in
-        if cache then t.info.value <- Some v;
         k v)
 
-    and value_of_elt : type r. cache:bool -> elt -> (P.Node.Val.value, r) cont =
+    and portable_value_of_elt :
+        type r. cache:bool -> elt -> (P.Node_portable.value, r) cont =
      fun ~cache e k ->
       match e with
-      | `Contents (c, m) -> k (`Contents (Contents.hash ~cache c, m))
+      | `Contents (c, m) ->
+          let hash = Contents.hash c in
+          k (`Contents (hash, m))
       | `Node n -> hash ~cache n (fun h -> k (`Node h))
 
-    and value_of_updates :
-        type r. cache:bool -> t -> value -> _ -> (value, r) cont =
-     fun ~cache t v updates k ->
+    and portable_value_of_updates :
+        type r.
+        cache:bool -> t -> value -> updatemap -> (P.Node_portable.t, r) cont =
+     fun ~cache _t v updates k ->
       let updates = StepMap.bindings updates in
       let rec aux acc = function
-        | [] ->
-            if cache then t.info.value <- Some acc;
-            k acc
+        | [] -> k acc
         | (k, Add e) :: rest ->
-            value_of_elt ~cache e (fun e -> aux (P.Node.Val.add acc k e) rest)
-        | (k, Remove) :: rest -> aux (P.Node.Val.remove acc k) rest
+            portable_value_of_elt ~cache e (fun e ->
+                aux (P.Node_portable.add acc k e) rest)
+        | (k, Remove) :: rest -> aux (P.Node_portable.remove acc k) rest
       in
-      aux v updates
+      aux (P.Node_portable.of_node v) updates
 
     let hash ~cache k = hash ~cache k (fun x -> x)
 
-    let value_of_hash ~cache t repo k =
+    let value_of_key ~cache t repo k =
       match cached_value t with
       | Some v -> Lwt.return_ok v
       | None -> (
           cnt.node_find <- cnt.node_find + 1;
           P.Node.find (P.Repo.node_t repo) k >|= function
-          | None -> Error (`Dangling_hash k)
+          | None -> Error (`Dangling_hash (P.Node.Key.to_hash k))
           | Some v as some_v ->
               if cache then t.info.value <- some_v;
               Ok v)
@@ -546,9 +613,24 @@ module Make (P : Private.S) = struct
       | None -> (
           match t.v with
           | Value (_, v, None) -> ok v
-          | Value (_, v, Some um) -> value_of_updates ~cache t v um ok
-          | Map m -> value_of_map ~cache t m ok
-          | Hash (repo, h) -> value_of_hash ~cache t repo h)
+          | Key (repo, h) -> value_of_key ~cache t repo h
+          | Value (_, _, Some _) | Map _ ->
+              invalid_arg
+                "Tree.Node.to_value: the supplied node has not been written to \
+                 disk. Either export it or convert it to a portable value \
+                 instead.")
+
+    let to_portable_value ~cache t =
+      match cached_value t with
+      | Some v -> ok (P.Node_portable.of_node v)
+      | None -> (
+          match t.v with
+          | Value (_, v, None) -> ok (P.Node_portable.of_node v)
+          | Value (_, v, Some um) -> portable_value_of_updates ~cache t v um ok
+          | Map m -> portable_value_of_map ~cache t m ok
+          | Key (repo, h) ->
+              value_of_key ~cache t repo h
+              |> Lwt_result.map P.Node_portable.of_node)
 
     let to_map ~cache t =
       match cached_map t with
@@ -575,12 +657,10 @@ module Make (P : Private.S) = struct
           match t.v with
           | Map m -> Lwt.return (Ok m)
           | Value (repo, v, m) -> Lwt.return (Ok (of_value repo v m))
-          | Hash (repo, k) -> (
-              value_of_hash ~cache t repo k >|= function
+          | Key (repo, k) -> (
+              value_of_key ~cache t repo k >|= function
               | Error _ as e -> e
               | Ok v -> Ok (of_value repo v None)))
-
-    let hash_equal x y = x == y || equal_hash x y
 
     let contents_equal ((c1, m1) as x1) ((c2, m2) as x2) =
       x1 == x2 || (Contents.equal c1 c2 && equal_metadata m1 m2)
@@ -606,7 +686,7 @@ module Make (P : Private.S) = struct
           | _ -> (
               match (cached_map x, cached_map y) with
               | Some x, Some y -> map_equal x y
-              | _ -> hash_equal (hash ~cache:true x) (hash ~cache:true y)))
+              | _ -> equal_hash (hash ~cache:true x) (hash ~cache:true y)))
 
     (* same as [equal] but do not compare in-memory maps
        recursively. *)
@@ -650,9 +730,20 @@ module Make (P : Private.S) = struct
     let length ~cache t =
       match cached_map t with
       | Some m -> StepMap.cardinal m |> Lwt.return
-      | None ->
-          let+ v = to_value ~cache t in
-          get_ok "length" v |> P.Node.Val.length
+      | None -> (
+          match cached_value t with
+          | Some v -> P.Node.Val.length v |> Lwt.return
+          | None -> (
+              match t.v with
+              | Map m -> StepMap.cardinal m |> Lwt.return
+              | Key (r, k) ->
+                  value_of_key ~cache t r k
+                  >|= get_ok "length"
+                  >|= P.Node.Val.length
+              | Value (_, v, None) -> P.Node.Val.length v |> Lwt.return
+              | Value (_, v, Some u) ->
+                  portable_value_of_updates ~cache t v u (fun x ->
+                      P.Node_portable.length x |> Lwt.return)))
 
     let is_empty ~cache t =
       match cached_map t with
@@ -663,7 +754,7 @@ module Make (P : Private.S) = struct
           | None -> (
               match t.v with
               | Value (_, v, Some um) -> is_empty_after_updates ~cache v um
-              | Hash (_, h) -> hash_equal empty_hash h
+              | Key (_, key) -> equal_hash (P.Node.Key.to_hash key) empty_hash
               | Map _ -> assert false (* [cached_map <> None] *)
               | Value (_, _, None) -> assert false (* [cached_value <> None] *))
           )
@@ -679,12 +770,12 @@ module Make (P : Private.S) = struct
         match P.Node.Val.find ~cache v step with
         | None -> None
         | Some (`Contents (c, m)) ->
-            let c = Contents.of_hash repo c in
+            let c = Contents.of_key repo c in
             let (v : elt) = `Contents (c, m) in
             if cache then add_to_findv_cache t step v;
             Some v
         | Some (`Node n) ->
-            let n = of_hash repo n in
+            let n = of_key repo n in
             let v = `Node n in
             if cache then add_to_findv_cache t step v;
             Some v
@@ -698,11 +789,11 @@ module Make (P : Private.S) = struct
             | Some (Add v) -> Lwt.return (Some v)
             | Some Remove -> Lwt.return None
             | None -> Lwt.return (of_value repo v))
-        | Hash (repo, h) -> (
+        | Key (repo, h) -> (
             match cached_value t with
             | Some v -> Lwt.return (of_value repo v)
             | None ->
-                let+ v = value_of_hash ~cache t repo h >|= get_ok ctx in
+                let+ v = value_of_key ~cache t repo h >|= get_ok ctx in
                 of_value repo v)
       in
       match cached_map t with
@@ -728,10 +819,10 @@ module Make (P : Private.S) = struct
         (fun (k, v) ->
           match v with
           | `Node n ->
-              let n = `Node (of_hash repo n) in
+              let n = `Node (of_key repo n) in
               (k, n)
           | `Contents (c, m) ->
-              let c = Contents.of_hash repo c in
+              let c = Contents.of_key repo c in
               (k, `Contents (c, m)))
         seq
 
@@ -742,8 +833,8 @@ module Make (P : Private.S) = struct
           match t.v with
           | Value (repo, n, None) ->
               ok (seq_of_value ?offset ?length ~cache repo n)
-          | Hash (repo, h) -> (
-              value_of_hash ~cache t repo h >>= function
+          | Key (repo, h) -> (
+              value_of_key ~cache t repo h >>= function
               | Error _ as e -> Lwt.return e
               | Ok v -> ok (seq_of_value ?offset ?length ~cache repo v))
           | _ -> (
@@ -759,7 +850,7 @@ module Make (P : Private.S) = struct
       | Ok m -> Ok (StepMap.bindings m)
 
     type ('v, 'acc, 'r) folder =
-      path:key -> 'acc -> int -> 'v -> ('acc, 'r) cont_lwt
+      path:Path.t -> 'acc -> int -> 'v -> ('acc, 'r) cont_lwt
     (** A ('val, 'acc, 'r) folder is a CPS, threaded fold function over values
         of type ['v] producing an accumulator of type ['acc]. *)
 
@@ -772,9 +863,9 @@ module Make (P : Private.S) = struct
         post:acc node_fn option ->
         path:Path.t ->
         ?depth:depth ->
-        node:(key -> _ -> acc -> acc Lwt.t) ->
-        contents:(key -> contents -> acc -> acc Lwt.t) ->
-        tree:(key -> _ -> acc -> acc Lwt.t) ->
+        node:(Path.t -> _ -> acc -> acc Lwt.t) ->
+        contents:(Path.t -> contents -> acc -> acc Lwt.t) ->
+        tree:(Path.t -> _ -> acc -> acc Lwt.t) ->
         t ->
         acc ->
         acc Lwt.t =
@@ -807,7 +898,7 @@ module Make (P : Private.S) = struct
           | `True, false -> (
               match t.v with
               | Map m -> (map [@tailcall]) ~path acc d (Some m) k
-              | Value (repo, _, _) | Hash (repo, _) ->
+              | Value (repo, _, _) | Key (repo, _) ->
                   let* v = to_value ~cache t >|= get_ok "fold" in
                   (value [@tailcall]) ~path acc d (repo, v) k)
           | `True, true ->
@@ -875,8 +966,8 @@ module Make (P : Private.S) = struct
       and value : type r. (repo * value, acc, r) folder =
        fun ~path acc d (repo, v) k ->
         let to_elt = function
-          | `Node h -> `Node (of_hash repo h)
-          | `Contents (c, m) -> `Contents (Contents.of_hash repo c, m)
+          | `Node n -> `Node (of_key repo n)
+          | `Contents (c, m) -> `Contents (Contents.of_key repo c, m)
         in
         let bindings =
           P.Node.Val.seq v |> Seq.map (fun (s, v) -> (s, to_elt v))
@@ -904,12 +995,12 @@ module Make (P : Private.S) = struct
       | Map m -> Lwt.return (of_map m)
       | Value (repo, n, None) -> Lwt.return (of_value repo n StepMap.empty)
       | Value (repo, n, Some um) -> Lwt.return (of_value repo n um)
-      | Hash (repo, h) -> (
+      | Key (repo, h) -> (
           match (cached_value t, cached_map t) with
           | Some v, _ -> Lwt.return (of_value repo v StepMap.empty)
           | _, Some m -> Lwt.return (of_map m)
           | None, None ->
-              let+ v = value_of_hash ~cache:true t repo h >|= get_ok "update" in
+              let+ v = value_of_key ~cache:true t repo h >|= get_ok "update" in
               of_value repo v StepMap.empty)
 
     let remove t step = update t step Remove
@@ -931,7 +1022,7 @@ module Make (P : Private.S) = struct
           (v, t))
 
     let elt_t = elt_t t
-    let dump = Type.pp_json ~minify:false t
+    let dump = Type.pp_dump t
 
     let rec merge : type a. (t Merge.t -> a) -> a =
      fun k ->
@@ -992,13 +1083,23 @@ module Make (P : Private.S) = struct
     let merge_elt = merge_elt (fun x -> x)
   end
 
-  type node = Node.t [@@deriving irmin]
+  type node = Node.t [@@deriving irmin ~pp]
+  type node_key = Node.key [@@deriving irmin ~pp]
+  type contents_key = Contents.key [@@deriving irmin ~pp]
+
+  type kinded_key = [ `Contents of Contents.key * metadata | `Node of Node.key ]
+  [@@deriving irmin]
 
   type t = [ `Node of node | `Contents of Contents.t * Metadata.t ]
   [@@deriving irmin]
 
+  let to_private_node n =
+    Node.to_value ~cache:true n >|= get_ok "to_private_node"
+
+  let to_private_portable_node n =
+    Node.to_portable_value ~cache:true n >|= get_ok "to_private_portable_node"
+
   let of_private_node repo n = Node.of_value repo n
-  let to_private_node = Node.to_value ~cache:true
 
   let dump ppf = function
     | `Node n -> Fmt.pf ppf "node: %a" Node.dump n
@@ -1177,7 +1278,7 @@ module Make (P : Private.S) = struct
         let empty_tree =
           match is_empty root_tree with
           | true -> root_tree
-          | false -> `Node Node.empty
+          | false -> `Node (Node.of_map StepMap.empty)
         in
         f (Some root_tree) >>= function
         (* Here we consider "deleting" a root contents value or node to consist
@@ -1294,18 +1395,22 @@ module Make (P : Private.S) = struct
   let import repo = function
     | `Contents (k, m) -> (
         P.Contents.mem (P.Repo.contents_t repo) k >|= function
-        | true -> Some (`Contents (Contents.of_hash repo k, m))
+        | true -> Some (`Contents (Contents.of_key repo k, m))
         | false -> None)
     | `Node k -> (
         cnt.node_mem <- cnt.node_mem + 1;
         P.Node.mem (P.Repo.node_t repo) k >|= function
-        | true -> Some (`Node (Node.of_hash repo k))
+        | true -> Some (`Node (Node.of_key repo k))
         | false -> None)
 
   let import_no_check repo = function
-    | `Node k -> `Node (Node.of_hash repo k)
-    | `Contents (k, m) -> `Contents (Contents.of_hash repo k, m)
+    | `Node k -> `Node (Node.of_key repo k)
+    | `Contents (k, m) -> `Contents (Contents.of_key repo k, m)
 
+  (* Given an arbitrary tree value, persist its contents to the given contents
+     and node stores via a depth-first {i post-order} traversal. We must export
+     a node's children before the node itself in order to get the {i keys} of
+     any un-persisted child values. *)
   let export ?clear repo contents_t node_t n =
     let cache =
       match clear with
@@ -1317,62 +1422,174 @@ module Make (P : Private.S) = struct
       | Some false -> true
     in
     let skip n =
-      match Node.cached_hash n with
-      | Some h ->
+      match Node.cached_key n with
+      | Some k ->
           cnt.node_mem <- cnt.node_mem + 1;
-          P.Node.mem node_t h
-      | None -> Lwt.return_false
+          P.Node.mem node_t k
+      | None -> (
+          (* XXX: should we compute the actual hash here if it's not cached? *)
+          match Node.cached_hash n with
+          | None -> Lwt.return_false
+          | Some h -> (
+              cnt.node_index <- cnt.node_index + 1;
+              P.Node.index node_t h >>= function
+              | None ->
+                  (* NOTE: it's possible that this value already has a key in the
+                     store, but it's not indexed. If so, we're adding a duplicate
+                     here – this isn't an issue for correctness, but does waste
+                     space. *)
+                  Lwt.return_false
+              | Some k ->
+                  (* We always prefer caching keys over hashes. In this case,
+                     caching the key ensures that any yet-to-be-exported parent
+                     nodes can reference this value. *)
+                  Node.unsafe_cache_key n k;
+                  cnt.node_mem <- cnt.node_mem + 1;
+                  P.Node.mem node_t k))
     in
-    let rec on_node (`Node n) k =
+
+    let add_node n v k =
+      cnt.node_add <- cnt.node_add + 1;
+      let* key = P.Node.add node_t v in
+      let () =
+        let h = P.Node.Key.to_hash key in
+        let h' = Node.hash ~cache:true n in
+        if not (equal_hash h h') then
+          backend_invariant_violation
+            "@[<v 2>Tree.export: added inconsistent node binding@,\
+             key: %a@,\
+             value: %a@,\
+             computed hash: %a@]" pp_node_key key Node.pp_value v pp_hash h'
+      in
+      Node.export ?clear repo n key;
+      k ()
+    in
+
+    let add_node_map n (x : Node.map) k =
+      let node =
+        (* Since we traverse in post-order, all children of [x] have already
+           been added. Thus, their keys are cached and we can retrieve them. *)
+        StepMap.to_seq x
+        |> Seq.map (fun (step, v) ->
+               match v with
+               | `Node n -> (
+                   match Node.cached_key n with
+                   | Some k -> (step, `Node k)
+                   | None ->
+                       assertion_failure
+                         "Encountered child node value with uncached key \
+                          during export:@,\
+                          @ @[%a@]" dump v)
+               | `Contents (c, m) -> (
+                   match Contents.cached_key c with
+                   | Some k -> (step, `Contents (k, m))
+                   | None ->
+                       assertion_failure
+                         "Encountered child contents value with uncached key \
+                          during export:@,\
+                          @ @[%a@]" dump v))
+        |> P.Node.Val.of_seq
+      in
+      add_node n node k
+    in
+
+    let add_updated_node n (v : Node.value) (updates : Node.updatemap) k =
+      let node =
+        StepMap.fold
+          (fun k v acc ->
+            match v with
+            | Node.Remove -> P.Node.Val.remove acc k
+            | Node.Add (`Node n as v) -> (
+                match Node.cached_key n with
+                | Some ptr -> P.Node.Val.add acc k (`Node ptr)
+                | None ->
+                    assertion_failure
+                      "Encountered child node value with uncached key during \
+                       export:@,\
+                       @ @[%a@]" dump v)
+            | Add (`Contents (c, m) as v) -> (
+                match Contents.cached_key c with
+                | Some ptr -> P.Node.Val.add acc k (`Contents (ptr, m))
+                | None ->
+                    assertion_failure
+                      "Encountered child contents value with uncached key \
+                       during export:@,\
+                       @ @[%a@]" dump v))
+          updates v
+      in
+      add_node n node k
+    in
+
+    let rec on_node : type r. [ `Node of node ] -> (unit, r) cont_lwt =
+     fun (`Node n) k ->
+      (* Invariant: when [k] is called, [Node.cached_key n = Some _]. *)
+      let k () =
+        (match Node.cached_key n with
+        | None ->
+            assertion_failure "After trying to export %a, key isn't cached."
+              dump (`Node n)
+        | Some _ -> ());
+        k ()
+      in
       match n.Node.v with
-      | Node.Hash (_, h) ->
-          Node.export ?clear repo n h;
-          k ()
-      | Node.Value (_, v, None) ->
-          let h = P.Node.Key.hash v in
-          Node.export ?clear repo n h;
+      | Node.Key (_, key) ->
+          Node.export ?clear repo n key;
           k ()
       | _ -> (
           skip n >>= function
           | true -> k ()
-          | false ->
+          | false -> (
               let new_children_seq =
                 let seq =
                   match n.Node.v with
-                  | Node.Value (_, _, Some m) ->
+                  | Value (_, _, Some m) ->
                       StepMap.to_seq m
                       |> Seq.filter_map (function
                            | step, Node.Add v -> Some (step, v)
                            | _, Remove -> None)
-                  | Node.Map m -> StepMap.to_seq m
-                  | _ -> fun () -> Seq.Nil
+                  | Map m -> StepMap.to_seq m
+                  | Value (_, _, None) -> Seq.empty
+                  | Key _ ->
+                      (* [n.v = Key _] is excluded above. *)
+                      assert false
                 in
                 Seq.map (fun (_, x) -> x) seq
               in
               on_node_seq new_children_seq @@ fun () ->
-              let* v = Node.to_value ~cache n in
-              let v = get_ok "export" v in
-              let key = Node.hash ~cache n in
-              cnt.node_add <- cnt.node_add + 1;
-              let* key' = P.Node.add node_t v in
-              assert (equal_hash key key');
-              Node.export ?clear repo n key;
-              k ())
-    and on_contents (`Contents (c, _)) k =
+              match (n.Node.v, Node.cached_value n) with
+              | Map x, _ -> add_node_map n x k
+              | Value (_, v, None), None | _, Some v -> add_node n v k
+              | Value (_, v, Some um), _ -> add_updated_node n v um k
+              | Key _, _ ->
+                  (* [n.v = Key _] is excluded above. *)
+                  assert false))
+    and on_contents :
+        type r. [ `Contents of Contents.t * metadata ] -> (unit, r) cont_lwt =
+     fun (`Contents (c, _)) k ->
       match c.Contents.v with
-      | Contents.Hash (_, key) ->
+      | Contents.Key (_, key) ->
           Contents.export ?clear repo c key;
           k ()
       | Contents.Value _ ->
           let* v = Contents.to_value ~cache c in
           let v = get_ok "export" v in
-          let key = Contents.hash ~cache c in
           cnt.contents_add <- cnt.contents_add + 1;
-          let* key' = P.Contents.add contents_t v in
-          assert (equal_hash key key');
+          let* key = P.Contents.add contents_t v in
+          let () =
+            let h = P.Contents.Key.to_hash key in
+            let h' = Contents.hash ~cache c in
+            if not (equal_hash h h') then
+              backend_invariant_violation
+                "@[<v 2>Tree.export: added inconsistent contents binding@,\
+                 key: %a@,\
+                 value: %a@,\
+                 computed hash: %a@]" pp_contents_key key pp_contents v pp_hash
+                h'
+          in
           Contents.export ?clear repo c key;
           k ()
-    and on_node_seq seq k =
+    and on_node_seq : type r. Node.elt Seq.t -> (unit, r) cont_lwt =
+     fun seq k ->
       match seq () with
       | Seq.Nil ->
           (* Have iterated on all children, let's export parent now *)
@@ -1382,8 +1599,12 @@ module Make (P : Private.S) = struct
       | Seq.Cons ((`Contents _ as c), rest) ->
           on_contents c (fun () -> on_node_seq rest k)
     in
-    let+ () = on_node (`Node n) (fun () -> Lwt.return_unit) in
-    Node.hash ~cache n
+    on_node (`Node n) (fun () ->
+        match Node.cached_key n with
+        | Some x -> Lwt.return x
+        | None ->
+            (* We just exported this node: it must have a key. *)
+            assert false)
 
   let merge : t Merge.t =
     let f ~old (x : t) y =
@@ -1598,6 +1819,16 @@ module Make (P : Private.S) = struct
     in
     tree t (fun x -> Lwt.return x)
 
+  let key (t : t) =
+    Log.debug (fun l -> l "Tree.key");
+    match t with
+    | `Node n -> (
+        match Node.key n with Some key -> Some (`Node key) | None -> None)
+    | `Contents (c, m) -> (
+        match Contents.key c with
+        | Some key -> Some (`Contents (key, m))
+        | None -> None)
+
   let hash ?(cache = true) (t : t) =
     Log.debug (fun l -> l "Tree.hash");
     match t with
@@ -1629,5 +1860,5 @@ module Make (P : Private.S) = struct
           (match n.Node.v with
           | Map _ -> `Map
           | Value _ -> `Value
-          | Hash _ -> `Hash)
+          | Key _ -> `Key)
 end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -218,7 +218,7 @@ module Make (P : Private.S) = struct
 
     let cached_hash t =
       match (t.v, t.info.ptr) with
-      | Key (_, k), Ptr_none ->
+      | Key (_, k), (Ptr_none | Hash _) ->
           let h = Some (P.Contents.Key.to_hash k) in
           t.info.ptr <- Key k;
           h

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1165,6 +1165,9 @@ module Make (P : Private.S) = struct
   type kinded_key = [ `Contents of Contents.key * metadata | `Node of Node.key ]
   [@@deriving irmin]
 
+  type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
+  [@@deriving irmin]
+
   type t = [ `Node of node | `Contents of Contents.t * Metadata.t ]
   [@@deriving irmin]
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -345,7 +345,8 @@ module type Sigs = sig
          and type contents_key = P.Contents.Key.t
          and type hash = P.Hash.t
 
-    type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]
+    type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
+    [@@deriving irmin]
 
     type kinded_key =
       [ `Contents of P.Contents.Key.t * metadata | `Node of P.Node.Key.t ]

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -22,6 +22,7 @@ module type S = sig
   type step [@@deriving irmin]
   type metadata [@@deriving irmin]
   type contents [@@deriving irmin]
+  type contents_key [@@deriving irmin]
   type node [@@deriving irmin]
   type hash [@@deriving irmin]
 
@@ -98,6 +99,10 @@ module type S = sig
 
         [cache = false] doesn't replace a call to [clear], it only prevents the
         storing of new data, it doesn't discard the existing one. *)
+
+    val key : t -> contents_key option
+    (** [key t] is the key of the {!contents} value returned when [t] is
+        {!force}d successfully. *)
 
     val force : t -> contents or_error Lwt.t
     (** [force t] forces evaluation of the lazy content value [t], or returns an
@@ -310,6 +315,7 @@ module type S = sig
     mutable contents_add : int;
     mutable node_hash : int;
     mutable node_mem : int;
+    mutable node_index : int;
     mutable node_add : int;
     mutable node_find : int;
     mutable node_val_v : int;
@@ -320,7 +326,7 @@ module type S = sig
   val counters : unit -> counters
   val dump_counters : unit Fmt.t
   val reset_counters : unit -> unit
-  val inspect : t -> [ `Contents | `Node of [ `Map | `Hash | `Value ] ]
+  val inspect : t -> [ `Contents | `Node of [ `Map | `Key | `Value ] ]
 end
 
 module type Sigs = sig
@@ -336,12 +342,17 @@ module type Sigs = sig
          and type step = P.Node.Path.step
          and type metadata = P.Node.Metadata.t
          and type contents = P.Contents.value
+         and type contents_key = P.Contents.Key.t
          and type hash = P.Hash.t
 
     type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]
 
-    val import : P.Repo.t -> kinded_hash -> t option Lwt.t
-    val import_no_check : P.Repo.t -> kinded_hash -> t
+    type kinded_key =
+      [ `Contents of P.Contents.Key.t * metadata | `Node of P.Node.Key.t ]
+    [@@deriving irmin]
+
+    val import : P.Repo.t -> kinded_key -> t option Lwt.t
+    val import_no_check : P.Repo.t -> kinded_key -> t
 
     val export :
       ?clear:bool ->
@@ -353,8 +364,10 @@ module type Sigs = sig
 
     val dump : t Fmt.t
     val equal : t -> t -> bool
+    val key : t -> kinded_key option
     val hash : ?cache:bool -> t -> kinded_hash
+    val to_private_node : node -> P.Node.Val.t Lwt.t
+    val to_private_portable_node : node -> P.Node_portable.t Lwt.t
     val of_private_node : P.Repo.t -> P.Node.value -> node
-    val to_private_node : node -> P.Node.value or_error Lwt.t
   end
 end

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -65,8 +65,6 @@ module MemChunk = struct
   let v () = v small_config
 end
 
-let init () = Lwt.return_unit
-
 let store =
   Irmin_test.store
     (module Irmin.Maker
@@ -77,22 +75,5 @@ let store =
 
 let config = Irmin_chunk.config (Irmin_mem.config ())
 
-let clean () =
-  let (module S : Irmin_test.S) = store in
-  let module P = S.Private in
-  let clear repo =
-    Lwt.join
-      [
-        P.Commit.clear (P.Repo.commit_t repo);
-        P.Node.clear (P.Repo.node_t repo);
-        P.Contents.clear (P.Repo.contents_t repo);
-        P.Branch.clear (P.Repo.branch_t repo);
-      ]
-  in
-  let* repo = S.Repo.v config in
-  let* () = clear repo in
-  S.Repo.close repo
-
 let suite =
-  Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean ~stats:None
-    ~layered_store:None ()
+  Irmin_test.Suite.create ~name:"CHUNK" ~store ~config ~layered_store:None ()

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -95,4 +95,4 @@ let clean () =
 
 let suite =
   Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean ~stats:None
-    ~layered_store:None
+    ~layered_store:None ()

--- a/test/irmin-fs/test_fs.ml
+++ b/test/irmin-fs/test_fs.ml
@@ -21,11 +21,10 @@ let test_db = Filename.concat "_build" "test-db"
 let init () = IO.clear () >|= fun () -> IO.set_listen_hook ()
 let config = Irmin_fs.config test_db
 let clean () = Lwt.return_unit
-let stats = None
 
 let store =
   Irmin_test.store (module Irmin_fs.Maker (IO)) (module Irmin.Metadata.None)
 
 let suite =
-  Irmin_test.Suite.create ~name:"FS" ~init ~store ~config ~clean ~stats
+  Irmin_test.Suite.create ~name:"FS" ~init ~store ~config ~clean
     ~layered_store:None ()

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -80,7 +80,7 @@ let suite =
   let clean () = S.init () in
   let stats = None in
   Irmin_test.Suite.create ~name:"GIT" ~init ~store ~config ~clean ~stats
-    ~layered_store:None
+    ~layered_store:None ()
 
 let suite_generic =
   let module S = Generic (Irmin.Contents.String) in
@@ -89,7 +89,7 @@ let suite_generic =
   let init () = S.init () in
   let stats = None in
   Irmin_test.Suite.create ~name:"GIT.generic" ~init ~store ~config ~clean ~stats
-    ~layered_store:None
+    ~layered_store:None ()
 
 let get = function Some x -> x | None -> Alcotest.fail "get"
 

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -78,8 +78,7 @@ let suite =
   let store = (module S : Irmin_test.S) in
   let init () = S.init () in
   let clean () = S.init () in
-  let stats = None in
-  Irmin_test.Suite.create ~name:"GIT" ~init ~store ~config ~clean ~stats
+  Irmin_test.Suite.create ~name:"GIT" ~init ~store ~config ~clean
     ~layered_store:None ()
 
 let suite_generic =
@@ -87,8 +86,7 @@ let suite_generic =
   let store = (module S : Irmin_test.S) in
   let clean () = S.clean () in
   let init () = S.init () in
-  let stats = None in
-  Irmin_test.Suite.create ~name:"GIT.generic" ~init ~store ~config ~clean ~stats
+  Irmin_test.Suite.create ~name:"GIT.generic" ~init ~store ~config ~clean
     ~layered_store:None ()
 
 let get = function Some x -> x | None -> Alcotest.fail "get"

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -200,6 +200,9 @@ let test_blobs (module S : S) =
   let* repo = X.Repo.v (Irmin_git.config test_db) in
   let* k2 =
     X.Private.Repo.batch repo (fun x y _ -> X.save_tree ~clear:false repo x y t)
+    >|= function
+    | `Node k -> k
+    | `Contents k -> k
   in
   let hash = Irmin_test.testable X.Hash.t in
   Alcotest.(check hash) "blob" k1 k2;

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -216,7 +216,7 @@ let suite i server =
     ~config:
       (Irmin_http.config uri (Irmin.Private.Conf.empty Irmin_http.Conf.spec))
     ~store:(http_store id (get_store server))
-    ~layered_store:None
+    ~layered_store:None ()
 
 let suites servers =
   if Sys.os_type = "Win32" then

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -131,6 +131,14 @@ let rec lock id =
 
 let unlock fd = Lwt_unix.close fd
 
+let get_store suite =
+  match Irmin_test.Suite.store suite with
+  | Some x -> x
+  | None ->
+      failwith
+        "Cannot construct `irmin-http` test suite for non-content-addressable \
+         backend. Pass a store of type `Irmin.S`."
+
 let serve servers n id =
   Logs.set_level ~all:true (Some Logs.Debug);
   Logs.debug (fun l -> l "pwd: %s" @@ Unix.getcwd ());
@@ -139,7 +147,7 @@ let serve servers n id =
       l "Got server: %s, root=%s"
         (Irmin_test.Suite.name server)
         (root (Irmin_test.Suite.config server)));
-  let (module Server : Irmin_test.S) = Irmin_test.Suite.store server in
+  let (module Server : Irmin_test.S) = get_store server in
   let module HTTP = Irmin_http.Server (Cohttp_lwt_unix.Server) (Server) in
   let test = { name = Irmin_test.Suite.name server; id } in
   let socket = socket test in
@@ -207,7 +215,7 @@ let suite i server =
       Irmin_test.Suite.clean server ())
     ~config:
       (Irmin_http.config uri (Irmin.Private.Conf.empty Irmin_http.Conf.spec))
-    ~store:(http_store id (Irmin_test.Suite.store server))
+    ~store:(http_store id (get_store server))
     ~layered_store:None
 
 let suites servers =

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -209,7 +209,6 @@ let suite i server =
       let _ = Sys.command cmd in
       let+ pid = wait_for_the_server_to_start id in
       server_pid := pid)
-    ~stats:None
     ~clean:(fun () ->
       kill_server socket !server_pid;
       Irmin_test.Suite.clean server ())

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -37,7 +37,6 @@ let clean () =
 
 let init () = Lwt.return_unit
 let stats = None
-let lower_name = "lower"
 
 let suite =
   Irmin_test.Suite.create ~name:"MEM" ~init ~store ~config ~clean ~stats:None

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -14,30 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Irmin.Export_for_backends
-
 let store = Irmin_test.store (module Irmin_mem) (module Irmin.Metadata.None)
 let config = Irmin_mem.config ()
-
-let clean () =
-  let (module S : Irmin_test.S) = store in
-  let module P = S.Private in
-  let clear repo =
-    Lwt.join
-      [
-        P.Commit.clear (P.Repo.commit_t repo);
-        P.Node.clear (P.Repo.node_t repo);
-        P.Contents.clear (P.Repo.contents_t repo);
-        P.Branch.clear (P.Repo.branch_t repo);
-      ]
-  in
-  let* repo = S.Repo.v config in
-  let* () = clear repo in
-  S.Repo.close repo
-
 let init () = Lwt.return_unit
-let stats = None
 
 let suite =
-  Irmin_test.Suite.create ~name:"MEM" ~init ~store ~config ~clean ~stats:None
-    ~layered_store:None ()
+  Irmin_test.Suite.create ~name:"MEM" ~init ~store ~config ~layered_store:None
+    ()

--- a/test/irmin-mem/test_mem.ml
+++ b/test/irmin-mem/test_mem.ml
@@ -40,4 +40,4 @@ let stats = None
 
 let suite =
   Irmin_test.Suite.create ~name:"MEM" ~init ~store ~config ~clean ~stats:None
-    ~layered_store:None
+    ~layered_store:None ()

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -48,7 +48,7 @@ module Schema = struct
   module Branch = Branch.String
   module Hash = Hash.SHA1
   module Node = Node.Generic_key.Make (Hash) (Path) (Metadata)
-  module Commit = Commit.Make (Hash)
+  module Commit = Commit.Generic_key.Make (Hash)
   module Info = Info.Default
 end
 

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -47,7 +47,7 @@ module Schema = struct
   module Path = Path.String_list
   module Branch = Branch.String
   module Hash = Hash.SHA1
-  module Node = Node.Make (Hash) (Path) (Metadata)
+  module Node = Node.Generic_key.Make (Hash) (Path) (Metadata)
   module Commit = Commit.Make (Hash)
   module Info = Info.Default
 end

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -21,7 +21,7 @@ module I = Index
 module Conf : Irmin_pack.Conf.S
 
 module Schema :
-  Irmin.Schema.S
+  Irmin.Schema.Extended
     with type Hash.t = Irmin.Hash.SHA1.t
      and type Path.step = string
      and type Path.t = string list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -94,7 +94,7 @@ let suite_pack =
   in
   let stats = None in
   Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean ~stats
-    ~layered_store:(Some layered_store)
+    ~layered_store:(Some layered_store) ()
 
 module Irmin_pack_mem_maker = struct
   include Irmin_pack_mem.Maker (Config)
@@ -138,7 +138,7 @@ let suite_mem =
   in
   let stats = None in
   Irmin_test.Suite.create ~name:"PACK MEM" ~init ~store ~config ~clean ~stats
-    ~layered_store:None
+    ~layered_store:None ()
 
 let suite = [ suite_pack; suite_mem ]
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -30,7 +30,7 @@ module Irmin_pack_maker : Irmin.Maker = struct
   module Make (Schema : Irmin.Schema.S) = Make (struct
     include Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
-    module Commit_maker = Irmin.Commit.Maker (Info)
+    module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
     module Commit = Commit_maker.Make (Hash)
   end)
 end
@@ -41,7 +41,7 @@ module Irmin_pack_layered = struct
   module Make (Schema : Irmin.Schema.S) = Make (struct
     include Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
-    module Commit_maker = Irmin.Commit.Maker (Info)
+    module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
     module Commit = Commit_maker.Make (Hash)
   end)
 end
@@ -101,7 +101,7 @@ module Irmin_pack_mem_maker = struct
   module Make (Schema : Irmin.Schema.S) = Make (struct
     include Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
-    module Commit_maker = Irmin.Commit.Maker (Info)
+    module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
     module Commit = Commit_maker.Make (Hash)
   end)
 end

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -24,8 +24,27 @@ end
 
 let test_dir = Filename.concat "_build" "test-db-pack"
 
-module Irmin_pack_maker = Irmin_pack.V2 (Config)
-module Irmin_pack_layered = Irmin_pack_layered.Maker (Config)
+module Irmin_pack_maker : Irmin.Maker = struct
+  include Irmin_pack.V2 (Config)
+
+  module Make (Schema : Irmin.Schema.S) = Make (struct
+    include Schema
+    module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
+    module Commit_maker = Irmin.Commit.Maker (Info)
+    module Commit = Commit_maker.Make (Hash)
+  end)
+end
+
+module Irmin_pack_layered = struct
+  include Irmin_pack_layered.Maker (Config)
+
+  module Make (Schema : Irmin.Schema.S) = Make (struct
+    include Schema
+    module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
+    module Commit_maker = Irmin.Commit.Maker (Info)
+    module Commit = Commit_maker.Make (Hash)
+  end)
+end
 
 let suite_pack =
   let store =
@@ -77,7 +96,16 @@ let suite_pack =
   Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean ~stats
     ~layered_store:(Some layered_store)
 
-module Irmin_pack_mem_maker = Irmin_pack_mem.Maker (Config)
+module Irmin_pack_mem_maker = struct
+  include Irmin_pack_mem.Maker (Config)
+
+  module Make (Schema : Irmin.Schema.S) = Make (struct
+    include Schema
+    module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
+    module Commit_maker = Irmin.Commit.Maker (Info)
+    module Commit = Commit_maker.Make (Hash)
+  end)
+end
 
 let suite_mem =
   let store =

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -92,8 +92,7 @@ let suite_pack =
     let* repo = S.Repo.v config in
     clear repo >>= fun () -> S.Repo.close repo
   in
-  let stats = None in
-  Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean ~stats
+  Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean
     ~layered_store:(Some layered_store) ()
 
 module Irmin_pack_mem_maker = struct
@@ -112,33 +111,7 @@ let suite_mem =
     Irmin_test.store (module Irmin_pack_mem_maker) (module Irmin.Metadata.None)
   in
   let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_dir in
-  let init () =
-    if Sys.file_exists test_dir then (
-      let cmd = Printf.sprintf "rm -rf %s" test_dir in
-      Fmt.epr "exec: %s\n%!" cmd;
-      let _ = Sys.command cmd in
-      ());
-    Lwt.return_unit
-  in
-  let clean () =
-    let (module S : Irmin_test.S) = store in
-    let module P = S.Private in
-    let clear repo =
-      Lwt.join
-        [
-          P.Commit.clear (P.Repo.commit_t repo);
-          P.Node.clear (P.Repo.node_t repo);
-          P.Contents.clear (P.Repo.contents_t repo);
-          P.Branch.clear (P.Repo.branch_t repo);
-        ]
-    in
-    let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_dir in
-    S.Repo.v config >>= fun repo ->
-    clear repo >>= fun () -> S.Repo.close repo
-  in
-  let stats = None in
-  Irmin_test.Suite.create ~name:"PACK MEM" ~init ~store ~config ~clean ~stats
-    ~layered_store:None ()
+  Irmin_test.Suite.create ~name:"PACK MEM" ~store ~config ~layered_store:None ()
 
 let suite = [ suite_pack; suite_mem ]
 

--- a/test/irmin-unix/test_unix.ml
+++ b/test/irmin-unix/test_unix.ml
@@ -45,7 +45,7 @@ module FS = struct
 
   let suite =
     Irmin_test.Suite.create ~name:"FS" ~init ~store ~config ~clean ~stats
-      ~layered_store:None
+      ~layered_store:None ()
 end
 
 (* GIT *)
@@ -84,7 +84,7 @@ module Git = struct
   let suite =
     let store = (module S : Irmin_test.S) in
     Irmin_test.Suite.create ~name:"GIT" ~init ~store ~config ~clean ~stats
-      ~layered_store:None
+      ~layered_store:None ()
 
   let test_non_bare () =
     init () >>= fun () ->

--- a/test/irmin-unix/test_unix.ml
+++ b/test/irmin-unix/test_unix.ml
@@ -16,11 +16,9 @@
 
 open! Import
 
-let stats =
-  Some
-    (fun () ->
-      let stats = Irmin_watcher.stats () in
-      (stats.Irmin_watcher.watchdogs, Irmin.Private.Watch.workers ()))
+let stats () =
+  let stats = Irmin_watcher.stats () in
+  (stats.Irmin_watcher.watchdogs, Irmin.Private.Watch.workers ())
 
 (* FS *)
 

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -3,4 +3,5 @@
  (package irmin)
  (preprocess
   (pps ppx_irmin))
- (libraries irmin irmin.mem alcotest alcotest-lwt lwt hex logs logs.fmt))
+ (libraries irmin irmin.mem irmin-test alcotest alcotest-lwt lwt hex logs
+   logs.fmt))

--- a/test/irmin/generic-key/dune
+++ b/test/irmin/generic-key/dune
@@ -1,0 +1,6 @@
+(test
+ (name test)
+ (package irmin)
+ (preprocess
+  (pps ppx_irmin))
+ (libraries irmin irmin-test alcotest alcotest-lwt lwt vector))

--- a/test/irmin/generic-key/test.ml
+++ b/test/irmin/generic-key/test.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2013-2021 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2021 Tarides <contact@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,18 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt.Infix
-module IO = Irmin_fs.IO_mem
-
-let test_db = Filename.concat "_build" "test-db"
-let init () = IO.clear () >|= fun () -> IO.set_listen_hook ()
-let config = Irmin_fs.config test_db
-let clean () = Lwt.return_unit
-let stats = None
-
-let store =
-  Irmin_test.store (module Irmin_fs.Maker (IO)) (module Irmin.Metadata.None)
-
-let suite =
-  Irmin_test.Suite.create ~name:"FS" ~init ~store ~config ~clean ~stats
-    ~layered_store:None ()
+let () =
+  Irmin_test.Store.run __FILE__ ~slow:true ~misc:[]
+    [ (`Quick, Test_store_offset.suite) ]

--- a/test/irmin/generic-key/test.ml
+++ b/test/irmin/generic-key/test.ml
@@ -16,4 +16,4 @@
 
 let () =
   Irmin_test.Store.run __FILE__ ~slow:true ~misc:[]
-    [ (`Quick, Test_store_offset.suite) ]
+    [ (`Quick, Test_store_offset.suite); (`Quick, Test_inlined_contents.suite) ]

--- a/test/irmin/generic-key/test_inlined_contents.ml
+++ b/test/irmin/generic-key/test_inlined_contents.ml
@@ -1,0 +1,105 @@
+open Irmin
+
+(** A store in which all values are stored as immediates inside their respective
+    keys. The store itself keeps no information, except for the bookkeeping
+    needed to handle [clear]-ing the in-memory keys. *)
+module Keyed_by_value = struct
+  type (_, 'v) key = { value : 'v; clear_since_add : bool ref }
+
+  module Key (Hash : Hash.S) (Value : Type.S) = struct
+    type t = (Hash.t, Value.t) key
+    type hash = Hash.t [@@deriving irmin ~pre_hash]
+    type value = Value.t [@@deriving irmin ~pre_hash]
+
+    let value_to_hash t = Hash.hash (fun f -> pre_hash_value t f)
+    let to_hash t = value_to_hash t.value
+
+    let (t : t Type.t) =
+      let open Type in
+      map
+        ~pre_hash:
+          (stage (fun t f ->
+               let hash = value_to_hash t.value in
+               pre_hash_hash hash f))
+        Value.t
+        (fun _ ->
+          Alcotest.fail ~pos:__POS__ "Key implementation is non-serialisable")
+        (fun t -> t.value)
+  end
+
+  module Make (Hash : Hash.S) (Value : Type.S) = struct
+    type instance = { mutable clear_signal : bool ref }
+    type _ t = { instance : instance option ref }
+    type hash = Hash.t
+    type value = Value.t
+
+    module Key = Key (Hash) (Value)
+
+    type key = Key.t
+
+    let check_not_closed t =
+      match !(t.instance) with None -> raise Closed | Some t -> t
+
+    let v =
+      let singleton = { clear_signal = ref false } in
+      fun _ -> Lwt.return { instance = ref (Some singleton) }
+
+    let mem t _ =
+      let _ = check_not_closed t in
+      Lwt.return_true
+
+    let unsafe_add t _ value =
+      let t = check_not_closed t in
+      Lwt.return { value; clear_since_add = t.clear_signal }
+
+    let add t v = unsafe_add t () v
+
+    let find t k =
+      let _ = check_not_closed t in
+      if !(k.clear_since_add) then Lwt.return_none else Lwt.return_some k.value
+
+    let index _ _ = Lwt.return_none
+
+    let clear t =
+      let t = check_not_closed t in
+      t.clear_signal := true;
+      t.clear_signal <- ref false;
+      Lwt.return_unit
+
+    let batch t f = f (t :> Perms.read_write t)
+
+    let close t =
+      t.instance := None;
+      Lwt.return_unit
+  end
+end
+
+module Plain = struct
+  type 'h key = 'h
+
+  module Key = Key.Of_hash
+
+  module Make (H : Hash.S) (V : Type.S) = struct
+    module CA =
+      Content_addressable.Check_closed (Irmin_mem.Content_addressable) (H) (V)
+
+    include Indexable.Of_content_addressable (H) (CA)
+
+    let v = CA.v
+  end
+end
+
+module Store_maker = Generic_key.Maker (struct
+  module Contents_store = Keyed_by_value
+  module Node_store = Plain
+  module Commit_store = Plain
+  module Branch_store = Atomic_write.Check_closed (Irmin_mem.Atomic_write)
+end)
+
+module Store = Store_maker.Make (Schema.KV (Contents.String))
+
+let suite =
+  let store = (module Store : Irmin_test.Generic_key) in
+  let config = Irmin_mem.config () in
+  Irmin_test.Suite.create_generic_key ~name:"inlined_contents" ~store ~config
+    ~layered_store:None ~import_supported:false ()

--- a/test/irmin/generic-key/test_store_offset.ml
+++ b/test/irmin/generic-key/test_store_offset.ml
@@ -168,23 +168,5 @@ module Store = Store_maker.Make (Schema.KV (Contents.String))
 let suite =
   let store = (module Store : Irmin_test.Generic_key) in
   let config = Irmin_mem.config () in
-  let clean () =
-    let open Lwt.Syntax in
-    let module P = Store.Private in
-    let clear repo =
-      Lwt.join
-        [
-          P.Commit.clear (P.Repo.commit_t repo);
-          P.Node.clear (P.Repo.node_t repo);
-          P.Contents.clear (P.Repo.contents_t repo);
-          P.Branch.clear (P.Repo.branch_t repo);
-        ]
-    in
-    let* repo = Store.Repo.v config in
-    let* () = clear repo in
-    Store.Repo.close repo
-  in
-  Irmin_test.Suite.create_generic_key ~name:"store_offset"
-    ~init:(fun () -> Lwt.return_unit)
-    ~store ~config ~clean ~stats:None ~layered_store:None
-    ~import_supported:false ()
+  Irmin_test.Suite.create_generic_key ~name:"store_offset" ~store ~config
+    ~layered_store:None ~import_supported:false ()

--- a/test/irmin/generic-key/test_store_offset.ml
+++ b/test/irmin/generic-key/test_store_offset.ml
@@ -1,0 +1,190 @@
+(*
+ * Copyright (c) 2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Irmin
+
+(** A store abstraction over an append-only sequence of values. The key of a
+    value is the slot at which it's stored in this sequence. There is no index
+    for finding stored values by their hash, so any sharing must be achieved at
+    the level of keys. *)
+module Slot_keyed_vector : Indexable.Maker_concrete_key1 = struct
+  type 'h key = {
+    slot : int;
+    hash : 'h;
+    (* Number of clears in the corresponding store when this key was created: *)
+    generation : int;
+    (* Sanity check that keys are used only w/ the stores that created them: *)
+    store_id : < >;
+  }
+
+  let key_t hash_t =
+    let open Type in
+    let hash_equal = unstage (equal hash_t) in
+    let hash_pre_hash = unstage (pre_hash hash_t) in
+    record "key" (fun _ _ ->
+        Alcotest.fail ~pos:__POS__ "Key implementation is non-serialisable")
+    |+ field "slot" int (fun t -> t.slot)
+    |+ field "hash" hash_t (fun t -> t.hash)
+    |> sealr
+    |> like (* TODO: write tests that expose the need for these directly *)
+         ~equal:(stage (fun a b -> hash_equal a.hash b.hash))
+         ~pre_hash:(stage (fun t f -> hash_pre_hash t.hash f))
+
+  module Key (Hash : Hash.S) = struct
+    type t = Hash.t key [@@deriving irmin]
+    type hash = Hash.t
+
+    let to_hash t = t.hash
+  end
+
+  module Make (Hash : Hash.S) (Value : Type.S) = struct
+    type instance = {
+      mutable generation : int;
+      data : (Hash.t * Value.t) option Vector.t;
+      id : < >;
+    }
+
+    type _ t = { instance : instance option ref }
+
+    let v =
+      (* NOTE: at time of writing, [irmin-test] relies on the fact that the
+         store constructor is memoised (modulo [close] semantics, which must be
+         non-memoised), so we must use a singleton here. *)
+      let singleton =
+        { generation = 0; data = Vector.create ~dummy:None; id = object end }
+      in
+      fun _ -> Lwt.return { instance = ref (Some singleton) }
+
+    type nonrec key = Hash.t key [@@deriving irmin]
+    type value = Value.t
+    type hash = Hash.t [@@deriving irmin ~equal]
+
+    let index _ _ = Lwt.return_none
+
+    module Key = struct
+      type t = key [@@deriving irmin]
+      type hash = Hash.t
+
+      let to_hash t = t.hash
+    end
+
+    module Hash = Irmin.Hash.Typed (Hash) (Value)
+
+    let check_not_closed t =
+      match !(t.instance) with None -> raise Closed | Some t -> t
+
+    let check_key_belongs_to_store pos (k : key) (t : instance) =
+      let key_store_id = k.store_id and expected_id = t.id in
+      let r = key_store_id == expected_id in
+      if not r then
+        Alcotest.(check ~pos int)
+          "Key ID matches the given store ID" (Oo.id expected_id)
+          (Oo.id key_store_id)
+
+    let check_hash_is_consistent pos k recovered_hash =
+      let r = equal_hash k.hash recovered_hash in
+      if not r then
+        Alcotest.(check ~pos (Irmin_test.testable Hash.t))
+          "Recovered hash is consistent with the key" k.hash recovered_hash
+
+    let unsafe_add t hash v =
+      let t = check_not_closed t in
+      Vector.push t.data (Some (hash, v));
+      let key =
+        {
+          slot = Vector.length t.data - 1;
+          generation = t.generation;
+          hash;
+          store_id = t.id;
+        }
+      in
+      Lwt.return key
+
+    let add t v = unsafe_add t (Hash.hash v) v
+
+    let find t k =
+      let t = check_not_closed t in
+      check_key_belongs_to_store __POS__ k t;
+      if k.generation < t.generation then
+        (* Clear since this key was created *)
+        Lwt.return_none
+      else (
+        assert (t.generation = k.generation);
+        match Vector.get t.data k.slot with
+        | exception Not_found -> Lwt.return_none
+        | None ->
+            Alcotest.failf "Invalid key slot %d. No data contained here." k.slot
+        | Some (recovered_hash, data) ->
+            check_hash_is_consistent __POS__ k recovered_hash;
+            Lwt.return (Some data))
+
+    let mem t k =
+      let t = check_not_closed t in
+      check_key_belongs_to_store __POS__ k t;
+      if k.generation < t.generation then Lwt.return_false
+      else (
+        assert (t.generation = k.generation);
+        assert (k.slot < Vector.length t.data);
+        Lwt.return_true)
+
+    let clear t =
+      let t = check_not_closed t in
+      Vector.clear t.data;
+      t.generation <- t.generation + 1;
+      Lwt.return_unit
+
+    let batch t f =
+      let _ = check_not_closed t in
+      f (t :> Perms.read_write t)
+
+    let close t =
+      t.instance := None;
+      Lwt.return_unit
+  end
+end
+
+module Store_maker = Generic_key.Maker (struct
+  module Contents_store = Indexable.Maker_concrete_key2_of_1 (Slot_keyed_vector)
+  module Node_store = Slot_keyed_vector
+  module Commit_store = Slot_keyed_vector
+  module Branch_store = Atomic_write.Check_closed (Irmin_mem.Atomic_write)
+end)
+
+module Store = Store_maker.Make (Schema.KV (Contents.String))
+
+let suite =
+  let store = (module Store : Irmin_test.Generic_key) in
+  let config = Irmin_mem.config () in
+  let clean () =
+    let open Lwt.Syntax in
+    let module P = Store.Private in
+    let clear repo =
+      Lwt.join
+        [
+          P.Commit.clear (P.Repo.commit_t repo);
+          P.Node.clear (P.Repo.node_t repo);
+          P.Contents.clear (P.Repo.contents_t repo);
+          P.Branch.clear (P.Repo.branch_t repo);
+        ]
+    in
+    let* repo = Store.Repo.v config in
+    let* () = clear repo in
+    Store.Repo.close repo
+  in
+  Irmin_test.Suite.create_generic_key ~name:"store_offset"
+    ~init:(fun () -> Lwt.return_unit)
+    ~store ~config ~clean ~stats:None ~layered_store:None
+    ~import_supported:false ()

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -14,9 +14,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module Test_node = Irmin_test.Node.Make (Irmin.Node.Generic_key.Make)
+
+let lift_suite_to_lwt :
+    unit Alcotest.test_case list -> unit Alcotest_lwt.test_case list =
+  List.map (fun (n, s, f) -> (n, s, Fun.const (Lwt.wrap f)))
+
 let suite =
   [
     ("tree", Test_tree.suite);
+    ("node", Test_node.suite |> lift_suite_to_lwt);
     ("hash", Test_hash.suite);
     ("conf", Test_conf.suite);
   ]

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -32,7 +32,7 @@ module Schema = struct
   module Path = Path.String_list
   module Branch = Branch.String
   module Hash = Hash.BLAKE2B
-  module Node = Node.Make (Hash) (Path) (Metadata)
+  module Node = Node.Generic_key.Make (Hash) (Path) (Metadata)
   module Commit = Commit.Make (Hash)
   module Info = Info.Default
 end
@@ -413,7 +413,7 @@ let inspect =
   Alcotest.testable
     (fun ppf -> function
       | `Contents -> Fmt.string ppf "contents"
-      | `Node `Hash -> Fmt.string ppf "hash"
+      | `Node `Key -> Fmt.string ppf "key"
       | `Node `Map -> Fmt.string ppf "map"
       | `Node `Value -> Fmt.string ppf "value")
     ( = )
@@ -461,7 +461,7 @@ let test_clear _ () =
   (* 3. Persist (and implicitly clear) *)
   let* _ = persist_tree t in
   (* Check the state of the root *)
-  Alcotest.(check inspect) "After persist+clear" (`Node `Hash) (Tree.inspect t);
+  Alcotest.(check inspect) "After persist+clear" (`Node `Key) (Tree.inspect t);
   let* () =
     Tree.stats ~force:false t
     >|= Alcotest.(gcheck Tree.stats_t)


### PR DESCRIPTION
This PR contains an attempt at supporting "structured keys" in Irmin core while minimising churn to other backends. It's still quite rough around the edges, but could benefit from review. The feature is currently unused, as I've extracted this diff from a larger one that also changes `irmin-pack` to use structured keys.

### What are structured keys?

Currently Irmin's core is functorised over three store implementations – supplied by the backend as part of `Irmin.Private` – for storing contents / nodes / commits. These stores must be _content-addressable_, i.e. they must be keyed by hashes of values and support the following operations:

```ocaml
(* A content-addressable store *)
type _ t
type hash
type value

val find : [> `read ] t -> hash -> value option Lwt.t
val add  : [> `write ] t -> value -> hash Lwt.t
```

This constraint simplifies much of Irmin's core, which then doesn't have to distinguish (a) `hash` values that act as pointers to a value in some _specific_ store from (b) `hash` values that exist only in memory (for which the values are unknown / have not yet been written to the backend). Unfortunately, this prevents the backends from keeping more information in their key types – e.g. the offset at which a particular key is stored on disk – that might bring big performance benefits.

This PR proposes solving this problem by distinguishing (a) and (b) above. Backends can now make fewer promises to Irmin core:

```ocaml
(* An indexable store *)
type _ t
type hash
type key
type value

val find : [> `read ] t -> key -> value option Lwt.t
val add : [> `write ] t -> value -> key Lwt.t
val index :  [> `read ] t -> hash -> key option Lwt.t

module Key : sig
  val to_hash : key -> hash
end
```

This new type of store is called an "indexable" store. All content-addressable stores are trivially indexable, but the reverse is not true. The key type being referenced has been called a "structured" key (or a "generic key" in the code) – see `key.mli` for more information.

### Complications

Some existing uses of Irmin are hard to translate to non-content-addressable backends:

- Various functions in `Irmin.Tree` expect to be able to construct backend nodes containing keys that don't necessarily exist in the backend (for instance, when using `shallow`, or computing hashes of concrete trees). To get around this problem, I've split the `Private.Node.Val` type into two: the existing `Private.Node.Val` (now keyed by a `Key.t` type) and a new `Private.Node_portable` type that is always keyed by hashes. The idea is that "portable" nodes have the same hashing properties as their non-portable equivalents, but can't be written to the underlying node store.

- Key types are specified by backends, not users. Unfortunately, two types that _are_ currently specified by users must depend on the implementation of keys used by a particular store: nodes (which may contain keys for contents and other nodes) and commits (which may contain keys for nodes). This makes it difficult to provide simple functor types for constructing stores with structured keys; I've given it a go, but the result is a bit of a mess.