### PR TITLE
irmin: compare lazy nodes and contents by hash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
     interpreting such paths as ending with empty nodes (#1477, @CraigFe)
   - Fix the pre-hashing function for big-endian architectures. (#1505,
     @Ngoguey42, @dinosaure)
+  - Fix the implementation of comparison on `Irmin.Tree` objects to use the
+    comparison defined on hashes. The previous implementation was unstable.
+    (#1519, @CraigFe)
 
 ### Added
 


### PR DESCRIPTION
... rather than using the default structural definition supplied by Repr, which is sensitive to caching and not stable.

Fix https://github.com/mirage/irmin/issues/1396.