### PR TITLE
Expose a `prune_inplace` function 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
     objects with known hashes. (#1537, @CraigFe)
   - Added a `order` argument to specify the order of traversal in `Tree.fold`
     (#1548, @icristescu, @CraigFe)
+  - Add a `unsafe_prune_inplace` function to remove a tree and replace with the
+    hash of its root. (#1552, @icristescu, @Ngoguey42)
 
 - **irmin-bench**
   - Many improvements to the actions trace replay:

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -435,6 +435,11 @@ module type S_generic_key = sig
     val hash : ?cache:bool -> tree -> hash
     (** [hash t] is the hash of tree [t]. *)
 
+    val unsafe_prune_inplace : tree -> hash -> unit
+    (** [unsafe_prune_inplace t hash] modifies [t] to only contain [h] as its
+        root. This operation makes [t] unuseable, apart for hash computations,
+        and is not safe when the tree is shared. *)
+
     type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
     (** Like {!kinded_key}, but with hashes as value references rather than
         keys. *)

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -287,6 +287,10 @@ module Make (P : Backend.S) = struct
               if cache then c.info.ptr <- Hash h;
               h)
 
+    let unsafe_prune_inplace t h =
+      clear_info t.info;
+      t.v <- Pruned h
+
     let key t =
       match t.v with Key (_, k) -> Some k | Value _ | Pruned _ -> None
 
@@ -707,6 +711,10 @@ module Make (P : Backend.S) = struct
       aux (Pnode (P.Node_portable.of_node v)) updates
 
     let hash ~cache k = hash ~cache k (fun x -> x)
+
+    let unsafe_prune_inplace t h =
+      clear_info_fields t.info;
+      t.v <- Pruned h
 
     let value_of_key ~cache t repo k =
       match cached_value t with
@@ -1295,6 +1303,11 @@ module Make (P : Backend.S) = struct
   let pruned : kinded_hash -> t = function
     | `Contents (h, meta) -> `Contents (Contents.pruned h, meta)
     | `Node h -> `Node (Node.pruned h)
+
+  let unsafe_prune_inplace (t : t) h =
+    match t with
+    | `Node n -> Node.unsafe_prune_inplace n h
+    | `Contents (c, _) -> Contents.unsafe_prune_inplace c h
 
   let destruct x = x
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -389,6 +389,7 @@ module type Sigs = sig
     val equal : t -> t -> bool
     val key : t -> kinded_key option
     val hash : ?cache:bool -> t -> kinded_hash
+    val unsafe_prune_inplace : t -> hash -> unit
     val to_backend_node : node -> P.Node.Val.t Lwt.t
     val to_backend_portable_node : node -> P.Node_portable.t Lwt.t
     val of_backend_node : P.Repo.t -> P.Node.value -> node


### PR DESCRIPTION
A possible way to use `pruned` to clear the tree after computing the hash of its root.