### PR TITLE
Use seq in Tree.fold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,9 @@
   - `Node.v` is renamed to `Node.of_list` (#1508, @samoht)
   - Rewrite `Tree.export` in order to minimise the memory footprint.
     (#1508, @Ngoguey42)
+  - The order in which nodes are visited in `Tree.fold` is now unstable and
+    depends on whether the node is in memory or on disk (#1525, @icristescu,
+    @Ngoguey42, @CraigFe)
 
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to

--- a/src/irmin/import.ml
+++ b/src/irmin/import.ml
@@ -90,4 +90,11 @@ module Seq = struct
    fun n l () ->
     if n = 0 then Nil
     else match l () with Nil -> Nil | Cons (x, l') -> Cons (x, take (n - 1) l')
+
+  let for_all : type a. (a -> bool) -> a Seq.t -> bool =
+   fun f s ->
+    let rec aux s =
+      match s () with Seq.Nil -> true | Seq.Cons (v, s) -> f v && aux s
+    in
+    aux s
 end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -447,13 +447,12 @@ module Make (P : Private.S) = struct
 
     let map_of_value repo (n : value) : map =
       cnt.node_val_list <- cnt.node_val_list + 1;
-      let entries = P.Node.Val.list n in
-      (* XXX: The map could be built using a seq instead of a list *)
+      let entries = P.Node.Val.seq n in
       let aux = function
         | `Node h -> `Node (of_hash repo h)
         | `Contents (c, m) -> `Contents (Contents.of_hash repo c, m)
       in
-      List.fold_left
+      Seq.fold_left
         (fun acc (k, v) -> StepMap.add k (aux v) acc)
         StepMap.empty entries
 
@@ -650,9 +649,8 @@ module Make (P : Private.S) = struct
             (* Starting from this point the function is expensive, but there is
                no alternative. *)
             cnt.node_val_list <- cnt.node_val_list + 1;
-            let entries = P.Node.Val.list v in
-            (* XXX: A sequence could be used here *)
-            List.for_all (fun (step, _) -> StepMap.mem step um) entries)
+            let entries = P.Node.Val.seq v in
+            Seq.for_all (fun (step, _) -> StepMap.mem step um) entries)
 
     let length t =
       match cached_map t with
@@ -774,8 +772,8 @@ module Make (P : Private.S) = struct
         type acc.
         force:acc force ->
         uniq:uniq ->
-        pre:acc node_fn ->
-        post:acc node_fn ->
+        pre:acc node_fn option ->
+        post:acc node_fn option ->
         path:Path.t ->
         ?depth:depth ->
         node:(key -> _ -> acc -> acc Lwt.t) ->
@@ -790,15 +788,36 @@ module Make (P : Private.S) = struct
         | `True -> empty_marks ()
         | `Marks n -> n
       in
+      let pre path bindings acc =
+        match pre with
+        | None -> Lwt.return acc
+        | Some pre ->
+            let s = Seq.fold_left (fun acc (s, _) -> s :: acc) [] bindings in
+            pre path s acc
+      in
+      let post path bindings acc =
+        match post with
+        | None -> Lwt.return acc
+        | Some post ->
+            let s = Seq.fold_left (fun acc (s, _) -> s :: acc) [] bindings in
+            post path s acc
+      in
       let rec aux : type r. (t, acc, r) folder =
        fun ~path acc d t k ->
         let apply acc = node path t acc in
         let next acc =
           match force with
-          | `True | `And_clear ->
-              (* XXX: Let's not call [to_map] when [Value] *)
+          | `And_clear -> (
+              match t.v with
+              | Map m ->
+                  clear ~depth:0 t;
+                  (map [@tailcall]) ~path acc d (Some m) k
+              | Value (repo, _, _) | Hash (repo, _) ->
+                  let* v = to_value t >|= get_ok "fold" in
+                  clear ~depth:0 t;
+                  (value [@tailcall]) ~path acc d (repo, v) k)
+          | `True ->
               let* m = to_map t >|= get_ok "fold" in
-              if force = `And_clear then clear ~depth:0 t;
               (map [@tailcall]) ~path acc d (Some m) k
           | `False skip -> (
               match cached_map t with
@@ -842,11 +861,11 @@ module Make (P : Private.S) = struct
             | Some (`Lt depth) -> if d < depth - 1 then apply () else k acc
             | Some (`Ge depth) -> if d >= depth - 1 then apply () else k acc
             | Some (`Gt depth) -> if d >= depth then apply () else k acc)
-      and steps : type r. ((step * elt) list, acc, r) folder =
+      and steps : type r. ((step * elt) Seq.t, acc, r) folder =
        fun ~path acc d s k ->
-        match s with
-        | [] -> k acc
-        | h :: t ->
+        match s () with
+        | Seq.Nil -> k acc
+        | Seq.Cons (h, t) ->
             (step [@tailcall]) ~path acc d h (fun acc ->
                 (steps [@tailcall]) ~path acc d t k)
       and map : type r. (map option, acc, r) folder =
@@ -854,11 +873,22 @@ module Make (P : Private.S) = struct
         match m with
         | None -> k acc
         | Some m ->
-            let bindings = StepMap.bindings m in
-            let s = List.rev_map fst bindings in
-            let* acc = pre path s acc in
+            let bindings = StepMap.to_seq m in
+            let* acc = pre path bindings acc in
             (steps [@tailcall]) ~path acc d bindings (fun acc ->
-                post path s acc >>= k)
+                post path bindings acc >>= k)
+      and value : type r. (repo * value, acc, r) folder =
+       fun ~path acc d (repo, v) k ->
+        let to_elt = function
+          | `Node h -> `Node (of_hash repo h)
+          | `Contents (c, m) -> `Contents (Contents.of_hash repo c, m)
+        in
+        let bindings =
+          P.Node.Val.seq v |> Seq.map (fun (s, v) -> (s, to_elt v))
+        in
+        let* acc = pre path bindings acc in
+        (steps [@tailcall]) ~path acc d bindings (fun acc ->
+            post path bindings acc >>= k)
       in
       aux_uniq ~path acc 0 t Lwt.return
 
@@ -1034,8 +1064,8 @@ module Make (P : Private.S) = struct
 
   let id _ _ acc = Lwt.return acc
 
-  let fold ?(force = `And_clear) ?(uniq = `False) ?(pre = id) ?(post = id)
-      ?depth ?(contents = id) ?(node = id) (t : t) acc =
+  let fold ?(force = `And_clear) ?(uniq = `False) ?pre ?post ?depth
+      ?(contents = id) ?(node = id) (t : t) acc =
     match t with
     | `Contents (c, _) -> Contents.fold ~force ~path:Path.empty contents c acc
     | `Node n ->

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -227,7 +227,9 @@ module type S = sig
       For every node [n], ui [n] is a leaf node, call [f path n]. Otherwise:
 
       - Call [pre path n]. By default [pre] is the identity;
-      - Recursively call [fold] on each children, in lexicographic order;
+      - Recursively call [fold] on each children - the order in which we visit
+        the children is unstable. The order is lexicographic if the node is
+        completely in-memory and undefined otherwise.
       - Call [post path n]; By default [post] is the identity.
 
       See {!force} for details about the [force] parameters. By default it is


### PR DESCRIPTION
This is a small improvement in the memory usage for the migration - in my benchmarks the peak allocations are down by 0.5G, but the maxrss only of approx 0.2G.