### PR TITLE
Test for prehash collisions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
   - Add `Node.clear` to clear internal caches (#1526, @Ngoguey42)
   - Added a `tree` argument to `Tree.fold` to manipulate the subtrees (#1527,
     @icristescu, @Ngoguey42)
+  - Add a function `Store.Tree.singleton` for building trees with a single
+    contents binding. (#1567, @CraigFe)
   - Add a function `Store.Tree.pruned` for building purely in-memory tree
     objects with known hashes. (#1537, @CraigFe)
   - Added a `order` argument to specify the order of traversal in `Tree.fold`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,7 @@
   - `` `Tree.fold ~force:`True`` and `` `Tree.fold ~force:`False`` don't
     cache the lazily loaded data any more. Pass `~cache:true` to enable it
     again. (#1526, @Ngoguey42)
+  - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
 
   - Add support for non-content-addressed ("generic key") backend stores. This
     allows Irmin to work with backends in which not all values are addressed by

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -75,7 +75,7 @@ let init config =
 module Trees = Generate_trees (Store)
 
 let init_commit repo =
-  Store.Commit.v repo ~info:(Info.f ()) ~parents:[] Store.Tree.empty
+  Store.Commit.v repo ~info:(Info.f ()) ~parents:[] (Store.Tree.empty ())
 
 let checkout_and_commit config repo c nb =
   Store.Commit.of_hash repo c >>= function

--- a/bench/irmin-pack/trace_replay.ml
+++ b/bench/irmin-pack/trace_replay.ml
@@ -325,7 +325,7 @@ module Make (Store : Store) = struct
     in
 
     (* Manually add genesis context *)
-    Hashtbl.add t.contexts 0L { tree = Store.Tree.empty };
+    Hashtbl.add t.contexts 0L { tree = Store.Tree.empty () };
 
     let rec aux commit_seq i =
       match commit_seq () with

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -75,7 +75,7 @@ module Bench_suite (Store : Store) = struct
   module Info = Info (Store.Info)
 
   let init_commit repo =
-    Store.Commit.v repo ~info:(Info.f ()) ~parents:[] Store.Tree.empty
+    Store.Commit.v repo ~info:(Info.f ()) ~parents:[] (Store.Tree.empty ())
 
   module Trees = Generate_trees (Store)
   module Trace_replay = Trace_replay.Make (Store)

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -30,9 +30,9 @@ let provision repo =
   Config.init ();
   let provision = info ~user:"Automatic VM provisioning" in
   let* t = Store.of_branch repo "upstream" in
-  let v = Store.Tree.empty () in
-  let* v =
-    Store.Tree.add v [ "etc"; "manpath" ] "/usr/share/man\n/usr/local/share/man"
+  let v =
+    Store.Tree.singleton [ "etc"; "manpath" ]
+      "/usr/share/man\n/usr/local/share/man"
   in
   let* v =
     Store.Tree.add v [ "bin"; "sh" ]

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -30,7 +30,7 @@ let provision repo =
   Config.init ();
   let provision = info ~user:"Automatic VM provisioning" in
   let* t = Store.of_branch repo "upstream" in
-  let v = Store.Tree.empty in
+  let v = Store.Tree.empty () in
   let* v =
     Store.Tree.add v [ "etc"; "manpath" ] "/usr/share/man\n/usr/local/share/man"
   in

--- a/examples/trees.ml
+++ b/examples/trees.ml
@@ -34,7 +34,8 @@ let tree_of_t t =
         let* v = Tree.add v [ si; "x" ] t2.x in
         let+ v = Tree.add v [ si; "y" ] (string_of_int t2.y) in
         (v, i + 1))
-      (Tree.empty, 0) t
+      (Tree.empty (), 0)
+      t
   in
   tree
 

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -511,7 +511,7 @@ struct
             let* info, retries, allow_empty, parents = txn_args s i in
             Lwt.catch
               (fun () ->
-                let tree = Store.Tree.empty in
+                let tree = Store.Tree.empty () in
                 let* tree = to_tree tree items in
                 Store.set_tree t ?retries ?allow_empty ?parents ~info k tree
                 >>= function
@@ -535,7 +535,9 @@ struct
                 Store.with_tree t ?retries ?allow_empty ?parents k ~info
                   (fun tree ->
                     let tree =
-                      match tree with Some t -> t | None -> Store.Tree.empty
+                      match tree with
+                      | Some t -> t
+                      | None -> Store.Tree.empty ()
                     in
                     to_tree tree items >>= Lwt.return_some)
                 >>= function
@@ -558,7 +560,7 @@ struct
             let* tree =
               Store.find_tree t k >>= function
               | Some tree -> Lwt.return tree
-              | None -> Lwt.return Store.Tree.empty
+              | None -> Lwt.return (Store.Tree.empty ())
             in
             let* tree = Store.Tree.add tree k ?metadata:m v in
             Store.set_tree t ?retries ?allow_empty ?parents k tree ~info
@@ -642,14 +644,14 @@ struct
             let* old =
               match old with
               | Some old ->
-                  let tree = Store.Tree.empty in
+                  let tree = Store.Tree.empty () in
                   to_tree tree old >>= Lwt.return_some
               | None -> Lwt.return_none
             in
             let* value =
               match value with
               | Some value ->
-                  let tree = Store.Tree.empty in
+                  let tree = Store.Tree.empty () in
                   to_tree tree value >>= Lwt.return_some
               | None -> Lwt.return_none
             in

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -169,7 +169,7 @@ module KV_RO (G : Git.S) = struct
   let tree t =
     let repo = S.repo t.t in
     (S.find_tree t.t t.root >|= function
-     | None -> S.Tree.empty
+     | None -> S.Tree.empty ()
      | Some tree -> tree)
     >|= fun tree -> { Tree.repo; tree }
 
@@ -292,7 +292,7 @@ module KV_RW (G : Irmin_git.G) (C : Mirage_clock.PCLOCK) = struct
         let tree = S.Commit.tree origin in
         S.Tree.find_tree tree t.root >|= function
         | Some t -> Some (origin, t)
-        | None -> Some (origin, S.Tree.empty))
+        | None -> Some (origin, S.Tree.empty ()))
 
   let batch t ?(retries = 42) f =
     let info = info t `Batch in

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -132,7 +132,7 @@ struct
   (* init: create a tree with [t.depth] levels and each levels has
      [t.tree_add] files + one directory going to the next levele. *)
   let init t config =
-    let tree = Store.Tree.empty in
+    let tree = Store.Tree.empty () in
     let* v = Store.Repo.v config >>= Store.master in
     let* tree =
       times ~n:t.depth ~init:tree (fun depth tree ->

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -145,8 +145,7 @@ module Make_Layered (S : Layered_store) = struct
                  \-> c3
     *)
     let tree1 repo =
-      let tree = S.Tree.empty () in
-      let* tree = S.Tree.add tree [ "c"; "b"; "a" ] "x" in
+      let tree = S.Tree.singleton [ "c"; "b"; "a" ] "x" in
       let* c0 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b"; "a1" ] "x1" in
       let* c1 = S.Commit.v repo ~info ~parents:[ S.Commit.key c0 ] tree in
@@ -161,8 +160,7 @@ module Make_Layered (S : Layered_store) = struct
      \->  c4      \-> c8
     *)
     let tree2 repo =
-      let tree = S.Tree.empty () in
-      let* tree = S.Tree.add tree [ "c"; "b1" ] "x4" in
+      let tree = S.Tree.singleton [ "c"; "b1" ] "x4" in
       let* c4 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b2" ] "x5" in
       let* c5 = S.Commit.v repo ~info ~parents:[] tree in
@@ -289,7 +287,7 @@ module Make_Layered (S : Layered_store) = struct
   let test_set_tree x () =
     let test repo =
       let* t = S.master repo in
-      let* t1 = S.Tree.add (S.Tree.empty ()) [ "a"; "d" ] v1 in
+      let t1 = S.Tree.singleton [ "a"; "d" ] v1 in
       let* t1 = S.Tree.add t1 [ "a"; "b"; "c" ] v2 in
       S.set_tree_exn ~info:(infof "commit 1") ~parents:[] t [] t1 >>= fun () ->
       S.freeze repo ~max_upper:[] >>= fun () ->
@@ -441,8 +439,8 @@ module Make_Layered (S : Layered_store) = struct
   let test_branch_squash x () =
     let check_val = check T.(option S.contents_t) in
     let setup repo =
-      let* tree1 = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
-      let* tree2 = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "d" ] v2 in
+      let tree1 = S.Tree.singleton [ "a"; "b"; "c" ] v1 in
+      let tree2 = S.Tree.singleton [ "a"; "b"; "d" ] v2 in
       let* foo = S.of_branch repo "foo" in
       S.set_tree_exn ~parents:[] ~info:(infof "tree1") foo [] tree1
       >>= fun () ->
@@ -961,7 +959,7 @@ module Make_Layered (S : Layered_store) = struct
         Alcotest.(check (option string)) "v1" v' (Some v)
       in
       let add_and_find_commit ~hook v =
-        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v in
+        let tree = S.Tree.singleton [ "a"; "b"; "c" ] v in
         let* c = S.Commit.v repo ~info ~parents:[] tree in
         let hook, p = hook (find_commit c v) in
         let* () =
@@ -993,7 +991,7 @@ module Make_Layered (S : Layered_store) = struct
         Alcotest.(check (option string)) "v" v' (Some v)
       in
       let add_commit t v () =
-        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v in
+        let tree = S.Tree.singleton [ "a"; "b"; "c" ] v in
         S.set_tree_exn ~parents:[] ~info:(infof "tree1") t [] tree
       in
       let add_and_find_commit ~hook t v =
@@ -1017,12 +1015,12 @@ module Make_Layered (S : Layered_store) = struct
   let test_add_again x () =
     let test repo =
       let* t = S.master repo in
-      let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
+      let tree = S.Tree.singleton [ "a"; "b"; "c" ] v1 in
       S.set_tree_exn ~parents:[] ~info:(infof "v1") t [] tree >>= fun () ->
-      let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "d" ] v2 in
+      let tree = S.Tree.singleton [ "a"; "d" ] v2 in
       S.set_tree_exn ~parents:[] ~info:(infof "v2") t [] tree >>= fun () ->
       let add_commit () =
-        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
+        let tree = S.Tree.singleton [ "a"; "b"; "c" ] v1 in
         let* tree = S.Tree.add tree [ "a"; "e" ] v3 in
         S.set_tree_exn ~parents:[] ~info:(infof "v3") t [] tree
       in

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -145,7 +145,7 @@ module Make_Layered (S : Layered_store) = struct
                  \-> c3
     *)
     let tree1 repo =
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let* tree = S.Tree.add tree [ "c"; "b"; "a" ] "x" in
       let* c0 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b"; "a1" ] "x1" in
@@ -161,7 +161,7 @@ module Make_Layered (S : Layered_store) = struct
      \->  c4      \-> c8
     *)
     let tree2 repo =
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let* tree = S.Tree.add tree [ "c"; "b1" ] "x4" in
       let* c4 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b2" ] "x5" in
@@ -289,7 +289,7 @@ module Make_Layered (S : Layered_store) = struct
   let test_set_tree x () =
     let test repo =
       let* t = S.master repo in
-      let* t1 = S.Tree.add S.Tree.empty [ "a"; "d" ] v1 in
+      let* t1 = S.Tree.add (S.Tree.empty ()) [ "a"; "d" ] v1 in
       let* t1 = S.Tree.add t1 [ "a"; "b"; "c" ] v2 in
       S.set_tree_exn ~info:(infof "commit 1") ~parents:[] t [] t1 >>= fun () ->
       S.freeze repo ~max_upper:[] >>= fun () ->
@@ -441,8 +441,8 @@ module Make_Layered (S : Layered_store) = struct
   let test_branch_squash x () =
     let check_val = check T.(option S.contents_t) in
     let setup repo =
-      let* tree1 = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v1 in
-      let* tree2 = S.Tree.add S.Tree.empty [ "a"; "b"; "d" ] v2 in
+      let* tree1 = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
+      let* tree2 = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "d" ] v2 in
       let* foo = S.of_branch repo "foo" in
       S.set_tree_exn ~parents:[] ~info:(infof "tree1") foo [] tree1
       >>= fun () ->
@@ -531,7 +531,7 @@ module Make_Layered (S : Layered_store) = struct
     let test repo =
       let info = info "freezes" in
       let check_val repo = check (T.option @@ S.commit_t repo) in
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let rec commits tree acc i =
         if i = 10 then Lwt.return acc
         else
@@ -583,7 +583,7 @@ module Make_Layered (S : Layered_store) = struct
         let+ x = S.Tree.find tree [ "5" ] in
         Alcotest.(check (option string)) "x5" (Some "x5") x
       in
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let* tree = S.Tree.add tree [ "1"; "2"; "3" ] "x1" in
       let* tree = S.Tree.add tree [ "4" ] "x4" in
       let* tree = S.Tree.add tree [ "5" ] "x5" in
@@ -735,7 +735,7 @@ module Make_Layered (S : Layered_store) = struct
     let check_commit = check (T.option P.Commit.Val.t) in
     let check_branch repo = check (T.option @@ S.commit_t repo) in
     let test repo =
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let rec setup i tree commits contents =
         if i > 6 then Lwt.return (commits, List.rev contents)
         else
@@ -961,7 +961,7 @@ module Make_Layered (S : Layered_store) = struct
         Alcotest.(check (option string)) "v1" v' (Some v)
       in
       let add_and_find_commit ~hook v =
-        let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v in
+        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v in
         let* c = S.Commit.v repo ~info ~parents:[] tree in
         let hook, p = hook (find_commit c v) in
         let* () =
@@ -993,7 +993,7 @@ module Make_Layered (S : Layered_store) = struct
         Alcotest.(check (option string)) "v" v' (Some v)
       in
       let add_commit t v () =
-        let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v in
+        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v in
         S.set_tree_exn ~parents:[] ~info:(infof "tree1") t [] tree
       in
       let add_and_find_commit ~hook t v =
@@ -1017,12 +1017,12 @@ module Make_Layered (S : Layered_store) = struct
   let test_add_again x () =
     let test repo =
       let* t = S.master repo in
-      let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v1 in
+      let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
       S.set_tree_exn ~parents:[] ~info:(infof "v1") t [] tree >>= fun () ->
-      let* tree = S.Tree.add S.Tree.empty [ "a"; "d" ] v2 in
+      let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "d" ] v2 in
       S.set_tree_exn ~parents:[] ~info:(infof "v2") t [] tree >>= fun () ->
       let add_commit () =
-        let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v1 in
+        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
         let* tree = S.Tree.add tree [ "a"; "e" ] v3 in
         S.set_tree_exn ~parents:[] ~info:(infof "v3") t [] tree
       in

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1054,9 +1054,8 @@ module Make (S : Generic_key) = struct
       let foo1 = random_value 10 in
       let foo2 = random_value 10 in
       let* v1 =
-        S.Tree.empty ()
-        |> with_binding [ "foo"; "bar"; "toto" ] foo2
-        >>= with_binding [ "foo"; "toto" ] foo1
+        S.Tree.singleton [ "foo"; "bar"; "toto" ] foo2
+        |> with_binding [ "foo"; "toto" ] foo1
       in
       S.Tree.clear v1;
       let* () =
@@ -1233,9 +1232,8 @@ module Make (S : Generic_key) = struct
         check_ls "5 paginated list" ls (l1 @ l2)
       in
       let* c0 =
-        S.Tree.empty ()
-        |> with_binding [ "foo"; "a" ] "1"
-        >>= with_binding [ "foo"; "b"; "c" ] "2"
+        S.Tree.singleton [ "foo"; "a" ] "1"
+        |> with_binding [ "foo"; "b"; "c" ] "2"
         >>= with_binding [ "foo"; "c" ] "3"
         >>= with_binding [ "foo"; "d" ] "4"
       in
@@ -1390,8 +1388,7 @@ module Make (S : Generic_key) = struct
         s;
       let* vx' = S.Tree.find_all tree px in
       check_val "updates" (normal vx) vx';
-      let v = S.Tree.empty () in
-      let* v = S.Tree.add v [] vx in
+      let v = S.Tree.singleton [] vx in
       let* () =
         S.set_tree_exn t ~info:(infof "update file as tree") [ "a" ] v
       in

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -477,7 +477,7 @@ module Make (S : Generic_key) = struct
       let tree bindings =
         Lwt_list.fold_left_s
           (fun t (k, v) -> S.Tree.add t k v)
-          S.Tree.empty bindings
+          (S.Tree.empty ()) bindings
       in
       let check_hash msg bindings =
         let* node = node bindings in
@@ -659,7 +659,7 @@ module Make (S : Generic_key) = struct
         >|= S.History.is_empty
         >|= Alcotest.(check bool) msg expected
       in
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let k0 = random_path ~label:8 ~path:5 in
       let k1 = random_path ~label:8 ~path:4 in
       let k2 = random_path ~label:8 ~path:6 in
@@ -1054,7 +1054,7 @@ module Make (S : Generic_key) = struct
       let foo1 = random_value 10 in
       let foo2 = random_value 10 in
       let* v1 =
-        S.Tree.empty
+        S.Tree.empty ()
         |> with_binding [ "foo"; "bar"; "toto" ] foo2
         >>= with_binding [ "foo"; "toto" ] foo1
       in
@@ -1066,7 +1066,7 @@ module Make (S : Generic_key) = struct
         S.Tree.fold ~depth:(`Eq 1) ~force:(`False dont_skip) v1 ()
       in
       let* () =
-        S.Tree.fold ~depth:(`Eq 1) ~force:`True S.Tree.empty ()
+        S.Tree.fold ~depth:(`Eq 1) ~force:`True (S.Tree.empty ()) ()
           ~contents:(fun k _ ->
             assert (List.length k = 1);
             Alcotest.fail "contents")
@@ -1117,7 +1117,7 @@ module Make (S : Generic_key) = struct
       let* v1 = S.Tree.remove v1 [ "foo"; "bar"; "toto" ] in
       let* v = S.Tree.find v1 [ "foo"; "toto" ] in
       Alcotest.(check (option string)) "remove" (Some foo1) v;
-      S.Tree.empty |> fun v1 ->
+      let v1 = S.Tree.empty () in
       let* s = S.Tree.stats v1 in
       Alcotest.(check stats_t) "empty stats" empty_stats s;
       let* v1 = S.Tree.add v1 [ "foo"; "1" ] foo1 in
@@ -1147,9 +1147,9 @@ module Make (S : Generic_key) = struct
       let check_ls = checks T.(pair S.step_t S.tree_t) in
       let normal c = Some (c, S.Metadata.default) in
       let d0 = S.Metadata.default in
-      S.Tree.empty |> fun v0 ->
-      S.Tree.empty |> fun v1 ->
-      S.Tree.empty |> fun v2 ->
+      let v0 = S.Tree.empty () in
+      let v1 = S.Tree.empty () in
+      let v2 = S.Tree.empty () in
       let* v1 = S.Tree.add v1 [ "foo"; "1" ] foo1 in
       let* f = S.Tree.find_all v1 [ "foo"; "1" ] in
       check_val "tree update" (normal foo1) f;
@@ -1233,7 +1233,7 @@ module Make (S : Generic_key) = struct
         check_ls "5 paginated list" ls (l1 @ l2)
       in
       let* c0 =
-        S.Tree.empty
+        S.Tree.empty ()
         |> with_binding [ "foo"; "a" ] "1"
         >>= with_binding [ "foo"; "b"; "c" ] "2"
         >>= with_binding [ "foo"; "c" ] "3"
@@ -1255,7 +1255,7 @@ module Make (S : Generic_key) = struct
 
       (* Testing concrete representation *)
       let* c0 =
-        Lwt.return S.Tree.empty
+        Lwt.return (S.Tree.empty ())
         >>= with_binding [ "foo"; "a" ] "1"
         >>= with_binding [ "foo"; "b"; "c" ] "2"
         >>= with_binding [ "bar"; "d" ] "3"
@@ -1283,7 +1283,7 @@ module Make (S : Generic_key) = struct
       in
 
       (* Testing other tree operations. *)
-      S.Tree.empty |> fun v0 ->
+      let v0 = S.Tree.empty () in
       let* c = S.Tree.to_concrete v0 in
       (match c with
       | `Tree [] -> ()
