### PR TITLE
irmin-pack: add support for reading contents length headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -146,6 +146,9 @@
 - **irmin-pack**
   - The `Irmin_pack.Maker` module type now no longer takes a `Conf` argument.
     (#1641, @CraigFe)
+  - The backend configuration type `Conf.S` requires a new parameter
+    `contents_length_header` that (optionally) further specifies the encoding
+    format used for commits in order to improve performance. (#1644, @CraigFe)
 
 - **irmin-unix**
   - Clean up command line interface. Allow config file to be specified when

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -19,6 +19,7 @@ let config ~root = Irmin_pack.config ~fresh:false root
 module Config = struct
   let entries = 2
   let stable_hash = 3
+  let contents_length_header = Some `Varint
 end
 
 module KV = struct

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -232,6 +232,7 @@ let store_of_config config =
   let module Conf = struct
     let entries = entries
     let stable_hash = stable_hash
+    let contents_length_header = Some `Varint
   end in
   match config.store_type with
   | `Pack -> (module Bench_suite (Make_store_pack (Conf)) : B)

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -14,9 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type length_header = [ `Varint ] option
+
 module type S = sig
   val entries : int
   val stable_hash : int
+  val contents_length_header : length_header
 end
 
 module Default = struct

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -14,9 +14,20 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type length_header = [ `Varint ] option
+
 module type S = sig
   val entries : int
   val stable_hash : int
+
+  val contents_length_header : length_header
+  (** Describes the length header of the user's contents values when
+      binary-encoded. Supported modes are:
+
+      - [Some `Varint]: the length header is a LEB128-encoded integer at the
+        very beginning of the encoded value.
+
+      - [None]: there is no length header, and values have unknown size. *)
 end
 
 val spec : Irmin.Backend.Conf.Spec.t

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -43,7 +43,7 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
       [@@deriving irmin]
 
       module Contents = struct
-        module Pack_value = Pack_value.Of_contents (H) (XKey) (C)
+        module Pack_value = Pack_value.Of_contents (Config) (H) (XKey) (C)
         module CA = Pack.Make (Pack_value)
         include Irmin.Contents.Store_indexable (CA) (H) (C)
       end

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1048,6 +1048,7 @@ struct
     let step_of_bin = T.step_of_bin_string
     let encode_compress = Irmin.Type.(unstage (encode_bin Compress.t))
     let decode_compress = Irmin.Type.(unstage (decode_bin Compress.t))
+    let length_header = `Never
 
     let decode_compress_length =
       match Irmin.Type.Size.of_encoding Compress.t with

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -54,7 +54,8 @@ module Maker' (Config : Conf.Pack.S) (Schema : Irmin.Schema.Extended) = struct
     module Hash = H
 
     module Contents = struct
-      module Pack_value = Irmin_pack.Pack_value.Of_contents (H) (XKey) (C)
+      module Pack_value =
+        Irmin_pack.Pack_value.Of_contents (Config) (H) (XKey) (C)
 
       (* FIXME: remove duplication with irmin-pack/ext.ml *)
       module CA = struct

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -58,7 +58,9 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
       module Info = Schema.Info
 
       module Contents = struct
-        module Pack_value = Irmin_pack.Pack_value.Of_contents (H) (XKey) (C)
+        module Pack_value =
+          Irmin_pack.Pack_value.Of_contents (Config) (H) (XKey) (C)
+
         module Indexable = Indexable_mem (H) (Pack_value)
         include Irmin.Contents.Store_indexable (Indexable) (H) (C)
       end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -28,6 +28,7 @@ module type Persistent = Persistent with type kind := Kind.t
 
 module Make (Config : sig
   val selected_kind : Kind.t
+  val length_header : length_header
 end)
 (Hash : Irmin.Hash.S)
 (Key : T)
@@ -41,6 +42,12 @@ struct
 
   let hash = Hash.hash
   let kind = Config.selected_kind
+
+  let length_header =
+    match Config.length_header with
+    | None -> `Never
+    | Some _ as x -> `Sometimes (Fun.const x)
+
   let value = [%typ: (Hash.t, Data.t) value]
   let encode_value = Irmin.Type.(unstage (encode_bin value))
   let decode_value = Irmin.Type.(unstage (decode_bin value))
@@ -49,6 +56,8 @@ struct
   let decode_bin ~dict:_ ~hash:_ s off =
     let t = decode_value s off in
     t.v
+
+  type nonrec int = int [@@deriving irmin ~decode_bin]
 
   let decode_bin_length =
     match Irmin.Type.(Size.of_encoding value) with
@@ -61,10 +70,15 @@ struct
   let kind _ = Config.selected_kind
 end
 
-module Of_contents = Make (struct
+module Of_contents (Conf : sig
+  val contents_length_header : length_header
+end) =
+Make (struct
   let selected_kind = Kind.Contents
+  let length_header = Conf.contents_length_header
 end)
 
 module Of_commit = Make (struct
   let selected_kind = Kind.Commit
+  let length_header = None
 end)

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -1,5 +1,7 @@
 open! Import
 
+type length_header = [ `Varint ] option
+
 module type S = sig
   include Irmin.Type.S
 
