### PR TITLE
Upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,6 @@
-version = 0.19.0
+version = 0.20.0
 profile = conventional
+
+ocaml-version = 4.08.0
 break-infix = fit-or-vertical
 parse-docstrings = true
-module-item-spacing = compact

--- a/bench/irmin-pack/trace_stat_summary_cb.ml
+++ b/bench/irmin-pack/trace_stat_summary_cb.ml
@@ -130,8 +130,8 @@ let create_raw_results1 s : result list =
          let vs = Span.(Map.find k s.span).duration in
          ( Printf.sprintf "%s (ms)" (Span.Key.to_string k),
            [
-             vs.mean *. 1000.;
-             (* TODO: {min / max / avg}, maybe on a log scale? *)
+             vs.mean *. 1000.
+             (* TODO: {min / max / avg}, maybe on a log scale? *);
            ] )
     in
     { name; metrics }
@@ -145,7 +145,7 @@ let create_raw_results1 s : result list =
          let vs = Span.(Map.find k s.span).duration in
          ( Printf.sprintf "%s (\xc2\xb5s)" (Span.Key.to_string k),
            [
-             vs.mean *. 1e6; (* TODO: {min / max / avg}, maybe on a log scale? *)
+             vs.mean *. 1e6 (* TODO: {min / max / avg}, maybe on a log scale? *);
            ] )
     in
     { name; metrics }

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -67,8 +67,8 @@ module Make (G : Git.S) = struct
       Git.User.{ name; email; date = (date, None) }
     in
     let message = Info.message info in
-    G.Value.Commit.make (* FIXME: should be v *) ~tree ~parents ~author
-      ~committer:author
+    G.Value.Commit.make (* FIXME: should be v *)
+      ~tree ~parents ~author ~committer:author
       (if message = "" then None else Some message)
 
   let v ~info ~node ~parents = to_git info node parents

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -230,13 +230,15 @@ module RO (Client : Cohttp_lwt.S.Client) (K : Irmin.Type.S) (V : Irmin.Type.S) :
   let val_of_str = Irmin.Type.of_string V.t
 
   let find t key =
-    HTTP.map_call `GET t.uri t.ctx ~keep_alive:false [ t.item; key_str key ]
+    HTTP.map_call `GET t.uri t.ctx ~keep_alive:false
+      [ t.item; key_str key ]
       (fun ((r, _) as x) ->
         if Cohttp.Response.status r = `Not_found then Lwt.return_none
         else HTTP.map_string_response val_of_str x >|= Option.some)
 
   let mem t key =
-    HTTP.map_call `GET t.uri t.ctx ~keep_alive:false [ t.item; key_str key ]
+    HTTP.map_call `GET t.uri t.ctx ~keep_alive:false
+      [ t.item; key_str key ]
       (fun (r, _) ->
         if Cohttp.Response.status r = `Not_found then Lwt.return_false
         else Lwt.return_true)
@@ -331,7 +333,8 @@ functor
 
     let remove t key =
       HTTP.map_call `DELETE (RO.uri t.t) t.t.ctx ~keep_alive:false
-        [ RO.item t.t; key_str key ] (fun (r, b) ->
+        [ RO.item t.t; key_str key ]
+        (fun (r, b) ->
           match Cohttp.Response.status r with
           | `Not_found | `OK -> Lwt.return_unit
           | _ ->

--- a/src/irmin-pack/checks_intf.ml
+++ b/src/irmin-pack/checks_intf.ml
@@ -56,11 +56,11 @@ module type S = sig
   module Reconstruct_index :
     Subcommand
       with type run :=
-            root:string ->
-            output:string option ->
-            ?index_log_size:int ->
-            unit ->
-            unit
+        root:string ->
+        output:string option ->
+        ?index_log_size:int ->
+        unit ->
+        unit
   (** Rebuilds an index for an existing pack file *)
 
   (** Checks the integrity of a store *)
@@ -95,11 +95,11 @@ module type S = sig
     include
       Subcommand
         with type run :=
-              root:string ->
-              commit:string option ->
-              dump_blob_paths_to:string option ->
-              unit ->
-              unit Lwt.t
+          root:string ->
+          commit:string option ->
+          dump_blob_paths_to:string option ->
+          unit ->
+          unit Lwt.t
   end
 
   val cli :

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -541,7 +541,6 @@ struct
               collected on [clear] because it will be needed for [save]. *)
 
     and partial_ptr = { mutable target : partial_ptr_target }
-
     and total_ptr = Total_ptr of total_ptr t [@@unboxed]
 
     and truncated_ptr =
@@ -551,7 +550,6 @@ struct
       | Intact of truncated_ptr t
 
     and 'ptr tree = { depth : int; length : int; entries : 'ptr option array }
-
     and 'ptr v = Values of value StepMap.t | Tree of 'ptr tree
 
     and 'ptr t = {

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -260,7 +260,8 @@ module Make_helpers (S : Generic_key) = struct
     S.Tree.of_key repo (`Node kn3) >>= function
     | None -> Alcotest.fail "r2"
     | Some t3 ->
