### PR TITLE
irmin-pack: provide utility functions over value kinds

### DIFF
--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -17,8 +17,17 @@ module Kind = struct
     | 'N' -> Node
     | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
 
-  let t = Irmin.Type.(map char) of_magic_exn to_magic
-  let pp = Fmt.using to_magic Fmt.char
+  let all = [ Commit; Contents; Inode; Node ]
+  let to_enum = function Commit -> 0 | Contents -> 1 | Inode -> 2 | Node -> 3
+
+  let pp =
+    Fmt.of_to_string (function
+      | Commit -> "Commit"
+      | Contents -> "Contents"
+      | Inode -> "Inode"
+      | Node -> "Node")
+
+  let t = Irmin.Type.map ~pp Irmin.Type.char of_magic_exn to_magic
 end
 
 type ('h, 'a) value = { hash : 'h; kind : Kind.t; v : 'a } [@@deriving irmin]

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -31,6 +31,8 @@ module type Sigs = sig
   module Kind : sig
     type t = Commit | Contents | Inode | Node [@@deriving irmin]
 
+    val all : t list
+    val to_enum : t -> int
     val to_magic : t -> char
     val of_magic_exn : char -> t
     val pp : t Fmt.t


### PR DESCRIPTION
These simplify the process of extending the `Pack_value.Kind.t` type with extra cases.

Extracted from https://github.com/mirage/irmin/pull/1534.