### PR TITLE
Change `Tree.list ~cache` to true

### DIFF
--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1328,7 +1328,7 @@ module Make (P : Backend.S) = struct
         | Error _ -> Seq.empty
         | Ok l -> l)
 
-  let list t ?offset ?length ?(cache = false) path =
+  let list t ?offset ?length ?(cache = true) path =
     seq t ?offset ?length ~cache path >|= List.of_seq
 
   let empty = `Node Node.empty

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -144,7 +144,7 @@ module type S = sig
 
       [offset] and [length] are used for pagination.
 
-      [cache] defaults to [false], see {!caching} for an explanation of the
+      [cache] defaults to [true], see {!caching} for an explanation of the
       parameter. *)
 
   val get : t -> key -> contents Lwt.t
@@ -266,7 +266,8 @@ module type S = sig
 
       The fold depth is controlled by the [depth] parameter.
 
-      See {!caching} for an explanation of the [cache] parameter *)
+      [cache] defaults to [false], see {!caching} for an explanation of the
+      parameter. *)
 
   (** {1 Stats} *)
 
@@ -305,7 +306,10 @@ module type S = sig
   val clear : ?depth:int -> t -> unit
   (** [clear ?depth t] clears all caches in the tree [t] for subtrees with a
       depth higher than [depth]. If [depth] is not set, all of the subtrees are
-      cleared. *)
+      cleared.
+
+      A call to [clear] doesn't discard the subtrees of [t], only their cache
+      are discarded. Even the lazily loaded and unmodified subtrees remain. *)
 
   (** {1 Performance counters} *)
 


### PR DESCRIPTION
In order to match the released behaviour