### PR TITLE
Remove Git_paf and lint dependencies according to the last version of Git

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,7 @@
     - `Irmin_git.dot_git` is now `Irmin_git.Conf.dot_git`
    (#1347, @samoht)
   - Renamed `Irmin_git.Make` into `Irmin_git.Maker` (#1369, @samoht)
+  -  Require at least `git.3.7.0` in the codebase (#1632, @dinosaure)
 
 - **irmin-graphql**:
   - Changed the name of the default branch node from `master` to `main` in the

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -18,7 +18,7 @@ depends: [
   "dune"       {>= "2.7.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.5.0"}
+  "git"        {>= "3.7.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"
@@ -27,9 +27,8 @@ depends: [
   "logs"
   "lwt"        {>= "5.3.0"}
   "uri"
-  "git-cohttp-unix" {with-test}
   "irmin-test" {with-test & = version}
-  "git-unix"   {with-test}
+  "git-unix"   {with-test & >= "3.7.0"}
   "mtime"      {with-test & >= "1.0.0"}
   "alcotest"   {with-test}
 ]

--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -17,9 +17,8 @@ depends: [
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
   "mirage-kv"    {>= "3.0.0"}
-  "git-paf"      {>= "3.5.0"}
   "fmt"
-  "git"          {>= "3.5.0"}
+  "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}
   "mirage-clock"
   "uri"

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -26,7 +26,7 @@ depends: [
   "irmin-graphql" {= version}
   "irmin-layers"  {= version}
   "irmin-tezos"   {= version}
-  "git-unix"      {>= "3.5.0"}
+  "git-unix"      {>= "3.7.0"}
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "0.1.0"}
@@ -43,8 +43,7 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.5.0"}
-  "git-cohttp-unix" {>= "3.5.0"}
+  "git"           {>= "3.7.0"}
   "lwt"           {>= "5.3.0"}
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}

--- a/src/irmin-mirage/git/dune
+++ b/src/irmin-mirage/git/dune
@@ -1,5 +1,5 @@
 (library
  (name irmin_mirage_git)
  (public_name irmin-mirage-git)
- (libraries fmt git irmin irmin-mirage irmin-git git-paf lwt mirage-clock
-   mirage-kv uri))
+ (libraries fmt git irmin irmin-mirage irmin-git lwt mirage-clock mirage-kv
+   uri))

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -32,7 +32,7 @@ let remote ?(ctx = Mimic.empty) ?headers uri =
 module Maker (G : Irmin_git.G) = struct
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
-  module Maker = Irmin_git.Maker (G) (Git.Mem.Sync (G) (Git_paf))
+  module Maker = Irmin_git.Maker (G) (Git.Mem.Sync (G))
 
   module Make
       (S : Irmin_git.Schema.S
@@ -47,7 +47,7 @@ module Maker (G : Irmin_git.G) = struct
 end
 
 module Ref (G : Irmin_git.G) = struct
-  module Maker = Irmin_git.Ref (G) (Git.Mem.Sync (G) (Git_paf))
+  module Maker = Irmin_git.Ref (G) (Git.Mem.Sync (G))
   module G = G
 
   type branch = Maker.branch
@@ -61,7 +61,7 @@ module Ref (G : Irmin_git.G) = struct
 end
 
 module KV (G : Irmin_git.G) = struct
-  module Maker = Irmin_git.KV (G) (Git.Mem.Sync (G) (Git_paf))
+  module Maker = Irmin_git.KV (G) (Git.Mem.Sync (G))
   module G = G
 
   type endpoint = Maker.endpoint

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -2,8 +2,8 @@
  (name irmin_unix)
  (public_name irmin-unix)
  (libraries astring cmdliner cohttp cohttp-lwt cohttp-lwt-unix conduit
-   conduit-lwt-unix git-cohttp-unix fmt.cli fmt.tty git git-unix irmin
-   irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack
-   irmin-tezos irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml)
+   conduit-lwt-unix fmt.cli fmt.tty git git-unix irmin irmin-fs irmin-git
+   irmin-graphql irmin-http irmin.mem irmin-pack irmin-tezos irmin-watcher
+   logs.cli logs.fmt lwt lwt.unix uri yaml)
  (preprocess
   (pps ppx_irmin.internal)))

--- a/src/irmin-unix/xgit.ml
+++ b/src/irmin-unix/xgit.ml
@@ -39,9 +39,9 @@ module Maker (G : Irmin_git.G) = struct
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   module Maker = struct
-    module S = Irmin_git.Maker (G) (Git_unix.Sync (G) (Git_cohttp_unix))
-    module KV = Irmin_git.KV (G) (Git_unix.Sync (G) (Git_cohttp_unix))
-    module Ref = Irmin_git.Ref (G) (Git_unix.Sync (G) (Git_cohttp_unix))
+    module S = Irmin_git.Maker (G) (Git_unix.Sync (G))
+    module KV = Irmin_git.KV (G) (Git_unix.Sync (G))
+    module Ref = Irmin_git.Ref (G) (Git_unix.Sync (G))
   end
 
   module Make

--- a/test/irmin-git/dune
+++ b/test/irmin-git/dune
@@ -2,7 +2,7 @@
  (name test_git)
  (modules test_git)
  (libraries alcotest fmt fpath irmin irmin-test irmin.mem irmin-git git
-   git-unix git-cohttp-unix lwt lwt.unix)
+   git-unix lwt lwt.unix)
  (preprocess
   (pps ppx_irmin ppx_irmin.internal)))
 

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -48,7 +48,7 @@ module type X =
 
 module Mem (C : Irmin.Contents.S) = struct
   module G = Irmin_git.Mem
-  module M = Irmin_git.KV (G) (Git_unix.Sync (G) (Git_cohttp_unix))
+  module M = Irmin_git.KV (G) (Git_unix.Sync (G))
   module S = M.Make (C)
   include S
 
@@ -126,7 +126,7 @@ let test_sort_order (module S : S) =
   Lwt.return_unit
 
 module Ref (S : Irmin_git.G) = struct
-  module M = Irmin_git.Ref (S) (Git_unix.Sync (S) (Git_cohttp_unix))
+  module M = Irmin_git.Ref (S) (Git_unix.Sync (S))
   include M.Make (Irmin.Contents.String)
 end
 


### PR DESCRIPTION
No more dependencies about protocols to implement the client when all of them are discovered and added _via_  `functoria` and `mimic`. It's a draft to check the CI status.