### PR TITLE
irmin-pack: restructure store functors to use generic types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,10 @@
   - Renamed `Irmin_mirage_git.Make` into `Irmin_mirage_git.Maker`
     (#1369, @samoht)
 
+- **irmin-pack**
+  - The `Irmin_pack.Maker` module type now no longer takes a `Conf` argument.
+    (#1641, @CraigFe)
+
 - **irmin-unix**
   - Clean up command line interface. Allow config file to be specified when
     using `Irmin_unix.Resolver.load_config` and make command line options

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -195,7 +195,10 @@ module Make_store_layered (Conf : Irmin_pack.Conf.S) = struct
   include Store
 end
 
-module Make_basic (Maker : Irmin_pack.Maker) (Conf : Irmin_pack.Conf.S) = struct
+module Make_basic (Maker : functor (_ : Irmin_pack.Conf.S) ->
+  Irmin_pack.Maker)
+(Conf : Irmin_pack.Conf.S) =
+struct
   type store_config = config
 
   module Store = struct

--- a/src/irmin-pack/indexable.ml
+++ b/src/irmin-pack/indexable.ml
@@ -14,14 +14,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Content_addressable_intf
+include Indexable_intf
 open! Import
 
-(* FIXME: remove code duplication with irmin/content_addressable *)
+(* FIXME: remove code duplication with irmin/indexable *)
 module Closeable (S : S) = struct
   type 'a t = { closed : bool ref; t : 'a S.t }
   type key = S.key
+  type hash = S.hash
   type value = S.value
+
+  module Key = S.Key
 
   let check_not_closed t = if !(t.closed) then raise Irmin.Closed
 
@@ -32,6 +35,14 @@ module Closeable (S : S) = struct
   let find t k =
     check_not_closed t;
     S.find t.t k
+
+  let index t h =
+    check_not_closed t;
+    S.index t.t h
+
+  let index_direct t h =
+    check_not_closed t;
+    S.index_direct t.t h
 
   let add t v =
     check_not_closed t;

--- a/src/irmin-pack/indexable.mli
+++ b/src/irmin-pack/indexable.mli
@@ -13,17 +13,6 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
-open! Import
 
-module Maker (K : Irmin.Hash.S) : sig
-  type key = K.t
-
-  module Make (Val : Irmin_pack.Pack_value.S with type hash := K.t) : sig
-    include
-      Irmin_pack.Content_addressable.S
-        with type key = K.t
-         and type value = Val.t
-
-    val v : string -> read t Lwt.t
-  end
-end
+include Indexable_intf.Sigs
+(** @inline *)

--- a/src/irmin-pack/indexable_intf.ml
+++ b/src/irmin-pack/indexable_intf.ml
@@ -17,16 +17,18 @@
 open! Import
 
 module type S = sig
-  include Irmin.Content_addressable.S
+  include Irmin.Indexable.S
 
   val add : 'a t -> value -> key Lwt.t
   (** Overwrite [add] to work with a read-only database handler. *)
 
-  val unsafe_add : 'a t -> key -> value -> unit Lwt.t
+  val unsafe_add : 'a t -> hash -> value -> key Lwt.t
   (** Overwrite [unsafe_add] to work with a read-only database handler. *)
 
+  val index_direct : _ t -> hash -> key option
+
   val unsafe_append :
-    ensure_unique:bool -> overcommit:bool -> 'a t -> key -> value -> unit
+    ensure_unique:bool -> overcommit:bool -> 'a t -> hash -> value -> key
 
   val unsafe_mem : 'a t -> key -> bool
   val unsafe_find : check_integrity:bool -> 'a t -> key -> value option
@@ -50,7 +52,8 @@ module type Sigs = sig
   module type S = S
 
   module Closeable (CA : S) : sig
-    include S with type key = CA.key and type value = CA.value
+    include
+      S with type key = CA.key and type hash = CA.hash and type value = CA.value
 
     val make_closeable : 'a CA.t -> 'a t
     val get_open_exn : 'a t -> 'a CA.t

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -17,7 +17,12 @@
 open! Import
 
 module type Value = sig
-  include Irmin.Node.S
+  type key
+
+  include
+    Irmin.Node.Generic_key.S
+      with type node_key = key
+       and type contents_key = key
 
   val pred :
     t ->
@@ -42,6 +47,7 @@ module type S = sig
   module Val :
     Value
       with type t = value
+       and type key = key
        and type hash = Hash.t
        and type Portable.hash := hash
 
@@ -61,7 +67,7 @@ module type Persistent = sig
     string ->
     read t Lwt.t
 
-  include S.Checkable with type 'a t := 'a t and type key := key
+  include S.Checkable with type 'a t := 'a t and type hash := hash
 
   val sync : ?on_generation_change:(unit -> unit) -> 'a t -> unit
   val clear_caches : 'a t -> unit
@@ -72,17 +78,18 @@ end
     implement or test inodes. *)
 module type Internal = sig
   type hash
+  type key
 
   val pp_hash : hash Fmt.t
 
-  module Raw : Pack_value.S with type hash = hash
+  module Raw : Pack_value.S with type hash = hash and type key = key
 
   module Val : sig
-    include Value with type hash = hash
+    include Value with type hash = hash and type key = key
 
-    val of_raw : (hash -> Raw.t option) -> Raw.t -> t
+    val of_raw : (key -> Raw.t option) -> Raw.t -> t
     val to_raw : t -> Raw.t
