### PR TITLE
Forward-port changes introduced in the 2.8 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,17 +3,9 @@
 ### Fixed
 
 - **irmin**
-  - `Tree` operations now raise a `Dangling_hash` exception when called with a
-    path that contains dangling hashes in the underlying store, rather than
-    interpreting such paths as ending with empty nodes (#1477 #1559, @CraigFe)
-  - Fix the pre-hashing function for big-endian architectures. (#1505,
-    @Ngoguey42, @dinosaure)
   - Fix the implementation of comparison on `Irmin.Tree` objects to use the
     comparison defined on hashes. The previous implementation was unstable.
     (#1519, @CraigFe)
-  - Fix a bug in `Tree.export` where nodes could be exported before
-    some of their contents, resulting in indirect hashes in irmin-pack
-    (#1508, @Ngoguey42)
 
 ### Added
 
@@ -23,20 +15,8 @@
     provide `close` and `batch` functions (#1345, @samoht)
   - Atomic-write backend implementations have to provide a `close` function
     (#1345, @samoht)
-  - `Node.seq` and `Node.of_seq` are added to avoid allocating intermediate
-    lists when it is not necessary (#1508, @samoht)
-  - New optional `cache` parameter to `Tree.hash`, `Tree.Contents.hash`,
-    `Tree.list`, `Node.list`, `Node.seq` and `Node.find` to control the storing
-    of lazily loaded data (#1526, @Ngoguey42)
-  - Add `Node.clear` to clear internal caches (#1526, @Ngoguey42)
-  - Added a `tree` argument to `Tree.fold` to manipulate the subtrees (#1527,
-    @icristescu, @Ngoguey42)
   - Add a function `Store.Tree.singleton` for building trees with a single
     contents binding. (#1567, @CraigFe)
-  - Add a function `Store.Tree.pruned` for building purely in-memory tree
-    objects with known hashes. (#1537, @CraigFe)
-  - Added a `order` argument to specify the order of traversal in `Tree.fold`
-    (#1548, @icristescu, @CraigFe)
 
 - **irmin-bench**
   - Many improvements to the actions trace replay:
@@ -112,15 +92,6 @@
   - Add `Irmin.Backend.Conf.Schema` for grouping configuration keys. Now
     `Irmin.Backend.Conf.key` takes an additional `~spec` parameter.
     (#1492, @zshipko)
-  - Do not allocate large lists in `Irmin.Tree.clear` (#1515, @samoht)
-  - `Node.v` is renamed to `Node.of_list` (#1508, @samoht)
-  - Rewrite `Tree.export` in order to minimise the memory footprint.
-    (#1508, @Ngoguey42)
-  - Remove the ``~force:`And_clear`` case parameter from `Tree.fold`,
-    ``~force:`True ~cache:false`` is the new equivalent. (#1526, @Ngoguey42)
-  - `` `Tree.fold ~force:`True`` and `` `Tree.fold ~force:`False`` don't
-    cache the lazily loaded data any more. Pass `~cache:true` to enable it
-    again. (#1526, @Ngoguey42)
   - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
   - Rename `key` type to `path` and `Key` module to `Path` when it is in a path
     context in `Tree` and `Store`. (#1569, @maiste)
@@ -153,7 +124,6 @@
     - `Irmin_git.dot_git` is now `Irmin_git.Conf.dot_git`
    (#1347, @samoht)
   - Renamed `Irmin_git.Make` into `Irmin_git.Maker` (#1369, @samoht)
-  - Upgrade `irmin-git` to `git.3.5.0`. (#1495, @dinosaure)
 
 - **irmin-mirage**
   - Renamed `Irmin_mirage_git.Make` into `Irmin_mirage_git.Maker`

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -6,7 +6,7 @@
  (preprocess
   (pps ppx_irmin.internal ppx_repr))
  (libraries irmin-pack irmin-pack.layered irmin-test.bench irmin-layers lwt
-   unix cmdliner logs memtrace repr ppx_repr bench_common rusage))
+   unix cmdliner logs repr ppx_repr bench_common rusage))
 
 (library
  (name bench_common)
@@ -31,8 +31,8 @@
  (preprocess
   (pps ppx_irmin.internal ppx_repr))
  (libraries irmin-pack irmin-pack.layered irmin-pack.mem irmin-test.bench
-   irmin-layers lwt unix cmdliner logs memtrace repr ppx_repr bench_common
-   irmin-tezos irmin_traces))
+   irmin-layers lwt unix cmdliner logs repr ppx_repr bench_common irmin-tezos
+   irmin_traces))
 
 (executable
  (name trace_stats)

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -69,7 +69,6 @@ let configure_store root merge_throttle freeze_throttle =
 
 let init config =
   FSHelper.rm_dir config.root;
-  Memtrace.trace_if_requested ();
   reset_stats ()
 
 module Trees = Generate_trees (Store)

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -22,7 +22,7 @@ end
 module Default = struct
   let fresh = false
   let lru_size = 100_000
-  let index_log_size = 500_000
+  let index_log_size = 2_500_000
   let readonly = false
   let merge_throttle = `Block_writes
   let freeze_throttle = `Block_writes

--- a/test/irmin-tezos/stat.t/run.t
+++ b/test/irmin-tezos/stat.t/run.t
@@ -9,7 +9,7 @@ Running stat on a layered store after a first freeze
     "hash_size": {
       "Bytes": 64
     },
-    "log_size": 500000,
+    "log_size": 2500000,
     "files": {
       "flip": "Upper0",
       "lower": {


### PR DESCRIPTION
As mentioned [here](https://github.com/mirage/irmin/pull/1555#pullrequestreview-787904335), there were some changes included in 2.8 not yet in `main`. This PR fixes that.