### PR TITLE
Use a `tree` parameter in `fold` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
     (#1345, @samoht)
   - `Node.seq` and `Node.of_seq` are added to avoid allocating intermediate
     lists when it is not necessary (#1508, @samoht)
+  - Added a `tree` argument to `Tree.fold` to manipulate the subtrees (#1527,
+    @icristescu, @Ngoguey42)
 
 - **irmin-bench**
   - Many improvements to the actions trace replay:

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -219,6 +219,7 @@ module type S = sig
     ?depth:depth ->
     ?contents:(key -> contents -> 'a -> 'a Lwt.t) ->
     ?node:(key -> node -> 'a -> 'a Lwt.t) ->
+    ?tree:(key -> t -> 'a -> 'a Lwt.t) ->
     t ->
     'a ->
     'a Lwt.t


### PR DESCRIPTION
In tezos, the [`fold`](https://gitlab.com/tezos/tezos/-/blob/master/src/lib_context/helpers/context.ml#L73) is called with a `contents` function which requires the value of a content to build up a tree of it. But the fold function already manipulates the contents as trees, so there is an unnecessary indirection to go from `Contents.t` to `contents`.

Printing out stats during the migration, shows that we are looking up a lot of contents on disk (and incrementing the `contents_find` [here](https://github.com/mirage/irmin/blob/master/src/irmin/tree.ml#L228)). For example for flattening `contracts/index 1 delegated` we have:
```
  "contents_hash": 43709,
  "contents_find": 70956,
  "contents_add": 43709,
```
This PR adds a `tree` function as parameter to `fold` that allows us to rewrite the fold in helpers/context.ml as
```
Store.Tree.fold ?depth ~force:`And_clear ~uniq:`False ~tree:f t init
```
and manipulate directly the tree.