### PR TITLE
Box the hash of parents and nodes in a commit's prehash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,7 +95,9 @@
     (#1401, @samoht)
   - `Info` implementations are not part of store: use `S.Info.v`
     instead of `Irmin.Info.v` (#1400, @samoht)
-  - Rename `Commit.V1` to `Commit.V1.Make` (#1431, @CraigFe)
+  - Rename `Commit.V1` to `Commit.V1.Make`. This functor now takes separate
+    hash and key implementations as arguments. (#1431 #1634, @CraigFe
+    @icristescu)
   - Introduce a `Schema` module to hold all the types that users can
     define in an Irmin store. Use this as a parameter to every `Maker`
     functor. This is a large change which touches all the backends.

--- a/src/irmin-tezos/schema.ml
+++ b/src/irmin-tezos/schema.ml
@@ -128,7 +128,7 @@ module Commit
     (Commit_key : Irmin.Key.S with type hash = Hash.t) =
 struct
   module M = Irmin.Commit.Generic_key.Make (Hash) (Node_key) (Commit_key)
-  module V1 = Irmin.Commit.V1.Make (M)
+  module V1 = Irmin.Commit.V1.Make (Hash) (M)
   include M
 
   let pre_hash_v1_t = Irmin.Type.(unstage (pre_hash V1.t))

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -592,23 +592,22 @@ module V1 = struct
   struct
     module K (K : Type.S) = struct
       let h = Type.string_of `Int64
-      let hash_to_bin_string = Type.(unstage (to_bin_string K.t))
-      let hash_of_bin_string = Type.(unstage (of_bin_string K.t))
-      let size_of = Type.Size.using hash_to_bin_string (Type.Size.t h)
+
+      type t = K.t [@@deriving irmin ~pre_hash ~to_bin_string ~of_bin_string]
+
+      let size_of = Type.Size.using to_bin_string (Type.Size.t h)
 
       let encode_bin =
         let encode_bin = Type.(unstage (encode_bin h)) in
-        fun e k -> encode_bin (hash_to_bin_string e) k
+        fun e k -> encode_bin (to_bin_string e) k
 
       let decode_bin =
         let decode_bin = Type.(unstage (decode_bin h)) in
         fun buf pos_ref ->
           let v = decode_bin buf pos_ref in
-          match hash_of_bin_string v with
+          match of_bin_string v with
           | Ok v -> v
           | Error (`Msg e) -> Fmt.failwith "decode_bin: %s" e
-
-      type t = K.t [@@deriving irmin ~pre_hash]
 
       (* Manually box hashes in V1 commits with length headers: *)
       let pre_hash =

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -245,7 +245,7 @@ module type Sigs = sig
     module Info : Info.S with type t = Info.Default.t
     (** Serialisation format for V1 info. *)
 
-    module Make (C : Generic_key.S with module Info := Info) : sig
+    module Make (Hash : Hash.S) (C : Generic_key.S with module Info := Info) : sig
       include
         Generic_key.S
           with module Info = Info


### PR DESCRIPTION
When computing the hash of a commit, we want to use the `pre_hash` of node keys and parent keys, instead of their `encode_bin`. This change is necessary for the structured keys PR.

The `encode_bin` was only necessary as a substitute for `pre_hash`, and it is not called anywhere else (I'm not sure why).

On top of https://github.com/mirage/irmin/pull/1633.