@@ -1390,7 +1390,7 @@ module Make (S : Generic_key) = struct
         s;
       let* vx' = S.Tree.find_all tree px in
       check_val "updates" (normal vx) vx';
-      S.Tree.empty |> fun v ->
+      let v = S.Tree.empty () in
       let* v = S.Tree.add v [] vx in
       let* () =
         S.set_tree_exn t ~info:(infof "update file as tree") [ "a" ] v
@@ -1404,7 +1404,7 @@ module Make (S : Generic_key) = struct
   let test_wide_nodes x () =
     let test repo =
       let size = 500_000 in
-      let c0 = S.Tree.empty in
+      let c0 = S.Tree.empty () in
       let rec wide_node i c =
         if i >= size then Lwt.return c
         else
@@ -1484,7 +1484,7 @@ module Make (S : Generic_key) = struct
   let test_commit_wide_node x () =
     let test repo =
       let size = 500_000 in
-      let c0 = S.Tree.empty in
+      let c0 = S.Tree.empty () in
       let rec wide_node i c =
         if i >= size then Lwt.return c
         else

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2033,6 +2033,68 @@ module Make (S : Generic_key) = struct
       P.Repo.close repo
     in
     run x test
+
+  let test_pre_hash_collisions x () =
+    let pre_hash_of ty =
+      let f = Irmin.Type.(pre_hash ty |> unstage) in
+      fun x ->
+        let buf = Buffer.create 0 in
+        f x (Buffer.add_string buf);
+        Buffer.contents buf
+    in
+    let rec add_entries acc = function
+      | 0 -> Lwt.return acc
+      | i ->
+          let s = string_of_int i in
+          let* acc = S.Tree.add acc [ s ] s in
+          add_entries acc (i - 1)
+    in
+    let equal_hash = Irmin.Type.(equal S.Hash.t |> unstage) in
+    let test create_tree repo =
+      let* tree = create_tree () in
+      let* c = S.Commit.v repo ~info:S.Info.empty ~parents:[] tree in
+
+      let* node_b =
+        S.Tree.destruct tree
+        |> (function `Contents _ -> assert false | `Node n -> n)
+        |> S.to_backend_node
+      in
+      let node_ph = pre_hash_of P.Node.Val.t node_b in
+      let node_h = P.Node.Hash.hash node_b in
+
+      let commit_b = S.to_backend_commit c in
+      let commit_ph = pre_hash_of P.Commit.Val.t commit_b in
+      let commit_h = P.Commit.Hash.hash commit_b in
+
+      let* blob_k = with_contents repo (fun t -> P.Contents.add t node_ph) in
+      let blob_h = P.Contents.Key.to_hash blob_k in
+      if equal_hash node_h blob_h then
+        Alcotest.failf
+          "node pre-hash attack succeeded. pre-hash is \"%s\". backend node is \
+           %a."
+          (String.escaped node_ph)
+          (Irmin.Type.pp P.Node.Val.t)
+          node_b;
+
+      let* blob_k = with_contents repo (fun t -> P.Contents.add t commit_ph) in
+      let blob_h = P.Contents.Key.to_hash blob_k in
+      if equal_hash commit_h blob_h then
+        Alcotest.failf
+          "commit pre-hash attack succeeded. pre-hash is \"%s\". backend \
+           commit is %a."
+          (String.escaped commit_ph)
+          (Irmin.Type.pp P.Commit.Val.t)
+          commit_b;
+
+      P.Repo.close repo
+    in
+    (* Test collisions with the empty node (and its commit), *)
+    run x (test @@ fun () -> S.Tree.empty () |> Lwt.return);
+    (* with a length one node, *)
+    run x (test @@ fun () -> add_entries (S.Tree.empty ()) 1);
+    (* and with a length >256 node (which is the threshold for unstable inodes
+       in irmin pack). *)
+    run x (test @@ fun () -> add_entries (S.Tree.empty ()) 260)
 end
 
 let suite' l ?(prefix = "") (_, x) =
