### PR TITLE
irmin-unix: Update `Irmin_unix.Resolver.Store.create` to use `hash` argument

### DIFF
--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -289,7 +289,11 @@ module Store = struct
       Irmin.Backend.Conf.Spec.t -> (module Irmin.Maker) -> hash -> contents -> t
       =
    fun spec (module S) (module H) (module C) ->
-    let module S = S.Make (Irmin.Schema.KV (C)) in
+    let module Schema = struct
+      include Irmin.Schema.KV (C)
+      module Hash = H
+    end in
+    let module S = S.Make (Schema) in
     v spec (module S)
 
   let mem = create Irmin_mem.Conf.spec (module Irmin_mem)

--- a/test/irmin-unix/test_command_line.t
+++ b/test/irmin-unix/test_command_line.t
@@ -78,3 +78,9 @@ Check that g/h/i has been deleted after merge
   <none>
   [1]
 
+Check mismatched hash function
+  $ irmin set --root ./test-hash -s irf -h sha1 abc 123
+  $ irmin snapshot --root ./test-hash -s irf -h blake2b
+  irmin: [ERROR] Irmin_fs.value invalid hash size
+  ERROR: (Invalid_argument "Irmin.head: no head")
+  [1]


### PR DESCRIPTION
Fixes #1636