### PR TITLE
irmin-test: disable flaky test 'Watch.Basic operations'

### DIFF
--- a/src/irmin-test/store_watch.ml
+++ b/src/irmin-test/store_watch.ml
@@ -367,8 +367,9 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
     run x test
 
   let tests =
-    [
-      ("Callbacks and exceptions", test_watch_exn);
-      ("Basic operations", test_watches);
-    ]
+    (* [test_watches] has been disabled for being flaky.
+        TODO: work out why, fix it, and re-enable it.
+        See https://github.com/mirage/irmin/issues/1447. *)
+    let _ = ("Basic operations", test_watches) in
+    [ ("Callbacks and exceptions", test_watch_exn) ]
 end


### PR DESCRIPTION
See https://github.com/mirage/irmin/issues/1447.

This is currently failing our CI very frequently. It's hard to reproduce locally and noone has yet had time to debug it. Let's just disable it in the mean-time.