### PR TITLE
irmin: change `Node.empty` to take a unit argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,7 +99,8 @@
   - Add `Irmin.Backend.Conf.Schema` for grouping configuration keys. Now
     `Irmin.Backend.Conf.key` takes an additional `~spec` parameter.
     (#1492, @zshipko)
-  - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
+  - `Tree.empty` and `Node.empty` now both take a unit argument. (#1566 #1629,
+    @CraigFe)
   - Rename `key` type to `path` and `Key` module to `Path` when it is in a path
     context in `Tree` and `Store`. (#1569, @maiste)
   - Move `Node.default` metadata default values into a `Node.Metadata.default`

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -102,7 +102,9 @@ module Make (G : Git.S) (P : Irmin.Path.S) = struct
           in
           Git.Tree.of_list (entry :: entries)
 
-  let empty : t = Git.Tree.of_list []
+  let empty : unit -> t =
+    (* [Git.Tree.t] is immutable, so sharing a singleton empty tree is safe *)
+    Fun.const (Git.Tree.of_list [])
 
   let to_git perm (name, node) =
     G.Value.Tree.entry ~name:(of_step name) perm node

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -785,7 +785,7 @@ struct
 
     let empty : 'a. 'a layout -> 'a t =
      fun _ ->
-      let hash = lazy (Node.hash Node.empty) in
+      let hash = lazy (Node.hash (Node.empty ())) in
       { stable = true; hash; v = Values StepMap.empty }
 
     let values layout vs =
@@ -1181,7 +1181,7 @@ struct
     let list ?offset ?length ?cache t =
       List.of_seq (seq ?offset ?length ?cache t)
 
-    let empty = of_list []
+    let empty () = of_list []
     let is_empty t = apply t { f = (fun _ v -> I.is_empty v) }
 
     let find ?cache t s =

--- a/src/irmin-test/node.ml
+++ b/src/irmin-test/node.ml
@@ -25,21 +25,22 @@ end = struct
       | Error _ -> assert false
 
   let test_empty () =
-    check __POS__ [%typ: bool] ~expected:true X.(is_empty empty);
-    check __POS__ [%typ: int] ~expected:0 X.(length empty);
-    check __POS__ [%typ: (X.step * X.value) list] ~expected:[] X.(list empty)
+    check __POS__ [%typ: bool] ~expected:true X.(is_empty (empty ()));
+    check __POS__ [%typ: int] ~expected:0 X.(length (empty ()));
+    check __POS__ [%typ: (X.step * X.value) list] ~expected:[]
+      X.(list (empty ()))
 
   let test_add () =
     let with_binding k v t = X.add t k v in
     let k1 = random_key () and k2 = random_key () in
     let a =
-      X.empty |> with_binding "a" (`Node k1) |> with_binding "b" (`Node k2)
+      X.empty () |> with_binding "a" (`Node k1) |> with_binding "b" (`Node k2)
     in
     check __POS__ [%typ: int] ~expected:2 (X.length a)
 
   let test_remove () =
     (* Remove is a no-op on an empty node *)
-    check __POS__ [%typ: X.t] ~expected:X.empty X.(remove empty "foo")
+    check __POS__ [%typ: X.t] ~expected:(X.empty ()) X.(remove (empty ()) "foo")
 
   let suite =
     [

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -129,7 +129,7 @@ module Make (S : Generic_key) = struct
         let+ key = with_node repo (fun n -> B.Node.add n v) in
         check_hash (msg ^ ": hash(v) = add(v)") (B.Node.Key.to_hash key) h'
       in
-      let v = B.Node.Val.empty in
+      let v = B.Node.Val.empty () in
       check_node "empty node" v >>= fun () ->
       let v1 = B.Node.Val.add v "x" k in
       check_node "node: x" v1 >>= fun () ->
@@ -1136,7 +1136,11 @@ module Make (S : Generic_key) = struct
       let* commit = B.Commit.find (ct repo) head in
       let node = B.Commit.Val.node (get commit) in
       let* node = B.Node.find (n repo) node in
-      check T.(option B.Node.Val.t) "empty tree" (Some B.Node.Val.empty) node;
+      check
+        T.(option B.Node.Val.t)
+        "empty tree"
+        (Some (B.Node.Val.empty ()))
+        node;
 
       (* Testing [Tree.diff] *)
       let contents_t = T.pair S.contents_t S.metadata_t in
@@ -1934,7 +1938,7 @@ module Make (S : Generic_key) = struct
       let node (s : string) : S.node_key Lwt.t =
         with_node repo (fun n ->
             let* contents = contents s in
-            let node = B.Node.Val.(add empty) s (normal contents) in
+            let node = B.Node.Val.(add (empty ())) s (normal contents) in
             B.Node.add n node)
       in
       let commit (s : string) : S.commit_key Lwt.t =

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -107,7 +107,7 @@ struct
     S.find t k >>= function None -> err_not_found k | Some v -> Lwt.return v
 
   let empty_if_none (n, _) = function
-    | None -> N.add n N.Val.empty
+    | None -> N.add n (N.Val.empty ())
     | Some node -> Lwt.return node
 
   let equal_key = Type.(unstage (equal Key.t))

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -95,8 +95,8 @@ module type S_generic_key = sig
 
       See {!caching} for an explanation of the [cache] parameter *)
 
-  val empty : t
-  (** [empty] is the empty node. *)
+  val empty : unit -> t
+  (** [empty ()] is the empty node. *)
 
   val is_empty : t -> bool
   (** [is_empty t] is true iff [t] is {!empty}. *)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -222,8 +222,8 @@ let check_hardcoded_hash msg h v =
 let test_add_values () =
   rm_dir root;
   let* t = Context.get_store () in
-  check_node "hash empty node" Inode.Val.empty t >>= fun () ->
-  let v1 = Inode.Val.add Inode.Val.empty "x" (normal foo) in
+  check_node "hash empty node" (Inode.Val.empty ()) t >>= fun () ->
+  let v1 = Inode.Val.add (Inode.Val.empty ()) "x" (normal foo) in
   let v2 = Inode.Val.add v1 "y" (normal bar) in
   check_node "node x+y" v2 t >>= fun () ->
   check_hardcoded_hash "hash v2" "d4b55db5d2d806283766354f0d7597d332156f74" v2;
@@ -277,7 +277,8 @@ let test_remove_values () =
   check_values "node x obtained two ways" v2 v3;
   check_hardcoded_hash "hash v2" "a1996f4309ea31cc7ba2d4c81012885aa0e08789" v2;
   let v4 = Inode.Val.remove v2 "x" in
-  check_node "remove results in an empty node" Inode.Val.empty t >>= fun () ->
+  check_node "remove results in an empty node" (Inode.Val.empty ()) t
+  >>= fun () ->
   let v5 = Inode.Val.remove v4 "x" in
   check_values "remove on an already empty node" v4 v5;
   check_hardcoded_hash "hash v4" "5ba93c9db0cff93f52b521d7420e43f6eda2784f" v4;


### PR DESCRIPTION
This ensures that users get fresh empty nodes, so they cache their `key` values obtained during export separately. This is required for an efficient implementation of structured keys in `irmin-pack` (that caches export state within inodes).

Very similar to https://github.com/mirage/irmin/pull/1566. Extracted from https://github.com/mirage/irmin/pull/1534.