### PR TITLE
irmin-bench: drop invalid `with-test` specifiers on Opam dependencies

### DIFF
--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -28,14 +28,14 @@ depends: [
   "uuidm"
   "progress"     {>="0.2.1"}
   "fpath"        {with-test}
-  "bentov"       {with-test}
-  "mtime"        {with-test}
-  "ppx_deriving" {with-test}
+  "bentov"
+  "mtime"
+  "ppx_deriving"
   "alcotest"     {with-test}
   "rusage"
-  "uutf"         {with-test}
-  "uucp"         {with-test}
-  "printbox"     {with-test}
+  "uutf"
+  "uucp"
+  "printbox"
 ]
 
 synopsis: "Irmin benchmarking suite"


### PR DESCRIPTION
These dependencies aren't really test depencencies. `ocaml-benchmarks` recently stopped adding using `--with-test` when installing the Opam dependencies of projects, so they are no longer found.

This commit fixes the CB to pick up the test dependencies correctly.