### PR TITLE
irmin-pack: avoid assuming the encoding of atomic write keys

### DIFF
--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -75,7 +75,11 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
       module Branch = struct
         module Key = B
         module Val = H
-        module AW = Atomic_write.Make_persistent (V) (Key) (Val)
+
+        module AW =
+          Atomic_write.Make_persistent (V) (Key)
+            (Atomic_write.Value.Of_hash (Val))
+
         include Atomic_write.Closeable (AW)
 
         let v ?fresh ?readonly path =

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -92,7 +92,10 @@ module Maker' (Config : Conf.Pack.S) (Schema : Irmin.Schema.S) = struct
       module Val = H
 
       module Atomic_write = struct
-        module AW = Irmin_pack.Atomic_write.Make_persistent (V) (Key) (Val)
+        module AW =
+          Irmin_pack.Atomic_write.Make_persistent (V) (Key)
+            (Irmin_pack.Atomic_write.Value.Of_hash (Val))
+
         include Irmin_pack.Atomic_write.Closeable (AW)
 
         let v ?fresh ?readonly path =

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -86,7 +86,7 @@ module Branch =
   Irmin_pack.Atomic_write.Make_persistent
     (Irmin_pack.Version.V2)
     (Irmin.Branch.String)
-    (Schema.Hash)
+    (Irmin_pack.Atomic_write.Value.Of_hash (Schema.Hash))
 
 module Make_context (Config : sig
   val root : string

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -603,7 +603,7 @@ module Branch = struct
     Irmin_pack.Atomic_write.Make_persistent
       (Irmin_pack.Version.V2)
       (Irmin.Branch.String)
-      (Irmin.Hash.SHA1)
+      (Irmin_pack.Atomic_write.Value.Of_hash (Irmin.Hash.SHA1))
 
   let pp_hash = Irmin.Type.pp Irmin.Hash.SHA1.t
 


### PR DESCRIPTION
We currently use `Repr.of_bin_string` in `Irmin_pack.Atomic_write` to construct a "zero" value that is assumed never to be constructed by the user. This doesn't extend to non-hash keys (as will be required by https://github.com/mirage/irmin/pull/1389), so this commit changes the API to be more upfront about what properties are required.