### PR TITLE
[2.10] more powerful proof API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,20 @@
 - *irmin*
   - Conversion between proofs and trees are now done in CPS (#1624, @samoht)
 
+### Added
+
+- **irmin**
+  - Add `Tree.produce_proof` and `Tree.verify_proof` to produce and verify
+    proofs from complex computations. `produce_proof` and `verify_proof`
+    takes a callback over tree and instead of a static list of operations
+    -- this now means that the full `Tree` API can now be used in proofs,
+    including sub-tree operations, folds and paginated lists (#1625, @samoht)
+
 ### Changed
 
 - **irmin**
+  - Remove `Tree.Proof.of_keys`. Use `Tree.produce_proof` instead
+    (#1625, @samoht)
   - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
 
 ## 2.9.0 (2021-11-15)

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1145,7 +1145,11 @@ struct
 
       let of_proof (proof : proof) =
         let c = concrete_of_proof 0 proof in
-        of_concrete_exn c
+        match of_concrete c with
+        | Ok v -> v
+        | Error e ->
+            Fmt.kstr Irmin.Proof.bad_proof_exn "Irmin_pack.Inode.of_proof: %a"
+              Concrete.pp_error e
 
       let of_concrete t = proof_of_concrete (lazy (failwith "blinded root")) t
       let to_concrete = concrete_of_proof 0

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -21,6 +21,7 @@ module Content_addressable = Store.Content_addressable
 module Contents = Contents
 module Merge = Merge
 module Branch = Branch
+module Proof = Proof
 module Info = Info
 module Dot = Dot.Make
 module Hash = Hash

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -130,6 +130,7 @@ module Contents = Contents
     {{!Contents.Json} JSON} contents are provided. *)
 
 module Branch = Branch
+module Proof = Proof
 
 type remote = S.remote = ..
 (** The type for remote stores. *)

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -14,29 +14,63 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+include Proof_intf
+
 type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
 
-type ('hash, 'step, 'metadata) t =
+type ('contents, 'hash, 'step, 'metadata) tree =
   | Blinded_node of 'hash
+  | Node of ('step * ('contents, 'hash, 'step, 'metadata) tree) list
+  | Inode of ('contents, 'hash, 'step, 'metadata) tree inode
   | Blinded_contents of 'hash * 'metadata
-  | Node of ('step * ('hash, 'step, 'metadata) t) list
-  | Inode of ('hash, 'step, 'metadata) t inode
+  | Contents of 'contents * 'metadata
 
 (* TODO(craigfe): fix [ppx_irmin] for inline parameters. *)
-let t hash_t step_t metadata_t =
+let tree_t contents_t hash_t step_t metadata_t =
   let open Type in
   mu (fun t ->
-      variant "proof" (fun blinded_node node inode blinded_contents -> function
+      variant "proof" (fun blinded_node node inode blinded_contents contents ->
+        function
         | Blinded_node x1 -> blinded_node x1
         | Node x1 -> node x1
         | Inode i -> inode i
-        | Blinded_contents (x1, x2) -> blinded_contents (x1, x2))
+        | Blinded_contents (x1, x2) -> blinded_contents (x1, x2)
+        | Contents (c, m) -> contents (c, m))
       |~ case1 "Blinded_node" hash_t (fun x1 -> Blinded_node x1)
       |~ case1 "Node" [%typ: (step * t) list] (fun x1 -> Node x1)
       |~ case1 "Inode" [%typ: t inode] (fun i -> Inode i)
       |~ case1 "Blinded_contents" [%typ: hash * metadata] (fun (x1, x2) ->
              Blinded_contents (x1, x2))
+      |~ case1 "Contents" [%typ: contents * metadata] (fun (x1, x2) ->
+             Contents (x1, x2))
       |> Type.sealv)
+
+module Make
+    (C : Type.S)
+    (H : Type.S) (S : sig
+      type step [@@deriving irmin]
+    end)
+    (M : Type.S) =
+struct
+  type contents = C.t [@@deriving irmin]
+  type hash = H.t [@@deriving irmin]
+  type step = S.step [@@deriving irmin]
+  type metadata = M.t [@@deriving irmin]
+
+  type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
+  [@@deriving irmin]
+
+  type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
+  type tree_proof = (contents, hash, step, metadata) tree [@@deriving irmin]
+
+  type t = { before : kinded_hash; after : kinded_hash; proof : tree_proof }
+  [@@deriving irmin]
+
+  let before t = t.before
+  let after t = t.after
+  let proof t = t.proof
+  let v ~before ~after proof = { after; before; proof }
+end
 
 exception Bad_proof of { context : string }
 

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -84,6 +84,7 @@ module Make (P : Private.S) = struct
 
     let of_hash r h = import r h
     let shallow r h = import_no_check r h
+    let kinded_hash = hash
 
     let hash : ?cache:bool -> t -> hash =
      fun ?cache tr ->


### PR DESCRIPTION
Expose `Tree.produce_proof` and `Tree.verify_proof` which takes a dynamic computation as a callback instead of a static set of paths as `Tree.Proof.of_keys` was exposing.

This allows generating proof for all operations supported in the Tree API (including paginated lists and folds).

On top of #1624 