### PR TITLE
irmin-pack: collect location information for `find` operations

### DIFF
--- a/bench/irmin-pack/trace_collection.ml
+++ b/bench/irmin-pack/trace_collection.ml
@@ -43,8 +43,8 @@ module Make_stat (Store : Irmin.KV) = struct
       let v = get () in
       Def.
         {
-          finds = v.finds;
-          cache_misses = v.cache_misses;
+          finds = v.finds.total;
+          cache_misses = Find.cache_misses v.finds;
           appended_hashes = v.appended_hashes;
           appended_offsets = v.appended_offsets;
         }

--- a/bench/irmin-pack/trace_collection.ml
+++ b/bench/irmin-pack/trace_collection.ml
@@ -41,12 +41,29 @@ module Make_stat (Store : Irmin.KV) = struct
     let pack () =
       let open Irmin_pack.Stats in
       let v = get () in
+      let finds =
+        Def.
+          {
+            total = v.finds.total;
+            from_staging = v.finds.from_staging;
+            from_lru = v.finds.from_lru;
+            from_pack = v.finds.from_pack;
+          }
+      in
       Def.
         {
-          finds = v.finds.total;
-          cache_misses = Find.cache_misses v.finds;
+          finds;
           appended_hashes = v.appended_hashes;
           appended_offsets = v.appended_offsets;
+          inode_add = v.inode_add;
+          inode_remove = v.inode_remove;
+          inode_of_seq = v.inode_of_seq;
+          inode_of_raw = v.inode_of_raw;
+          inode_rec_add = v.inode_rec_add;
+          inode_rec_remove = v.inode_rec_remove;
+          inode_to_binv = v.inode_to_binv;
+          inode_decode_bin = v.inode_decode_bin;
+          inode_encode_bin = v.inode_encode_bin;
         }
 
     let tree () =

--- a/bench/irmin-pack/trace_definitions.ml
+++ b/bench/irmin-pack/trace_definitions.ml
@@ -160,9 +160,9 @@ end
     version. *)
 module Stat_trace = struct
   module V0 = struct
-    type float32 = int32 [@@deriving repr]
-
     let version = 0