-        S.Commit.v repo ~info:S.Info.empty ~parents:[ S.Commit.key kr1 ]
+        S.Commit.v repo ~info:S.Info.empty
+          ~parents:[ S.Commit.key kr1 ]
           (t3 :> S.tree)
 
   let ignore_thunk_errors f = Lwt.catch f (fun _ -> Lwt.return_unit)

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -61,7 +61,8 @@ module Make_Layered (S : Layered_store) = struct
     S.Tree.of_key repo (`Node kn3) >>= function
     | None -> Alcotest.fail "r2"
     | Some t3 ->
-        S.Commit.v repo ~info:(info "r2") ~parents:[ S.Commit.key kr1 ]
+        S.Commit.v repo ~info:(info "r2")
+          ~parents:[ S.Commit.key kr1 ]
           (t3 :> S.tree)
 
   let fail_with_none f msg =
@@ -789,13 +790,15 @@ module Make_Layered (S : Layered_store) = struct
       in
       let* commits, contents = setup 0 tree [] [] in
       let* () =
-        S.freeze repo ~min_lower:[ List.nth commits 1 ]
+        S.freeze repo
+          ~min_lower:[ List.nth commits 1 ]
           ~min_upper:[ List.nth commits 3 ]
           ~max_lower:[ List.nth commits 5; List.nth commits 6 ]
       in
       S.Backend_layer.wait_for_freeze repo >>= fun () ->
       let* () =
-        S.freeze repo ~min_lower:[ List.nth commits 1 ]
+        S.freeze repo
+          ~min_lower:[ List.nth commits 1 ]
           ~min_upper:[ List.nth commits 3 ]
           ~max_lower:[ List.nth commits 5; List.nth commits 6 ]
       in

--- a/src/irmin-test/store_graph.ml
+++ b/src/irmin-test/store_graph.ml
@@ -145,7 +145,8 @@ module Make (S : Generic_key) = struct
         >>= fun () ->
         visited := [];
         skipped := [];
-        test_skip ~max:[ k1 ] ~to_skip:[ `Node k1 ]
+        test_skip ~max:[ k1 ]
+          ~to_skip:[ `Node k1 ]
           ~not_visited:[ `Contents foo_k ]
       in
       let test3 () =
@@ -177,7 +178,8 @@ module Make (S : Generic_key) = struct
         visited := [];
         skipped := [];
         let* () =
-          test_skip ~max:[ kc ] ~to_skip:[ `Node ka1; `Node ka2 ]
+          test_skip ~max:[ kc ]
+            ~to_skip:[ `Node ka1; `Node ka2 ]
             ~not_visited:[ `Node kb1 ]
         in
         visited := [];

--- a/src/irmin-test/store_watch.ml
+++ b/src/irmin-test/store_watch.ml
@@ -296,8 +296,10 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
       in
       let* main = S.Branch.get repo "main" in
       let* u =
-        S.Branch.watch_all ~init:[ ("main", main) ] repo (fun _ ->
-            State.process state)
+        S.Branch.watch_all
+          ~init:[ ("main", main) ]
+          repo
+          (fun _ -> State.process state)
       in
       add true (0, 0, 0) 10 ~first:true >>= fun () ->
       remove true (10, 0, 0) 5 >>= fun () ->

--- a/src/irmin/object_graph_intf.ml
+++ b/src/irmin/object_graph_intf.ml
@@ -132,8 +132,8 @@ module type Sigs = sig
       (Branch : Type.S) :
     S
       with type V.t =
-            [ `Contents of Contents_key.t
-            | `Node of Node_key.t
-            | `Commit of Commit_key.t
-            | `Branch of Branch.t ]
+        [ `Contents of Contents_key.t
+        | `Node of Node_key.t
+        | `Commit of Commit_key.t
+        | `Branch of Branch.t ]
 end

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -372,11 +372,8 @@ module Make (P : Backend.S) = struct
     type nonrec ptr_option = key ptr_option
 
     type elt = [ `Node of t | `Contents of Contents.t * Metadata.t ]
-
     and update = Add of elt | Remove
-
     and updatemap = update StepMap.t
-
     and map = elt StepMap.t
 
     and info = {


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions
- formatting of list elements has been improved