### PR TITLE
irmin: remove cache for tree values

### DIFF
--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -95,9 +95,6 @@ module type S = sig
     val force_exn : t -> contents Lwt.t
     (** Equivalent to {!force}, but raises an exception if the lazy content
         value is not present in the underlying repository. *)
-
-    val clear : t -> unit
-    (** [clear t] clears [t]'s cache. *)
   end
 
   val mem : t -> key -> bool Lwt.t


### PR DESCRIPTION
This is an experiment to always re-hash the tree leaves - this is a bit slower (as expected) but uses a lot less memory.