+
+    type float32 = int32 [@@deriving repr]
 
     type pack = {
       finds : int;
@@ -228,8 +228,8 @@ module Stat_trace = struct
     [@@deriving repr]
     (** Stats extracted from filesystem. Requires the path to the irmin store. *)
 
-    type bag_of_stats = {
-      pack : pack;
+    type 'pack_stats bag_of_stats_base = {
+      pack : 'pack_stats;
       tree : tree;
       index : index;
       gc : gc;
@@ -269,16 +269,16 @@ module Stat_trace = struct
         the commit, when the inode has been reconstructed and that [Tree.length]
         is now innexpensive to perform. *)
 
-    type commit = {
+    type 'pack_stats commit_base = {
       duration : float32;
-      before : bag_of_stats;
-      after : bag_of_stats;
+      before : 'pack_stats bag_of_stats_base;
+      after : 'pack_stats bag_of_stats_base;
       store_before : store_before;
       store_after : store_after;
     }
     [@@deriving repr]
 
-    type row =
+    type 'pack_stats row_base =
       [ `Add of float32
       | `Remove of float32
       | `Find of float32
@@ -286,8 +286,10 @@ module Stat_trace = struct
       | `Mem_tree of float32
       | `Checkout of float32
       | `Copy of float32
-      | `Commit of commit ]
+      | `Commit of 'pack_stats commit_base ]
     [@@deriving repr]
+
+    type row = pack row_base [@@deriving repr]
     (** Stats gathered while running an operation.
 
         {3 Operation durations}
@@ -320,14 +322,16 @@ module Stat_trace = struct
     }
     [@@deriving repr]
 
-    type header = {
+    type 'pack_stats header_base = {
       config : config;
       hostname : string;
       timeofday : float;
       word_size : int;
-      initial_stats : bag_of_stats;
+      initial_stats : 'pack_stats bag_of_stats_base;
     }
     [@@deriving repr]
+
+    type header = pack header_base [@@deriving repr]
     (** File header.
 
         {3 Timestamps}
@@ -344,9 +348,103 @@ module Stat_trace = struct
         [stats.timestamp_cpu] may originate from [Sys.time].
 
         It would be great to be able to record the library/sources versions. *)
+
+    type commit = pack commit_base [@@deriving repr]
+    type bag_of_stats = pack bag_of_stats_base [@@deriving repr]
   end
 
-  module Latest = V0
+  module V1 = struct
+    include V0
+
+    let version = 1
+
+    type finds = {
+      total : int;
+      from_staging : int;
+      from_lru : int;
+      from_pack : int;
+    }
+    [@@deriving repr]
+    (** Stats extracted from [Irmin_pack.Stats.get ()]. *)
+
+    type pack = {
+      finds : finds;
+      appended_hashes : int;
+      appended_offsets : int;
+      inode_add : int;
+      inode_remove : int;
+      inode_of_seq : int;
+      inode_of_raw : int;
+      inode_rec_add : int;
+      inode_rec_remove : int;
+      inode_to_binv : int;
+      inode_decode_bin : int;
+      inode_encode_bin : int;
+    }
+    [@@deriving repr]
+    (** Stats extracted from [Irmin_pack.Stats.get ()]. *)
+
+    type commit = pack commit_base [@@deriving repr]
+    type bag_of_stats = pack bag_of_stats_base [@@deriving repr]
+    type row = pack row_base [@@deriving repr]
+    type header = pack header_base [@@deriving repr]
+
+    (* [v0.cache_misses] is lost *)
+    let v1pack_of_v0pack (v0 : V0.pack) : pack =
+      {
+        finds =
+          { total = v0.finds; from_staging = 0; from_lru = 0; from_pack = 0 };
+        appended_hashes = v0.appended_hashes;
+        appended_offsets = v0.appended_offsets;
+        inode_add = 0;
+        inode_remove = 0;
+        inode_of_seq = 0;
+        inode_of_raw = 0;
+        inode_rec_add = 0;
+        inode_rec_remove = 0;
+        inode_to_binv = 0;
+        inode_decode_bin = 0;
+        inode_encode_bin = 0;
+      }
+
+    let v1bos_of_v0bos (v0 : V0.bag_of_stats) : bag_of_stats =
+      {
+        pack = v1pack_of_v0pack v0.pack;
+        tree = v0.tree;
+        index = v0.index;
+        gc = v0.gc;
+        disk = v0.disk;
+        timestamp_wall = v0.timestamp_wall;
+        timestamp_cpu = v0.timestamp_cpu;
+      }
+
+    let v1commit_of_v0commit (v0 : V0.commit) : commit =
+      {
+        duration = v0.duration;
+        before = v1bos_of_v0bos v0.before;
+        after = v1bos_of_v0bos v0.after;
+        store_before = v0.store_before;
+        store_after = v0.store_after;
+      }
+
+    let v1row_of_v0row (v0 : V0.row) : row =
+      match v0 with
+      | `Commit payload -> `Commit (v1commit_of_v0commit payload)
+      | ( `Add _ | `Remove _ | `Find _ | `Mem _ | `Mem_tree _ | `Checkout _
+        | `Copy _ ) as v0 ->
+          v0
+
+    let v1header_of_v0header (v0 : V0.header) : header =
+      {
+        config = v0.config;
+        hostname = v0.hostname;
+        timeofday = v0.timeofday;
+        word_size = v0.word_size;
+        initial_stats = v1bos_of_v0bos v0.initial_stats;
+      }
+  end
+
+  module Latest = V1
   include Latest
 
   let watched_nodes : watched_node list =
@@ -384,6 +482,14 @@ module Stat_trace = struct
             {
               header_t = V0.header_t;
               row_t = V0.row_t;
+              upgrade_header = v1header_of_v0header;
+              upgrade_row = v1row_of_v0row;
+            }
+      | 1 ->
+          Trace_common.Version_converter
+            {
+              header_t = V1.header_t;
+              row_t = V1.row_t;
               upgrade_header = Fun.id;
               upgrade_row = Fun.id;
             }

--- a/bench/irmin-pack/trace_stat_summary.ml
+++ b/bench/irmin-pack/trace_stat_summary.ml
@@ -211,11 +211,29 @@ type bag_stat = {
     The [value_after_commit] is initially fed with the value in the header (i.e.
     the value recorded just before the start of the play). *)
 
+type finds = {
+  total : bag_stat;
+  from_staging : bag_stat;
+  from_lru : bag_stat;
+  from_pack : bag_stat;
+  missing : bag_stat;
+  cache_miss : bag_stat;
+}
+[@@deriving repr]
+
 type pack = {
-  finds : bag_stat;
-  cache_misses : bag_stat;
+  finds : finds;
   appended_hashes : bag_stat;
   appended_offsets : bag_stat;
+  inode_add : bag_stat;
+  inode_remove : bag_stat;
+  inode_of_seq : bag_stat;
+  inode_of_raw : bag_stat;
+  inode_rec_add : bag_stat;
+  inode_rec_remove : bag_stat;
+  inode_to_binv : bag_stat;
+  inode_decode_bin : bag_stat;
+  inode_encode_bin : bag_stat;
 }
 [@@deriving repr]
 
@@ -762,18 +780,68 @@ let summarise' header block_count (row_seq : Def.row Seq.t) =
       block_count value_of_bag
   in
 
-  let pack_folder =
-    let construct finds cache_misses appended_hashes appended_offsets =
-      { finds; cache_misses; appended_hashes; appended_offsets }
+  let finds_folder =
+    let construct total from_staging from_lru from_pack missing cache_miss =
+      { total; from_staging; from_lru; from_pack; missing; cache_miss }
     in
     let acc0 =
       let open Utils.Parallel_folders in
       let ofi = float_of_int in
       open_ construct
-      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.finds)
-      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.cache_misses)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.finds.total)
+      |+ bs_folder_of_bag_getter (fun bag ->
+             ofi bag.Def.pack.finds.from_staging)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.finds.from_lru)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.finds.from_pack)
+      |+ bs_folder_of_bag_getter (fun bag ->
+             let open Def in
+             let v = bag.pack.finds in
+             v.total - v.from_staging - v.from_lru - v.from_pack |> ofi)
+      |+ bs_folder_of_bag_getter (fun bag ->
+             let open Def in
+             let v = bag.pack.finds in
+             v.total - v.from_staging - v.from_lru |> ofi)
+      |> seal
+    in
+    Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate
+      Utils.Parallel_folders.finalise
+  in
+
+  let pack_folder =
+    let construct finds appended_hashes appended_offsets inode_add inode_remove
+        inode_of_seq inode_of_raw inode_rec_add inode_rec_remove inode_to_binv
+        inode_decode_bin inode_encode_bin =
+      {
+        finds;
+        appended_hashes;
+        appended_offsets;
+        inode_add;
+        inode_remove;
+        inode_of_seq;
+        inode_of_raw;
+        inode_rec_add;
+        inode_rec_remove;
+        inode_to_binv;
+        inode_decode_bin;
+        inode_encode_bin;
+      }
+    in
+    let acc0 =
+      let open Utils.Parallel_folders in
+      let ofi = float_of_int in
+      open_ construct
+      |+ finds_folder
       |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.appended_hashes)
       |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.appended_offsets)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_add)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_remove)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_of_seq)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_of_raw)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_rec_add)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_rec_remove)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_to_binv)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_decode_bin)
+      |+ bs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.inode_encode_bin)
       |> seal
     in
     Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate

--- a/bench/irmin-pack/trace_stat_summary_cb.ml
+++ b/bench/irmin-pack/trace_stat_summary_cb.ml
@@ -157,10 +157,23 @@ let create_raw_results2 s : result list =
   let metrics =
     let open Summary in
     [
-      ("finds", s.pack.finds);
-      ("cache_misses", s.pack.cache_misses);
+      ("finds", s.pack.finds.total);
+      ("finds.from_staging", s.pack.finds.from_staging);
+      ("finds.from_lru", s.pack.finds.from_lru);
+      ("finds.from_pack", s.pack.finds.from_pack);
+      ("finds.missing", s.pack.finds.missing);
+      ("finds.cache_miss", s.pack.finds.cache_miss);
       ("appended_hashes", s.pack.appended_hashes);
       ("appended_offsets", s.pack.appended_offsets);
+      ("inode_add", s.pack.inode_add);
+      ("inode_remove", s.pack.inode_remove);
+      ("inode_of_seq", s.pack.inode_of_seq);
+      ("inode_of_raw", s.pack.inode_of_raw);
+      ("inode_rec_add", s.pack.inode_rec_add);
+      ("inode_rec_remove", s.pack.inode_rec_remove);
+      ("inode_to_binv", s.pack.inode_to_binv);
+      ("inode_decode_bin", s.pack.inode_decode_bin);
+      ("inode_encode_bin", s.pack.inode_encode_bin);
     ]
     |> List.map @@ fun (name, lbs) -> (name, [ lbs.value_after_commit.diff ])
   in

--- a/bench/irmin-pack/trace_stat_summary_pp.ml
+++ b/bench/irmin-pack/trace_stat_summary_pp.ml
@@ -391,10 +391,23 @@ module Table2 = struct
       pb "Disk writes" (fun s -> s.index.nb_writes);
       pb "Disk both" (fun s -> s.index.nb_both);
       `Spacer;
-      pb "pack.finds" (fun s -> s.pack.finds);
-      pb "pack.cache_misses" (fun s -> s.pack.cache_misses);
+      pb "pack.finds" (fun s -> s.pack.finds.total);
+      pb "pack.finds.from_staging" (fun s -> s.pack.finds.from_staging);
+      pb "pack.finds.from_lru" (fun s -> s.pack.finds.from_lru);
+      pb "pack.finds.from_pack" (fun s -> s.pack.finds.from_pack);
+      pb "pack.finds.missing" (fun s -> s.pack.finds.missing);
+      pb "pack.finds.cache_miss" (fun s -> s.pack.finds.cache_miss);
       pb "pack.appended_hashes" (fun s -> s.pack.appended_hashes);
       pb "pack.appended_offsets" (fun s -> s.pack.appended_offsets);
+      pb "pack.inode_add" (fun s -> s.pack.inode_add);
+      pb "pack.inode_remove" (fun s -> s.pack.inode_remove);
+      pb "pack.inode_of_seq" (fun s -> s.pack.inode_of_seq);
+      pb "pack.inode_of_raw" (fun s -> s.pack.inode_of_raw);
+      pb "pack.inode_rec_add" (fun s -> s.pack.inode_rec_add);
+      pb "pack.inode_rec_remove" (fun s -> s.pack.inode_rec_remove);
+      pb "pack.inode_to_binv" (fun s -> s.pack.inode_to_binv);
+      pb "pack.inode_decode_bin" (fun s -> s.pack.inode_decode_bin);
+      pb "pack.inode_encode_bin" (fun s -> s.pack.inode_encode_bin);
       `Spacer;
       pb "tree.contents_hash" (fun s -> s.tree.contents_hash);
       pb "tree.contents_find" (fun s -> s.tree.contents_find);
@@ -867,11 +880,29 @@ module Table4 = struct
       ps ~f:`Ri "Disk write count per sec *LA *N" (fun s -> s.index.nb_writes);
       ps ~f:`Ri "Disk both  count per sec *LA *N" (fun s -> s.index.nb_both);
       `Spacer;
-      pb "pack.finds per block *LA" (fun s -> s.pack.finds);
-      pb "pack.cache_misses per block *LA" (fun s -> s.pack.cache_misses);
       pb "pack.appended_hashes per block *LA" (fun s -> s.pack.appended_hashes);
       pb "pack.appended_offsets per block *LA" (fun s ->
           s.pack.appended_offsets);
+      pb "pack.finds per block *LA" (fun s -> s.pack.finds.total);
+      pb "pack.finds.from_staging per block *LA" (fun s ->
+          s.pack.finds.from_staging);
+      pb "pack.finds.from_lru per block *LA" (fun s -> s.pack.finds.from_lru);
+      pb "pack.finds.from_pack per block *LA" (fun s -> s.pack.finds.from_pack);
+      pb "pack.finds.missing per block *LA" (fun s -> s.pack.finds.missing);
+      pb "pack.finds.cache_miss per block *LA" (fun s ->
+          s.pack.finds.cache_miss);
+      pb "pack.inode_add per block *LA" (fun s -> s.pack.inode_add);
+      pb "pack.inode_remove per block *LA" (fun s -> s.pack.inode_remove);
+      pb "pack.inode_of_seq per block *LA" (fun s -> s.pack.inode_of_seq);
+      pb "pack.inode_of_raw per block *LA" (fun s -> s.pack.inode_of_raw);
+      pb "pack.inode_rec_add per block *LA" (fun s -> s.pack.inode_rec_add);
+      pb "pack.inode_rec_remove per block *LA" (fun s ->
+          s.pack.inode_rec_remove);
+      pb "pack.inode_to_binv per block *LA" (fun s -> s.pack.inode_to_binv);
+      pb "pack.inode_decode_bin per block *LA" (fun s ->
+          s.pack.inode_decode_bin);
+      pb "pack.inode_encode_bin per block *LA" (fun s ->
+          s.pack.inode_encode_bin);
       `Spacer;
       pb "tree.contents_hash per block *LA" (fun s -> s.tree.contents_hash);
       pb "tree.contents_find per block *LA" (fun s -> s.tree.contents_find);

--- a/src/irmin-pack/stats.mli
+++ b/src/irmin-pack/stats.mli
@@ -14,9 +14,22 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module Find : sig
+  type location = Staging | Lru | Pack | Not_found [@@deriving irmin]
+
+  type t = {
+    mutable total : int;
+    mutable from_staging : int;
+    mutable from_lru : int;
+    mutable from_pack : int;
+  }
+  [@@deriving irmin]
+
+  val cache_misses : t -> int
+end
+
 type t = {
-  mutable finds : int;
-  mutable cache_misses : int;
+  finds : Find.t;
   mutable appended_hashes : int;
   mutable appended_offsets : int;
   mutable inode_add : int;
@@ -32,9 +45,9 @@ type t = {
 [@@deriving irmin]
 (** The type for stats for a store S.
 
-    - [finds] is the number of calls to [S.find];
-    - [cache_misses] is the number of times a cache miss occured during calls to
-      [S.find];
+    - [finds] stores the total number of calls to [S.find], and tracks the
+      source locations of successful finds (i.e. whether the value was recovered
+      from the staging table, LRU, or the pack file);
     - [appended_hashes] is the number of times a hash was appended, during calls
       to [add];
     - [appended_offsets] is the number of times an offset was appended, during
@@ -49,8 +62,7 @@ type t = {
 
 val reset_stats : unit -> unit
 val get : unit -> t
-val incr_finds : unit -> unit
-val incr_cache_misses : unit -> unit
+val report_find : location:Find.location -> unit
 val incr_appended_hashes : unit -> unit
 val incr_appended_offsets : unit -> unit
 val incr_inode_add : unit -> unit

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -82,8 +82,7 @@ let replay_1_commit () =
   let expected =
     Irmin_pack.Stats.
       {
-        finds = 2;
-        cache_misses = 0;
+        finds = { total = 2; from_staging = 0; from_lru = 2; from_pack = 0 };
         appended_hashes = 0;
         appended_offsets = 4;
         inode_add = 0;


### PR DESCRIPTION
Changes `irmin-pack/stats.ml` to keep more granular information about `Store.find` operations (namely, _where_ each successful find came from). Doesn't (yet) expose this in the pack trace.

Drops `t.cache_misses`, since this can now be derived from the location information.

Extracted from https://github.com/mirage/irmin/pull/1534, which also splits the `Pack` location into `Pack_indexed` and `Pack_direct` (corresponding to whether or not the index was consulted for the length information). The advantage is that we can handle breaking the trace format in this PR to reduce the diff of #1534 considerably.