-    val save : add:(hash -> Raw.t -> unit) -> mem:(hash -> bool) -> t -> unit
+    val save : add:(hash -> Raw.t -> unit) -> mem:(key -> bool) -> t -> unit
     val hash : t -> hash
     val stable : t -> bool
     val length : t -> int
@@ -146,25 +153,36 @@ module type Sigs = sig
   module Make_internal
       (Conf : Conf.S)
       (H : Irmin.Hash.S)
-      (Node : Irmin.Node.S with type hash = H.t) :
+      (Key : Irmin.Key.S with type hash = H.t and type t = H.t)
+      (Node : Irmin.Node.Generic_key.S
+                with type hash = H.t
+                 and type contents_key = Key.t
+                 and type node_key = Key.t) :
     Internal
       with type hash = H.t
+       and type key = Key.t
        and type Val.metadata = Node.metadata
        and type Val.step = Node.step
 
   module Make
       (H : Irmin.Hash.S)
-      (Node : Irmin.Node.S with type hash = H.t)
+      (Key : Irmin.Key.S with type hash = H.t and type t = H.t)
+      (Node : Irmin.Node.Generic_key.S
+                with type hash = H.t
+                 and type contents_key = Key.t
+                 and type node_key = Key.t)
       (Inter : Internal
                  with type hash = H.t
+                  and type key = Key.t
                   and type Val.metadata = Node.metadata
                   and type Val.step = Node.step)
-      (Pack : Content_addressable.S
-                with type key = H.t
+      (Pack : Indexable.S
+                with type key = Key.t
+                 and type hash = H.t
                  and type value = Inter.Raw.t) :
     S
       with type 'a t = 'a Pack.t
-       and type key = H.t
+       and type key = Key.t
        and type hash = H.t
        and type Val.metadata = Node.metadata
        and type Val.step = Node.step
@@ -172,21 +190,23 @@ module type Sigs = sig
 
   module Make_persistent
       (H : Irmin.Hash.S)
-      (Node : Irmin.Node.S with type hash = H.t)
+      (Node : Irmin.Node.Generic_key.S
+                with type hash = H.t
+                 and type contents_key = H.t Pack_key.t
+                 and type node_key = H.t Pack_key.t)
       (Inter : Internal
                  with type hash = H.t
+                  and type key = H.t Pack_key.t
                   and type Val.metadata = Node.metadata
                   and type Val.step = Node.step)
       (CA : Pack_store.Maker
-              with type key = H.t
-               and type index = Pack_index.Make(H).t) : sig
-    include
-      Persistent
-        with type key = H.t
-         and type hash = H.t
-         and type Val.metadata = Node.metadata
-         and type Val.step = Node.step
-         and type index = Pack_index.Make(H).t
-         and type value = Inter.Val.t
-  end
+              with type hash = H.t
+               and type index := Pack_index.Make(H).t) :
+    Persistent
+      with type key = H.t Pack_key.t
+       and type hash = H.t
+       and type Val.metadata = Node.metadata
+       and type Val.step = Node.step
+       and type index := Pack_index.Make(H).t
+       and type value = Inter.Val.t
 end

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -21,9 +21,7 @@ let config = Conf.init
 
 exception RO_not_allowed = S.RO_not_allowed
 
-module type S = S.S
-
-module Content_addressable = Content_addressable
+module Indexable = Indexable
 module Atomic_write = Atomic_write
 module Dict = Pack_dict
 module Hash = Irmin.Hash.BLAKE2B
@@ -44,7 +42,7 @@ module KV (V : Version.S) (Config : Conf.S) = struct
   type endpoint = unit
   type hash = Irmin.Schema.default_hash
 
-  include Irmin.Key.Store_spec.Hash_keyed
+  include Pack_key.Store_spec
   module Maker = Maker (V) (Config)
 
   type metadata = Metadata.t
@@ -58,14 +56,6 @@ module Checks = Checks
 module Inode = Inode
 module IO = IO
 module Utils = Utils
+module Pack_key = Pack_key
 module Pack_value = Pack_value
 module Pack_store = Pack_store
-module Vx = Version.V1
-
-module Cx = struct
-  let stable_hash = 0
-  let entries = 0
-end
-
-(* Enforce that {!KV} is a sub-type of {!Irmin.KV_maker}. *)
-module KV_is_a_KV_maker : Irmin.KV_maker = KV (Vx) (Cx)

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -20,18 +20,22 @@ include Inode_layers_intf
 module Make
     (Conf : Irmin_pack.Conf.S)
     (H : Irmin.Hash.S)
