### PR TITLE
irmin-unix: support resolvers for generic-keyed backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,6 +147,8 @@
     using `Irmin_unix.Resolver.load_config` and make command line options
     take precedence over config options.
     (#1464, #1543, #1607 @zshipko)
+  - `Irmin_unix.Resolver.destruct` has been removed (and partially replaced by
+    `Resolver.spec`). (#1603, @CraigFe)
   - Update `irmin` CLI to support empty path in `list` subcommand.
     (#1575, @maiste)
   - Add new commands to CLI: `branches` for listing available branches and


### PR DESCRIPTION
This generalises `Irmin_unix.Resolver.Store.t` to support backend implementations that use generic keys. Resolvers constructed in this way may not be used to build HTTP / GraphQL servers (and attempting to do so will raise
an exception).

This is an interim solution to unblock https://github.com/mirage/irmin/pull/1534 without requiring `irmin-http` and `irmin-graphql` to support structured keys immediately. That can be done in a follow-up PR (and we should make an issue to track that if we merge this).