### PR TITLE
New inode magics

### DIFF
--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -124,7 +124,9 @@ module Make (M : Maker) = struct
       let f _ (_, _, (kind : Pack_value.Kind.t)) =
         match kind with
         | Contents -> progress_contents ()
-        | Inode_v0_stable | Inode_v0_unstable -> progress_nodes ()
+        | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
+          ->
+            progress_nodes ()
         | Commit -> progress_commits ()
       in
       Index.iter f index;
@@ -434,7 +436,8 @@ module Index (Index : Pack_index.S) = struct
       | Contents ->
           progress_contents ();
           check ~kind:`Contents ~offset ~length k
-      | Inode_v0_stable | Inode_v0_unstable ->
+      | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
+        ->
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
       | Commit ->

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -124,7 +124,7 @@ module Make (M : Maker) = struct
       let f _ (_, _, (kind : Pack_value.Kind.t)) =
         match kind with
         | Contents -> progress_contents ()
-        | Node | Inode -> progress_nodes ()
+        | Inode_v0_stable | Inode_v0_unstable -> progress_nodes ()
         | Commit -> progress_commits ()
       in
       Index.iter f index;
@@ -434,7 +434,7 @@ module Index (Index : Pack_index.S) = struct
       | Contents ->
           progress_contents ();
           check ~kind:`Contents ~offset ~length k
-      | Node | Inode ->
+      | Inode_v0_stable | Inode_v0_unstable ->
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
       | Commit ->

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -204,15 +204,17 @@ struct
     type t = { hash : H.t; stable : bool; v : v }
 
     let v ~stable ~hash v = { hash; stable; v }
-    let kind_node = Pack_value.Kind.Node
-    let kind_inode = Pack_value.Kind.Inode
-    let magic_node = Pack_value.Kind.to_magic kind_node
-    let magic_inode = Pack_value.Kind.to_magic kind_inode
+    let to_magic = Pack_value.Kind.to_magic
+    let kind_inode_v0_stable = Pack_value.Kind.Inode_v0_stable
+    let kind_inode_v0_unstable = Pack_value.Kind.Inode_v0_unstable
+    let magic_inode_v0_stable = to_magic kind_inode_v0_stable
+    let magic_inode_v0_unstable = to_magic kind_inode_v0_unstable
 
     let stable_t : bool Irmin.Type.t =
       Irmin.Type.(map char)
-        (fun n -> n = magic_node)
-        (function true -> magic_node | false -> magic_inode)
+        (fun n -> n = magic_inode_v0_stable)
+        (function
+          | true -> magic_inode_v0_stable | false -> magic_inode_v0_unstable)
 
     let t =
       let open Irmin.Type in
@@ -1036,7 +1038,8 @@ struct
     let t = Bin.t
 
     let kind (t : t) =
-      if t.stable then Compress.kind_node else Compress.kind_inode
+      if t.stable then Compress.kind_inode_v0_stable
+      else Compress.kind_inode_v0_unstable
 
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -22,11 +22,6 @@ module Make_internal
     (H : Irmin.Hash.S)
     (Node : Irmin.Node.S with type hash = H.t) =
 struct
-  let () =
-    (* TODO: REMOVE *)
-    if Conf.entries > Conf.stable_hash then
-      invalid_arg "entries should be lower or equal to stable_hash"
-
   (** If [should_be_stable ~length ~root] is true for an inode [i], then [i]
       hashes the same way as a [Node.t] containings the same entries. *)
   let should_be_stable ~length ~root =
@@ -216,19 +211,67 @@ struct
     type kind = Pack_value.Kind.t
     [@@deriving irmin ~encode_bin ~decode_bin ~size_of]
 