-    (Maker : S.Content_addressable_maker
-               with type key = H.t
+    (Maker : S.Indexable_maker
+               with type hash = H.t
+                and type key = H.t Irmin_pack.Pack_key.t
                 and type index := Index.Make(H).t)
-    (Node : Irmin.Node.S with type hash = H.t) =
+    (Node : Irmin.Node.Generic_key.S
+              with type hash = H.t
+               and type contents_key = H.t Irmin_pack.Pack_key.t
+               and type node_key = H.t Irmin_pack.Pack_key.t) =
 struct
   type index = Index.Make(H).t
 
-  module Internal = Irmin_pack.Inode.Make_internal (Conf) (H) (Node)
+  module Key = Irmin_pack.Pack_key.Make (H)
+  module Internal = Irmin_pack.Inode.Make_internal (Conf) (H) (Key) (Node)
   module P = Maker.Make (Internal.Raw)
   module Val = Internal.Val
   module Hash = H
-  module Key = Irmin.Key.Of_hash (H)
 
   type 'a t = 'a P.t
   type key = Key.t
@@ -39,7 +43,7 @@ struct
   type hash = Hash.t
 
   let mem t k = P.mem t k
-  let index _ h = Lwt.return_some h
+  let index t h = P.index t h
   let unsafe_find = P.unsafe_find
 
   let find t k =
@@ -68,7 +72,12 @@ struct
   let clear_caches = P.clear_caches
 
   let save t v =
-    let add k v = P.unsafe_append ~ensure_unique:true ~overcommit:false t k v in
+    let add k v =
+      let (_ : P.hash) =
+        P.unsafe_append ~ensure_unique:true ~overcommit:false t k v
+      in
+      ()
+    in
     Val.save ~add ~mem:(P.unsafe_mem t) v
 
   let add t v =

--- a/src/irmin-pack/layered/inode_layers_intf.ml
+++ b/src/irmin-pack/layered/inode_layers_intf.ml
@@ -56,7 +56,7 @@ module type S = sig
     offset:int63 ->
     length:int ->
     layer:Irmin_layers.Layer_id.t ->
-    key ->
+    hash ->
     'a t ->
     (unit, Irmin_pack.Checks.integrity_error) result
 
@@ -80,12 +80,16 @@ module type Sigs = sig
   module Make
       (_ : Irmin_pack.Conf.S)
       (H : Irmin.Hash.S)
-      (_ : S.Content_addressable_maker
-             with type key = H.t
+      (_ : S.Indexable_maker
+             with type hash = H.t
+              and type key = H.t Irmin_pack.Pack_key.t
               and type index = Index.Make(H).t)
-      (Node : Irmin.Node.S with type hash = H.t) :
+      (Node : Irmin.Node.Generic_key.S
+                with type hash = H.t
+                 and type contents_key = H.t Irmin_pack.Pack_key.t
+                 and type node_key = H.t Irmin_pack.Pack_key.t) :
     S
-      with type key = H.t
+      with type key = H.t Irmin_pack.Pack_key.t
        and type hash = H.t
        and type Val.metadata = Node.metadata
        and type Val.step = Node.step

--- a/src/irmin-pack/layered/layered_store.ml
+++ b/src/irmin-pack/layered/layered_store.ml
@@ -25,10 +25,11 @@ let stats = function
   | _ -> failwith "unexpected type in stats"
 
 module Copy
-    (Key : Irmin.Hash.S)
-    (SRC : Irmin_pack.Content_addressable.S with type key := Key.t)
-    (DST : Irmin_pack.Content_addressable.S
-             with type key := Key.t
+    (Key : Irmin.Key.S)
+    (SRC : Irmin_pack.Indexable.S with type key = Key.t and type hash = Key.hash)
+    (DST : Irmin_pack.Indexable.S
+             with type key = Key.t
+              and type hash = Key.hash
               and type value = SRC.value) =
 struct
   let ignore_lwt _ = Lwt.return_unit
@@ -42,7 +43,11 @@ struct
             (Irmin.Type.pp Key.t) k]
     | Some v ->
         stats str;
-        DST.unsafe_append ~ensure_unique:false ~overcommit:true dst k v
+        let (_ : Key.t) =
+          DST.unsafe_append ~ensure_unique:false ~overcommit:true dst
+            (Key.to_hash k) v
+        in
+        ()
 
   let check ~src ?(some = ignore_lwt) ?(none = ignore_lwt) k =
     SRC.find src k >>= function None -> none () | Some v -> some v
@@ -56,18 +61,25 @@ let pp_layer_id = Irmin_layers.Layer_id.pp
 let pp_current_upper ppf t = pp_layer_id ppf (if t then `Upper1 else `Upper0)
 let pp_next_upper ppf t = pp_layer_id ppf (if t then `Upper0 else `Upper1)
 
-module Content_addressable
+module Indexable
     (H : Irmin.Hash.S)
     (Index : Irmin_pack.Index.S)
-    (U : S with type index := Index.t and type key = H.t)
+    (U : S
+           with type index := Index.t
+            and type hash = H.t
+            and type key = H.t Irmin_pack.Pack_key.t)
     (L : S
            with type index := Index.t
+            and type hash = U.hash
             and type key = U.key
             and type value = U.value) =
 struct
   type index = Index.t
+  type hash = U.hash
   type key = U.key
   type value = U.value
+
+  module Key = Irmin_pack.Pack_key.Make (H)
 
   type 'a t = {
     lower : read L.t option;
@@ -109,22 +121,24 @@ struct
     if freeze then t.newies <- k :: t.newies;
     k
 
-  let unsafe_add t k v =
+  let unsafe_add t hash v =
     let freeze = t.freeze_in_progress () in
     [%log.debug "unsafe_add in %a%a" pp_current_upper t pp_during_freeze freeze];
     Irmin_layers.Stats.add ();
     let upper = current_upper t in
-    U.unsafe_add upper k v >|= fun () ->
-    if freeze then t.newies <- k :: t.newies
+    let+ k = U.unsafe_add upper hash v in
+    if freeze then t.newies <- k :: t.newies;
+    k
 
-  let unsafe_append ~ensure_unique ~overcommit t k v =
+  let unsafe_append ~ensure_unique ~overcommit t hash v =
     let freeze = t.freeze_in_progress () in
     [%log.debug
       "unsafe_append in %a%a" pp_current_upper t pp_during_freeze freeze];
     Irmin_layers.Stats.add ();
     let upper = current_upper t in
-    U.unsafe_append ~ensure_unique ~overcommit upper k v;
-    if freeze then t.newies <- k :: t.newies
+    let k = U.unsafe_append ~ensure_unique ~overcommit upper hash v in
+    if freeze then t.newies <- k :: t.newies;
+    k
 
   (** Everything is in current upper, no need to look in next upper. *)
   let find t k =
@@ -159,6 +173,24 @@ struct
         match t.lower with
         | None -> Lwt.return_false
         | Some lower -> L.mem lower k)
+
+  let index t hash =
+    let current = current_upper t in
+    U.index current hash >>= function
+    | Some _ as r -> Lwt.return r
+    | None -> (
+        match t.lower with
+        | None -> Lwt.return_none
+        | Some lower -> L.index lower hash)
+
+  let index_direct t hash =
+    let current = current_upper t in
+    U.index_direct current hash |> function
+    | Some _ as r -> r
+    | None -> (
+        match t.lower with
+        | None -> None
+        | Some lower -> L.index_direct lower hash)
 
   let unsafe_mem t k =
     let current = current_upper t in
@@ -277,8 +309,8 @@ struct
     [%log.debug "flip_upper to %a" pp_next_upper t];
     t.flip <- not t.flip
 
-  module CopyUpper = Copy (H) (U) (U)
-  module CopyLower = Copy (H) (U) (L)
+  module CopyUpper = Copy (Key) (U) (U)
+  module CopyLower = Copy (Key) (U) (L)
 
   type 'a layer_type =
     | Upper : read U.t layer_type
@@ -293,7 +325,7 @@ struct
   let check t ?none ?some k =
     CopyUpper.check ~src:(current_upper t) ?none ?some k
 
-  let copy : type l. l layer_type * l -> read t -> string -> key -> unit =
+  let copy : type l. l layer_type * l -> read t -> string -> L.key -> unit =
    fun (ltype, dst) ->
     match ltype with Lower -> copy_to_lower ~dst | Upper -> copy_to_next ~dst
 
@@ -310,23 +342,28 @@ struct
         | Some v ->
             aux v >>= fun () ->
             stats str;
-            U.unsafe_add dst k v
-        | None -> Fmt.failwith "%s %a not found" str (Irmin.Type.pp H.t) k)
+            U.unsafe_add dst (Key.to_hash k) v >|= ignore
+        | None -> Fmt.failwith "%s %a not found" str (Irmin.Type.pp Key.t) k)
 end
 
 module Pack_maker
     (H : Irmin.Hash.S)
     (Index : Irmin_pack.Index.S)
     (P : Irmin_pack.Pack_store.Maker
-           with type key = H.t
+           with type hash = H.t
             and type index := Index.t) =
 struct
   type index = Index.t
