### PR TITLE
Rework caching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,8 +100,11 @@
   - `Node.v` is renamed to `Node.of_list` (#1508, @samoht)
   - Rewrite `Tree.export` in order to minimise the memory footprint.
     (#1508, @Ngoguey42)
-  - Remove the `` `And_clear`` case of the `force` parameter of `Tree.fold`.
-    Use `~cache:false ~force:true` instead. (#1526, @Ngoguey42)
+  - Remove the ``~force:`And_clear`` case parameter from `Tree.fold`,
+    ``~force:`True ~cache:false`` is the new equivalent. (#1526, @Ngoguey42)
+  - `` `Tree.fold ~force:`True`` and `` `Tree.fold ~force:`False`` don't
+    cache the lazily loaded data any more. Pass `~cache:true` to enable it
+    again. (#1526, @Ngoguey42)
   - The order in which nodes are visited in `Tree.fold` is now unstable and
     depends on whether the node is in memory or on disk (#1525, @icristescu,
     @Ngoguey42, @CraigFe)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,8 @@
   - `Node.seq` and `Node.of_seq` are added to avoid allocating intermediate
     lists when it is not necessary (#1508, @samoht)
   - New optional `cache` parameter to `Tree.hash`, `Tree.Contents.hash`,
-    `Node.list`, `Node.seq` and `Node.find` to avoid internal storing of lazily
-    loaded data when it is not necessary (#1526, @Ngoguey42)
+    `Tree.list`, `Node.list`, `Node.seq` and `Node.find` to control the storing
+    of lazily loaded data (#1526, @Ngoguey42)
   - Add `Node.clear` to clear internal caches (#1526, @Ngoguey42)
 
 - **irmin-bench**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,8 @@
   - `Node.v` is renamed to `Node.of_list` (#1508, @samoht)
   - Rewrite `Tree.export` in order to minimise the memory footprint.
     (#1508, @Ngoguey42)
+  - Remove the `` `And_clear`` case of the `force` parameter of `Tree.fold`.
+    Use `~cache:false ~force:true` instead.
 
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
     (#1345, @samoht)
   - `Node.seq` and `Node.of_seq` are added to avoid allocating intermediate
     lists when it is not necessary (#1508, @samoht)
+  - New optional `cache` parameter to `Tree.hash`, `Tree.Contents.hash`,
+    `Node.list`, `Node.seq` and `Node.find` to avoid internal storing of lazily
+    loaded data when it is not necessary (#1526, @Ngoguey42)
+  - Add `Node.clear` to clear internal caches (#1526, @Ngoguey42)
 
 - **irmin-bench**
   - Many improvements to the actions trace replay:

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -142,7 +142,10 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
   let to_bin t = Raw.to_raw (G.Value.tree t)
   let of_list = v
   let of_seq seq = List.of_seq seq |> v
-  let seq ?offset ?length ?cache t = list ?offset ?length ?cache t |> List.to_seq
+
+  let seq ?offset ?length ?cache t =
+    list ?offset ?length ?cache t |> List.to_seq
+
   let clear _ = ()
 
   let encode_bin =

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -40,7 +40,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
 
   exception Exit of (step * value) list
 
-  let list ?(offset = 0) ?length t =
+  let list ?(offset = 0) ?length ?cache:_ t =
     let t = G.Value.Tree.to_list t in
     let length = match length with None -> List.length t | Some n -> n in
     try
@@ -58,7 +58,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
       |> fun (_, acc) -> List.rev acc
     with Exit acc -> List.rev acc
 
-  let find t s =
+  let find ?cache:_ t s =
     let s = of_step s in
     let rec aux = function
       | [] -> None
@@ -142,7 +142,8 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
   let to_bin t = Raw.to_raw (G.Value.tree t)
   let of_list = v
   let of_seq seq = List.of_seq seq |> v
-  let seq ?offset ?length t = list ?offset ?length t |> List.to_seq
+  let seq ?offset ?length ?cache t = list ?offset ?length ?cache t |> List.to_seq
+  let clear _ = ()
 
   let encode_bin =
     Irmin.Type.stage @@ fun (t : t) k ->

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -920,7 +920,12 @@ struct
     let save layout ~add ~mem t =
       let clear =
         (* When set to [true], collect the loaded inodes as soon as they're
-           saved. *)
+           saved.
+
+           This parameter is not exposed yet. Ideally it would be exposed and
+           be forwarded from [Tree.export ?clear] through [P.Node.add].
+
+           It is currently set to true in order to preserve behaviour *)
         false
       in
       let iter_entries =

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -338,7 +338,7 @@ struct
         | Total -> fun (Total_ptr t) -> t
         | Partial find -> (
             function
-            | { target = Dirty entry; _ } | { target = Lazy_loaded entry; _ } ->
+            | { target = Dirty entry } | { target = Lazy_loaded entry } ->
                 (* [target] is already cached. [cache] is only concerned with
                    new cache entries, not the older ones for which the irmin
                    users can discard using [clear]. *)
@@ -404,7 +404,7 @@ struct
         match layout with
         | Partial _ -> (
             match ptr with
-            | { target = Lazy _; _ } -> ()
+            | { target = Lazy _} -> ()
             | { target = Dirty ptr; _ } -> iter_dirty layout ptr
             | { target = Lazy_loaded ptr; _ } as box ->
                 let hash = Lazy.force ptr.hash in

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -343,7 +343,7 @@ struct
                    new cache entries, not the older ones for which the irmin
                    users can discard using [clear]. *)
                 entry
-            | { target = Lazy _; _ } as t -> (
+            | { target = Lazy _ } as t -> (
                 let h = hash layout t in
                 match find h with
                 | None -> Fmt.failwith "%a: unknown key" pp_hash h
@@ -380,17 +380,17 @@ struct
         | Total -> fun (Total_ptr entry) -> (save_dirty [@tailcall]) entry
         | Partial _ -> (
             function
-            | { target = Dirty entry; _ } as box ->
+            | { target = Dirty entry } as box ->
                 if clear then box.target <- Lazy (Lazy.force entry.hash)
                 else
                   (* Promote from dirty to lazy as it will be saved during
                      [save_dirty]. *)
                   box.target <- Lazy_loaded entry;
                 (save_dirty [@tailcall]) entry
-            | { target = Lazy_loaded entry; _ } as box ->
+            | { target = Lazy_loaded entry } as box ->
                 if clear then box.target <- Lazy (Lazy.force entry.hash);
                 (save_dirty [@tailcall]) entry
-            | { target = Lazy _; _ } -> ())
+            | { target = Lazy _ } -> ())
         | Truncated -> (
             function
             | Broken h -> (broken [@tailcall]) h
@@ -404,9 +404,9 @@ struct
         match layout with
         | Partial _ -> (
             match ptr with
-            | { target = Lazy _} -> ()
-            | { target = Dirty ptr; _ } -> iter_dirty layout ptr
-            | { target = Lazy_loaded ptr; _ } as box ->
+            | { target = Lazy _ } -> ()
+            | { target = Dirty ptr } -> iter_dirty layout ptr
+            | { target = Lazy_loaded ptr } as box ->
                 let hash = Lazy.force ptr.hash in
                 (* Since a [Lazy_loaded] used to be a [Lazy], the hash is always
                    available. *)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1068,7 +1068,7 @@ module Make (S : S) = struct
       in
       let fold depth ecs ens =
         let* cs, ns =
-          S.Tree.fold v1 ?depth ~force:`And_clear
+          S.Tree.fold v1 ?depth ~force:`True ~cache:false
             ~contents:(fun path _ (cs, ns) -> Lwt.return (path :: cs, ns))
             ~node:(fun path _ (cs, ns) -> Lwt.return (cs, path :: ns))
             ([], [])

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -77,16 +77,16 @@ struct
 
   let of_list l = of_seq (List.to_seq l)
 
-  let seq ?(offset = 0) ?length (t : t) =
+  let seq ?(offset = 0) ?length ?cache:_ (t : t) =
     let take seq = match length with None -> seq | Some n -> Seq.take n seq in
     StepMap.to_seq t
     |> Seq.drop offset
     |> take
     |> Seq.map (fun (_, e) -> of_entry e)
 
-  let list ?offset ?length t = List.of_seq (seq ?offset ?length t)
+  let list ?offset ?length ?cache:_ t = List.of_seq (seq ?offset ?length t)
 
-  let find t s =
+  let find ?cache:_ t s =
     try
       let _, v = of_entry (StepMap.find s t) in
       Some v
@@ -95,6 +95,7 @@ struct
   let empty = StepMap.empty
   let is_empty e = StepMap.is_empty e
   let length e = StepMap.cardinal e
+  let clear _ = ()
 
   let add t k v =
     let e = to_entry (k, v) in
@@ -400,16 +401,17 @@ module V1 (N : S with type step = string) = struct
     let n = N.of_list entries in
     { n; entries }
 
-  let seq ?(offset = 0) ?length t =
+  let seq ?(offset = 0) ?length ?cache:_ t =
     let take seq = match length with None -> seq | Some n -> Seq.take n seq in
     List.to_seq t.entries |> Seq.drop offset |> take
 
-  let list ?offset ?length t = List.of_seq (seq ?offset ?length t)
+  let list ?offset ?length ?cache t = List.of_seq (seq ?offset ?length ?cache t)
   let empty = { n = N.empty; entries = [] }
   let is_empty t = t.entries = []
   let length e = N.length e.n
+  let clear _ = ()
   let default = N.default
-  let find t k = N.find t.n k
+  let find ?cache t k = N.find ?cache t.n k
 
   let add t k v =
     let n = N.add t.n k v in

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -40,14 +40,16 @@ module type S = sig
   val of_list : (step * value) list -> t
   (** [of_list l] is the node [n] such that [list n = l]. *)
 
-  val list : ?offset:int -> ?length:int -> t -> (step * value) list
+  val list :
+    ?offset:int -> ?length:int -> ?cache:bool -> t -> (step * value) list
   (** [list t] is the contents of [t]. [offset] and [length] are used to
       paginate results.*)
 
   val of_seq : (step * value) Seq.t -> t
   (** [of_seq s] is the node [n] such that [seq n = s]. *)
 
-  val seq : ?offset:int -> ?length:int -> t -> (step * value) Seq.t
+  val seq :
+    ?offset:int -> ?length:int -> ?cache:bool -> t -> (step * value) Seq.t
   (** [seq t] is the contents of [t]. [offset] and [length] are used to paginate
       results.*)
 
@@ -60,7 +62,10 @@ module type S = sig
   val length : t -> int
   (** [length t] is the number of entries in [t]. *)
 
-  val find : t -> step -> value option
+  val clear : t -> unit
+  (** Cleanup internal caches. *)
+
+  val find : ?cache:bool -> t -> step -> value option
   (** [find t s] is the value associated with [s] in [t].
 
       A node can point to user-defined {{!Node.S.contents} contents}. The edge

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -52,7 +52,7 @@ module type S = sig
       implementation.
 
       [cache] defaults to [true] which may greatly reduce the IOs and the
-      runtime but may also grealy increase the memory consumption.
+     may reduce the IOs and the runtime but also increase the memory consumption.
 
       [cache = false] doesn't replace a call to [clear], it only prevents the
       storing of new data, it doesn't discard the existing one. *)

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -43,7 +43,14 @@ module type S = sig
   val list :
     ?offset:int -> ?length:int -> ?cache:bool -> t -> (step * value) list
   (** [list t] is the contents of [t]. [offset] and [length] are used to
-      paginate results.*)
+      paginate results. [cache] regulates the caching behaviour regarding the
+      node's internal data which are lazily loaded.
+
+      [cache] defaults to [true] which may greatly reduce the IOs and the
+      runtime but may also grealy increase the memory consumption.
+
+      [cache = false] doesn't replace a call to [clear], it only prevents the
+      storing of new data, it doesn't discard the existing one. *)
 
   val of_seq : (step * value) Seq.t -> t
   (** [of_seq s] is the node [n] such that [seq n = s]. *)
@@ -51,7 +58,14 @@ module type S = sig
   val seq :
     ?offset:int -> ?length:int -> ?cache:bool -> t -> (step * value) Seq.t
   (** [seq t] is the contents of [t]. [offset] and [length] are used to paginate
-      results.*)
+      results. [cache] regulates the caching behaviour regarding the node's
+      internal data which are lazily loaded.
+
+      [cache] defaults to [true] which may greatly reduce the IOs and the
+      runtime but may also grealy increase the memory consumption.
+
+      [cache = false] doesn't replace a call to [clear], it only prevents the
+      storing of new data, it doesn't discard the existing one. *)
 
   val empty : t
   (** [empty] is the empty node. *)
@@ -69,7 +83,15 @@ module type S = sig
   (** [find t s] is the value associated with [s] in [t].
 
       A node can point to user-defined {{!Node.S.contents} contents}. The edge
-      between the node and the contents is labeled by a {{!Node.S.step} step}. *)
+      between the node and the contents is labeled by a {{!Node.S.step} step}.
+      [cache] regulates the caching behaviour regarding the node's internal data
+      which are lazily loaded.
+
+      [cache] defaults to [true] which may greatly reduce the IOs and the
+      runtime but may also grealy increase the memory consumption.
+
+      [cache = false] doesn't replace a call to [clear], it only prevents the
+      storing of new data, it doesn't discard the existing one. *)
 
   val add : t -> step -> value -> t
   (** [add t s v] is the node where [find t v] is [Some s] but is similar to [t]

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -52,7 +52,7 @@ module type S = sig
       implementation.
 
       [cache] defaults to [true] which may greatly reduce the IOs and the
-     may reduce the IOs and the runtime but also increase the memory consumption.
+      runtime but may also increase the memory consumption.
 
       [cache = false] doesn't replace a call to [clear], it only prevents the
       storing of new data, it doesn't discard the existing one. *)

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -43,8 +43,13 @@ module type S = sig
   val list :
     ?offset:int -> ?length:int -> ?cache:bool -> t -> (step * value) list
   (** [list t] is the contents of [t]. [offset] and [length] are used to
-      paginate results. [cache] regulates the caching behaviour regarding the
-      node's internal data which are lazily loaded.
+      paginate results.
+
+      {2 caching}
+
+      [cache] regulates the caching behaviour regarding the node's internal data
+      which may be lazily loaded from the backend, depending on the node
+      implementation.
 
       [cache] defaults to [true] which may greatly reduce the IOs and the
       runtime but may also grealy increase the memory consumption.
@@ -58,14 +63,9 @@ module type S = sig
   val seq :
     ?offset:int -> ?length:int -> ?cache:bool -> t -> (step * value) Seq.t
   (** [seq t] is the contents of [t]. [offset] and [length] are used to paginate
-      results. [cache] regulates the caching behaviour regarding the node's
-      internal data which are lazily loaded.
+      results.
 
-      [cache] defaults to [true] which may greatly reduce the IOs and the
-      runtime but may also grealy increase the memory consumption.
-
-      [cache = false] doesn't replace a call to [clear], it only prevents the
-      storing of new data, it doesn't discard the existing one. *)
+      See {!caching} for an explanation of the [cache] parameter *)
 
   val empty : t
   (** [empty] is the empty node. *)
@@ -84,14 +84,8 @@ module type S = sig
 
       A node can point to user-defined {{!Node.S.contents} contents}. The edge
       between the node and the contents is labeled by a {{!Node.S.step} step}.
-      [cache] regulates the caching behaviour regarding the node's internal data
-      which are lazily loaded.
 
-      [cache] defaults to [true] which may greatly reduce the IOs and the
-      runtime but may also grealy increase the memory consumption.
-
-      [cache = false] doesn't replace a call to [clear], it only prevents the
-      storing of new data, it doesn't discard the existing one. *)
+      See {!caching} for an explanation of the [cache] parameter *)
 
   val add : t -> step -> value -> t
   (** [add t s v] is the node where [find t v] is [Some s] but is similar to [t]

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -48,8 +48,9 @@ module Make (P : Private.S) = struct
     let of_hash r h = import r h
     let shallow r h = import_no_check r h
 
-    let hash : t -> hash =
-     fun tr -> match hash tr with `Node h -> h | `Contents (h, _) -> h
+    let hash : ?cache:bool -> t -> hash =
+     fun ?cache tr ->
+      match hash ?cache tr with `Node h -> h | `Contents (h, _) -> h
   end
 
   type branch = P.Branch.Key.t [@@deriving irmin]

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -382,7 +382,7 @@ module type S = sig
 
     (** {1 Import/Export} *)
 
-    val hash : tree -> hash
+    val hash : ?cache:bool -> tree -> hash
     (** [hash r c] it [c]'s hash in the repository [r]. *)
 
     type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1308,7 +1308,13 @@ module Make (P : Private.S) = struct
 
   let export ?clear repo contents_t node_t n =
     let cache =
-      match clear with Some true | None -> true | Some false -> false
+      match clear with
+      | Some true | None ->
+          (* This choice of [cache] flag has no impact, since we either
+             immediately clear the corresponding cache or are certain that
+             the it is already filled. *)
+          false
+      | Some false -> true
     in
     let skip n =
       match Node.cached_hash n with

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1308,10 +1308,7 @@ module Make (P : Private.S) = struct
 
   let export ?clear repo contents_t node_t n =
     let cache =
-      (* This choice of [cache] flag has no impact, since we either immediately
-         clear the corresponding cache or are certain that it is already
-         filled. *)
-      false
+      match clear with Some true | None -> true | Some false -> false
     in
     let skip n =
       match Node.cached_hash n with

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1145,11 +1145,7 @@ module Make (P : Private.S) = struct
 
   let length = Node.length ~cache:true
 
-  let seq t ?offset ?length path : (step * t) Seq.t Lwt.t =
-    let cache =
-      (* TODO: Maybe change *)
-      true
-    in
+  let seq t ?offset ?length ~cache path : (step * t) Seq.t Lwt.t =
     Log.debug (fun l -> l "Tree.seq %a" pp_key path);
     sub ~cache "seq.sub" t path >>= function
     | None -> Lwt.return Seq.empty
@@ -1158,7 +1154,9 @@ module Make (P : Private.S) = struct
         | Error _ -> Seq.empty
         | Ok l -> l)
 
-  let list t ?offset ?length path = seq t ?offset ?length path >|= List.of_seq
+  let list t ?offset ?length ?(cache = false) path =
+    seq t ?offset ?length ~cache path >|= List.of_seq
+
   let empty = `Node Node.empty
 
   (** During recursive updates, we keep track of whether or not we've made a

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -86,7 +86,14 @@ module type S = sig
 
     val hash : ?cache:bool -> t -> hash
     (** [hash t] is the hash of the {!contents} value returned when [t] is
-        {!force}d successfully. *)
+        {!force}d successfully. [cache] regulates the caching behaviour
+        regarding the node's internal data which are lazily loaded.
+
+        [cache] defaults to [true] which may greatly reduce the IOs and the
+        runtime but may also grealy increase the memory consumption.
+
+        [cache = false] doesn't replace a call to [clear], it only prevents the
+        storing of new data, it doesn't discard the existing one. *)
 
     val force : t -> contents or_error Lwt.t
     (** [force t] forces evaluation of the lazy content value [t], or returns an

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -84,7 +84,7 @@ module type S = sig
     type t
     (** The type of lazy tree contents. *)
 
-    val hash : t -> hash
+    val hash : ?cache:bool -> t -> hash
     (** [hash t] is the hash of the {!contents} value returned when [t] is
         {!force}d successfully. *)
 
@@ -329,7 +329,7 @@ module type Sigs = sig
 
     val dump : t Fmt.t
     val equal : t -> t -> bool
-    val hash : t -> kinded_hash
+    val hash : ?cache:bool -> t -> kinded_hash
     val of_private_node : P.Repo.t -> P.Node.value -> node
     val to_private_node : node -> P.Node.value or_error Lwt.t
   end

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -219,6 +219,7 @@ module type S = sig
     ?depth:depth ->
     ?contents:(key -> contents -> 'a -> 'a Lwt.t) ->
     ?node:(key -> node -> 'a -> 'a Lwt.t) ->
+    ?tree:(key -> t -> 'a -> 'a Lwt.t) ->
     t ->
     'a ->
     'a Lwt.t

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -127,11 +127,20 @@ module type S = sig
   val get_all : t -> key -> (contents * metadata) Lwt.t
   (** Same as {!find_all} but raise [Invalid_arg] if [k] is not present in [t]. *)
 
-  val list : t -> ?offset:int -> ?length:int -> key -> (step * t) list Lwt.t
+  val list :
+    t ->
+    ?offset:int ->
+    ?length:int ->
+    ?cache:bool ->
+    key ->
+    (step * t) list Lwt.t
   (** [list t key] is the list of files and sub-nodes stored under [k] in [t].
       The result order is not specified but is stable.
 
-      [offset] and [length] are used for pagination. *)
+      [offset] and [length] are used for pagination.
+
+      [cache] defaults to [false], see {!caching} for an explanation of the
+      parameter. *)
 
   val get : t -> key -> contents Lwt.t
   (** Same as {!get_all} but ignore the metadata. *)
@@ -343,7 +352,6 @@ module type Sigs = sig
 
     val dump : t Fmt.t
     val equal : t -> t -> bool
-
     val hash : ?cache:bool -> t -> kinded_hash
     val of_private_node : P.Repo.t -> P.Node.value -> node
     val to_private_node : node -> P.Node.value or_error Lwt.t

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -86,8 +86,12 @@ module type S = sig
 
     val hash : ?cache:bool -> t -> hash
     (** [hash t] is the hash of the {!contents} value returned when [t] is
-        {!force}d successfully. [cache] regulates the caching behaviour
-        regarding the node's internal data which are lazily loaded.
+        {!force}d successfully.
+
+        {2 caching}
+
+        [cache] regulates the caching behaviour regarding the node's internal
+        data which are be lazily loaded from the backend.
 
         [cache] defaults to [true] which may greatly reduce the IOs and the
         runtime but may also grealy increase the memory consumption.
@@ -193,7 +197,7 @@ module type S = sig
   val empty_marks : unit -> marks
   (** [empty_marks ()] is an empty collection of marks. *)
 
-  type 'a force = [ `True | `False of key -> 'a -> 'a Lwt.t | `And_clear ]
+  type 'a force = [ `True | `False of key -> 'a -> 'a Lwt.t ]
   (** The type for {!fold}'s [force] parameter. [`True] forces the fold to read
       the objects of the lazy nodes and contents. [`False f] is applying [f] on
       every lazy node and content value instead. [`And_clear] is like [`True]
@@ -220,6 +224,7 @@ module type S = sig
 
   val fold :
     ?force:'a force ->
+    ?cache:bool ->
     ?uniq:uniq ->
     ?pre:'a node_fn ->
     ?post:'a node_fn ->
@@ -244,7 +249,9 @@ module type S = sig
       See {!uniq} for details about the [uniq] parameters. By default it is
       [`False].
 
-      The fold depth is controlled by the [depth] parameter. *)
+      The fold depth is controlled by the [depth] parameter.
+
+      See {!caching} for an explanation of the [cache] parameter *)
 
   (** {1 Stats} *)
 
@@ -336,6 +343,7 @@ module type Sigs = sig
 
     val dump : t Fmt.t
     val equal : t -> t -> bool
+
     val hash : ?cache:bool -> t -> kinded_hash
     val of_private_node : P.Repo.t -> P.Node.value -> node
     val to_private_node : node -> P.Node.value or_error Lwt.t

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -209,8 +209,7 @@ module type S = sig
   type 'a force = [ `True | `False of key -> 'a -> 'a Lwt.t ]
   (** The type for {!fold}'s [force] parameter. [`True] forces the fold to read
       the objects of the lazy nodes and contents. [`False f] is applying [f] on
-      every lazy node and content value instead. [`And_clear] is like [`True]
-      but also eagerly empties the Tree caches when traversing sub-nodes. *)
+      every lazy node and content value instead. *)
 
   type uniq = [ `False | `True | `Marks of marks ]
   (** The type for {!fold}'s [uniq] parameters. [`False] folds over all the

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -522,12 +522,12 @@ let test_fold_force _ () =
           "After folding, the tree is eagerly evaluated" eager_stats
   in
 
-  (* Ensure that [fold ~force:`And_clear] visits all children and does not
-     leave them cached. *)
+  (* Ensure that [fold ~force:`True ~cache:false] visits all children and does
+     not leave them cached. *)
   let* () =
     clear_and_assert_lazy sample_tree >>= fun () ->
     let* contents =
-      Tree.fold ~force:`And_clear
+      Tree.fold ~force:`True ~cache:false
         ~contents:(fun _ -> Lwt.wrap2 List.cons)
         sample_tree []
     in

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -513,10 +513,10 @@ let test_fold_force _ () =
     Tree.{ nodes = 2; leafs = 5; skips = 0; depth = 2; width = 3 }
   in
 
-  (* Ensure that [fold ~force:`True] forces all lazy trees. *)
+  (* Ensure that [fold ~force:`True ~cache:true] forces all lazy trees. *)
   let* () =
     let* () = clear_and_assert_lazy sample_tree in
-    Tree.fold ~force:`True sample_tree () >>= fun () ->
+    Tree.fold ~force:`True ~cache:false sample_tree () >>= fun () ->
     Tree.stats ~force:false sample_tree
     >|= Alcotest.(gcheck Tree.stats_t)
           "After folding, the tree is eagerly evaluated" eager_stats

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -516,7 +516,7 @@ let test_fold_force _ () =
   (* Ensure that [fold ~force:`True ~cache:true] forces all lazy trees. *)
   let* () =
     let* () = clear_and_assert_lazy sample_tree in
-    Tree.fold ~force:`True ~cache:false sample_tree () >>= fun () ->
+    Tree.fold ~force:`True ~cache:true sample_tree () >>= fun () ->
     Tree.stats ~force:false sample_tree
     >|= Alcotest.(gcheck Tree.stats_t)
           "After folding, the tree is eagerly evaluated" eager_stats


### PR DESCRIPTION
This PR introduces GC in inodes and sets everything up to micro-manage the caching in tree.

For example, it allows (I believe) to compute the hash of a tree without keeping anything heaving in memory at any time.