+    type nonrec int63 = int63
+    [@@deriving irmin ~encode_bin ~decode_bin ~size_of]
+
+    let no_length = Int63.zero
+    let is_real_length length = not (Int63.equal length no_length)
+
+    type v1 = { mutable length : int63; v : v } [@@deriving irmin]
+    (** [length] is the length of the binary encoding of [t] (i.e. [hash] +
+        [kind] + [length] + [v]). It is not known right away. [length] is
+        [no_length] when it isn't known. Calling [encode_bin] or [size_of] will
+        make [length] known. *)
+
     (** [tagged_v] sits between [v] and [t]. It is a variant with the header
         binary encoded as the magic. *)
-    type tagged_v = V0_stable of v | V0_unstable of v [@@deriving irmin]
+    type tagged_v =
+      | V0_stable of v
+      | V0_unstable of v
+      | V1_root of v1
+      | V1_nonroot of v1
+    [@@deriving irmin]
 
-    let encode_bin_tv vt f =
-      (* TODO: Deprecate v0 at encode_time *)
-      match vt with
-      | V0_stable v ->
-          encode_bin_kind Pack_value.Kind.Inode_v0_stable f;
+    let encode_bin_tv_staggered v kind f =
+      (* We need to write [length] before [v], but we will know [length]
+         after [v] is encoded. The solution is to first encode [v], then write
+         [length] and then write [v]. *)
+      let l = ref [] in
+      encode_bin_v v (fun s -> l := s :: !l);
+      let length =
+        List.fold_left
+          (fun acc s -> acc + String.length s)
+          (H.hash_size + 1 + 8)
+          !l
+        |> Int63.of_int
+      in
+      encode_bin_kind kind f;
+      encode_bin_int63 length f;
+      List.iter f (List.rev !l);
+      length
+
+    let encode_bin_tv tv f =
+      match tv with
+      | V0_stable _ -> assert false
+      | V0_unstable _ -> assert false
+      | V1_root { length; v } when is_real_length length ->
+          encode_bin_kind Pack_value.Kind.Inode_v1_root f;
+          encode_bin_int63 length f;
           encode_bin_v v f
-      | V0_unstable v ->
-          encode_bin_kind Pack_value.Kind.Inode_v0_unstable f;
+      | V1_nonroot { length; v } when is_real_length length ->
+          encode_bin_kind Pack_value.Kind.Inode_v1_nonroot f;
+          encode_bin_int63 length f;
           encode_bin_v v f
+      | V1_root ({ v; _ } as tv) ->
+          let length =
+            encode_bin_tv_staggered v Pack_value.Kind.Inode_v1_root f
+          in
+          tv.length <- length
+      | V1_nonroot ({ v; _ } as tv) ->
+          let length =
+            encode_bin_tv_staggered v Pack_value.Kind.Inode_v1_nonroot f
+          in
+          tv.length <- length
 
     let decode_bin_tv s off =
       let kind = decode_bin_kind s off in
@@ -239,17 +282,43 @@ struct
       | Inode_v0_stable ->
           let v = decode_bin_v s off in
           V0_stable v
+      | Inode_v1_root ->
+          let length = decode_bin_int63 s off in
+          assert (is_real_length length);
+          let v = decode_bin_v s off in
+          V1_root { length; v }
+      | Inode_v1_nonroot ->
+          let length = decode_bin_int63 s off in
+          assert (is_real_length length);
+          let v = decode_bin_v s off in
+          V1_nonroot { length; v }
       | Commit | Contents -> assert false
 
     let size_of_tv =
-      let of_value vt =
-        match vt with V0_stable v | V0_unstable v -> dynamic_size_of_v v + 1
+      let of_value tv =
+        match tv with
+        | V0_stable v | V0_unstable v -> 1 + dynamic_size_of_v v
+        | (V1_root { length; _ } | V1_nonroot { length; _ })
+          when is_real_length length ->
+            Int63.to_int length - H.hash_size
+        | V1_root ({ v; _ } as tv) ->
+            let length = H.hash_size + 1 + 8 + dynamic_size_of_v v in
+            tv.length <- Int63.of_int length;
+            length - H.hash_size
+        | V1_nonroot ({ v; _ } as tv) ->
+            let length = H.hash_size + 1 + 8 + dynamic_size_of_v v in
+            tv.length <- Int63.of_int length;
+            length - H.hash_size
       in
       let of_encoding s off =
         let kind = decode_bin_kind s (ref off) in
