### PR TITLE
irmin-mirage: Add missing constraint on Irmin_mirage_git.KV_maker

### DIFF
--- a/src/irmin-mirage/git/irmin_mirage_git_intf.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git_intf.ml
@@ -52,6 +52,7 @@ module type KV_maker = sig
        and module Schema.Metadata = Irmin_git.Metadata
        and type Schema.Info.t = Irmin.Info.default
        and type Schema.Path.step = string
+       and type Schema.Path.t = string list
        and type Schema.Hash.t = G.hash
        and type Schema.Branch.t = branch
        and type Private.Remote.endpoint = endpoint


### PR DESCRIPTION
It seems that #1470 inadvertently changed the signature of a KV functor in irmin-mirage. 

Some other constraints might be missing in there but I'm not sure

CC @dinosaure 