### PR TITLE
irmin-pack: fix typo in name of the `irmin-test` suite

### DIFF
--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -92,7 +92,7 @@ let suite_pack =
     let* repo = S.Repo.v config in
     clear repo >>= fun () -> S.Repo.close repo
   in
-  Irmin_test.Suite.create ~name:"CHUNK" ~init ~store ~config ~clean
+  Irmin_test.Suite.create ~name:"PACK" ~init ~store ~config ~clean
     ~layered_store:(Some layered_store) ()
 
 module Irmin_pack_mem_maker = struct


### PR DESCRIPTION
Introduced by https://github.com/mirage/irmin/pull/1513.