@@ -2072,6 +2134,7 @@ let suite (speed, x) =
        ("Shallow objects", speed, T.test_shallow_objects x);
        ("Closure with disconnected commits", speed, T.test_closure x);
        ("Clear", speed, T.test_clear x);
+       ("Prehash collisions", speed, T.test_pre_hash_collisions x);
      ]
     @ when_ x.import_supported
         [

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -502,10 +502,10 @@ let watch =
                   let view (c, _) =
                     let* t = S.of_commit c in
                     S.find_tree t path >|= function
-                    | None -> S.Tree.empty
+                    | None -> S.Tree.empty ()
                     | Some v -> v
                   in
-                  let empty = Lwt.return S.Tree.empty in
+                  let empty = Lwt.return (S.Tree.empty ()) in
                   let x, y =
                     match d with
                     | `Updated (x, y) -> (view x, view y)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -587,7 +587,7 @@ module Make (P : Backend.S) = struct
 
   let tree t =
     tree_and_head t >|= function
-    | None -> Tree.empty
+    | None -> Tree.empty ()
     | Some (_, tree) -> (tree :> tree)
 
   let lift_head_diff repo fn = function
@@ -770,7 +770,8 @@ module Make (P : Backend.S) = struct
   let snapshot t key =
     tree_and_head t >>= function
     | None ->
-        Lwt.return { head = None; root = Tree.empty; tree = None; parents = [] }
+        Lwt.return
+          { head = None; root = Tree.empty (); tree = None; parents = [] }
     | Some (c, root) ->
         let root = (root :> tree) in
         let+ tree = Tree.find_tree root key in
@@ -1236,7 +1237,7 @@ struct
     of_concrete_tree c
 
   let set t key j ~info =
-    set_tree Store.Tree.empty Store.Key.empty j >>= function
+    set_tree (Store.Tree.empty ()) Store.Key.empty j >>= function
     | tree -> Store.set_tree_exn ~info t key tree
 
   let get t key =

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -45,6 +45,10 @@ module type S = sig
       backend configuration values, as they can perform in-memory operation,
       independently of any given backend. *)
 
+  val singleton : key -> ?metadata:metadata -> contents -> t
+  (** [singleton k c] is the tree with a single binding mapping the key [k] to
+      the contents [c]. *)
+
   val of_contents : ?metadata:metadata -> contents -> t
   (** [of_contents c] is the subtree built from the contents [c]. *)
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -40,9 +40,9 @@ module type S = sig
 
   (** {1 Constructors} *)
 
-  val empty : t
-  (** [empty] is the empty tree. The empty tree does not have associated backend
-      configuration values, as they can perform in-memory operation,
+  val empty : unit -> t
+  (** [empty ()] is the empty tree. The empty tree does not have associated
+      backend configuration values, as they can perform in-memory operation,
       independently of any given backend. *)
 
   val of_contents : ?metadata:metadata -> contents -> t

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -192,8 +192,7 @@ let test_blobs (module S : S) =
     "blob foo" "blob 19\000{\"Y\":[\"foo\",\"bar\"]}" str;
   let str = pre_hash X.Contents.t (X (1, 2)) in
   Alcotest.(check bin_string) "blob ''" "blob 11\000{\"X\":[1,2]}" str;
-  let t = X.Tree.empty () in
-  let* t = X.Tree.add t [ "foo" ] (X (1, 2)) in
+  let* t = X.Tree.singleton [ "foo" ] (X (1, 2)) in
   let k1 = X.Tree.hash t in
   let* repo = X.Repo.v (Irmin_git.config test_db) in
   let* k2 =

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -192,7 +192,7 @@ let test_blobs (module S : S) =
     "blob foo" "blob 19\000{\"Y\":[\"foo\",\"bar\"]}" str;
   let str = pre_hash X.Contents.t (X (1, 2)) in
   Alcotest.(check bin_string) "blob ''" "blob 11\000{\"X\":[1,2]}" str;
-  let t = X.Tree.empty in
+  let t = X.Tree.empty () in
   let* t = X.Tree.add t [ "foo" ] (X (1, 2)) in
   let k1 = X.Tree.hash t in
   let* repo = X.Repo.v (Irmin_git.config test_db) in

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -48,7 +48,7 @@ module Layered = struct
     rm_dir data_dir;
     let* repo = Store.Repo.v (config data_dir) in
     let* _t = Store.master repo in
-    let* tree = Store.Tree.add (Store.Tree.empty ()) [ "a"; "b"; "c" ] "x1" in
+    let tree = Store.Tree.singleton [ "a"; "b"; "c" ] "x1" in
     let* c = Store.Commit.v repo ~info ~parents:[] tree in
     let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
     let* () = Store.Backend_layer.wait_for_freeze repo in
@@ -80,9 +80,7 @@ module Simple = struct
   let create_store () =
     rm_dir data_dir;
     let* rw = Store.Repo.v (config data_dir) in
-    let* tree =
-      Store.Tree.add (Store.Tree.empty ()) [ "a"; "b1"; "c1"; "d1"; "e1" ] "x1"
-    in
+    let tree = Store.Tree.singleton [ "a"; "b1"; "c1"; "d1"; "e1" ] "x1" in
     let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d2"; "e2" ] "x2" in
     let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d3"; "e3" ] "x2" in
     let* tree = Store.Tree.add tree [ "a"; "b2"; "c2"; "e3" ] "x2" in

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -48,7 +48,7 @@ module Layered = struct
     rm_dir data_dir;
     let* repo = Store.Repo.v (config data_dir) in
     let* _t = Store.master repo in
-    let* tree = Store.Tree.add Store.Tree.empty [ "a"; "b"; "c" ] "x1" in
+    let* tree = Store.Tree.add (Store.Tree.empty ()) [ "a"; "b"; "c" ] "x1" in
     let* c = Store.Commit.v repo ~info ~parents:[] tree in
     let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
     let* () = Store.Backend_layer.wait_for_freeze repo in
@@ -81,7 +81,7 @@ module Simple = struct
     rm_dir data_dir;
     let* rw = Store.Repo.v (config data_dir) in
     let* tree =
-      Store.Tree.add Store.Tree.empty [ "a"; "b1"; "c1"; "d1"; "e1" ] "x1"
+      Store.Tree.add (Store.Tree.empty ()) [ "a"; "b1"; "c1"; "d1"; "e1" ] "x1"
     in
     let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d2"; "e2" ] "x2" in
     let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d3"; "e3" ] "x2" in

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -92,13 +92,13 @@ module Test = struct
     Common.rm_dir root;
     let+ repo = Store.Repo.v (config ?readonly ?with_lower root) in
     let index = { root; repo } in
-    let tree = Store.Tree.empty in
+    let tree = Store.Tree.empty () in
     { index; tree; parents = [] }
 
   let clone ?readonly ?with_lower root =
     let+ repo = Store.Repo.v (config ~fresh:false ?readonly ?with_lower root) in
     let index = { root; repo } in
-    let tree = Store.Tree.empty in
+    let tree = Store.Tree.empty () in
     { index; tree; parents = [] }
 
   let freeze ?copy_in_upper ctxt commit =
@@ -108,7 +108,7 @@ module Test = struct
       | None | Some true -> None
     in
     Store.freeze ?max_upper ctxt.index.repo ~max_lower:[ commit ] >|= fun () ->
-    { index = ctxt.index; tree = Store.Tree.empty; parents = [] }
+    { index = ctxt.index; tree = Store.Tree.empty (); parents = [] }
 
   let commit_block1 ctxt =
     let* ctxt = set ctxt [ "a"; "b" ] "Novembre" in
@@ -221,7 +221,7 @@ module Test = struct
 
   let commit_block1_simple_store repo =
     let* tree =
-      StoreSimple.Tree.add StoreSimple.Tree.empty [ "a"; "b" ] "Novembre"
+      StoreSimple.Tree.add (StoreSimple.Tree.empty ()) [ "a"; "b" ] "Novembre"
     in
     let* tree = StoreSimple.Tree.add tree [ "a"; "c" ] "Juin" in
     let* tree = StoreSimple.Tree.add tree [ "version" ] "0.0" in

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -220,9 +220,7 @@ module Test = struct
     | Some _ -> Alcotest.failf "should not find %s" msg
 
   let commit_block1_simple_store repo =
-    let* tree =
-      StoreSimple.Tree.add (StoreSimple.Tree.empty ()) [ "a"; "b" ] "Novembre"
-    in
+    let tree = StoreSimple.Tree.singleton [ "a"; "b" ] "Novembre" in
     let* tree = StoreSimple.Tree.add tree [ "a"; "c" ] "Juin" in
     let* tree = StoreSimple.Tree.add tree [ "version" ] "0.0" in
     let+ block1 =

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -43,7 +43,7 @@ let open_ro_after_rw_closed () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* t = S.master rw in
-  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
+  let tree = S.Tree.singleton [ "a" ] "x" in
   S.set_tree_exn ~parents:[] ~info t [] tree >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
   S.Repo.close rw >>= fun () ->
@@ -88,11 +88,11 @@ let ro_sync_after_add () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
+  let tree = S.Tree.singleton [ "a" ] "x" in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
   check ro c1 "a" "x" >>= fun () ->
-  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "y" in
+  let tree = S.Tree.singleton [ "a" ] "y" in
   let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   check ro c1 "a" "x" >>= fun () ->
   let* () =
@@ -109,7 +109,7 @@ let ro_sync_after_close () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = binding (S.Tree.add (S.Tree.empty ()) ?metadata:None) in
+  let tree = binding (S.Tree.singleton ?metadata:None) in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.Repo.close rw >>= fun () ->
   S.sync ro;
@@ -131,7 +131,7 @@ let clear_all repo =
 let clear_rw_open_ro () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
-  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
+  let tree = S.Tree.singleton [ "a" ] "x" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   clear_all rw >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
@@ -143,12 +143,12 @@ let clear_rw_find_ro () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
+  let tree = S.Tree.singleton [ "a" ] "x" in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
   check_binding ro c1 ~msg:"RO finds value" [ "a" ] "x" >>= fun () ->
   clear_all rw >>= fun () ->
-  let* tree = S.Tree.add (S.Tree.empty ()) [ "b" ] "y" in
+  let tree = S.Tree.singleton [ "b" ] "y" in
   let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let* () =
     check_binding ro c1 ~msg:"RO finds value after clear but before sync"
@@ -172,7 +172,7 @@ let clear_rw_twice () =
   in
   let add () =
     check_empty () >>= fun () ->
-    let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
+    let tree = S.Tree.singleton [ "a" ] "x" in
     S.set_tree_exn ~parents:[] ~info t [] tree
   in
   let add_after_clear () =
@@ -199,14 +199,14 @@ let dict_sync_after_clear_same_offset () =
         Alcotest.(check (option string)) "RO find" (Some value) x
   in
   let long_string = random_string 200 in
-  let* tree = S.Tree.add (S.Tree.empty ()) [ long_string ] "x" in
+  let tree = S.Tree.singleton [ long_string ] "x" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let h = S.Commit.hash c in
   S.sync ro;
   find_key h long_string "x" >>= fun () ->
   clear_all rw >>= fun () ->
   let long_string = random_string 200 in
-  let* tree = S.Tree.add (S.Tree.empty ()) [ long_string ] "y" in
+  let tree = S.Tree.singleton [ long_string ] "y" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let h = S.Commit.hash c in
   S.sync ro;

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -43,7 +43,7 @@ let open_ro_after_rw_closed () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* t = S.master rw in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   S.set_tree_exn ~parents:[] ~info t [] tree >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
   S.Repo.close rw >>= fun () ->
@@ -88,11 +88,11 @@ let ro_sync_after_add () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
   check ro c1 "a" "x" >>= fun () ->
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "y" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "y" in
   let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   check ro c1 "a" "x" >>= fun () ->
   let* () =
@@ -109,7 +109,7 @@ let ro_sync_after_close () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = binding (S.Tree.add S.Tree.empty ?metadata:None) in
+  let* tree = binding (S.Tree.add (S.Tree.empty ()) ?metadata:None) in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.Repo.close rw >>= fun () ->
   S.sync ro;
@@ -131,7 +131,7 @@ let clear_all repo =
 let clear_rw_open_ro () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   clear_all rw >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
@@ -143,12 +143,12 @@ let clear_rw_find_ro () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
   check_binding ro c1 ~msg:"RO finds value" [ "a" ] "x" >>= fun () ->
   clear_all rw >>= fun () ->
-  let* tree = S.Tree.add S.Tree.empty [ "b" ] "y" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "b" ] "y" in
   let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let* () =
     check_binding ro c1 ~msg:"RO finds value after clear but before sync"
@@ -172,7 +172,7 @@ let clear_rw_twice () =
   in
   let add () =
     check_empty () >>= fun () ->
-    let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+    let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
     S.set_tree_exn ~parents:[] ~info t [] tree
   in
   let add_after_clear () =
@@ -199,14 +199,14 @@ let dict_sync_after_clear_same_offset () =
         Alcotest.(check (option string)) "RO find" (Some value) x
   in
   let long_string = random_string 200 in
-  let* tree = S.Tree.add S.Tree.empty [ long_string ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ long_string ] "x" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let h = S.Commit.hash c in
   S.sync ro;
   find_key h long_string "x" >>= fun () ->
   clear_all rw >>= fun () ->
   let long_string = random_string 200 in
-  let* tree = S.Tree.add S.Tree.empty [ long_string ] "y" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ long_string ] "y" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let h = S.Commit.hash c in
   S.sync ro;

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -127,8 +127,8 @@ struct
       let* rw = S.Repo.v conf_rw in
       [%log.app "Checking new commits can be added to the V2 store"];
       let* new_commit =
-        S.Tree.add (S.Tree.empty ()) [ "c" ] "x"
-        >>= S.Commit.v rw ~parents:[] ~info:S.Info.empty
+        S.Tree.singleton [ "c" ] "x"
+        |> S.Commit.v rw ~parents:[] ~info:S.Info.empty
       in
       check_commit rw new_commit [ ([ "c" ], "x") ] >>= fun () ->
       let+ () = S.Repo.close rw in
@@ -368,8 +368,7 @@ module Test_corrupted_stores = struct
     setup_test ();
     let module S = Make_layered in
     let add_commit repo k v =
-      S.Tree.add (S.Tree.empty ()) k v
-      >>= S.Commit.v repo ~parents:[] ~info:S.Info.empty
+      S.Tree.singleton k v |> S.Commit.v repo ~parents:[] ~info:S.Info.empty
     in
     let check_commit repo commit k v =
       commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -127,7 +127,7 @@ struct
       let* rw = S.Repo.v conf_rw in
       [%log.app "Checking new commits can be added to the V2 store"];
       let* new_commit =
-        S.Tree.add S.Tree.empty [ "c" ] "x"
+        S.Tree.add (S.Tree.empty ()) [ "c" ] "x"
         >>= S.Commit.v rw ~parents:[] ~info:S.Info.empty
       in
       check_commit rw new_commit [ ([ "c" ], "x") ] >>= fun () ->
@@ -368,7 +368,7 @@ module Test_corrupted_stores = struct
     setup_test ();
     let module S = Make_layered in
     let add_commit repo k v =
-      S.Tree.add S.Tree.empty k v
+      S.Tree.add (S.Tree.empty ()) k v
       >>= S.Commit.v repo ~parents:[] ~info:S.Info.empty
     in
     let check_commit repo commit k v =

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -57,40 +57,12 @@ let suite_pack =
   in
   let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_dir in
   let init () =
-    if Sys.file_exists test_dir then (
-      let cmd = Printf.sprintf "rm -rf %s" test_dir in
-      Fmt.epr "exec: %s\n%!" cmd;
-      let _ = Sys.command cmd in
-      ());
+    rm_dir test_dir;
     Lwt.return_unit
   in
   let clean () =
-    let (module S : Irmin_test.S) = store in
-    let module P = S.Backend in
-    let clear repo =
-      Lwt.join
-        [
-          P.Commit.clear (P.Repo.commit_t repo);
-          P.Node.clear (P.Repo.node_t repo);
-          P.Contents.clear (P.Repo.contents_t repo);
-          P.Branch.clear (P.Repo.branch_t repo);
-        ]
-    in
-    let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_dir in
-    let* repo = S.Repo.v config in
-    clear repo >>= fun () ->
-    S.Repo.close repo >>= fun () ->
-    let (module S : Irmin_test.Layered_store) = layered_store in
-    let module P = S.Backend in
-    let clear repo =
-      P.Commit.clear (P.Repo.commit_t repo) >>= fun () ->
-      P.Node.clear (P.Repo.node_t repo) >>= fun () ->
-      P.Contents.clear (P.Repo.contents_t repo) >>= fun () ->
-      P.Branch.clear (P.Repo.branch_t repo)
-    in
-    let config = Irmin_pack.config ~fresh:true ~lru_size:0 test_dir in
-    let* repo = S.Repo.v config in
-    clear repo >>= fun () -> S.Repo.close repo
+    rm_dir test_dir;
+    Lwt.return_unit
   in
   Irmin_test.Suite.create ~name:"PACK" ~init ~store ~config ~clean
     ~layered_store:(Some layered_store) ()

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -96,7 +96,7 @@ let bindings steps =
   List.map (fun x -> ([ x ], zero)) steps
 
 let test_fold ~order bindings expected =
-  let tree = Tree.empty in
+  let tree = Tree.empty () in
   let* tree =
     Lwt_list.fold_left_s (fun tree (k, v) -> Tree.add tree k v) tree bindings
   in

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -539,9 +539,8 @@ let test_fold_force _ () =
      and that [f] is called the correct number of times. *)
   let* () =
     let* tree =
-      Lwt.return (Tree.empty ())
-      >>= with_binding [ "existing"; "subtree" ] (Tree.of_contents "value")
-      >>= with_binding [ "dangling"; "subtree"; "hash" ] invalid_tree
+      Tree.singleton [ "existing"; "subtree" ] "value"
+      |> with_binding [ "dangling"; "subtree"; "hash" ] invalid_tree
       >>= with_binding [ "other"; "lazy"; "path" ] invalid_tree
     in
     let force = `False (Lwt.wrap2 List.cons) in

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -180,7 +180,7 @@ let test_diff _ () =
 let test_empty _ () =
   let* () =
     Alcotest.check_tree_lwt "The empty tree is empty" ~expected:(`Tree [])
-      (Lwt.return Tree.empty)
+      (Lwt.return (Tree.empty ()))
   in
 
   (* Ensure that different [empty] values have disjoint cache state.
@@ -190,7 +190,7 @@ let test_empty _ () =
      avoid sharing keys from different repositories). *)
   let* () =
     let* repo = Store.Repo.v (Irmin_mem.config ()) in
-    let empty_exported = Tree.empty and empty_not_exported = Tree.empty in
+    let empty_exported = Tree.empty () and empty_not_exported = Tree.empty () in
     let+ () =
       Store.Backend.Repo.batch repo (fun c n _ ->
           Store.save_tree repo c n empty_exported >|= ignore)
@@ -216,7 +216,7 @@ let test_add _ () =
   let* () =
     Alcotest.check_tree_lwt "Adding a root value to an empty tree"
       ~expected:(c "1")
-      (Tree.add Tree.empty [] "1")
+      (Tree.add (Tree.empty ()) [] "1")
   in
 
   let* () =
@@ -259,7 +259,7 @@ let test_remove _ () =
   in
 
   let* () =
-    let t = Tree.empty in
+    let t = Tree.empty () in
     let+ t' = Tree.remove t [] in
     Alcotest.assert_ "Removing in an empty tree preserves physical equality"
       (t == t')
@@ -427,7 +427,7 @@ let test_update _ () =
       "Updating at a path in an empty tree creates the necessary intermediate \
        nodes with the new contents."
       ~expected:(`Tree [ ("a", `Tree [ ("b", `Tree [ ("c", c "1") ]) ]) ])