-  type key = P.key
+  type hash = H.t
+  type key = H.t Irmin_pack.Pack_key.t
 
-  module Make (V : Irmin_pack.Pack_value.S with type hash := key) = struct
+  module Make
+      (V : Irmin_pack.Pack_value.S
+             with type hash := hash
+              and type key := hash Irmin_pack.Pack_key.t) =
+  struct
     module Upper = P.Make (V)
-    include Content_addressable (H) (Index) (Upper) (Upper)
+    include Indexable (H) (Index) (Upper) (Upper)
   end
 end
 

--- a/src/irmin-pack/layered/layered_store.mli
+++ b/src/irmin-pack/layered/layered_store.mli
@@ -16,19 +16,22 @@
 
 val pp_current_upper : bool Fmt.t
 
-module Content_addressable
+module Indexable
     (H : Irmin.Hash.S)
     (Index : Irmin_pack.Index.S)
-    (U : Irmin_pack.Pack_store.S with type index := Index.t and type key = H.t)
+    (U : Irmin_pack.Pack_store.S
+           with type index := Index.t
+            and type hash = H.t
+            and type key = H.t Irmin_pack.Pack_key.t)
     (L : Irmin_pack.Pack_store.S
            with type index := Index.t
+            and type hash = U.hash
             and type key = U.key
             and type value = U.value) :
-  S.Content_addressable
-    with type index = Index.t
-     and type key = U.key
-     and type U.key = H.t
-     and type L.key = H.t
+  S.Indexable
+    with type hash = H.t
+     and type key = H.t Irmin_pack.Pack_key.t
+     and type index = Index.t
      and type value = U.value
      and type L.value = U.value
 
@@ -44,6 +47,9 @@ module Pack_maker
     (H : Irmin.Hash.S)
     (Index : Irmin_pack.Index.S)
     (P : Irmin_pack.Pack_store.Maker
-           with type key = H.t
+           with type hash = H.t
             and type index := Index.t) :
-  S.Content_addressable_maker with type key = P.key and type index = Index.t
+  S.Indexable_maker
+    with type hash = H.t
+     and type key = H.t Irmin_pack.Pack_key.t
+     and type index = Index.t

--- a/src/irmin-pack/mem/indexable.ml
+++ b/src/irmin-pack/mem/indexable.ml
@@ -56,14 +56,23 @@ end
 module Maker (K : Irmin.Hash.S) = struct
   type key = K.t
 