+        let off = off + 1 in
         match kind with
         | Pack_value.Kind.Inode_v0_unstable | Inode_v0_stable ->
-            dynamic_size_of_v_encoding s (off + 1) + 1
+            1 + dynamic_size_of_v_encoding s off
+        | Inode_v1_root | Inode_v1_nonroot ->
+            let len = decode_bin_int63 s (ref off) in
+            Int63.to_int len - H.hash_size
         | Commit | Contents -> assert false
       in
       Irmin.Type.Size.custom_dynamic ~of_value ~of_encoding ()
@@ -260,12 +329,10 @@ struct
     type t = { hash : H.t; v : tagged_v }
 
     let v ~root ~hash v =
-      (* TODO: Deprecate creation of V0 [Compress.t] *)
-      let length =
-        match v with Values v -> List.length v | Tree { length; _ } -> length
+      let length = no_length in
+      let v =
+        if root then V1_root { v; length } else V1_nonroot { v; length }
       in
-      let stable = should_be_stable ~length ~root in
-      let v = if stable then V0_stable v else V0_unstable v in
       { hash; v }
 
     let is_root = function
@@ -274,6 +341,8 @@ struct
       | { v = V0_stable (Tree { depth; _ }); _ }
       | { v = V0_unstable (Tree { depth; _ }); _ } ->
           depth = 0
+      | { v = V1_root _; _ } -> true
+      | { v = V1_nonroot _; _ } -> false
 
     let t =
       let open Irmin.Type in