-      (Tree.update Tree.empty [ "a"; "b"; "c" ] (None --> Some "1"))
+      (Tree.update (Tree.empty ()) [ "a"; "b"; "c" ] (None --> Some "1"))
   in
 
   let* () =
@@ -439,7 +439,7 @@ let test_update _ () =
   in
 
   let* () =
-    let t = Tree.empty in
+    let t = Tree.empty () in
     let+ t' = Tree.update t [] (None --> None) in
     Alcotest.assert_ "Removing from an empty tree preserves physical equality"
       (t == t')
@@ -448,7 +448,7 @@ let test_update _ () =
   let* () =
     let+ abc1' =
       Tree.update_tree abc1 [ "a"; "b"; "d" ] (function
-        | None -> Some Tree.empty
+        | None -> Some (Tree.empty ())
         | Some _ -> assert false)
     in
     Alcotest.assert_
@@ -475,7 +475,7 @@ let test_clear _ () =
   let size = 830829 in
   let* t =
     List.init size string_of_int
-    |> Lwt_list.fold_left_s (fun acc i -> Tree.add acc [ i ] i) Tree.empty
+    |> Lwt_list.fold_left_s (fun acc i -> Tree.add acc [ i ] i) (Tree.empty ())
   in
   (* Check the state of the root and root/42 *)
   Alcotest.(check inspect) "Before clear, root" (`Node `Map) (Tree.inspect t);
@@ -539,7 +539,7 @@ let test_fold_force _ () =
      and that [f] is called the correct number of times. *)
   let* () =
     let* tree =
