### PR TITLE
Use boxed primitives in pre_hash by default 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,7 @@
   - The backend configuration type `Conf.S` requires a new parameter
     `contents_length_header` that (optionally) further specifies the encoding
     format used for commits in order to improve performance. (#1644, @CraigFe)
+  - Adapt to repr#TODO (#1615, @icristescu)
 
 - **irmin-unix**
   - Clean up command line interface. Allow config file to be specified when

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -34,6 +34,8 @@ depends: [
 
 pin-depends: [
   [ "index.dev" "git+https://github.com/mirage/index#07bdd1b5da5737c92c743a65df685145ffdca603" ]
+  [ "repr.dev" "git+https://github.com/icristescu/repr#81a0d9f25202dd5625acba35c216a4b203fe1256" ]
+  [ "ppx_repr.dev" "git+https://github.com/icristescu/repr#81a0d9f25202dd5625acba35c216a4b203fe1256" ]
 ]
 
 synopsis: "Irmin backend which stores values in a pack file"

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -31,6 +31,12 @@ depends: [
   "metrics" {>= "0.2.0"}
 ]
 
+pin-depends: [
+  [ "repr.dev" "git+https://github.com/icristescu/repr#81a0d9f25202dd5625acba35c216a4b203fe1256" ]
+  [ "ppx_repr.dev" "git+https://github.com/icristescu/repr#81a0d9f25202dd5625acba35c216a4b203fe1256" ]
+]
+
+
 synopsis: "Irmin test suite"
 description: """
 `irmin-test` provides access to the Irmin test suite for testing storage backend

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -765,6 +765,10 @@ struct
           in
           { hash; stable = true; v = t.v }
 
+    let pre_hash_unboxed =
+      Irmin.Type.(unstage (pre_hash_unboxed_primitives step_t))
+
+    let step_t = Irmin.Type.like step_t ~pre_hash:pre_hash_unboxed
     let hash_key = Irmin.Type.(unstage (short_hash step_t))
     let index ~depth k = abs (hash_key ~seed:depth k) mod Conf.entries
 

--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -64,7 +64,13 @@ module Schema (M : Irmin.Metadata.S) = struct
   module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
   module Branch = Irmin.Branch.String
   module Info = Irmin.Info.Default
-  module Contents = Irmin.Contents.String
+
+  module Contents = struct
+    include Irmin.Contents.String
+
+    let pre_hash = Irmin.Type.(unstage (pre_hash_unboxed_primitives t))
+    let t = Irmin.Type.like t ~pre_hash
+  end
 end
 
 let store : (module Irmin.Maker) -> (module Irmin.Metadata.S) -> (module S) =

--- a/test/irmin-chunk/test_chunk.ml
+++ b/test/irmin-chunk/test_chunk.ml
@@ -25,8 +25,15 @@ module Key = struct
   let equal = Irmin.Type.(unstage (equal t))
 end
 
-module Value = struct
+module Contents = struct
   include Irmin.Contents.String
+
+  let pre_hash = Irmin.Type.(unstage (pre_hash_unboxed_primitives t))
+  let t = Irmin.Type.like t ~pre_hash
+end
+
+module Value = struct
+  include Contents
 
   let pp = Fmt.string
   let equal = String.equal

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -40,7 +40,14 @@ module Conf = Irmin_tezos.Conf
 module Schema = struct
   open Irmin
   module Metadata = Metadata.None
-  module Contents = Contents.String
+
+  module Contents = struct
+    include Contents.String
+
+    let pre_hash = Irmin.Type.(unstage (pre_hash_unboxed_primitives t))
+    let t = Irmin.Type.like t ~pre_hash
+  end
+
   module Path = Path.String_list
   module Branch = Branch.String
   module Hash = Hash.SHA1
@@ -71,6 +78,8 @@ module Contents = struct
     | Dynamic f -> f
     | _ -> assert false
 end
+
+let contents_hash = Contents.H.hash
 
 module I = Index
 module Index = Irmin_pack.Index.Make (Schema.Hash)

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -92,6 +92,7 @@ end
 
 val get : 'a option -> 'a
 val sha1 : string -> Schema.Hash.t
+val contents_hash : string -> Schema.Hash.t
 val rm_dir : string -> unit
 val index_log_size : int option
 val random_string : int -> string

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -114,14 +114,18 @@ type pred = [ `Contents of Key.t | `Inode of Key.t | `Node of Key.t ]
 
 let pp_pred = Irmin.Type.pp pred_t
 
-module H_contents =
-  Irmin.Hash.Typed
-    (Hash)
-    (struct
-      type t = string
+module H_contents = struct
+  include
+    Irmin.Hash.Typed
+      (Hash)
+      (struct
+        type t = string
 
-      let t = Irmin.Type.string
-    end)
+        let t = Irmin.Type.string
+        let pre_hash = Irmin.Type.(unstage (pre_hash_unboxed_primitives t))
+        let t = Irmin.Type.like t ~pre_hash
+      end)
+end
 
 let normal x = `Contents (x, Metadata.default)
 let node x = `Node x

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -220,10 +220,10 @@ module Pack = struct
     let x2 = "bar" in
     let x3 = "otoo" in
     let x4 = "sdadsadas" in
-    let h1 = sha1 x1 in
-    let h2 = sha1 x2 in
-    let h3 = sha1 x3 in
-    let h4 = sha1 x4 in
+    let h1 = contents_hash x1 in
+    let h2 = contents_hash x2 in
+    let h3 = contents_hash x3 in
+    let h4 = contents_hash x4 in
     let* () =
       Pack.batch t.pack (fun w ->
           Lwt_list.iter_s
@@ -261,8 +261,8 @@ module Pack = struct
       in
       let x1 = "foo" in
       let x2 = "bar" in
-      let h1 = sha1 x1 in
-      let h2 = sha1 x2 in
+      let h1 = contents_hash x1 in
+      let h2 = contents_hash x2 in
       adds [ (h1, x1); (h2, x2) ];
       let* y2 = Pack.find r h2 in
       Alcotest.(check (option string)) "before sync" None y2;
@@ -272,8 +272,8 @@ module Pack = struct
       Alcotest.(check (option string)) "after sync" (Some x2) y2;
       let x3 = "otoo" in
       let x4 = "sdadsadas" in
-      let h3 = sha1 x3 in
-      let h4 = sha1 x4 in
+      let h3 = contents_hash x3 in
+      let h4 = contents_hash x4 in
       adds [ (h3, x3); (h4, x4) ];
       Pack.flush w;
       Pack.sync r;
@@ -291,7 +291,7 @@ module Pack = struct
     let index = Index.v ~log_size:4 ~fresh:true (Context.fresh_name "index") in
     let* w1 = Pack.v ~fresh:true ~index (Context.fresh_name "pack") in
     let x1 = "foo" in
-    let h1 = sha1 x1 in
+    let h1 = contents_hash x1 in
     let (_ : Pack.hash) =
       Pack.unsafe_append ~ensure_unique:true ~overcommit:false w1 h1 x1
     in
@@ -305,7 +305,7 @@ module Pack = struct
     let* t = Context.get_pack () in
     let w = t.pack in
     let x1 = "foo" in
-    let h1 = sha1 x1 in
+    let h1 = contents_hash x1 in
     let (_ : Pack.hash) =
       Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h1 x1
     in
@@ -333,8 +333,8 @@ module Pack = struct
     let w = t.pack in
     let x1 = "foo" in
     let x2 = "bar" in
-    let h1 = sha1 x1 in
-    let h2 = sha1 x2 in
+    let h1 = contents_hash x1 in
+    let h2 = contents_hash x2 in
     let* () =
       Pack.batch w (fun w ->
           Lwt_list.iter_s
@@ -352,7 +352,7 @@ module Pack = struct
     Alcotest.(check string) "x1.1" x1 y1;
     (*open and close two packs *)
     let x3 = "toto" in
-    let h3 = sha1 x3 in
+    let h3 = contents_hash x3 in
     let (_ : Pack.hash) =
       Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h3 x3
     in
@@ -389,7 +389,7 @@ module Pack = struct
     let* i, r = t.clone_index_pack ~readonly:true in
     let test w =
       let x1 = "foo" in
-      let h1 = sha1 x1 in
+      let h1 = contents_hash x1 in
       let (_ : Pack.hash) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h1 x1
       in
@@ -401,7 +401,7 @@ module Pack = struct
       let* y1 = Pack.find r h1 in
       Alcotest.(check (option string)) "sync after filter" (Some x1) y1;
       let x2 = "foo" in
-      let h2 = sha1 x2 in
+      let h2 = contents_hash x2 in
       let (_ : Pack.hash) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h2 x2
       in
@@ -421,7 +421,7 @@ module Pack = struct
     in
     let test w =
       let x1 = "foo" in
-      let h1 = sha1 x1 in
+      let h1 = contents_hash x1 in
       let (_ : Pack.hash) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h1 x1
       in
@@ -431,7 +431,7 @@ module Pack = struct
       Index.filter t.index (fun _ -> true);
       check h1 x1 "find after filter" >>= fun () ->
       let x2 = "bar" in
-      let h2 = sha1 x2 in
+      let h2 = contents_hash x2 in
       let (_ : Pack.hash) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h2 x2
       in
@@ -439,7 +439,7 @@ module Pack = struct
       Pack.sync r;
       check h2 x2 "find before flush" >>= fun () ->
       let x3 = "toto" in
-      let h3 = sha1 x3 in
+      let h3 = contents_hash x3 in
       let (_ : Pack.hash) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h3 x3
       in
@@ -455,7 +455,7 @@ module Pack = struct
   let test_clear () =
     let* t = Context.get_pack ~lru_size:10 () in
     let v = "foo" in
-    let k = sha1 v in
+    let k = contents_hash v in
     let (_ : Pack.key) =
       Pack.unsafe_append ~ensure_unique:true ~overcommit:false t.pack k v
     in
@@ -479,7 +479,7 @@ module Pack = struct
       Alcotest.(check (option string)) msg x y
     in
     let x1 = "foo" in
-    let h1 = sha1 x1 in
+    let h1 = contents_hash x1 in
     let find_before_and_after_sync persist file =
       let (_ : Pack.key) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false t.pack h1 x1
@@ -514,9 +514,9 @@ module Pack = struct
       Alcotest.(check (option string)) msg x y
     in
     let x1 = "foo" in
-    let h1 = sha1 x1 in
+    let h1 = contents_hash x1 in
     let x2 = "bar" in
-    let h2 = sha1 x2 in
+    let h2 = contents_hash x2 in
     let find_before_and_after_sync persist file =
       let (_ : Pack.key) =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false t.pack h1 x1

--- a/test/irmin-tezos/generate.ml
+++ b/test/irmin-tezos/generate.ml
@@ -23,6 +23,15 @@ let rm_dir data_dir =
     let _ = Sys.command cmd in
     ())
 
+module Contents = struct
+  include Irmin.Contents.String
+
+  let pre_hash = Irmin.Type.(unstage (pre_hash_unboxed_primitives t))
+  let t = Irmin.Type.like t ~pre_hash
+end
+
+module Schema = Irmin.Schema.KV (Contents)
+
 module Simple = struct
   let data_dir = "data/pack"
 
@@ -31,8 +40,6 @@ module Simple = struct
     let stable_hash = 3
     let contents_length_header = Some `Varint
   end
-
-  module Schema = Irmin.Schema.KV (Irmin.Contents.String)
 
   module Store = struct
     open Irmin_pack.V2 (Conf)

--- a/test/irmin-tezos/irmin_fsck.ml
+++ b/test/irmin-tezos/irmin_fsck.ml
@@ -14,7 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Schema = Irmin.Schema.KV (Irmin.Contents.String)
+module Contents = struct
+  include Irmin.Contents.String
+
+  let pre_hash = Irmin.Type.(unstage (pre_hash_unboxed_primitives t))
+  let t = Irmin.Type.like t ~pre_hash
+end
+
+module Schema = Irmin.Schema.KV (Contents)
 
 module Maker (V : Irmin_pack.Version.S) = struct
   module Maker = Irmin_pack.Maker (V) (Irmin_tezos.Conf)


### PR DESCRIPTION
Depends on https://github.com/mirage/repr/pull/87

The index in inodes uses the unboxed step (by calling `short_hash` which in turn calls `pre_hash` - the step is at the top level, and so it relied on the `pre_hash` to unbox it). In the tests, we expect the contents to be unboxed - the hash of the contents relies on the `prehash` of the string primitive type.