### PR TITLE
Remove Git_paf and lint dependencies according to the last version of Git

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@
   - irmin-pack: add an option to configure the index function and pick
     the relevant bits in cryptographic a hash by default (#1677, @samoht)
 
+- **irmin-git**
+  -  Require at least `git.3.7.0` in the codebase (#1637, @dinosaure)
+
 ## 2.9.0 (2021-11-15)
 
 ### Fixed

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -27,7 +27,6 @@ depends: [
   "logs"
   "lwt"        {>= "5.3.0"}
   "uri"
-  "git-cohttp-unix" {with-test}
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test}
   "mtime"      {with-test & >= "1.0.0"}

--- a/irmin-mirage-git.opam
+++ b/irmin-mirage-git.opam
@@ -17,9 +17,8 @@ depends: [
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
   "mirage-kv"    {>= "3.0.0"}
-  "git-paf"      {>= "3.5.0"}
   "fmt"
-  "git"          {>= "3.5.0"}
+  "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}
   "mirage-clock"
   "uri"

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -26,7 +26,7 @@ depends: [
   "irmin-graphql" {= version}
   "irmin-layers"  {= version}
   "irmin-tezos"   {= version}
-  "git-unix"      {>= "3.5.0"}
+  "git-unix"      {>= "3.7.0"}
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "0.1.0"}
@@ -43,8 +43,7 @@ depends: [
   "cmdliner"
   "cohttp-lwt-unix"
   "fmt"
-  "git"             {>= "3.5.0"}
-  "git-cohttp-unix" {>= "3.5.0"}
+  "git"             {>= "3.7.0"}
   "lwt"           {>= "5.3.0"}
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}

--- a/src/irmin-mirage/git/dune
+++ b/src/irmin-mirage/git/dune
@@ -1,5 +1,5 @@
 (library
  (name irmin_mirage_git)
  (public_name irmin-mirage-git)
- (libraries fmt git irmin irmin-mirage irmin-git git-paf lwt mirage-clock
-   mirage-kv uri))
+ (libraries fmt git irmin irmin-mirage irmin-git lwt mirage-clock mirage-kv
+   uri))

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -57,19 +57,19 @@ module Make
     (P : Irmin.Path.S)
     (B : Irmin.Branch.S) =
 struct
-  include Irmin_git.Make (G) (Git.Mem.Sync (G) (Git_paf)) (C) (P) (B)
+  include Irmin_git.Make (G) (Git.Mem.Sync (G)) (C) (P) (B)
 
   let remote ?ctx ?headers uri = E (remote ?ctx ?headers uri)
 end
 
 module Ref (G : Irmin_git.G) (C : Irmin.Contents.S) = struct
-  include Irmin_git.Ref (G) (Git.Mem.Sync (G) (Git_paf)) (C)
+  include Irmin_git.Ref (G) (Git.Mem.Sync (G)) (C)
 
   let remote ?ctx ?headers uri = E (remote ?ctx ?headers uri)
 end
 
 module KV (G : Irmin_git.G) (C : Irmin.Contents.S) = struct
-  include Irmin_git.KV (G) (Git.Mem.Sync (G) (Git_paf)) (C)
+  include Irmin_git.KV (G) (Git.Mem.Sync (G)) (C)
 
   let remote ?ctx ?headers uri = E (remote ?ctx ?headers uri)
 end

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -2,6 +2,6 @@
  (name irmin_unix)
  (public_name irmin-unix)
  (libraries astring cmdliner cohttp cohttp-lwt cohttp-lwt-unix conduit
-   conduit-lwt-unix git-cohttp-unix fmt.cli fmt.tty git git-unix irmin
-   irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack
-   irmin-tezos irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml))
+   conduit-lwt-unix fmt.cli fmt.tty git git-unix irmin irmin-fs irmin-git
+   irmin-graphql irmin-http irmin.mem irmin-pack irmin-tezos irmin-watcher
+   logs.cli logs.fmt lwt lwt.unix uri yaml))

--- a/src/irmin-unix/xgit.ml
+++ b/src/irmin-unix/xgit.ml
@@ -76,26 +76,26 @@ module Make
     (P : Irmin.Path.S)
     (B : Irmin.Branch.S) =
 struct
-  include Irmin_git.Make (G) (Git_unix.Sync (G) (Git_cohttp_unix)) (C) (P) (B)
+  include Irmin_git.Make (G) (Git_unix.Sync (G)) (C) (P) (B)
 
   let remote ?ctx ?headers uri = E (remote ?ctx ?headers uri)
 end
 
 module KV (G : Irmin_git.G) (C : Irmin.Contents.S) = struct
-  include Irmin_git.KV (G) (Git_unix.Sync (G) (Git_cohttp_unix)) (C)
+  include Irmin_git.KV (G) (Git_unix.Sync (G)) (C)
 
   let remote ?ctx ?headers uri = E (remote ?ctx ?headers uri)
 end
 
 module Ref (G : Irmin_git.G) (C : Irmin.Contents.S) = struct
-  include Irmin_git.Ref (G) (Git_unix.Sync (G) (Git_cohttp_unix)) (C)
+  include Irmin_git.Ref (G) (Git_unix.Sync (G)) (C)
 
   let remote ?ctx ?headers uri = E (remote ?ctx ?headers uri)
 end
 
 module FS = struct
   module G = Git_unix.Store
-  module S = Git_unix.Sync (G) (Git_cohttp_unix)
+  module S = Git_unix.Sync (G)
   module Make = Make (G)
   module Ref = Ref (G)
   module KV = KV (G)
@@ -103,7 +103,7 @@ end
 
 module Mem = struct
   module G = Irmin_git.Mem
-  module S = Git.Mem.Sync (G) (Git_cohttp_unix)
+  module S = Git.Mem.Sync (G)
   module Content_addressable = Irmin_git.Content_addressable (G)
   module Atomic_write = Irmin_git.Atomic_write (G)
   module Make = Make (G)

--- a/test/irmin-git/dune
+++ b/test/irmin-git/dune
@@ -2,7 +2,7 @@
  (name test_git)
  (modules test_git)
  (libraries alcotest fmt fpath irmin irmin-test irmin.mem irmin-git git
-   git-unix git-cohttp-unix lwt lwt.unix)
+   git-unix lwt lwt.unix)
  (preprocess
   (pps ppx_irmin)))
 

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -48,7 +48,7 @@ module type X =
 
 module Mem (C : Irmin.Contents.S) = struct
   module G = Irmin_git.Mem
-  module S = Irmin_git.KV (G) (Git_unix.Sync (G) (Git_cohttp_unix)) (C)
+  module S = Irmin_git.KV (G) (Git_unix.Sync (G)) (C)
   include S
 
   let init () =
@@ -144,10 +144,7 @@ let test_sort_order (module S : S) =
   Lwt.return_unit
 
 module Ref (S : Irmin_git.G) =
-  Irmin_git.Ref
-    (S)
-    (Git_unix.Sync (S) (Git_cohttp_unix))
-    (Irmin.Contents.String)
+  Irmin_git.Ref (S) (Git_unix.Sync (S)) (Irmin.Contents.String)
 
 let pp_reference ppf = function
   | `Branch s -> Fmt.pf ppf "branch: %s" s


### PR DESCRIPTION
Same as #1632 for 2.10