### PR TITLE
[DRAFT] offsets for free

### DIFF
--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -38,6 +38,10 @@ module type S = sig
   val close : t -> unit
   val exists : string -> bool
   val size : t -> int
+  val page_idx_of_offset : t -> int63 -> int63
+  val bytes_remaning_in_page_from_offset : t -> int63 -> int63
+  val end_offset_of_page_idx : t -> int63 -> int63
+  val start_offset_of_page_idx : t -> int63 -> int63
 
   val truncate : t -> unit
   (** Sets the length of the underlying IO to be 0, without actually purging the

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -432,12 +432,15 @@ module Index (Index : Pack_index.S) = struct
     let f (k, (offset, length, (kind : Pack_value.Kind.t))) =
       match kind with
       | Contents ->
+         (* Fmt.epr " on b %a %d \n%!" Int63.pp offset length; *)
           progress_contents ();
           check ~kind:`Contents ~offset ~length k
       | Node | Inode ->
+         (* Fmt.epr " on i/n %a %d \n%!" Int63.pp offset length; *)
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
       | Commit ->
+         (* Fmt.epr " on c %a %d \n%!" Int63.pp offset length; *)
           progress_commits ();
           check ~kind:`Commit ~offset ~length k
     in
@@ -456,6 +459,8 @@ module Index (Index : Pack_index.S) = struct
       else (
         Index.iter
           (fun k v ->
+            (* Fmt.epr "\n%!"; *)
+            (* Fmt.epr "> Index iter step \n%!"; *)
             match f (k, v) with
             | Ok () -> ()
             | Error `Wrong_hash -> incr nb_corrupted

--- a/src/irmin-pack/dune
+++ b/src/irmin-pack/dune
@@ -2,6 +2,6 @@
  (public_name irmin-pack)
  (name irmin_pack)
  (libraries fmt index index.unix irmin irmin-layers logs lwt lwt.unix mtime
-   ppx_irmin cmdliner optint)
+   ppx_irmin cmdliner optint cachecache)
  (preprocess
   (pps ppx_irmin.internal)))


### PR DESCRIPTION

This is the result of my attempt to implement structured key's optimisation regarding calls to `index.find` for offsets that were known during the inode deserialisation.

This is overall not an improvement, I'm posting it here just in case someone is interested.

---

I implemented it using an LRU, the size of the LRU doesn't seem to matter a lot. I chose 1000. 1million showed similar performences.

Before the LRU I tried using ephemerons but it failed mysteriously because of the size of the weak map that reached tens of millions. I was expecting that during the fold we would only have ~1000 inodes in memory (I'm not refering to the new inodes here, only the ones read from disk in order to perfom the fold).


Some stats look good,
```
                                           |              |      total      
Disk bytes read                            | small        |  192.381 G      
                                           | small        |  192.381 G 100% 
                                           | small_offlru |  122.500 G  64% 
Disk reads                                 | small        |  241.853 M      
                                           | small        |  241.853 M 100% 
                                           | small_offlru |  150.927 M  62% 
pack.cache_misses                          | small        |   37.420 M      
                                           | small        |   37.420 M 100% 
                                           | small_offlru |    3.941 M  11% 
gc.minor_words allocated                   | small        |   81.775 G      
                                           | small        |   81.775 G 100% 
                                           | small_offlru |   68.981 G  84% 
rusage.stime                               | small        |    1min40s      
                                           | small        |    1min44s 104% 
                                           | small_offlru |     1min1s  61% 

```

and some don't:
```
gc.major_words allocated                   | small        |    5.334 G      
                                           | small        |    5.334 G 100% 
                                           | small_offlru |   12.957 G 243% 
rusage.maxrss                              | small        |    6.397 G      
                                           | small        |    6.397 G 100% 
                                           | small_offlru |    9.427 G 147% 
rusage.utime                               | small        |    6min27s      
                                           | small        |    6min30s 101% 
                                           | small_offlru |    7min59s 124% 
```

The new counters I added
```
"offlru_insertions":       70_322_991,

"unsafe_find":             41_751_735,
"unsafe_find_table_hit":            0,
"unsafe_find_vallru_hit":   4_335_565,
"unsafe_find_offlru_hit":  33_478_922, <============
"unsafe_find_long_none":            0,
"unsafe_find_long_some":    3_937_248,
 
"unsafe_append":                     2_605_446,
"unsafe_append_offset":             12_416_722,
"unsafe_append_offset_offlru_hit":   3_921_792, <============
"unsafe_append_offset_long_none":            0,
"unsafe_append_offset_long_some":    8_494_930,

"blindfolded_read_first_try":       33_380_443,
"blindfolded_read_second_try":          98_479,
"blindfolded_read_third_or_more_try":        0,
```