-  module Make (Val : Irmin_pack.Pack_value.S with type hash := K.t) = struct
+  module Make
+      (Val : Irmin_pack.Pack_value.S with type hash := K.t and type key := K.t) =
+  struct
+    (* TODO(craigfe): We could use the keys to skip traversal of the map on
+       lookup, but this must not introduce false-positives under [clear].
+
+       See https://github.com/mirage/irmin/pull/1389#discussion_r693789934. *)
+    module Key = Irmin.Key.Of_hash (K)
+
     module KMap = Map.Make (struct
       type t = K.t
 
       let compare = Irmin.Type.(unstage (compare K.t))
     end)
 
-    type key = K.t
+    type hash = K.t
+    type key = Key.t
     type value = Val.t
 
     type 'a t = {
@@ -71,6 +80,9 @@ module Maker (K : Irmin.Hash.S) = struct
       mutable t : value KMap.t;
       mutable generation : int63;
     }
+
+    let index_direct _ h = Some h
+    let index t h = Lwt.return (index_direct t h)
 
     let instances =
       Pool.create ~alloc:(fun name ->
@@ -97,7 +109,7 @@ module Maker (K : Irmin.Hash.S) = struct
 
     let cast t = (t :> read_write t)
     let batch t f = f (cast t)
-    let pp_key = Irmin.Type.pp K.t
+    let pp_hash = Irmin.Type.pp K.t
 
     let check_key k v =
       let k' = Val.hash v in
@@ -110,39 +122,36 @@ module Maker (K : Irmin.Hash.S) = struct
       with Not_found -> Ok None
 
     let unsafe_find ~check_integrity:_ t k =
-      [%log.debug "unsafe find %a" pp_key k];
+      [%log.debug "unsafe find %a" pp_hash k];
       find t k |> function
       | Ok r -> r
       | Error (k, k') ->
-          Fmt.invalid_arg "corrupted value: got %a, expecting %a" pp_key k'
-            pp_key k
+          Fmt.invalid_arg "corrupted value: got %a, expecting %a" pp_hash k'
+            pp_hash k
 
     let find t k =
-      [%log.debug "find %a" pp_key k];
+      [%log.debug "find %a" pp_hash k];
       find t k |> function
       | Ok r -> Lwt.return r
       | Error (k, k') ->
           Fmt.kstr Lwt.fail_invalid_arg "corrupted value: got %a, expecting %a"
-            pp_key k' pp_key k
+            pp_hash k' pp_hash k
 
     let unsafe_mem t k =
-      [%log.debug "mem %a" pp_key k];
+      [%log.debug "mem %a" pp_hash k];
       KMap.mem k t.t
 
     let mem t k = Lwt.return (unsafe_mem t k)
 
     let unsafe_append ~ensure_unique:_ ~overcommit:_ t k v =
-      [%log.debug "add -> %a" pp_key k];
-      t.t <- KMap.add k v t.t
+      [%log.debug "add -> %a" pp_hash k];
+      t.t <- KMap.add k v t.t;
+      k
 
     let unsafe_add t k v =
-      unsafe_append ~ensure_unique:true ~overcommit:true t k v;
-      Lwt.return_unit
+      Lwt.return (unsafe_append ~ensure_unique:true ~overcommit:true t k v)
 
-    let add t v =
-      let k = Val.hash v in
-      unsafe_add t k v >|= fun () -> k
-
+    let add t v = unsafe_add t (Val.hash v) v
     let generation t = t.generation
   end
 end

--- a/src/irmin-pack/mem/indexable.mli
+++ b/src/irmin-pack/mem/indexable.mli
@@ -13,5 +13,19 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
+open! Import
 
-module Maker (_ : Version.S) (_ : Conf.S) : S.Maker_persistent
+module Maker (K : Irmin.Hash.S) : sig
+  type key = K.t
+
+  module Make
+      (Val : Irmin_pack.Pack_value.S with type hash := K.t and type key := K.t) : sig
+    include
+      Irmin_pack.Indexable.S
+        with type hash = K.t
+         and type key = K.t
+         and type value = Val.t
+
+    val v : string -> read t Lwt.t
+  end
+end

--- a/src/irmin-pack/mem/irmin_pack_mem.mli
+++ b/src/irmin-pack/mem/irmin_pack_mem.mli
@@ -18,4 +18,8 @@
     backend, intended for users that must be interoperable with the
     idiosyncrasies of the persistent implementation. *)
 
-module Maker : Irmin_pack.Maker
+module Maker (_ : Irmin_pack.Conf.S) :
+  Irmin_pack.Maker
+    with type ('h, _) contents_key = 'h
+     and type 'h node_key = 'h
+     and type 'h commit_key = 'h

--- a/src/irmin-pack/pack_key.ml
+++ b/src/irmin-pack/pack_key.ml
@@ -14,4 +14,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Maker (_ : Version.S) (_ : Conf.S) : S.Maker_persistent
+open! Import
+include Pack_key_intf
+
+type 'hash t = 'hash
+
+module Make (Hash : Irmin.Hash.S) = struct
+  include Irmin.Key.Of_hash (Hash)
+
+  type nonrec t = t [@@deriving irmin ~of_bin_string]
+
+  let null =
+    match of_bin_string (String.make Hash.hash_size '\000') with
+    | Ok x -> x
+    | Error _ -> assert false
+end
+
+module type Store_spec = sig
+  type ('h, _) contents_key = 'h t
+  type 'h node_key = 'h t
+  type 'h commit_key = 'h t
+end
+
+module rec Store_spec : Store_spec = Store_spec

--- a/src/irmin-pack/pack_key.mli
+++ b/src/irmin-pack/pack_key.mli
@@ -13,5 +13,6 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
-include Content_addressable_intf.Sigs
+
+include Pack_key_intf.Sigs
 (** @inline *)

--- a/src/irmin-pack/pack_key_intf.ml
+++ b/src/irmin-pack/pack_key_intf.ml
@@ -14,4 +14,30 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Maker (_ : Version.S) (_ : Conf.S) : S.Maker_persistent
+open! Import
+
+module type S = sig
+  type hash
+
+  include Irmin.Key.S with type t = hash and type hash := hash
+
+  val null : t
+end
+
+module type Sigs = sig
+  type 'hash t = 'hash
+  (** The type of {i keys} referencing values stored in the [irmin-pack]
+      backend. *)
+
+  module type S = S
+
+  module Make (Hash : Irmin.Hash.S) : S with type hash = Hash.t
+
+  module type Store_spec = sig
+    type ('h, _) contents_key = 'h t
+    type 'h node_key = 'h t
+    type 'h commit_key = 'h t
+  end
+
+  module Store_spec : Store_spec
+end

--- a/src/irmin-pack/pack_store_intf.ml
+++ b/src/irmin-pack/pack_store_intf.ml
@@ -5,7 +5,7 @@ open! Import
     data blocks. The data file is indexed by hash via {!Pack_index.S}
     implementation. *)
 module type S = sig
-  include Content_addressable.S
+  include Indexable.S
 
   type index
 
@@ -33,18 +33,25 @@ module type S = sig
       are not removed. *)
 
   (** @inline *)
-  include S.Checkable with type 'a t := 'a t and type key := key
+  include S.Checkable with type 'a t := 'a t and type hash := hash
 end
 
 module type Maker = sig
-  type key
+  type hash
   type index
 
   (** Save multiple kind of values in the same pack file. Values will be
       distinguished using [V.magic], so they have to all be different. *)
 
-  module Make (V : Pack_value.S with type hash := key) :
-    S with type key = key and type value = V.t and type index = index
+  module Make
+      (V : Pack_value.Persistent
+             with type hash := hash
+              and type key := hash Pack_key.t) :
+    S
+      with type key = hash Pack_key.t
+       and type hash = hash
+       and type value = V.t
+       and type index := index
 end
 
 module type Sigs = sig
@@ -54,6 +61,6 @@ module type Sigs = sig
   module Maker
       (V : Version.S)
       (Index : Pack_index.S)
-      (K : Irmin.Hash.S with type t = Index.key) :
-    Maker with type key = K.t and type index = Index.t
+      (Hash : Irmin.Hash.S with type t = Index.key) :
+    Maker with type hash = Hash.t and type index := Index.t
 end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -24,16 +24,19 @@ end
 type ('h, 'a) value = { hash : 'h; kind : Kind.t; v : 'a } [@@deriving irmin]
 
 module type S = S with type kind := Kind.t
+module type Persistent = Persistent with type kind := Kind.t
 
 module Make (Config : sig
   val selected_kind : Kind.t
 end)
 (Hash : Irmin.Hash.S)
+(Key : T)
 (Data : Irmin.Type.S) =
 struct
   module Hash = Irmin.Hash.Typed (Hash) (Data)
 
   type t = Data.t [@@deriving irmin]
+  type key = Key.t
   type hash = Hash.t
 
   let hash = Hash.hash

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -4,6 +4,7 @@ module type S = sig
   include Irmin.Type.S
 
   type hash
+  type key
   type kind
 
   val hash : t -> hash
@@ -11,20 +12,26 @@ module type S = sig
 
   val encode_bin :
     dict:(string -> int option) ->
-    offset:(hash -> int63 option) ->
+    offset:(key -> int63 option) ->
     t ->
     hash ->
     (string -> unit) ->
     unit
 
   val decode_bin :
-    dict:(int -> string option) ->
-    hash:(int63 -> hash) ->
-    string ->
-    int ref ->
-    t
+    dict:(int -> string option) -> hash:(int63 -> key) -> string -> int ref -> t
 
   val decode_bin_length : string -> int -> int
+end
+
+module type Persistent = sig
+  type hash
+
+  include S with type hash := hash and type key = hash Pack_key.t
+end
+
+module type T = sig
+  type t
 end
 
 module type Sigs = sig
@@ -37,16 +44,21 @@ module type Sigs = sig
   end
 
   module type S = S with type kind := Kind.t
+  module type Persistent = Persistent with type kind := Kind.t
 
   module Make (_ : sig
     val selected_kind : Kind.t
   end)
   (Hash : Irmin.Hash.S)
-  (Data : Irmin.Type.S) : S with type hash = Hash.t
+  (Key : T)
+  (Data : Irmin.Type.S) : S with type hash = Hash.t and type key = Key.t
 
-  module Of_contents (Hash : Irmin.Hash.S) (Contents : Irmin.Contents.S) :
-    S with type t = Contents.t and type hash = Hash.t
+  module Of_contents
+      (Hash : Irmin.Hash.S)
+      (Key : T)
+      (Contents : Irmin.Contents.S) :
+    S with type t = Contents.t and type hash = Hash.t and type key = Key.t
 
-  module Of_commit (Hash : Irmin.Hash.S) (Commit : Irmin.Commit.S) :
-    S with type t = Commit.t and type hash = Hash.t
+  module Of_commit (Hash : Irmin.Hash.S) (Key : T) (Commit : Irmin.Commit.S) :
+    S with type t = Commit.t and type hash = Hash.t and type key = Key.t
 end

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -50,7 +50,7 @@ module type Args = sig
   module Version : Version.S
   module Hash : Irmin.Hash.S
   module Index : Pack_index.S with type key := Hash.t
-  module Inode : Inode.S with type key := Hash.t
+  module Inode : Inode.S with type hash := Hash.t
   module Dict : Pack_dict.S
   module Contents : Pack_value.S
   module Commit : Pack_value.S

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -108,12 +108,6 @@ module Make (S : Generic_key) = struct
 
   let get = function None -> Alcotest.fail "get" | Some v -> v
 
-  module H_node = struct
-    include Irmin.Hash.Typed (B.Hash) (B.Node.Val)
-
-    type nonrec t = t [@@deriving irmin ~equal]
-  end
-
   let test_nodes x () =
     let test repo =
       let g = g repo and n = n repo in

--- a/src/irmin-tezos/irmin_tezos.mli
+++ b/src/irmin-tezos/irmin_tezos.mli
@@ -26,6 +26,6 @@ module Store :
      and type Schema.Path.step = Schema.Path.step
      and type Schema.Contents.t = Schema.Contents.t
      and type Backend.Remote.endpoint = unit
-     and type contents_key = Schema.Hash.t
-     and type node_key = Schema.Hash.t
-     and type commit_key = Schema.Hash.t
+     and type contents_key = Schema.Hash.t Irmin_pack.Pack_key.t
+     and type node_key = Schema.Hash.t Irmin_pack.Pack_key.t
+     and type commit_key = Schema.Hash.t Irmin_pack.Pack_key.t

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -73,6 +73,7 @@ end
 
 module I = Index
 module Index = Irmin_pack.Index.Make (Schema.Hash)
+module Key = Irmin_pack.Pack_key.Make (Schema.Hash)
 
 module P =
   Irmin_pack.Pack_store.Maker (Irmin_pack.Version.V2) (Index) (Schema.Hash)

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -49,18 +49,20 @@ module Alcotest : sig
   val check_repr : 'a Irmin.Type.t -> string -> 'a -> 'a -> unit
 end
 
-module Index : Irmin_pack.Index.S with type key = Schema.Hash.t
+module Index : module type of Irmin_pack.Index.Make (Schema.Hash)
+module Key : Irmin_pack.Pack_key.S with type hash = Schema.Hash.t
 
 module Pack :
   Irmin_pack.Pack_store.S
-    with type key = Schema.Hash.t
+    with type hash = Schema.Hash.t
+     and type key = Key.t
      and type value = string
-     and type index = Index.t
+     and type index := Index.t
 
 module P :
   Irmin_pack.Pack_store.Maker
-    with type key = Schema.Hash.t
-     and type index = Irmin_pack.Index.Make(Schema.Hash).t
+    with type hash = Schema.Hash.t
+     and type index := Irmin_pack.Index.Make(Schema.Hash).t
 
 (** Helper constructors for fresh pre-initialised dictionaries and packs *)
 module Make_context (Config : sig

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -66,7 +66,7 @@ module Test = struct
   let info = Store.Info.empty
 
   let commit ctxt =
-    let parents = List.map Store.Commit.hash ctxt.parents in
+    let parents = List.map Store.Commit.key ctxt.parents in
     let+ h = Store.Commit.v ctxt.index.repo ~info ~parents ctxt.tree in
     Store.Tree.clear ctxt.tree;
     h
@@ -118,7 +118,7 @@ module Test = struct
     (ctxt, h)
 
   let check_block1 repo block1 =
-    Store.Commit.of_hash repo (Store.Commit.hash block1) >>= function
+    Store.Commit.of_key repo (Store.Commit.key block1) >>= function
     | None -> Alcotest.fail "no hash found in repo"
     | Some commit ->
         let tree = Store.Commit.tree commit in
@@ -136,7 +136,7 @@ module Test = struct
     (ctxt, h)
 
   let check_block1a repo block1a =
-    Store.Commit.of_hash repo (Store.Commit.hash block1a) >>= function
+    Store.Commit.of_key repo (Store.Commit.key block1a) >>= function
     | None -> Alcotest.fail "no hash found in repo"
     | Some commit ->
         let tree = Store.Commit.tree commit in
@@ -154,7 +154,7 @@ module Test = struct
     (ctxt, h)
 
   let check_block1b repo block1 =
-    Store.Commit.of_hash repo (Store.Commit.hash block1) >>= function
+    Store.Commit.of_key repo (Store.Commit.key block1) >>= function
     | None -> Alcotest.fail "no hash found in repo"
     | Some commit ->
         let tree = Store.Commit.tree commit in
@@ -168,7 +168,7 @@ module Test = struct
     (ctxt, h)
 
   let check_block1c repo block =
-    Store.Commit.of_hash repo (Store.Commit.hash block) >>= function
+    Store.Commit.of_key repo (Store.Commit.key block) >>= function
     | None -> Alcotest.fail "no hash found in repo"
     | Some commit ->
         let tree = Store.Commit.tree commit in
@@ -181,7 +181,7 @@ module Test = struct
     (ctxt, h)
 
   let check_block2a repo block1a =
-    Store.Commit.of_hash repo (Store.Commit.hash block1a) >>= function
+    Store.Commit.of_key repo (Store.Commit.key block1a) >>= function
     | None -> Alcotest.fail "no hash found in repo"
     | Some commit ->
         let tree = Store.Commit.tree commit in
@@ -194,7 +194,7 @@ module Test = struct
     (ctxt, h)
 
   let check_block3a repo block =
-    Store.Commit.of_hash repo (Store.Commit.hash block) >>= function
+    Store.Commit.of_key repo (Store.Commit.key block) >>= function
     | None -> Alcotest.fail "no hash found in repo"
     | Some commit ->
         let tree = Store.Commit.tree commit in
@@ -489,7 +489,7 @@ module Test = struct
     Store.freeze ctxt.index.repo ~max_lower:[ block1a ] >>= fun () ->
     Store.Backend_layer.wait_for_freeze ctxt.index.repo >>= fun () ->
     let check_layer block msg exp =
-      Store.layer_id ctxt.index.repo (Store.Commit_t (Store.Commit.hash block))
+      Store.layer_id ctxt.index.repo (Store.Commit_t (Store.Commit.key block))
       >|= Irmin_test.check Irmin_layers.Layer_id.t msg exp
     in
     check_layer block1 "check layer of block1" `Lower >>= fun () ->

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -57,7 +57,7 @@ let exec_cmd cmd =
 
 module type Migrate_store = sig
   include
-    Irmin.S
+    Irmin.Generic_key.S
       with type Schema.Path.step = string
        and type Schema.Path.t = string list
        and type Schema.Contents.t = string
@@ -73,7 +73,7 @@ module Test
     end) =
 struct
   let check_commit repo commit bindings =
-    commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
+    commit |> S.Commit.key |> S.Commit.of_key repo >>= function
     | None ->
         Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash commit
     | Some commit ->
@@ -371,7 +371,7 @@ module Test_corrupted_stores = struct
       S.Tree.singleton k v |> S.Commit.v repo ~parents:[] ~info:S.Info.empty
     in
     let check_commit repo commit k v =
-      commit |> S.Commit.hash |> S.Commit.of_hash repo >>= function
+      commit |> S.Commit.key |> S.Commit.of_key repo >>= function
       | None ->
           Alcotest.failf "Commit `%a' is dangling in repo" S.Commit.pp_hash
             commit

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -32,9 +32,10 @@ let log_size = 1000
 module Path = Irmin.Path.String_list
 module Metadata = Irmin.Metadata.None
 module H = Schema.Hash
-module Node = Irmin.Node.Make (H) (Path) (Metadata)
+module Key = Irmin_pack.Pack_key.Make (H)
+module Node = Irmin.Node.Generic_key.Make (H) (Path) (Metadata) (Key) (Key)
 module Index = Irmin_pack.Index.Make (H)
-module Inter = Irmin_pack.Inode.Make_internal (Conf) (H) (Node)
+module Inter = Irmin_pack.Inode.Make_internal (Conf) (H) (Key) (Node)
 module Inode = Irmin_pack.Inode.Make_persistent (H) (Node) (Inter) (P)
 
 module Context = struct
@@ -60,7 +61,7 @@ end
 
 open Schema
 
-type pred = [ `Contents of Hash.t | `Inode of Hash.t | `Node of Hash.t ]
+type pred = [ `Contents of Key.t | `Inode of Key.t | `Node of Key.t ]
 [@@deriving irmin]
 
 let pp_pred = Irmin.Type.pp pred_t

--- a/test/irmin-tezos/generate.ml
+++ b/test/irmin-tezos/generate.ml
@@ -48,8 +48,8 @@ module Layered = struct
     let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
     let* () = Store.Backend_layer.wait_for_freeze repo in
     let* tree = Store.Tree.add tree [ "a"; "b"; "d" ] "x2" in
-    let hash = Store.Commit.hash c in
-    let* c3 = Store.Commit.v repo ~info ~parents:[ hash ] tree in
+    let key = Store.Commit.key c in
+    let* c3 = Store.Commit.v repo ~info ~parents:[ key ] tree in
     let* () = Store.Branch.set repo "master" c3 in
     Store.Repo.close repo
 end
@@ -82,10 +82,10 @@ module Simple = struct
     let* c1 = Store.Commit.v rw ~parents:[] ~info tree in
 
     let* tree = Store.Tree.add tree [ "a"; "b3" ] "x3" in
-    let* c2 = Store.Commit.v rw ~parents:[ Store.Commit.hash c1 ] ~info tree in
+    let* c2 = Store.Commit.v rw ~parents:[ Store.Commit.key c1 ] ~info tree in
 
     let* tree = Store.Tree.remove tree [ "a"; "b1"; "c1" ] in
-    let* _ = Store.Commit.v rw ~parents:[ Store.Commit.hash c2 ] ~info tree in
+    let* _ = Store.Commit.v rw ~parents:[ Store.Commit.key c2 ] ~info tree in
 
     Store.Repo.close rw
 end


### PR DESCRIPTION
This PR contains many of the functor diffs currently included in https://github.com/mirage/irmin/pull/1534, without actually changing `irmin-pack` to use structured kes. Introduces a new module `Pack_key` to hold a chosen key type, which is currently just a simple hash.

Reduces the diff introduced by #1534 by about 20%:

```diff
-62 files changed, 2509 insertions(+), 960 deletions(-)
+55 files changed, 2064 insertions(+), 799 deletions(-)
```