### PR TITLE
CLI: Cleanup config parsing using `Yaml.Util` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,7 +144,7 @@
   - Clean up command line interface. Allow config file to be specified when
     using `Irmin_unix.Resolver.load_config` and make command line options
     take precedence over config options.
-    (#1464, #1543, @zshipko)
+    (#1464, #1543, #1607 @zshipko)
   - Update `irmin` CLI to support empty path in `list` subcommand.
     (#1575, @maiste)
 

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -54,6 +54,7 @@ module Store : sig
   type store_functor =
     | Fixed_hash of (contents -> t)
     | Variable_hash of (hash -> contents -> t)
+    | Fixed of t
         (** The type of constructors of a store configuration. Depending on the
             backend, a store may require a hash function. *)
 


### PR DESCRIPTION
This PR utilizes `Yaml.Util` functions instead of `List.assoc` and renames some functions involved in parsing config files which makes the whole process a little straight forward. 