### PR TITLE
irmin: rename the default store branch to `main`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,8 +74,10 @@
   - `Irmin.Sync` is now a namespace: use `Irmin.Sync.Make(S)` instead of
     `Irmin.Sync(S)` (#1338, @samoht)
   - `Irmin.Private` is now `Irmin.Backend` (#1530, @CraigFe)
+  - `Store.master` is now `Store.main` (#1564, @CraigFe)
   - `Store.Private` is now `Store.Backend` (#1530, @CraigFe)
   - `Store.Private.Sync` is now `Store.Backend.Remote` (#1338, @samoht)
+  - `Irmin.Branch.S.master` is now `Irmin.Branch.S.main` (#1564, @CraigFe)
   - `Irmin.Private.{Commit,Node}` are now `Irmin.{Node,Commit}`. (#1471,
     @CraigFe)
   - All module types are now using snake-case and are not capitalized anymore.
@@ -154,6 +156,10 @@
    (#1347, @samoht)
   - Renamed `Irmin_git.Make` into `Irmin_git.Maker` (#1369, @samoht)
   - Upgrade `irmin-git` to `git.3.5.0`. (#1495, @dinosaure)
+
+- **irmin-graphql**:
+  - Changed the name of the default branch node from `master` to `main` in the
+    GraphQL API. (#1564, @CraigFe)
 
 - **irmin-mirage**
   - Renamed `Irmin_mirage_git.Make` into `Irmin_mirage_git.Maker`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,7 +74,8 @@
   - `Irmin.Sync` is now a namespace: use `Irmin.Sync.Make(S)` instead of
     `Irmin.Sync(S)` (#1338, @samoht)
   - `Irmin.Private` is now `Irmin.Backend` (#1530, @CraigFe)
-  - `Store.master` is now `Store.main` (#1564, @CraigFe)
+  - `Store.master` is now `Store.main`. The existing `Store.master` function is
+    deprecated and will be removed in a future release. (#1564, @CraigFe)
   - `Store.Private` is now `Store.Backend` (#1530, @CraigFe)
   - `Store.Private.Sync` is now `Store.Backend.Remote` (#1338, @samoht)
   - `Irmin.Branch.S.master` is now `Irmin.Branch.S.main` (#1564, @CraigFe)

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ let main =
   (* Open the repo *)
   let* repo = Store.Repo.v config in
 
-  (* Load the master branch *)
-  let* t = Store.master repo in
+  (* Load the main branch *)
+  let* t = Store.main repo in
 
   (* Set key "foo/bar" to "testing 123" *)
   let* () =

--- a/examples/custom_merge.ml
+++ b/examples/custom_merge.ml
@@ -141,7 +141,7 @@ let print_logs name t =
 let main () =
   Config.init ();
   let* repo = Store.Repo.v config in
-  let* t = Store.master repo in
+  let* t = Store.main repo in
 
   (* populate the log with some random messages *)
   let* () =

--- a/examples/irmin_git_store.ml
+++ b/examples/irmin_git_store.ml
@@ -36,7 +36,7 @@ let main () =
   Config.init ();
   let config = Irmin_git.config ~bare:true Config.root in
   let* repo = Store.Repo.v config in
-  let* t = Store.master repo in
+  let* t = Store.main repo in
   let* () = update t [ "root"; "misc"; "1.txt" ] "Hello world!" in
   let* () = update t [ "root"; "misc"; "2.txt" ] "Hi!" in
   let* () = update t [ "root"; "misc"; "3.txt" ] "How are you ?" in

--- a/examples/process.ml
+++ b/examples/process.ml
@@ -110,12 +110,12 @@ let info image message () =
   let author = image.name in
   Store.Info.v ~author ~message date
 
-let master = branch images.(0)
+let main = branch images.(0)
 
 let init () =
   Config.init ();
   let* repo = Store.Repo.v config in
-  let* t = Store.of_branch repo master in
+  let* t = Store.of_branch repo main in
   let* () = Store.set_exn t ~info:(info images.(0) "init") [ "0" ] "0" in
   Lwt_list.iter_s
     (fun i ->

--- a/examples/push.ml
+++ b/examples/push.ml
@@ -37,7 +37,7 @@ let test () =
   Config.init ();
   let config = Irmin_git.config Config.root in
   let* repo = Store.Repo.v config in
-  let* t = Store.master repo in
+  let* t = Store.main repo in
   let* _ = Sync.pull_exn t remote `Set in
   let* readme = Store.get t [ "README.md" ] in
   let* tree = Store.get_tree t [] in

--- a/examples/readme.ml
+++ b/examples/readme.ml
@@ -35,8 +35,8 @@ let main =
   (* Open the repo *)
   let* repo = Store.Repo.v config in
 
-  (* Load the master branch *)
-  let* t = Store.master repo in
+  (* Load the main branch *)
+  let* t = Store.main repo in
 
   (* Set key "foo/bar" to "testing 123" *)
   let* () =

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -31,7 +31,7 @@ let test () =
   Config.init ();
   let config = Irmin_git.config Config.root in
   let* repo = Store.Repo.v config in
-  let* t = Store.master repo in
+  let* t = Store.main repo in
   let* _ = Sync.pull_exn t upstream `Set in
   let* readme = Store.get t [ "README.md" ] in
   let* tree = Store.get_tree t [] in

--- a/examples/trees.ml
+++ b/examples/trees.ml
@@ -59,7 +59,7 @@ let main () =
   in
   let* v = tree_of_t t in
   let* repo = Store.Repo.v config in
-  let* t = Store.master repo in
+  let* t = Store.main repo in
   let* () = Store.set_tree_exn t ~info:(info "update a/b") [ "a"; "b" ] v in
   let* v = Store.get_tree t [ "a"; "b" ] in
   let* tt = t_of_tree v in

--- a/src/irmin-git/atomic_write.ml
+++ b/src/irmin-git/atomic_write.ml
@@ -173,7 +173,7 @@ module Make (K : Key) (G : Git.S) = struct
           let* r = G.Ref.read t Git.Reference.head in
           match r with
           | Error (`Reference_not_found _ | `Not_found _) ->
-              write_head (git_of_branch K.master)
+              write_head (git_of_branch K.main)
           | Error e -> Fmt.kstr Lwt.fail_with "%a" G.pp_error e
           | Ok r -> Lwt.return r)
     in

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -168,8 +168,8 @@ module Atomic_write (G : Git.S) = struct
     module K = struct
       include K
 
-      let master =
-        match Irmin.Type.of_string K.t "master" with
+      let main =
+        match Irmin.Type.of_string K.t "main" with
         | Ok x -> x
         | Error (`Msg e) -> failwith e
     end

--- a/src/irmin-git/reference.ml
+++ b/src/irmin-git/reference.ml
@@ -39,7 +39,7 @@ let of_ref str =
   | _ -> Error (`Msg (Fmt.str "%s is not a valid reference" str))
 
 let t = Irmin.Type.like t ~pp:pp_ref ~of_string:of_ref
-let master = `Branch Irmin.Branch.String.master
+let main = `Branch Irmin.Branch.String.main
 
 let is_valid = function
   | `Branch s | `Tag s | `Remote s | `Other s -> Irmin.Branch.String.is_valid s

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -191,7 +191,7 @@ struct
 
   let mk_branch repo = function
     | Some b -> Store.of_branch repo b
-    | None -> Store.master repo
+    | None -> Store.main repo
 
   let rec concat_key a b =
     match Store.Path.decons a with
@@ -783,10 +783,9 @@ struct
                       let+ store = Store.of_branch s branch in
                       (store, branch))
               >|= Result.ok);
-          io_field "master" ~typ:(Lazy.force branch) ~args:[]
-            ~resolve:(fun _ _ ->
-              let+ t = Store.master s in
-              Ok (Some (t, Store.Branch.master)));
+          io_field "main" ~typ:(Lazy.force branch) ~args:[] ~resolve:(fun _ _ ->
+              let+ t = Store.main s in
+              Ok (Some (t, Store.Branch.main)));
           io_field "branch" ~typ:(Lazy.force branch)
             ~args:Arg.[ arg "name" ~typ:(non_null Input.branch) ]
             ~resolve:(fun _ _ branch ->

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -156,7 +156,7 @@ module KV_RO (G : Git.S) = struct
     | [] -> Error (`Not_found key)
     | h :: _ -> Ok (0, S.Info.date (S.Commit.info h))
 
-  let connect ?depth ?(branch = "master") ?(root = Mirage_kv.Key.empty) ?ctx
+  let connect ?depth ?(branch = "main") ?(root = Mirage_kv.Key.empty) ?ctx
       ?headers t uri =
     let remote = S.remote ?ctx ?headers uri in
     let head = Git.Reference.v ("refs/heads/" ^ branch) in

--- a/src/irmin-mirage/git/irmin_mirage_git_intf.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git_intf.ml
@@ -74,7 +74,7 @@ module type KV_RO = sig
     t Lwt.t
   (** [connect ?depth ?branch ?path g uri] clones the given [uri] into [g]
       repository, using the given [branch], [depth] and ['/']-separated
-      sub-[path]. By default, [branch] is master, [depth] is [1] and [path] is
+      sub-[path]. By default, [branch] is main, [depth] is [1] and [path] is
       empty, ie. reads will be relative to the root of the repository. *)
 end
 
@@ -96,7 +96,7 @@ module type KV_RW = sig
     t Lwt.t
   (** [connect ?depth ?branch ?path ?author ?msg g c uri] clones the given [uri]
       into [g] repository, using the given [branch], [depth] and ['/']-separated
-      sub-[path]. By default, [branch] is master, [depth] is [1] and [path] is
+      sub-[path]. By default, [branch] is main, [depth] is [1] and [path] is
       empty, ie. reads will be relative to the root of the repository. [author],
       [msg] and [c] are used to create new commit info values on every update.
       By defaut [author] is [fun () -> "irmin" <irmin@mirage.io>] and [msg]

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -133,7 +133,7 @@ struct
      [t.tree_add] files + one directory going to the next levele. *)
   let init t config =
     let tree = Store.Tree.empty () in
-    let* v = Store.Repo.v config >>= Store.master in
+    let* v = Store.Repo.v config >>= Store.main in
     let* tree =
       times ~n:t.depth ~init:tree (fun depth tree ->
           let paths = Array.init (t.tree_add + 1) (path ~depth) in
@@ -144,7 +144,7 @@ struct
 
   let run t config size =
     let* r = Store.Repo.v config in
-    let* v = Store.master r in
+    let* v = Store.main r in
     Store.Tree.reset_counters ();
     let paths = Array.init (t.tree_add + 1) (path ~depth:t.depth) in
     let* () =

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -253,7 +253,7 @@ module Make_Layered (S : Layered_store) = struct
     let check_parents = checks B.Commit.Key.t in
     let contents v = S.Tree.v (`Contents (v, S.Metadata.default)) in
     let test repo =
-      let* t = S.master repo in
+      let* t = S.main repo in
       S.set_exn t [ "a"; "b"; "c" ] v1 ~info:(infof "commit 1") >>= fun () ->
       let* c1 = S.Head.get t in
       S.freeze repo ~max_lower:[ c1 ] ~max_upper:[] >>= fun () ->
@@ -286,7 +286,7 @@ module Make_Layered (S : Layered_store) = struct
   (* Set tree, add and remove to a tree; get head from lower. *)
   let test_set_tree x () =
     let test repo =
-      let* t = S.master repo in
+      let* t = S.main repo in
       let t1 = S.Tree.singleton [ "a"; "d" ] v1 in
       let* t1 = S.Tree.add t1 [ "a"; "b"; "c" ] v2 in
       S.set_tree_exn ~info:(infof "commit 1") ~parents:[] t [] t1 >>= fun () ->
@@ -364,7 +364,7 @@ module Make_Layered (S : Layered_store) = struct
   let test_squash x () =
     let check_val = check T.(option S.contents_t) in
     let test repo =
-      let* t = S.master repo in
+      let* t = S.main repo in
       Irmin_layers.Stats.reset_stats ();
       S.set_exn t ~info:(infof "add x/y/z") [ "x"; "y"; "z" ] v1 >>= fun () ->
       let* c = S.Head.get t in
@@ -445,7 +445,7 @@ module Make_Layered (S : Layered_store) = struct
       S.set_tree_exn ~parents:[] ~info:(infof "tree1") foo [] tree1
       >>= fun () ->
       let* c1 = S.Head.get foo in
-      let* t = S.master repo in
+      let* t = S.main repo in
       S.set_tree_exn ~parents:[] ~info:(infof "tree2") t [] tree2 >>= fun () ->
       let+ c2 = S.Head.get t in
       (c1, c2)
@@ -477,7 +477,7 @@ module Make_Layered (S : Layered_store) = struct
       let* foo = S.of_branch repo "foo" in
       let* v1' = S.find foo [ "a"; "b"; "c" ] in
       check_val "copy v1 to dst" (Some v1) v1';
-      let* t = S.master repo in
+      let* t = S.main repo in
       let* v2' = S.find t [ "a"; "b"; "d" ] in
       check_val "copy v2 to dst" (Some v2) v2';
       B.Repo.close repo
@@ -501,7 +501,7 @@ module Make_Layered (S : Layered_store) = struct
         | false ->
             Alcotest.failf "should copy commit %a to dst" S.Commit.pp_hash c2
       in
-      let* t = S.master repo in
+      let* t = S.main repo in
       let* v2' = S.find t [ "a"; "b"; "d" ] in
       check_val "copy v2 to dst" (Some v2) v2';
       let* () =
@@ -1002,7 +1002,7 @@ module Make_Layered (S : Layered_store) = struct
         find_commit t v () >>= fun () ->
         S.Backend_layer.wait_for_freeze repo >>= fun () -> find_commit t v ()
       in
-      let* t = S.master repo in
+      let* t = S.main repo in
       add_and_find_commit ~hook:before_copy t v1 >>= fun () ->
       add_and_find_commit ~hook:before_copy_newies t v2 >>= fun () ->
       add_and_find_commit ~hook:before_copy_last_newies t v3 >>= fun () ->
@@ -1014,7 +1014,7 @@ module Make_Layered (S : Layered_store) = struct
 
   let test_add_again x () =
     let test repo =
-      let* t = S.master repo in
+      let* t = S.main repo in
       let tree = S.Tree.singleton [ "a"; "b"; "c" ] v1 in
       S.set_tree_exn ~parents:[] ~info:(infof "v1") t [] tree >>= fun () ->
       let tree = S.Tree.singleton [ "a"; "d" ] v2 in
@@ -1034,7 +1034,7 @@ module Make_Layered (S : Layered_store) = struct
       S.Backend_layer.wait_for_freeze repo >>= fun () ->
       S.Repo.close repo >>= fun () ->
       let* repo = S.Repo.v x.config in
-      let* t = S.master repo in
+      let* t = S.main repo in
       let* c = S.Head.get t in
       let* commit =
         fail_with_none

--- a/src/irmin-test/store_watch.ml
+++ b/src/irmin-test/store_watch.ml
@@ -48,7 +48,7 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
 
   let test_watch_exn x () =
     let test repo =
-      let* t = S.master repo in
+      let* t = S.main repo in
       let* h = S.Head.find t in
       let key = [ "a" ] in
       let v1 = "bar" in
@@ -244,9 +244,9 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
         aux s n
     end in
     let test repo1 =
-      let* t1 = S.master repo1 in
+      let* t1 = S.main repo1 in
       let* repo = S.Repo.v x.config in
-      let* t2 = S.master repo in
+      let* t2 = S.main repo in
       [%log.debug "WATCH"];
       let state = State.empty () in
       let sleep_t = 0.02 in
@@ -265,7 +265,7 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
       let v1 = "X1" in
       let v2 = "X2" in
       S.set_exn t1 ~info:(infof "update") [ "a"; "b" ] v1 >>= fun () ->
-      S.Branch.remove repo1 S.Branch.master >>= fun () ->
+      S.Branch.remove repo1 S.Branch.main >>= fun () ->
       State.check "init" (0, 0) (0, 0, 0) state >>= fun () ->
       watch 100 >>= fun () ->
       State.check "watches on" (1, 0) (0, 0, 0) state >>= fun () ->
@@ -273,7 +273,7 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
       State.check "watches adds" (1, 1) (100, 0, 0) state >>= fun () ->
       S.set_exn t2 ~info:(infof "update") [ "a"; "c" ] v1 >>= fun () ->
       State.check "watches updates" (1, 1) (100, 100, 0) state >>= fun () ->
-      S.Branch.remove repo S.Branch.master >>= fun () ->
+      S.Branch.remove repo S.Branch.main >>= fun () ->
       State.check "watches removes" (1, 1) (100, 100, 100) state >>= fun () ->
       Lwt_list.iter_s (fun f -> S.unwatch f) !stops_0 >>= fun () ->
       S.set_exn t2 ~info:(infof "update") [ "a" ] v1 >>= fun () ->
@@ -294,9 +294,9 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
             let tag = Fmt.str "t%d" n in
             S.Branch.remove repo tag)
       in
-      let* master = S.Branch.get repo "master" in
+      let* main = S.Branch.get repo "main" in
       let* u =
-        S.Branch.watch_all ~init:[ ("master", master) ] repo (fun _ ->
+        S.Branch.watch_all ~init:[ ("main", main) ] repo (fun _ ->
             State.process state)
       in
       add true (0, 0, 0) 10 ~first:true >>= fun () ->

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -524,7 +524,7 @@ let from_config_file_with_defaults root config_path (store, hash, contents) opts
             config)
           config (List.flatten opts)
       in
-      let mk_master () = S.Repo.v config >>= S.master in
+      let mk_main () = S.Repo.v config >>= S.main in
       let mk_branch b = S.Repo.v config >>= fun repo -> S.of_branch repo b in
       let branch =
         let of_string = Irmin.Type.of_string S.Branch.t in
@@ -540,7 +540,7 @@ let from_config_file_with_defaults root config_path (store, hash, contents) opts
             | Error (`Msg e) -> failwith e)
       in
       match branch with
-      | None -> S ((module S), mk_master (), remote)
+      | None -> S ((module S), mk_main (), remote)
       | Some b -> S ((module S), mk_branch b, remote))
 
 let load_config ?root ?config_path ?store ?hash ?contents () =
@@ -548,8 +548,7 @@ let load_config ?root ?config_path ?store ?hash ?contents () =
 
 let branch =
   let doc =
-    Arg.info
-      ~doc:"The current branch name. Default is the store's master branch."
+    Arg.info ~doc:"The current branch name. Default is the store's main branch."
       ~docs:global_option_section ~docv:"BRANCH" [ "b"; "branch" ]
   in
   Arg.(value & opt (some string) None & doc)
@@ -606,7 +605,7 @@ let infer_remote hash contents headers str =
           | _ -> config
         in
         let* repo = R.Repo.v config in
-        let+ r = R.master repo in
+        let+ r = R.main repo in
         Irmin.remote_store (module R) r
   else
     let headers =

--- a/src/irmin/branch.ml
+++ b/src/irmin/branch.ml
@@ -20,7 +20,7 @@ module String = struct
   type t = string
 
   let t = Type.string
-  let master = "master"
+  let main = "main"
 
   let is_valid s =
     let ok = ref true in

--- a/src/irmin/branch_intf.ml
+++ b/src/irmin/branch_intf.ml
@@ -20,8 +20,8 @@ module type S = sig
   type t [@@deriving irmin]
   (** The type for branches. *)
 
-  val master : t
-  (** The name of the master branch. *)
+  val main : t
+  (** The name of the main branch. *)
 
   val is_valid : t -> bool
   (** Check if the branch is valid. *)
@@ -47,12 +47,12 @@ module type Sigs = sig
   module type S = S
   (** The signature for branches. Irmin branches are similar to Git branches:
       they are used to associated user-defined names to head commits. Branches
-      have a default value: the {{!Branch.S.master} master} branch. *)
+      have a default value: the {{!Branch.S.main} main} branch. *)
 
   module String : S with type t = string
   (** [String] is an implementation of {{!Branch.S} S} where branches are
-      strings. The [master] branch is ["master"]. Valid branch names contain
-      only alpha-numeric characters, [-], [_], [.], and [/]. *)
+      strings. The [main] branch is ["main"]. Valid branch names contain only
+      alpha-numeric characters, [-], [_], [.], and [/]. *)
 
   module type Store = Store
   (** [Store] specifies the signature for branch stores.

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -41,7 +41,7 @@ module Type = Repr
 (** Dynamic types for Irmin values, supplied by
     {{:https://github.com/mirage/repr} [Repr]}. These values can be derived from
     type definitions via [\[@@deriving irmin\]] (see the
-    {{:https://github.com/mirage/irmin/blob/master/README_PPX.md} documentation
+    {{:https://github.com/mirage/irmin/blob/main/README_PPX.md} documentation
     for [ppx_irmin]})*)
 
 module Info = Info
@@ -269,7 +269,7 @@ module Sync = Sync
           exit 1)
 
       let test () =
-        S.Repo.v config >>= S.master >>= fun t ->
+        S.Repo.v config >>= S.main >>= fun t ->
         Sync.pull_exn t upstream `Set >>= fun () ->
         S.get t [ "README.md" ] >|= fun r -> Printf.printf "%s\n%!" r
 
@@ -425,7 +425,7 @@ module Sync = Sync
       let main () =
         Config.init ();
         Store.Repo.v config >>= fun repo ->
-        Store.master repo >>= fun t ->
+        Store.main repo >>= fun t ->
         (* populate the log with some random messages *)
         Lwt_list.iter_s
           (fun msg -> log t "This is my %s " msg)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -506,7 +506,7 @@ module Make (B : Backend.S) = struct
     if Branch_store.Key.is_valid key then of_ref repo (`Branch key)
     else err_invalid_branch key
 
-  let master repo = of_branch repo Branch_store.Key.master
+  let main repo = of_branch repo Branch_store.Key.main
   let empty repo = of_ref repo (`Head (ref None))
   let of_commit c = of_ref c.r (`Head (ref (Some c)))
 

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -507,6 +507,7 @@ module Make (B : Backend.S) = struct
     else err_invalid_branch key
 
   let main repo = of_branch repo Branch_store.Key.main
+  let master = main
   let empty repo = of_ref repo (`Head (ref None))
   let of_commit c = of_ref c.r (`Head (ref (Some c)))
 

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -224,13 +224,13 @@ module type S_generic_key = sig
   (** [empty repo] is a temporary, empty store. Becomes a normal temporary store
       after the first update. *)
 
-  val master : repo -> t Lwt.t
-  (** [master repo] is a persistent store based on [r]'s master branch. This
+  val main : repo -> t Lwt.t
+  (** [main repo] is a persistent store based on [r]'s main branch. This
       operation is cheap, can be repeated multiple times. *)
 
   val of_branch : repo -> branch -> t Lwt.t
   (** [of_branch r name] is a persistent store based on the branch [name].
-      Similar to [master], but use [name] instead {!Branch.S.master}. *)
+      Similar to [main], but use [name] instead {!Branch.S.main}. *)
 
   val of_commit : commit -> t Lwt.t
   (** [of_commit c] is a temporary store, based on the commit [c].

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -937,6 +937,12 @@ module type S_generic_key = sig
     kinded_key Lwt.t
   (** Save a tree into the database. Does not do any reads. If [clear] is set
       (it is by default), the tree cache will be cleared after the save. *)
+
+  (** {Deprecated} *)
+
+  val master : repo -> t Lwt.t
+    [@@ocaml.deprecated "Use `main` instead."]
+  (** @deprecated Use {!main} instead *)
 end
 
 module type S = sig

--- a/test/irmin-containers/blob_log.ml
+++ b/test/irmin-containers/blob_log.ml
@@ -25,28 +25,28 @@ let merge_into_exn = merge_into_exn (module B.Store)
 
 let test_empty_read _ () =
   config ()
-  >>= B.Store.master
+  >>= B.Store.main
   >>= B.read_all ~path
   >|= Alcotest.(check (list string)) "checked - reading empty log" []
 
 let test_append _ () =
-  let* t = config () >>= B.Store.master in
-  B.append ~path t "master.1" >>= fun () ->
-  B.append ~path t "master.2" >>= fun () ->
+  let* t = config () >>= B.Store.main in
+  B.append ~path t "main.1" >>= fun () ->
+  B.append ~path t "main.2" >>= fun () ->
   B.read_all ~path t
   >|= Alcotest.(check (list string))
-        "checked - log after appending" [ "master.2"; "master.1" ]
+        "checked - log after appending" [ "main.2"; "main.1" ]
 
 let test_clone_merge _ () =
-  let* t = config () >>= B.Store.master in
+  let* t = config () >>= B.Store.main in
   let* b = B.Store.clone ~src:t ~dst:"cl" in
   B.append ~path b "clone.1" >>= fun () ->
-  B.append ~path t "master.3" >>= fun () ->
+  B.append ~path t "main.3" >>= fun () ->
   merge_into_exn b ~into:t >>= fun () ->
   B.read_all ~path t
   >|= Alcotest.(check (list string))
         "checked - log after appending"
-        [ "master.3"; "clone.1"; "master.2"; "master.1" ]
+        [ "main.3"; "clone.1"; "main.2"; "main.1" ]
 
 let test_branch_merge _ () =
   let* r = config () in

--- a/test/irmin-containers/counter.ml
+++ b/test/irmin-containers/counter.ml
@@ -24,7 +24,7 @@ let config () = C.Store.Repo.v (Irmin_mem.config ())
 let merge_into_exn = merge_into_exn (module C.Store)
 
 let test_inc _ () =
-  let* t = config () >>= C.Store.master in
+  let* t = config () >>= C.Store.main in
   C.inc ~path t >>= fun () ->
   let* () =
     C.read ~path t
@@ -34,7 +34,7 @@ let test_inc _ () =
   C.read ~path t >|= Alcotest.(check int64) "checked - increment using by" 3L
 
 let test_dec _ () =
-  let* t = config () >>= C.Store.master in
+  let* t = config () >>= C.Store.main in
   C.dec ~path t >>= fun () ->
   let* () =
     C.read ~path t
@@ -44,20 +44,20 @@ let test_dec _ () =
   C.read ~path t >|= Alcotest.(check int64) "checked - decrement using by" 0L
 
 let test_clone_merge _ () =
-  let* t = config () >>= C.Store.master in
+  let* t = config () >>= C.Store.main in
   C.inc ~by:5L ~path t >>= fun () ->
   let* b = C.Store.clone ~src:t ~dst:"cl" in
   C.inc ~by:2L ~path b >>= fun () ->
   C.dec ~by:4L ~path t >>= fun () ->
   let* () =
-    C.read ~path t >|= Alcotest.(check int64) "checked - value of master" 1L
+    C.read ~path t >|= Alcotest.(check int64) "checked - value of main" 1L
   in
   let* () =
     C.read ~path b >|= Alcotest.(check int64) "checked - value of clone" 7L
   in
   merge_into_exn b ~into:t >>= fun () ->
   C.read t ~path
-  >|= Alcotest.(check int64) "checked - value of master after merging" 3L
+  >|= Alcotest.(check int64) "checked - value of main after merging" 3L
 
 let test_branch_merge _ () =
   let* r = config () in

--- a/test/irmin-containers/linked_log.ml
+++ b/test/irmin-containers/linked_log.ml
@@ -32,43 +32,43 @@ let config () = L.Store.Repo.v (Irmin_mem.config ())
 
 let test_empty_read _ () =
   config ()
-  >>= L.Store.master
+  >>= L.Store.main
   >>= L.read_all ~path
   >|= Alcotest.(check (list string)) "checked - reading empty log" []
 
 let test_append_read_all _ () =
-  let* t = config () >>= L.Store.master in
-  L.append ~path t "master.1" >>= fun () ->
-  L.append ~path t "master.2" >>= fun () ->
+  let* t = config () >>= L.Store.main in
+  L.append ~path t "main.1" >>= fun () ->
+  L.append ~path t "main.2" >>= fun () ->
   L.read_all ~path t
   >|= Alcotest.(check (list string))
-        "checked - log after appending" [ "master.2"; "master.1" ]
+        "checked - log after appending" [ "main.2"; "main.1" ]
 
 let test_read_incr _ () =
-  let* cur = config () >>= L.Store.master >>= L.get_cursor ~path in
+  let* cur = config () >>= L.Store.main >>= L.get_cursor ~path in
   let* l, cur = L.read ~num_items:1 cur in
-  Alcotest.(check (list string)) "checked - read one item" [ "master.2" ] l;
+  Alcotest.(check (list string)) "checked - read one item" [ "main.2" ] l;
   let* l, cur = L.read ~num_items:1 cur in
-  Alcotest.(check (list string)) "checked - read one more item" [ "master.1" ] l;
+  Alcotest.(check (list string)) "checked - read one more item" [ "main.1" ] l;
   let+ l, _ = L.read ~num_items:1 cur in
   Alcotest.(check (list string)) "checked - read one more item" [] l
 
 let test_read_excess _ () =
-  let* cur = config () >>= L.Store.master >>= L.get_cursor ~path in
+  let* cur = config () >>= L.Store.main >>= L.get_cursor ~path in
   let+ l, _ = L.read ~num_items:10 cur in
   Alcotest.(check (list string))
-    "checked - read 10 items" [ "master.2"; "master.1" ] l
+    "checked - read 10 items" [ "main.2"; "main.1" ] l
 
 let test_clone_merge _ () =
-  let* t = config () >>= L.Store.master in
+  let* t = config () >>= L.Store.main in
   let* b = L.Store.clone ~src:t ~dst:"cl" in
   L.append ~path b "clone.1" >>= fun () ->
-  L.append ~path t "master.3" >>= fun () ->
+  L.append ~path t "main.3" >>= fun () ->
   merge_into_exn b ~into:t >>= fun () ->
   L.read_all ~path t
   >|= Alcotest.(check (list string))
         "checked - log after appending"
-        [ "master.3"; "clone.1"; "master.2"; "master.1" ]
+        [ "main.3"; "clone.1"; "main.2"; "main.1" ]
 
 let test_branch_merge _ () =
   let* r = config () in

--- a/test/irmin-containers/lww_register.ml
+++ b/test/irmin-containers/lww_register.ml
@@ -32,26 +32,26 @@ let config () = L.Store.Repo.v (Irmin_mem.config ())
 
 let test_empty_read _ () =
   config ()
-  >>= L.Store.master
+  >>= L.Store.main
   >>= L.read ~path
   >|= Alcotest.(check (option int))
         "checked - reading register without writing" None
 
 let test_write _ () =
-  let* t = config () >>= L.Store.master in
+  let* t = config () >>= L.Store.main in
   L.write ~path t 1 >>= fun () ->
   L.write ~path t 3 >>= fun () ->
   L.read ~path t
   >|= Alcotest.(check (option int)) "checked - writing to register" (Some 3)
 
 let test_clone_merge _ () =
-  let* t = config () >>= L.Store.master in
+  let* t = config () >>= L.Store.main in
   let* b = L.Store.clone ~src:t ~dst:"cl" in
   L.write ~path t 5 >>= fun () ->
   L.write ~path b 10 >>= fun () ->
   let* () =
     L.read ~path t
-    >|= Alcotest.(check (option int)) "checked - value of master" (Some 5)
+    >|= Alcotest.(check (option int)) "checked - value of main" (Some 5)
   in
   let* () =
     L.read ~path b
@@ -60,7 +60,7 @@ let test_clone_merge _ () =
   merge_into_exn b ~into:t >>= fun () ->
   L.read ~path t
   >|= Alcotest.(check (option int))
-        "checked - value of master after merging" (Some 10)
+        "checked - value of main after merging" (Some 10)
 
 let test_branch_merge _ () =
   let* r = config () in

--- a/test/irmin-graphql/common.ml
+++ b/test/irmin-graphql/common.ml
@@ -72,11 +72,11 @@ type server = {
 let spawn_graphql_server () =
   let config = Irmin_mem.config () in
   let* repo = Store.Repo.v config in
-  let+ master = Store.master repo in
+  let+ main = Store.main repo in
   let event_loop = server_of_repo repo
   and set_tree tree =
     Store.Tree.of_concrete tree
-    |> Store.set_tree_exn ~info:Store.Info.none master []
+    |> Store.set_tree_exn ~info:Store.Info.none main []
   in
   { event_loop; set_tree }
 

--- a/test/irmin-graphql/common.mli
+++ b/test/irmin-graphql/common.mli
@@ -26,7 +26,7 @@ type server = {
   event_loop : 'a. 'a Lwt.t;
       (** The server runtime. Cancelling this thread terminates the server. *)
   set_tree : Store.Tree.concrete -> unit Lwt.t;
-      (** Set the state of the [master] branch in the underlying store. *)
+      (** Set the state of the [main] branch in the underlying store. *)
 }
 
 val spawn_graphql_server : unit -> server Lwt.t

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -50,7 +50,7 @@ let test_get_contents_list : test_case =
   let data = strees [ "a"; "b"; "c" ] (contents "data")
   and query =
     {|{
-  master {
+  main {
     tree {
       get_contents(key: "/a/b/c") {
         key
@@ -64,7 +64,7 @@ let test_get_contents_list : test_case =
   let+ result = send_query query >|= assert_ok >|= Yojson.Safe.from_string in
   let result : (string * Yojson.Safe.t) list =
     let open Yojson.Safe.Util in
-    result |> members [ "data"; "master"; "tree"; "get_contents" ] |> to_assoc
+    result |> members [ "data"; "main"; "tree"; "get_contents" ] |> to_assoc
   in
   Alcotest.(check (list (pair string yojson)))
     "Returned entry data is valid"
@@ -80,7 +80,7 @@ let test_get_tree_list : test_case =
         [ ("leaf", contents "data1"); ("branch", stree "f" (contents "data2")) ])
   and query =
     {|{
-  master {
+  main {
     tree {
       get_tree(key: "/a/b/c") {
         list {
@@ -97,7 +97,7 @@ let test_get_tree_list : test_case =
   let key_data : (string * Yojson.Safe.t) list list =
     let open Yojson.Safe.Util in
     result
-    |> members [ "data"; "master"; "tree"; "get_tree"; "list" ]
+    |> members [ "data"; "main"; "tree"; "get_tree"; "list" ]
     |> to_list
     |> List.map to_assoc
   in
@@ -115,7 +115,7 @@ let test_get_last_modified : test_case =
   let data = stree "a" (contents "data")
   and query =
     {|{
-        master {
+        main {
           last_modified(key: "a", n: 1, depth:1) {
             tree {
               get_contents(key: "a") {
@@ -132,7 +132,7 @@ let test_get_last_modified : test_case =
   let result : (string * Yojson.Safe.t) list list =
     let open Yojson.Safe.Util in
     result
-    |> members [ "data"; "master"; "last_modified" ]
+    |> members [ "data"; "main"; "last_modified" ]
     |> to_list
     |> List.map (members [ "tree"; "get_contents" ])
     |> List.map to_assoc

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -42,12 +42,12 @@ let info () = S.Info.empty
 let open_ro_after_rw_closed () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
-  let* t = S.master rw in
+  let* t = S.main rw in
   let tree = S.Tree.singleton [ "a" ] "x" in
   S.set_tree_exn ~parents:[] ~info t [] tree >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
   S.Repo.close rw >>= fun () ->
-  let* t = S.master ro in
+  let* t = S.main ro in
   let* c = S.Head.get t in
   S.Commit.of_hash ro (S.Commit.hash c) >>= function
   | None -> Alcotest.fail "no hash"
@@ -164,7 +164,7 @@ let clear_rw_find_ro () =
 let clear_rw_twice () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
-  let* t = S.master rw in
+  let* t = S.main rw in
   let check_empty () =
     S.Head.find t >|= function
     | None -> ()

--- a/test/irmin-tezos/generate.ml
+++ b/test/irmin-tezos/generate.ml
@@ -42,7 +42,7 @@ module Layered = struct
   let create_store () =
     rm_dir data_dir;
     let* repo = Store.Repo.v (config data_dir) in
-    let* _t = Store.master repo in
+    let* _t = Store.of_branch repo "master" in
     let tree = Store.Tree.singleton [ "a"; "b"; "c" ] "x1" in
     let* c = Store.Commit.v repo ~info ~parents:[] tree in
     let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in

--- a/test/irmin-unix/test_command_line.t
+++ b/test/irmin-unix/test_command_line.t
@@ -44,7 +44,7 @@ List keys in ./test but no path is specified
 Set g/h/i => 789 in ./test
   $ irmin set /g/h/i/ 789
 
-Snapshot master branch
+Snapshot main branch
   $ export SNAPSHOT=`irmin snapshot`
 
 List keys under g/h in ./test
@@ -64,13 +64,13 @@ Get g/h/i in ./test
   $ irmin get g/h/i/
   789
 
-Create branch a from master
-  $ irmin merge --branch a master
+Create branch a from main
+  $ irmin merge --branch a main
 
 Remove g/h/i in branch a
   $ irmin remove --branch a /g/h/i/
 
-Merge branch a in master
+Merge branch a in main
   $ irmin merge a
 
 Check that g/h/i has been deleted after merge

--- a/test/irmin-unix/test_unix.ml
+++ b/test/irmin-unix/test_unix.ml
@@ -89,7 +89,7 @@ module Git = struct
     let config = Irmin_git.config ~bare:false test_db in
     let info = Irmin_unix.info in
     let* repo = S.Repo.v config in
-    let* t = S.master repo in
+    let* t = S.main repo in
     S.set_exn t ~info:(info "fst one") [ "fst" ] "ok" >>= fun () ->
     S.set_exn t ~info:(info "snd one") [ "fst"; "snd" ] "maybe?" >>= fun () ->
     S.set_exn t ~info:(info "fst one") [ "fst" ] "hoho"


### PR DESCRIPTION
The default branch in an Irmin store is currently called `master`. This commit changes occurrences of this name to `main` instead. In particular:

- `Store.master` is now `Store.main`;
- `Branch.S.master` is now `Branch.S.main`;
- the GraphQL API exposed by the `irmin-graphql` backend now uses the `main` node to refer to the default branch.