### PR TITLE
CLI: Update watch command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,8 @@
     (#1575, @maiste)
   - Add new commands to CLI: `branches` for listing available branches and
     `log` which is similar to `git log` (#1609, @zshipko)
+  - Update `irmin watch` to take parameters to specify a command that should
+    be executed when there are new changes (#1608, @zshipko)
 
 ### Removed
 

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -607,11 +607,7 @@ let watch =
     term =
       (let watch (S (impl, store, _)) path command =
          let (module S) = Store.Impl.generic_keyed impl in
-         let path =
-           match path with
-           | Empty -> S.Path.empty
-           | Path str -> key S.Path.t str
-         in
+         let path = key S.Path.t path in
          let proc = ref None in
          let () =
            at_exit (fun () ->
@@ -634,7 +630,7 @@ let watch =
          let doc = Arg.info ~docv:"COMMAND" ~doc:"Command to execute" [] in
          Arg.(value & pos_right 0 string [] & doc)
        in
-       Term.(mk watch $ store () $ path_or_empty $ command));
+       Term.(mk watch $ store () $ path $ command));
   }
 
 (* DOT *)


### PR DESCRIPTION
Adds parameters to `irmin watch` that allow the user to specify a command that should be executed or written to for each update.