@@ -1078,15 +1147,8 @@ struct
 
     let kind (t : t) =
       (* This is the kind of newly appended values, let's use v1 then *)
-      (* TODO: Use v1 *)
-      let length =
-        match t.v with
-        | Bin.Values l -> List.length l
-        | Tree { length; _ } -> length
-      in
-      if should_be_stable ~length ~root:t.root then
-        Pack_value.Kind.Inode_v0_stable
-      else Pack_value.Kind.Inode_v0_unstable
+      if t.root then Pack_value.Kind.Inode_v1_root
+      else Pack_value.Kind.Inode_v1_nonroot
 
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string
@@ -1170,17 +1232,24 @@ struct
             let hash = hash h in
             (name, `Node hash)
       in
-      let t : Compress.tagged_v -> Bin.v =
+      let t : Compress.tagged_v -> Bin.v * int63 option =
        fun tv ->
-        let v = match tv with V0_stable v -> v | V0_unstable v -> v in
+        let v, len_opt =
+          match tv with
+          | V0_stable v -> (v, None)
+          | V0_unstable v -> (v, None)
+          | V1_root { v; length } -> (v, Some length)
+          | V1_nonroot { v; length } -> (v, Some length)
+        in
         match v with
-        | Values vs -> Values (List.rev_map value (List.rev vs))
+        | Values vs -> (Values (List.rev_map value (List.rev vs)), len_opt)
         | Tree { depth; length; entries } ->
             let entries = List.map ptr entries in
-            Tree { depth; length; entries }
+            (Tree { depth; length; entries }, len_opt)
       in
       let root = Compress.is_root i in
-      Bin.v ~root ~hash:(lazy i.hash) (t i.v)
+      let v, _len_opt = t i.v in
+      Bin.v ~root ~hash:(lazy i.hash) v
 
     let decode_bin_length = decode_compress_length
   end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -2,19 +2,19 @@ open! Import
 include Pack_value_intf
 
 module Kind = struct
-  type t = Commit | Contents | Inode | Node
+  type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable
 
   let to_magic = function
     | Commit -> 'C'
     | Contents -> 'B'
-    | Inode -> 'I'
-    | Node -> 'N'
+    | Inode_v0_unstable -> 'I'
+    | Inode_v0_stable -> 'N'
 
   let of_magic_exn = function
     | 'C' -> Commit
     | 'B' -> Contents
-    | 'I' -> Inode
-    | 'N' -> Node
+    | 'I' -> Inode_v0_unstable
+    | 'N' -> Inode_v0_stable
     | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
 
   let t = Irmin.Type.(map char) of_magic_exn to_magic

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -2,19 +2,29 @@ open! Import
 include Pack_value_intf
 
 module Kind = struct
-  type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable
+  type t =
+    | Commit
+    | Contents
+    | Inode_v0_unstable
+    | Inode_v0_stable
+    | Inode_v1_root
+    | Inode_v1_nonroot
 
   let to_magic = function
     | Commit -> 'C'
     | Contents -> 'B'
     | Inode_v0_unstable -> 'I'
     | Inode_v0_stable -> 'N'
+    | Inode_v1_root -> 'R'
+    | Inode_v1_nonroot -> 'O'
 
   let of_magic_exn = function
     | 'C' -> Commit
     | 'B' -> Contents
     | 'I' -> Inode_v0_unstable
     | 'N' -> Inode_v0_stable
+    | 'R' -> Inode_v1_root
+    | 'O' -> Inode_v1_nonroot
     | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
 
   let t = Irmin.Type.(map char) of_magic_exn to_magic

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -29,7 +29,14 @@ end
 
 module type Sigs = sig
   module Kind : sig
-    type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable [@@deriving irmin]
+    type t =
+      | Commit
+      | Contents
+      | Inode_v0_unstable
+      | Inode_v0_stable
+      | Inode_v1_root
+      | Inode_v1_nonroot
+    [@@deriving irmin]
 
     val to_magic : t -> char
     val of_magic_exn : char -> t

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -29,7 +29,7 @@ end
 
 module type Sigs = sig
   module Kind : sig
-    type t = Commit | Contents | Inode | Node [@@deriving irmin]
+    type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable [@@deriving irmin]
 
     val to_magic : t -> char
     val of_magic_exn : char -> t

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -19,7 +19,7 @@ end = struct
   }
 
   let empty () =
-    let pack_values = Array.make 4 0 in
+    let pack_values = Array.make 6 0 in
     { pack_values; duplicates = 0; missing_hashes = 0 }
 
   let incr t n = t.pack_values.(n) <- t.pack_values.(n) + 1
@@ -29,6 +29,8 @@ end = struct
     | Commit -> incr t 1
     | Inode_v0_stable -> incr t 2
     | Inode_v0_unstable -> incr t 3
+    | Inode_v1_root -> incr t 4
+    | Inode_v1_nonroot -> incr t 5
 
   let duplicate_entry t = t.duplicates <- t.duplicates + 1
   let missing_hash t = t.missing_hashes <- t.missing_hashes + 1
@@ -41,6 +43,8 @@ end = struct
         field "Commit" (fun t -> t.pack_values.(1)) Fmt.int;
         field "Inode_v0_stable" (fun t -> t.pack_values.(2)) Fmt.int;
         field "Inode_v0_unstable" (fun t -> t.pack_values.(3)) Fmt.int;
+        field "Inode_v1_root" (fun t -> t.pack_values.(4)) Fmt.int;
+        field "Inode_v1_nonroot" (fun t -> t.pack_values.(5)) Fmt.int;
         field "Duplicated entries" (fun t -> t.duplicates) Fmt.int;
         field "Missing entries" (fun t -> t.missing_hashes) Fmt.int;
       ]
@@ -88,7 +92,9 @@ end = struct
       | Pack_value.Kind.Contents -> "Contents"
       | Commit -> "Commit"
       | Inode_v0_stable -> "Inode_v0_stable"
-      | Inode_v0_unstable -> "Inode_v0_unstable")
+      | Inode_v0_unstable -> "Inode_v0_unstable"
+      | Inode_v1_root -> "Inode_v1_root"
+      | Inode_v1_nonroot -> "Inode_v1_nonroot")
       pp_key x.key Int63.pp off len
 
   module Index_reconstructor = struct
@@ -174,7 +180,8 @@ end = struct
   let decode_entry_length = function
     | Pack_value.Kind.Contents -> Contents.decode_bin_length
     | Commit -> Commit.decode_bin_length
-    | Inode_v0_stable | Inode_v0_unstable -> Inode.decode_bin_length
+    | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot ->
+        Inode.decode_bin_length
 
   let decode_entry_exn ~off ~buffer ~buffer_off =
     try

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -27,8 +27,8 @@ end = struct
   let add t = function
     | Contents -> incr t 0
     | Commit -> incr t 1
-    | Node -> incr t 2
-    | Inode -> incr t 3
+    | Inode_v0_stable -> incr t 2
+    | Inode_v0_unstable -> incr t 3
 
   let duplicate_entry t = t.duplicates <- t.duplicates + 1
   let missing_hash t = t.missing_hashes <- t.missing_hashes + 1
@@ -39,8 +39,8 @@ end = struct
       [
         field "Contents" (fun t -> t.pack_values.(0)) Fmt.int;
         field "Commit" (fun t -> t.pack_values.(1)) Fmt.int;
-        field "Node" (fun t -> t.pack_values.(2)) Fmt.int;
-        field "Inode" (fun t -> t.pack_values.(3)) Fmt.int;
+        field "Inode_v0_stable" (fun t -> t.pack_values.(2)) Fmt.int;
+        field "Inode_v0_unstable" (fun t -> t.pack_values.(3)) Fmt.int;
         field "Duplicated entries" (fun t -> t.duplicates) Fmt.int;
         field "Missing entries" (fun t -> t.missing_hashes) Fmt.int;
       ]
@@ -87,8 +87,8 @@ end = struct
       (match kind with
       | Pack_value.Kind.Contents -> "Contents"
       | Commit -> "Commit"
-      | Node -> "Node"
-      | Inode -> "Inode")
+      | Inode_v0_stable -> "Inode_v0_stable"
+      | Inode_v0_unstable -> "Inode_v0_unstable")
       pp_key x.key Int63.pp off len
 
   module Index_reconstructor = struct
@@ -174,7 +174,7 @@ end = struct
   let decode_entry_length = function
     | Pack_value.Kind.Contents -> Contents.decode_bin_length
     | Commit -> Commit.decode_bin_length
-    | Node | Inode -> Inode.decode_bin_length
+    | Inode_v0_stable | Inode_v0_unstable -> Inode.decode_bin_length
 
   let decode_entry_exn ~off ~buffer ~buffer_off =
     try

--- a/test/irmin-tezos/stat.t/run.t
+++ b/test/irmin-tezos/stat.t/run.t
@@ -15,9 +15,9 @@ Running stat on a layered store after a first freeze
       "lower": {
         "pack": {
           "size": {
-            "Bytes": 466
+            "Bytes": 478
           },
-          "offset": 442,
+          "offset": 454,
           "generation": 0,
           "version": "V2"
         },
@@ -67,9 +67,9 @@ Running stat on a layered store after a first freeze
       "upper0": {
         "pack": {
           "size": {
-            "Bytes": 597
+            "Bytes": 609
           },
-          "offset": 573,
+          "offset": 585,
           "generation": 0,
           "version": "V2"
         },


### PR DESCRIPTION
This PR tackles 2 problems at once:
1. It makes `is_root` the first class inode discriminator instead of `is_stable`. It makes the code easier to understand IMO. (250cda0499f753ad99f8acfe59b2c875a895a757, irmin-pack: Inodes store `root` instead of `stable`)
2. Store the length of the inode encoding inside the inode encoding. This will represent a perf improvement when structured keys are there.


All commits independently compile and pass the unit tests.
