### PR TITLE
Avoid implicit use of polymorphic equality via `List.mem`

### DIFF
--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -339,7 +339,7 @@ module Atomic_write
            with type key = U.key
             and type value = U.value) =
 struct
-  type key = U.key
+  type key = K.t [@@deriving irmin ~equal]
   type value = U.value
 
   module U = U
@@ -434,7 +434,8 @@ struct
     (match t.lower with None -> Lwt.return_nil | Some lower -> L.list lower)
     >|= fun lower ->
     List.fold_left
-      (fun acc b -> if List.mem b acc then acc else b :: acc)
+      (fun acc b ->
+        if List.exists (fun x -> equal_key b x) acc then acc else b :: acc)
       lower upper
 
   type watch = U.watch

--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -434,8 +434,7 @@ struct
     (match t.lower with None -> Lwt.return_nil | Some lower -> L.list lower)
     >|= fun lower ->
     List.fold_left
-      (fun acc b ->
-        if List.exists (fun x -> equal_key b x) acc then acc else b :: acc)
+      (fun acc b -> if List.mem ~equal:equal_key b acc then acc else b :: acc)
       lower upper
 
   type watch = U.watch

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -177,7 +177,7 @@ module Make_helpers (S : S) = struct
 end
 
 let ignore_srcs src =
-  List.mem (Logs.Src.name src)
+  List.mem ~equal:String.equal (Logs.Src.name src)
     [
       "git.inflater.decoder";
       "git.deflater.encoder";

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -224,7 +224,8 @@ module Make (S : S) = struct
         let+ all = Graph.list g node in
         List.iter
           (fun (s, _) ->
-            if List.mem s !names then Alcotest.failf "%s: duplicate!" n
+            if List.mem ~equal:String.equal s !names then
+              Alcotest.failf "%s: duplicate!" n
             else names := s :: !names)
           all
       in
@@ -402,7 +403,7 @@ module Make (S : S) = struct
       in
       let* () =
         let+ ls = History.closure h ~min:[ commits.(7) ] ~max:[ commits.(6) ] in
-        if List.exists (fun x -> H_node.equal commits.(7) x) ls then
+        if List.mem ~equal:H_node.equal commits.(7) ls then
           Alcotest.fail "disconnected node should not be in closure"
       in
       let* krs =
@@ -417,7 +418,7 @@ module Make (S : S) = struct
             ~min:[ commits.(4); commits.(0) ]
             ~max:[ commits.(4); commits.(6) ]
         in
-        if List.exists (fun x -> H_node.equal commits.(0) x) ls then
+        if List.mem ~equal:H_node.equal commits.(0) ls then
           Alcotest.fail "disconnected node should not be in closure"
       in
       S.Repo.close repo

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -108,7 +108,11 @@ module Make (S : S) = struct
 
   let get = function None -> Alcotest.fail "get" | Some v -> v
 
-  module H_node = Irmin.Hash.Typed (P.Hash) (P.Node.Val)
+  module H_node = struct
+    include Irmin.Hash.Typed (P.Hash) (P.Node.Val)
+
+    type nonrec t = t [@@deriving irmin ~equal]
+  end
 
   let test_nodes x () =
     let test repo =
@@ -398,7 +402,7 @@ module Make (S : S) = struct
       in
       let* () =
         let+ ls = History.closure h ~min:[ commits.(7) ] ~max:[ commits.(6) ] in
-        if List.mem commits.(7) ls then
+        if List.exists (fun x -> H_node.equal commits.(7) x) ls then
           Alcotest.fail "disconnected node should not be in closure"
       in
       let* krs =
@@ -413,7 +417,7 @@ module Make (S : S) = struct
             ~min:[ commits.(4); commits.(0) ]
             ~max:[ commits.(4); commits.(6) ]
         in
-        if List.mem commits.(0) ls then
+        if List.exists (fun x -> H_node.equal commits.(0) x) ls then
           Alcotest.fail "disconnected node should not be in closure"
       in
       S.Repo.close repo

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -89,9 +89,8 @@ struct
   let merge_commit info t ~old k1 k2 =
     let* v1 = get t k1 in
     let* v2 = get t k2 in
-    if List.exists (fun x -> equal_key k1 x) (Val.parents v2) then Merge.ok k2
-    else if List.exists (fun x -> equal_key k2 x) (Val.parents v1) then
-      Merge.ok k1
+    if List.mem ~equal:equal_key k1 (Val.parents v2) then Merge.ok k2
+    else if List.mem ~equal:equal_key k2 (Val.parents v1) then Merge.ok k1
     else
       (* If we get an error while looking the the lca, then we
          assume that there is no common ancestor. Maybe we want to

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -56,7 +56,7 @@ struct
   module Key = Hash.Typed (K) (Val)
 
   type 'a t = 'a N.t * 'a S.t
-  type key = S.key
+  type key = Key.t [@@deriving irmin ~equal]
   type value = S.value
 
   let add (_, t) = S.add t
@@ -89,8 +89,9 @@ struct
   let merge_commit info t ~old k1 k2 =
     let* v1 = get t k1 in
     let* v2 = get t k2 in
-    if List.mem k1 (Val.parents v2) then Merge.ok k2
-    else if List.mem k2 (Val.parents v1) then Merge.ok k1
+    if List.exists (fun x -> equal_key k1 x) (Val.parents v2) then Merge.ok k2
+    else if List.exists (fun x -> equal_key k2 x) (Val.parents v1) then
+      Merge.ok k1
     else
       (* If we get an error while looking the the lca, then we
          assume that there is no common ancestor. Maybe we want to

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -61,6 +61,11 @@ module List = struct
       | h :: t, l -> (aux [@tailcall]) (h :: acc) t l
     in
     aux [] [] l
+
+  let rec mem : type a. equal:(a -> a -> bool) -> a -> a t -> bool =
+   fun ~equal y -> function
+    | [] -> false
+    | x :: xs -> equal x y || mem ~equal y xs
 end
 
 module Seq = struct


### PR DESCRIPTION
Fix https://github.com/mirage/irmin/issues/1517.