### PR TITLE
offsets for free 2.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 2.9.1 (TODO)
+
+### Changed
+
+- **irmin-pack**
+  - Perf improvement under heavy read-only access patterns (#TODO, @Ngoguey42)
+
 ## 2.9.0 (2021-11-15)
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Changed
 
 - **irmin-pack**
-  - Perf improvement under heavy read-only access patterns (#TODO, @Ngoguey42)
+  - Perf improvement under heavy read-only access patterns (#1619, @Ngoguey42)
 
 ## 2.9.0 (2021-11-15)
 

--- a/src/irmin-pack/IO.ml
+++ b/src/irmin-pack/IO.ml
@@ -34,12 +34,48 @@ module Unix : S = struct
     version : Version.t;
     buf : Buffer.t;
   }
+  (* [offset] is virt
+     [flushed] is phy
+
+     Invariant: [buf length + flushed = offset + header size] *)
 
   let name t = t.file
 
   let header = function
     | `V1 -> (* offset + version *) Int63.of_int 16
     | `V2 -> (* offset + version + generation *) Int63.of_int 24
+
+  let page_len = Int63.of_int 4096
+  let virt_of_phy t v = v -- header t.version
+  let phy_of_virt t v = v ++ header t.version
+
+  let page_idx_of_offset t virt_off =
+    let phy_off = phy_of_virt t virt_off in
+    Int63.(div phy_off page_len)
+
+  let start_offset_of_page_idx t page_idx =
+    let virt_of_phy = virt_of_phy t in
+    let open Int63 in
+    let open Infix in
+    let phy_off = page_idx * page_len in
+    virt_of_phy phy_off
+
+  let bytes_remaning_in_page_from_offset t virt_off =
+    let phy_off = phy_of_virt t virt_off in
+    let page_idx = page_idx_of_offset t virt_off in
+    let open Int63 in
+    let open Infix in
+    (succ page_idx * page_len) - phy_off
+
+  (** i.e. first offset of the following page, or t.offset *)
+  let end_offset_of_page_idx t page_idx =
+    let virt_of_phy = virt_of_phy t in
+    let virt_maxoff = t.offset in
+    let open Int63 in
+    let open Infix in
+    let virt_endoff = virt_of_phy (succ page_idx * page_len) in
+    if Int63.compare virt_endoff virt_maxoff <= 0 then virt_endoff
+    else virt_maxoff
 
   let unsafe_flush t =
     Log.debug (fun l -> l "IO flush %s" t.file);
@@ -80,10 +116,37 @@ module Unix : S = struct
       let off = header t.version ++ off ++ len in
       off <= t.flushed)
 
+  (* let read_buffer t ~off ~buf ~len =
+   *   let off = header t.version ++ off in
+   *   assert (if not t.readonly then off <= t.flushed else true);
+   *   Raw.unsafe_read t.raw ~off ~len buf *)
+
   let read_buffer t ~off ~buf ~len =
+    let off0 = off in
     let off = header t.version ++ off in
     assert (if not t.readonly then off <= t.flushed else true);
-    Raw.unsafe_read t.raw ~off ~len buf
+    let n = Raw.unsafe_read t.raw ~off ~len buf in
+    let missing = len - n in
+    assert (missing >= 0);
+    if missing = 0 then n
+    else if Buffer.length t.buf < missing then (
+      let off0 = Int63.to_int off0 in
+      let flushed = Int63.to_int t.flushed in
+      let offset = Int63.to_int t.offset in
+      let h = header t.version |> Int63.to_int in
+      Log.err (fun l ->
+          l
+            "FAILED IO.read_buffer \n\
+             | request: off:%#d len:%#d \n\
+             | io status: t.buflen:%#d + t.flushed:%#d = t.offset:%#d + h:%#d \n\
+             | read: n:%#d missing %#d \n\
+             %!"
+            off0 len (Buffer.length t.buf) flushed offset h n missing);
+      n)
+    else
+      let src = Buffer.sub t.buf 0 missing |> Bytes.unsafe_of_string in
+      Bytes.blit src 0 buf n missing;
+      len
 
   let read t ~off buf = read_buffer t ~off ~buf ~len:(Bytes.length buf)
   let offset t = t.offset

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -38,6 +38,10 @@ module type S = sig
   val close : t -> unit
   val exists : string -> bool
   val size : t -> int
+  val page_idx_of_offset : t -> int63 -> int63
+  val bytes_remaning_in_page_from_offset : t -> int63 -> int63
+  val end_offset_of_page_idx : t -> int63 -> int63
+  val start_offset_of_page_idx : t -> int63 -> int63
 
   val truncate : t -> unit
   (** Sets the length of the underlying IO to be 0, without actually purging the

--- a/src/irmin-pack/pack_store.ml
+++ b/src/irmin-pack/pack_store.ml
@@ -324,7 +324,9 @@ module Maker
         Log.debug (fun l -> l "[pack] append %a" pp_hash k);
         let offset k =
           match Lru.find t.offset_lru k with
-          | off -> Some off
+          | off ->
+              Stats.incr_appended_offsets ();
+              Some off
           | exception Not_found -> (
               match Index.find t.pack.index k with
               | None ->


### PR DESCRIPTION

- [X] Clean + rebase on 2.9
- [X] Investigate broken layered store
- [ ] Need bulletproof reviews of the new offset arithmetic in IO.ml
- [X] Change back from cachecache to lru
- [X] Take care of clearing the new LRU from inside `clear`
- [x] Setup back a migration benchmark machine and bench 
- [ ] Investigate maxrss issue
- [ ] assert all bench stats look normal
- [ ] assert that this PR represents a big improvement

An finally, I'm worried about that one. I'm not sure we should merge it without a good explanation:

- [ ] Investigate the need for reads from buffer in IO.ml, the `Tbl` in `pack_store` should cover that