@@ -9,6 +11,7 @@ module type S = sig
 
   val hash : t -> hash
   val kind : t -> kind
+  val length_header : [ `Never | `Sometimes of kind -> [ `Varint ] option ]
 
   val encode_bin :
     dict:(string -> int option) ->
@@ -48,15 +51,18 @@ module type Sigs = sig
 
   module Make (_ : sig
     val selected_kind : Kind.t
+    val length_header : length_header
   end)
   (Hash : Irmin.Hash.S)
   (Key : T)
   (Data : Irmin.Type.S) : S with type hash = Hash.t and type key = Key.t
 
-  module Of_contents
-      (Hash : Irmin.Hash.S)
-      (Key : T)
-      (Contents : Irmin.Contents.S) :
+  module Of_contents (_ : sig
+    val contents_length_header : length_header
+  end)
+  (Hash : Irmin.Hash.S)
+  (Key : T)
+  (Contents : Irmin.Contents.S) :
     S with type t = Contents.t and type hash = Hash.t and type key = Key.t
 
   module Of_commit (Hash : Irmin.Hash.S) (Key : T) (Commit : Irmin.Commit.S) :

--- a/src/irmin-tezos/irmin_tezos.ml
+++ b/src/irmin-tezos/irmin_tezos.ml
@@ -23,6 +23,7 @@ end
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let contents_length_header = Some `Varint
 end
 
 module Maker = Irmin_pack.Maker_ext (V1) (Conf)

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -59,6 +59,7 @@ module Contents = struct
   let hash = H.hash
   let encode_pair = Irmin.Type.(unstage (encode_bin (pair H.t t)))
   let decode_pair = Irmin.Type.(unstage (decode_bin (pair H.t t)))
+  let length_header = `Sometimes (Fun.const (Some `Varint))
   let encode_bin ~dict:_ ~offset:_ x k = encode_pair (k, x)
 
   let decode_bin ~dict:_ ~hash:_ x pos_ref =

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -163,6 +163,7 @@ end
 module Small_conf = struct
   let entries = 2
   let stable_hash = 3
+  let contents_length_header = Some `Varint
 end
 
 module V1_maker = Irmin_pack.V1 (Small_conf)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -25,6 +25,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Conf = struct
   let entries = 2
   let stable_hash = 3
+  let contents_length_header = Some `Varint
 end
 
 let log_size = 1000

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -20,6 +20,7 @@ open Common
 module Config = struct
   let entries = 2
   let stable_hash = 3
+  let contents_length_header = Some `Varint
 end
 
 let test_dir = Filename.concat "_build" "test-db-pack"

--- a/test/irmin-tezos/generate.ml
+++ b/test/irmin-tezos/generate.ml
@@ -60,6 +60,7 @@ module Simple = struct
   module Conf = struct
     let entries = 2
     let stable_hash = 3
+    let contents_length_header = Some `Varint
   end
 
   module Schema = Irmin.Schema.KV (Irmin.Contents.String)


### PR DESCRIPTION
Adds a configuration option requiring the user to specify whether or not their contents value uses an LEB128-encoded length header. This option is currently unused, but will be required to enable direct pointers to contents values in a future version of `irmin-pack`.

Extracted from https://github.com/mirage/irmin/pull/1534.