### PR TITLE
irmin-git: temporary disable the package on s390x

### DIFF
--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -33,6 +33,7 @@ depends: [
   "mtime"      {with-test & >= "1.0.0"}
   "alcotest"   {with-test}
 ]
+available: [ arch != "s390x" ] # temporary disable until ocaml-git works properly
 
 synopsis: "Git backend for Irmin"
 description: """


### PR DESCRIPTION
The tests currently segfaults on s390x with:

```
Backtrace stopped: Cannot access memory at address 0x3ffff7fffb0
```

(from ocaml-git's Value.to_raw)