### PR TITLE
Expose Irmin_unix.Resolver.Store impl and remote fields

### DIFF
--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -354,6 +354,17 @@ module Store = struct
         in
         failwith msg
 
+  let generic_keyed = function
+    | T { impl = Generic_keyed (module S); _ } ->
+        (module S : Irmin.Generic_key.S)
+    | T { impl = Hash_keyed (module S); _ } -> (module S : Irmin.Generic_key.S)
+
+  let hash_keyed = function
+    | T { impl = Generic_keyed (module S); _ } -> None
+    | T { impl = Hash_keyed (module S); _ } -> Some (module S : Irmin.S)
+
+  let remote (T { remote; _ }) = remote
+
   let term =
     let store =
       let store_types = !all |> List.map (fun (name, _) -> (name, name)) in

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -93,6 +93,9 @@ module Store : sig
   val find : string -> store_functor
   val add : string -> ?default:bool -> store_functor -> unit
   val spec : t -> Irmin.Backend.Conf.Spec.t
+  val generic_keyed : t -> (module Irmin.Generic_key.S)
+  val hash_keyed : t -> (module Irmin.S) option
+  val remote : t -> remote_fn option
   val term : (string option * hash option * string option) Cmdliner.Term.t
 end
 


### PR DESCRIPTION
This is needed after the changes to `Irmin_unix.Resolver` in #1603, which removed `Irmin_unix.Resolver.Store.destruct` because `irmin-server` and `irmin-rs`/`libirimin` need a way to access the store module and remote function from `Irmin_unix.Resolver.Store.t` directly.