-      Lwt.return Tree.empty
+      Lwt.return (Tree.empty ())
       >>= with_binding [ "existing"; "subtree" ] (Tree.of_contents "value")
       >>= with_binding [ "dangling"; "subtree"; "hash" ] invalid_tree
       >>= with_binding [ "other"; "lazy"; "path" ] invalid_tree
@@ -654,8 +654,10 @@ module Broken = struct
       [ ("shallow", shallow_of_ptr); ("pruned", pruned_of_ptr) ]
     and&* path = [ []; [ "k" ] ] in
     let* leaf_broken = operation leaf_ptr in
-    let* hash_actual = Tree.(add_tree empty) path leaf >|= Tree.hash in
-    let+ hash_expected = Tree.(add_tree empty) path leaf_broken >|= Tree.hash in
+    let* hash_actual = Tree.(add_tree (empty ())) path leaf >|= Tree.hash in
+    let+ hash_expected =
+      Tree.(add_tree (empty ())) path leaf_broken >|= Tree.hash
+    in
     Alcotest.(gcheck Store.Hash.t)
       (Fmt.str
          "Hashing a %s %s value at path %a is equivalent to hashing the \
@@ -669,12 +671,16 @@ module Broken = struct
     let run_tests ~exn_type ~broken_contents ~broken_node ~path =
       [%logs.app
         "Testing operations on a tree with a broken position at %a" pp_key path];
-      let* broken_leaf = Tree.(add_tree empty) path broken_contents in
-      let* broken_node = Tree.(add_tree empty) path broken_node in
+      let* broken_leaf = Tree.(add_tree (empty ())) path broken_contents in
+      let* broken_node = Tree.(add_tree (empty ())) path broken_node in
       let beneath = path @ [ "a"; "b"; "c" ] in
       let blob = "v" in
-      let* singleton_at_path = Tree.(add empty path blob >>= to_concrete) in
-      let* singleton_beneath = Tree.(add empty beneath blob >>= to_concrete) in
+      let* singleton_at_path =
+        Tree.(add (empty ()) path blob >>= to_concrete)
+      in
+      let* singleton_beneath =
+        Tree.(add (empty ()) beneath blob >>= to_concrete)
+      in
 
       (* [add] on broken nodes/contents replaces the broken position. *)
       let* () =
@@ -726,7 +732,7 @@ module Broken = struct
   let test_pruned_fold _ () =
     let&* _, ptr = [ random_contents (); random_node () ]
     and&* path = [ []; [ "k" ] ] in
-    let* tree = Tree.(add_tree empty) path (Tree.pruned ptr) in
+    let* tree = Tree.(add_tree (empty ())) path (Tree.pruned ptr) in
 
     (* Folding over a pruned tree with [force:`True] should fail: *)
     let* () =
@@ -765,7 +771,8 @@ let test_generic_equality _ () =
   let* tree = persist_tree (tree [ ("k", c "v") ]) in
   let+ should_be_empty = Tree.remove tree [ "k" ] in
   Alcotest.(gcheck Store.tree_t)
-    "Modified empty tree is equal to [Tree.empty]" Tree.empty should_be_empty
+    "Modified empty tree is equal to [(Tree.empty ())]" (Tree.empty ())
+    should_be_empty
 
 let test_is_empty _ () =
   (* Test for equivalence against an [is_equal] derived from generic equality,
@@ -773,14 +780,14 @@ let test_is_empty _ () =
   let is_empty =
     let equal = Type.unstage (Type.equal Store.tree_t) in
     fun t ->
-      let reference = equal t Tree.empty in
+      let reference = equal t (Tree.empty ()) in
       let candidate = Tree.is_empty t in
       Alcotest.(check bool)
-        "`equal Tree.empty` agrees with `is_empty`" reference candidate;
+        "`equal (Tree.empty ())` agrees with `is_empty`" reference candidate;
       candidate
   in
   let kv = tree [ ("k", c "v") ] in
-  let () = Alcotest.(check bool) "empty tree" true (is_empty Tree.empty) in
+  let () = Alcotest.(check bool) "empty tree" true (is_empty (Tree.empty ())) in
   let () = Alcotest.(check bool) "non-empty tree" false (is_empty kv) in
   let* () =
     let+ tree = Tree.remove kv [ "k" ] in
@@ -788,7 +795,7 @@ let test_is_empty _ () =
   in
   let* repo = Store.Repo.v (Irmin_mem.config ()) in
   let () =
-    let shallow_empty = Tree.(shallow repo (`Node (hash empty))) in
+    let shallow_empty = Tree.(shallow repo (`Node (hash (empty ())))) in
     Alcotest.(check bool) "shallow empty tree" true (is_empty shallow_empty)
   in
   let () =


### PR DESCRIPTION
Adds a generic test for #1304 

Only irmin-pack fails. Error:
```
node pre-hash attack succeeded. pre-hash is "\000". backend node is {"hash":"5ba93c9db0cff93f52b521d7420e43f6eda2784f","stable":true,"v":{"Values":[]}}.
Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 152, characters 20-48
Called from Irmin_test__Store.Make.test_pre_hash_collisions.test in file "src/irmin-test/store.ml", line 2077, characters 8-210
Called from Irmin_test__Common.Make_helpers.run.(fun) in file "src/irmin-test/common.ml", line 239, characters 11-20
Called from Lwt.Sequential_composition.catch in file "src/core/lwt.ml", line 2023, characters 16-20
Re-raised at Irmin_test__Common.Make_helpers.run.(fun) in file "src/irmin-test/common.ml", line 242, characters 36-72
Called from Irmin_test__Common.Make_helpers.run in file "src/irmin-test/common.ml", line 235, characters 6-297
Called from Irmin_test__Store.Make.test_pre_hash_collisions in file "src/irmin-test/store.ml", line 2097, characters 4-53
Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 229, characters 17-23
Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
```

We still need a way to run that unit test using tezos-context-hash, and a fix for irmin-pack
