### PR TITLE
Avoid use of deprecated `Lwt_main.yield`

### DIFF
--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1662,7 +1662,7 @@ module Make (S : Generic_key) = struct
 
   let rec write fn = function
     | 0 -> []
-    | i -> (fun () -> fn i >>= Lwt_unix.yield) :: write fn (i - 1)
+    | i -> (fun () -> fn i >>= Lwt.pause) :: write fn (i - 1)
 
   let perform l = Lwt_list.iter_p (fun f -> f ()) l
 
@@ -1751,7 +1751,7 @@ module Make (S : Generic_key) = struct
             let tag = Fmt.str "tmp-%d-%d" n i in
             let* m = S.clone ~src:t ~dst:tag in
             S.set_exn m ~info:(infof "update") (k i) (v i) >>= fun () ->
-            Lwt_unix.yield () >>= fun () ->
+            Lwt.pause () >>= fun () ->
             S.merge_into ~info:(infof "update: multi %d" i) m ~into:t
             >>= merge_exn "update: multi")
       in
@@ -1906,7 +1906,7 @@ module Make (S : Generic_key) = struct
                 let* m = S.clone ~src:t ~dst:tag in
                 S.set_exn m ~info:(infof "update") (k i) (v i) >>= fun () ->
                 let* set = S.Head.find m in
-                Lwt_unix.yield () >>= fun () -> S.Head.test_and_set t ~test ~set))
+                Lwt.pause () >>= fun () -> S.Head.test_and_set t ~test ~set))
       in
       let read t =
         read

--- a/src/irmin-test/store_watch.ml
+++ b/src/irmin-test/store_watch.ml
@@ -22,7 +22,7 @@ module Make (Log : Logs.LOG) (S : Generic_key) = struct
 
   let sleep ?(sleep_t = 0.01) () =
     let sleep_t = min sleep_t 1. in
-    Lwt_unix.yield () >>= fun () -> Lwt_unix.sleep sleep_t
+    Lwt.pause () >>= fun () -> Lwt_unix.sleep sleep_t
 
   let now_s () = Mtime.Span.to_s (Mtime_clock.elapsed ())
 


### PR DESCRIPTION
... by replacing them with the almost-equivalent `Lwt.pause`. Promises constructed in this way have slightly different scheduling behaviour, but this shouldn't impact the correctness of our code.

This may make our tests that use these functions more or less flaky; I'm not sure.

See https://github.com/ocsigen/lwt/issues/855 for more details.