### PR TITLE
[2.10] Tree.empty now takes a unit argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@
 - *irmin*
   - Conversion between proofs and trees are now done in CPS (#1624, @samoht)
 
+### Changed
+
+- **irmin**
+  - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
+
 ## 2.9.0 (2021-11-15)
 
 ### Fixed

--- a/bench/irmin-pack/layers.ml
+++ b/bench/irmin-pack/layers.ml
@@ -38,7 +38,7 @@ let init config =
 module Trees = Generate_trees (Store)
 
 let init_commit repo =
-  Store.Commit.v repo ~info:(info ()) ~parents:[] Store.Tree.empty
+  Store.Commit.v repo ~info:(info ()) ~parents:[] (Store.Tree.empty ())
 
 let checkout_and_commit config repo c nb =
   Store.Commit.of_hash repo c >>= function

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -282,7 +282,7 @@ struct
     with_progress_bar ~message:"Replaying trace" ~n:(Array.length commits)
       ~unit:"commits"
     @@ fun prog ->
-    let t = { tree = Store.Tree.empty } in
+    let t = { tree = Store.Tree.empty () } in
     let rec array_iter_lwt prev_commit i =
       if i >= Array.length commits then Lwt.return_unit
       else
@@ -336,7 +336,7 @@ struct
       (Hash)
 
   let init_commit repo =
-    Store.Commit.v repo ~info:(info ()) ~parents:[] Store.Tree.empty
+    Store.Commit.v repo ~info:(info ()) ~parents:[] (Store.Tree.empty ())
 
   module Trees = Generate_trees (Store)
   module Trees_trace = Generate_trees_from_trace (Store)

--- a/examples/deploy.ml
+++ b/examples/deploy.ml
@@ -18,7 +18,7 @@ let provision repo =
   Config.init ();
   let provision = info ~user:"Automatic VM provisioning" in
   let* t = Store.of_branch repo "upstream" in
-  let v = Store.Tree.empty in
+  let v = Store.Tree.empty () in
   let* v =
     Store.Tree.add v [ "etc"; "manpath" ] "/usr/share/man\n/usr/local/share/man"
   in

--- a/examples/trees.ml
+++ b/examples/trees.ml
@@ -12,14 +12,17 @@ type t2 = { x : string; y : t1 }
 type t = t2 list
 
 let tree_of_t t =
-  Lwt_list.fold_left_s
-    (fun (v, i) t2 ->
-      let si = string_of_int i in
-      let* v = Tree.add v [ si; "x" ] t2.x in
-      let+ v = Tree.add v [ si; "y" ] (string_of_int t2.y) in
-      (v, i + 1))
-    (Tree.empty, 0) t
-  >|= fst
+  let+ tree, _ =
+    Lwt_list.fold_left_s
+      (fun (v, i) t2 ->
+        let si = string_of_int i in
+        let* v = Tree.add v [ si; "x" ] t2.x in
+        let+ v = Tree.add v [ si; "y" ] (string_of_int t2.y) in
+        (v, i + 1))
+      (Tree.empty (), 0)
+      t
+  in
+  tree
 
 let t_of_tree v =
   let aux acc i =

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -491,7 +491,7 @@ struct
             let* info, retries, allow_empty, parents = txn_args s i in
             Lwt.catch
               (fun () ->
-                let tree = Store.Tree.empty in
+                let tree = Store.Tree.empty () in
                 let* tree = to_tree tree items in
                 Store.set_tree t ?retries ?allow_empty ?parents ~info k tree
                 >>= function
@@ -515,7 +515,9 @@ struct
                 Store.with_tree t ?retries ?allow_empty ?parents k ~info
                   (fun tree ->
                     let tree =
-                      match tree with Some t -> t | None -> Store.Tree.empty
+                      match tree with
+                      | Some t -> t
+                      | None -> Store.Tree.empty ()
                     in
                     to_tree tree items >>= Lwt.return_some)
                 >>= function
@@ -538,7 +540,7 @@ struct
             let* tree =
               Store.find_tree t k >>= function
               | Some tree -> Lwt.return tree
-              | None -> Lwt.return Store.Tree.empty
+              | None -> Lwt.return (Store.Tree.empty ())
             in
             let* tree = Store.Tree.add tree k ?metadata:m v in
             Store.set_tree t ?retries ?allow_empty ?parents k tree ~info
@@ -622,14 +624,14 @@ struct
             let* old =
               match old with
               | Some old ->
-                  let tree = Store.Tree.empty in
+                  let tree = Store.Tree.empty () in
                   to_tree tree old >>= Lwt.return_some
               | None -> Lwt.return_none
             in
             let* value =
               match value with
               | Some value ->
-                  let tree = Store.Tree.empty in
+                  let tree = Store.Tree.empty () in
                   to_tree tree value >>= Lwt.return_some
               | None -> Lwt.return_none
             in

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -185,7 +185,7 @@ module KV_RO (G : Git.S) = struct
   let tree t =
     let repo = S.repo t.t in
     (S.find_tree t.t t.root >|= function
-     | None -> S.Tree.empty
+     | None -> S.Tree.empty ()
      | Some tree -> tree)
     >|= fun tree -> { Tree.repo; tree }
 
@@ -326,7 +326,7 @@ module KV_RW (G : Irmin_git.G) (C : Mirage_clock.PCLOCK) = struct
         let tree = S.Commit.tree origin in
         S.Tree.find_tree tree t.root >|= function
         | Some t -> Some (origin, t)
-        | None -> Some (origin, S.Tree.empty))
+        | None -> Some (origin, S.Tree.empty ()))
 
   let batch t ?(retries = 42) f =
     let info = info t `Batch in

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -166,7 +166,7 @@ module Make (Store : Irmin.KV with type contents = string) = struct
   (* init: create a tree with [t.depth] levels and each levels has
      [t.tree_add] files + one directory going to the next levele. *)
   let init t config =
-    let tree = Store.Tree.empty in
+    let tree = Store.Tree.empty () in
     let* v = Store.Repo.v config >>= Store.master in
     let* tree =
       times ~n:t.depth ~init:tree (fun depth tree ->

--- a/src/irmin-test/layered_store.ml
+++ b/src/irmin-test/layered_store.ml
@@ -139,7 +139,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
                  \-> c3
     *)
     let tree1 repo =
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let* tree = S.Tree.add tree [ "c"; "b"; "a" ] "x" in
       let* c0 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b"; "a1" ] "x1" in
@@ -155,7 +155,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
      \->  c4      \-> c8
     *)
     let tree2 repo =
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let* tree = S.Tree.add tree [ "c"; "b1" ] "x4" in
       let* c4 = S.Commit.v repo ~info ~parents:[] tree in
       let* tree = S.Tree.add tree [ "c"; "b2" ] "x5" in
@@ -286,7 +286,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
   let test_set_tree x () =
     let test repo =
       let* t = S.master repo in
-      let* t1 = S.Tree.add S.Tree.empty [ "a"; "d" ] v1 in
+      let* t1 = S.Tree.add (S.Tree.empty ()) [ "a"; "d" ] v1 in
       let* t1 = S.Tree.add t1 [ "a"; "b"; "c" ] v2 in
       S.set_tree_exn ~info:(infof "commit 1") ~parents:[] t [] t1 >>= fun () ->
       S.freeze repo ~max_upper:[] >>= fun () ->
@@ -438,8 +438,8 @@ module Make_Layered (S : LAYERED_STORE) = struct
   let test_branch_squash x () =
     let check_val = check T.(option S.contents_t) in
     let setup repo =
-      let* tree1 = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v1 in
-      let* tree2 = S.Tree.add S.Tree.empty [ "a"; "b"; "d" ] v2 in
+      let* tree1 = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
+      let* tree2 = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "d" ] v2 in
       let* foo = S.of_branch repo "foo" in
       S.set_tree_exn ~parents:[] ~info:(infof "tree1") foo [] tree1
       >>= fun () ->
@@ -528,7 +528,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
     let test repo =
       let info = info "freezes" in
       let check_val repo = check (T.option @@ S.commit_t repo) in
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let rec commits tree acc i =
         if i = 10 then Lwt.return acc
         else
@@ -578,7 +578,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
         let+ x = S.Tree.find tree [ "5" ] in
         Alcotest.(check (option string)) "x5" (Some "x5") x
       in
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let* tree = S.Tree.add tree [ "1"; "2"; "3" ] "x1" in
       let* tree = S.Tree.add tree [ "4" ] "x4" in
       let* tree = S.Tree.add tree [ "5" ] "x5" in
@@ -730,7 +730,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
     let check_commit = check (T.option P.Commit.Val.t) in
     let check_branch repo = check (T.option @@ S.commit_t repo) in
     let test repo =
-      let tree = S.Tree.empty in
+      let tree = S.Tree.empty () in
       let rec setup i tree commits contents =
         if i > 6 then Lwt.return (commits, List.rev contents)
         else
@@ -952,7 +952,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
         Alcotest.(check (option string)) "v1" v' (Some v)
       in
       let add_and_find_commit ~hook v =
-        let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v in
+        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v in
         let* c = S.Commit.v repo ~info ~parents:[] tree in
         let hook, p = hook (find_commit c v) in
         let* () =
@@ -984,7 +984,7 @@ module Make_Layered (S : LAYERED_STORE) = struct
         Alcotest.(check (option string)) "v" v' (Some v)
       in
       let add_commit t v () =
-        let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v in
+        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v in
         S.set_tree_exn ~parents:[] ~info:(infof "tree1") t [] tree
       in
       let add_and_find_commit ~hook t v =
@@ -1008,12 +1008,12 @@ module Make_Layered (S : LAYERED_STORE) = struct
   let test_add_again x () =
     let test repo =
       let* t = S.master repo in
-      let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v1 in
+      let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
       S.set_tree_exn ~parents:[] ~info:(infof "v1") t [] tree >>= fun () ->
-      let* tree = S.Tree.add S.Tree.empty [ "a"; "d" ] v2 in
+      let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "d" ] v2 in
       S.set_tree_exn ~parents:[] ~info:(infof "v2") t [] tree >>= fun () ->
       let add_commit () =
-        let* tree = S.Tree.add S.Tree.empty [ "a"; "b"; "c" ] v1 in
+        let* tree = S.Tree.add (S.Tree.empty ()) [ "a"; "b"; "c" ] v1 in
         let* tree = S.Tree.add tree [ "a"; "e" ] v3 in
         S.set_tree_exn ~parents:[] ~info:(infof "v3") t [] tree
       in

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -492,10 +492,10 @@ let watch =
                   let view (c, _) =
                     let* t = S.of_commit c in
                     S.find_tree t path >|= function
-                    | None -> S.Tree.empty
+                    | None -> S.Tree.empty ()
                     | Some v -> v
                   in
-                  let empty = Lwt.return S.Tree.empty in
+                  let empty = Lwt.return (S.Tree.empty ()) in
                   let x, y =
                     match d with
                     | `Updated (x, y) -> (view x, view y)

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -517,7 +517,7 @@ module Make (P : Private.S) = struct
 
   let tree t =
     tree_and_head t >|= function
-    | None -> Tree.empty
+    | None -> Tree.empty ()
     | Some (_, tree) -> (tree :> tree)
 
   let lift_head_diff repo fn = function
@@ -707,7 +707,8 @@ module Make (P : Private.S) = struct
   let snapshot t key =
     tree_and_head t >>= function
     | None ->
-        Lwt.return { head = None; root = Tree.empty; tree = None; parents = [] }
+        Lwt.return
+          { head = None; root = Tree.empty (); tree = None; parents = [] }
     | Some (c, root) ->
         let root = (root :> tree) in
         let+ tree = Tree.find_tree root key in
@@ -1189,7 +1190,7 @@ module Json_tree (Store : S with type contents = Contents.json) = struct
     of_concrete_tree c
 
   let set t key j ~info =
-    set_tree Store.Tree.empty Store.Key.empty j >>= function
+    set_tree (Store.Tree.empty ()) Store.Key.empty j >>= function
     | tree -> Store.set_tree_exn ~info t key tree
 
   let get t key =

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -39,9 +39,9 @@ module type S = sig
 
   (** {1 Constructors} *)
 
-  val empty : t
-  (** [empty] is the empty tree. The empty tree does not have associated backend
-      configuration values, as they can perform in-memory operation,
+  val empty : unit -> t
+  (** [empty ()] is the empty tree. The empty tree does not have associated
+      backend configuration values, as they can perform in-memory operation,
       independently of any given backend. *)
 
   val of_contents : ?metadata:metadata -> contents -> t

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -211,7 +211,7 @@ let test_blobs (module S : S) =
     "blob foo" "blob 19\000{\"Y\":[\"foo\",\"bar\"]}" str;
   let str = pre_hash X.Contents.t (X (1, 2)) in
   Alcotest.(check bin_string) "blob ''" "blob 11\000{\"X\":[1,2]}" str;
-  let t = X.Tree.empty in
+  let t = X.Tree.empty () in
   let* t = X.Tree.add t [ "foo" ] (X (1, 2)) in
   let k1 = X.Tree.hash t in
   let* repo = X.Repo.v (Irmin_git.config test_db) in

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -46,7 +46,7 @@ let create_store () =
   rm_dir ();
   let* repo = Store.Repo.v (config data_dir) in
   let* _t = Store.master repo in
-  let* tree = Store.Tree.add Store.Tree.empty [ "a"; "b"; "c" ] "x1" in
+  let* tree = Store.Tree.add (Store.Tree.empty ()) [ "a"; "b"; "c" ] "x1" in
   let* c = Store.Commit.v repo ~info ~parents:[] tree in
   let* () = Store.freeze ~max_lower:[ c ] ~max_upper:[] repo in
   let* () = Store.Private_layer.wait_for_freeze repo in

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -98,13 +98,13 @@ module Test = struct
     Common.rm_dir root;
     let+ repo = Store.Repo.v (config ?readonly ?with_lower root) in
     let index = { root; repo } in
-    let tree = Store.Tree.empty in
+    let tree = Store.Tree.empty () in
     { index; tree; parents = [] }
 
   let clone ?readonly ?with_lower root =
     let+ repo = Store.Repo.v (config ~fresh:false ?readonly ?with_lower root) in
     let index = { root; repo } in
-    let tree = Store.Tree.empty in
+    let tree = Store.Tree.empty () in
     { index; tree; parents = [] }
 
   let freeze ?copy_in_upper ctxt commit =
@@ -114,7 +114,7 @@ module Test = struct
       | None | Some true -> None
     in
     Store.freeze ?max_upper ctxt.index.repo ~max_lower:[ commit ] >|= fun () ->
-    { index = ctxt.index; tree = Store.Tree.empty; parents = [] }
+    { index = ctxt.index; tree = Store.Tree.empty (); parents = [] }
 
   let commit_block1 ctxt =
     let* ctxt = set ctxt [ "a"; "b" ] "Novembre" in
@@ -227,7 +227,7 @@ module Test = struct
 
   let commit_block1_simple_store repo =
     let* tree =
-      StoreSimple.Tree.add StoreSimple.Tree.empty [ "a"; "b" ] "Novembre"
+      StoreSimple.Tree.add (StoreSimple.Tree.empty ()) [ "a"; "b" ] "Novembre"
     in
     let* tree = StoreSimple.Tree.add tree [ "a"; "c" ] "Juin" in
     let* tree = StoreSimple.Tree.add tree [ "version" ] "0.0" in

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -54,7 +54,7 @@ let open_ro_after_rw_closed () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* t = S.master rw in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   S.set_tree_exn ~parents:[] ~info t [] tree >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
   S.Repo.close rw >>= fun () ->
@@ -99,11 +99,11 @@ let ro_sync_after_add () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
   check ro c1 "a" "x" >>= fun () ->
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "y" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "y" in
   let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   check ro c1 "a" "x" >>= fun () ->
   let* () =
@@ -120,7 +120,7 @@ let ro_sync_after_close () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = binding (S.Tree.add S.Tree.empty ?metadata:None) in
+  let* tree = binding (S.Tree.add (S.Tree.empty ()) ?metadata:None) in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.Repo.close rw >>= fun () ->
   S.sync ro;
@@ -142,7 +142,7 @@ let clear_all repo =
 let clear_rw_open_ro () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   clear_all rw >>= fun () ->
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
@@ -154,12 +154,12 @@ let clear_rw_find_ro () =
   rm_dir root;
   let* rw = S.Repo.v (config ~readonly:false ~fresh:true root) in
   let* ro = S.Repo.v (config ~readonly:true ~fresh:false root) in
-  let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
   let* c1 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   S.sync ro;
   check_binding ro c1 ~msg:"RO finds value" [ "a" ] "x" >>= fun () ->
   clear_all rw >>= fun () ->
-  let* tree = S.Tree.add S.Tree.empty [ "b" ] "y" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ "b" ] "y" in
   let* c2 = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let* () =
     check_binding ro c1 ~msg:"RO finds value after clear but before sync"
@@ -183,7 +183,7 @@ let clear_rw_twice () =
   in
   let add () =
     check_empty () >>= fun () ->
-    let* tree = S.Tree.add S.Tree.empty [ "a" ] "x" in
+    let* tree = S.Tree.add (S.Tree.empty ()) [ "a" ] "x" in
     S.set_tree_exn ~parents:[] ~info t [] tree
   in
   let add_after_clear () =
@@ -210,14 +210,14 @@ let dict_sync_after_clear_same_offset () =
         Alcotest.(check (option string)) "RO find" (Some value) x
   in
   let long_string = random_string 200 in
-  let* tree = S.Tree.add S.Tree.empty [ long_string ] "x" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ long_string ] "x" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let h = S.Commit.hash c in
   S.sync ro;
   find_key h long_string "x" >>= fun () ->
   clear_all rw >>= fun () ->
   let long_string = random_string 200 in
-  let* tree = S.Tree.add S.Tree.empty [ long_string ] "y" in
+  let* tree = S.Tree.add (S.Tree.empty ()) [ long_string ] "y" in
   let* c = S.Commit.v rw ~parents:[] ~info:(info ()) tree in
   let h = S.Commit.hash c in
   S.sync ro;

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -128,7 +128,7 @@ struct
       let* rw = S.Repo.v conf_rw in
       Log.app (fun m -> m "Checking new commits can be added to the V2 store");
       let* new_commit =
-        S.Tree.add S.Tree.empty [ "c" ] "x"
+        S.Tree.add (S.Tree.empty ()) [ "c" ] "x"
         >>= S.Commit.v rw ~parents:[] ~info:Irmin.Info.empty
       in
       check_commit rw new_commit [ ([ "c" ], "x") ] >>= fun () ->
@@ -383,7 +383,7 @@ module Test_corrupted_stores = struct
     setup_test ();
     let module S = Make_layered in
     let add_commit repo k v =
-      S.Tree.add S.Tree.empty k v
+      S.Tree.add (S.Tree.empty ()) k v
       >>= S.Commit.v repo ~parents:[] ~info:Irmin.Info.empty
     in
     let check_commit repo commit k v =

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -67,7 +67,7 @@ module Make (Conf : Irmin_pack.Conf.S) = struct
         ([ h ], zero))
 
   let init_tree bindings =
-    let tree = Tree.empty in
+    let tree = Tree.empty () in
     let* tree =
       Lwt_list.fold_left_s (fun tree (k, v) -> Tree.add tree k v) tree bindings
     in
@@ -135,7 +135,7 @@ let zero = String.make 10 '0'
 let bindings steps = List.map (fun x -> ([ x ], zero)) steps
 
 let test_fold ~order bindings expected =
-  let tree = Tree.empty in
+  let tree = Tree.empty () in
   let* tree =
     Lwt_list.fold_left_s (fun tree (k, v) -> Tree.add tree k v) tree bindings
   in
@@ -280,7 +280,7 @@ let test_small_inode () =
 
 let test_deeper_proof () =
   let* ctxt =
-    let tree = Tree.empty in
+    let tree = Tree.empty () in
     let* level_one =
       let bindings = bindings fewer_steps in
       Lwt_list.fold_left_s (fun tree (k, v) -> Tree.add tree k v) tree bindings

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -155,7 +155,7 @@ let test_diff _ () =
 let test_empty _ () =
   let* () =
     Alcotest.check_tree_lwt "The empty tree is empty" ~expected:(`Tree [])
-      (Lwt.return Tree.empty)
+      (Lwt.return (Tree.empty ()))
   in
 
   (* Ensure that different [empty] values have disjoint cache state.
@@ -165,7 +165,7 @@ let test_empty _ () =
      avoid sharing keys from different repositories). *)
   let* () =
     let* repo = Store.Repo.v (Irmin_mem.config ()) in
-    let empty_exported = Tree.empty and empty_not_exported = Tree.empty in
+    let empty_exported = Tree.empty () and empty_not_exported = Tree.empty () in
     let+ () =
       Store.Private.Repo.batch repo (fun c n _ ->
           Store.save_tree repo c n empty_exported >|= ignore)
@@ -191,7 +191,7 @@ let test_add _ () =
   let* () =
     Alcotest.check_tree_lwt "Adding a root value to an empty tree"
       ~expected:(c "1")
-      (Tree.add Tree.empty [] "1")
+      (Tree.add (Tree.empty ()) [] "1")
   in
 
   let* () =
@@ -234,7 +234,7 @@ let test_remove _ () =
   in
 
   let* () =
-    let t = Tree.empty in
+    let t = Tree.empty () in
     let+ t' = Tree.remove t [] in
     Alcotest.assert_ "Removing in an empty tree preserves physical equality"
       (t == t')
@@ -402,7 +402,7 @@ let test_update _ () =
       "Updating at a path in an empty tree creates the necessary intermediate \
        nodes with the new contents."
       ~expected:(`Tree [ ("a", `Tree [ ("b", `Tree [ ("c", c "1") ]) ]) ])
-      (Tree.update Tree.empty [ "a"; "b"; "c" ] (None --> Some "1"))
+      (Tree.update (Tree.empty ()) [ "a"; "b"; "c" ] (None --> Some "1"))
   in
 
   let* () =
@@ -414,7 +414,7 @@ let test_update _ () =
   in
 
   let* () =
-    let t = Tree.empty in
+    let t = Tree.empty () in
     let+ t' = Tree.update t [] (None --> None) in
     Alcotest.assert_ "Removing from an empty tree preserves physical equality"
       (t == t')
@@ -423,7 +423,7 @@ let test_update _ () =
   let* () =
     let+ abc1' =
       Tree.update_tree abc1 [ "a"; "b"; "d" ] (function
-        | None -> Some Tree.empty
+        | None -> Some (Tree.empty ())
         | Some _ -> assert false)
     in
     Alcotest.assert_
@@ -450,7 +450,7 @@ let test_clear _ () =
   let size = 830829 in
   let* t =
     List.init size string_of_int
-    |> Lwt_list.fold_left_s (fun acc i -> Tree.add acc [ i ] i) Tree.empty
+    |> Lwt_list.fold_left_s (fun acc i -> Tree.add acc [ i ] i) (Tree.empty ())
   in
   (* Check the state of the root and root/42 *)
   Alcotest.(check inspect) "Before clear, root" (`Node `Map) (Tree.inspect t);
@@ -514,7 +514,7 @@ let test_fold_force _ () =
      and that [f] is called the correct number of times. *)
   let* () =
     let* tree =
-      Lwt.return Tree.empty
+      Lwt.return (Tree.empty ())
       >>= with_binding [ "existing"; "subtree" ] (Tree.of_contents "value")
       >>= with_binding [ "dangling"; "subtree"; "hash" ] invalid_tree
       >>= with_binding [ "other"; "lazy"; "path" ] invalid_tree
@@ -629,8 +629,10 @@ module Broken = struct
       [ ("shallow", shallow_of_ptr); ("pruned", pruned_of_ptr) ]
     and&* path = [ []; [ "k" ] ] in
     let* leaf_broken = operation leaf_ptr in
-    let* hash_actual = Tree.(add_tree empty) path leaf >|= Tree.hash in
-    let+ hash_expected = Tree.(add_tree empty) path leaf_broken >|= Tree.hash in
+    let* hash_actual = Tree.(add_tree (empty ())) path leaf >|= Tree.hash in
+    let+ hash_expected =
+      Tree.(add_tree (empty ())) path leaf_broken >|= Tree.hash
+    in
     Alcotest.(gcheck Store.Hash.t)
       (Fmt.str
          "Hashing a %s %s value at path %a is equivalent to hashing the \
@@ -645,12 +647,16 @@ module Broken = struct
       Logs.app (fun l ->
           l "Testing operations on a tree with a broken position at %a" pp_key
             path);
-      let* broken_leaf = Tree.(add_tree empty) path broken_contents in
-      let* broken_node = Tree.(add_tree empty) path broken_node in
+      let* broken_leaf = Tree.(add_tree (empty ())) path broken_contents in
+      let* broken_node = Tree.(add_tree (empty ())) path broken_node in
       let beneath = path @ [ "a"; "b"; "c" ] in
       let blob = "v" in
-      let* singleton_at_path = Tree.(add empty path blob >>= to_concrete) in
-      let* singleton_beneath = Tree.(add empty beneath blob >>= to_concrete) in
+      let* singleton_at_path =
+        Tree.(add (empty ()) path blob >>= to_concrete)
+      in
+      let* singleton_beneath =
+        Tree.(add (empty ()) beneath blob >>= to_concrete)
+      in
 
       (* [add] on broken nodes/contents replaces the broken position. *)
       let* () =
@@ -702,7 +708,7 @@ module Broken = struct
   let test_pruned_fold _ () =
     let&* _, ptr = [ random_contents (); random_node () ]
     and&* path = [ []; [ "k" ] ] in
-    let* tree = Tree.(add_tree empty) path (Tree.pruned ptr) in
+    let* tree = Tree.(add_tree (empty ())) path (Tree.pruned ptr) in
 
     (* Folding over a pruned tree with [force:`True] should fail: *)
     let* () =
@@ -741,7 +747,8 @@ let test_generic_equality _ () =
   let* tree = persist_tree (tree [ ("k", c "v") ]) in
   let+ should_be_empty = Tree.remove tree [ "k" ] in
   Alcotest.(gcheck Store.tree_t)
-    "Modified empty tree is equal to [Tree.empty]" Tree.empty should_be_empty
+    "Modified empty tree is equal to [(Tree.empty ())]" (Tree.empty ())
+    should_be_empty
 
 let test_is_empty _ () =
   (* Test for equivalence against an [is_equal] derived from generic equality,
@@ -749,14 +756,14 @@ let test_is_empty _ () =
   let is_empty =
     let equal = Type.unstage (Type.equal Store.tree_t) in
     fun t ->
-      let reference = equal t Tree.empty in
+      let reference = equal t (Tree.empty ()) in
       let candidate = Tree.is_empty t in
       Alcotest.(check bool)
-        "`equal Tree.empty` agrees with `is_empty`" reference candidate;
+        "`equal (Tree.empty ())` agrees with `is_empty`" reference candidate;
       candidate
   in
   let kv = tree [ ("k", c "v") ] in
-  let () = Alcotest.(check bool) "empty tree" true (is_empty Tree.empty) in
+  let () = Alcotest.(check bool) "empty tree" true (is_empty (Tree.empty ())) in
   let () = Alcotest.(check bool) "non-empty tree" false (is_empty kv) in
   let* () =
     let+ tree = Tree.remove kv [ "k" ] in
@@ -764,7 +771,7 @@ let test_is_empty _ () =
   in
   let* repo = Store.Repo.v (Irmin_mem.config ()) in
   let () =
-    let shallow_empty = Tree.(shallow repo (`Node (hash empty))) in
+    let shallow_empty = Tree.(shallow repo (`Node (hash (empty ())))) in
     Alcotest.(check bool) "shallow empty tree" true (is_empty shallow_empty)
   in
   let () =

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -35,6 +35,16 @@ module Alcotest = struct
       b_lwt
       >>= Tree.to_concrete
       >|= Alcotest.check ?pos concrete_tree msg expected
+
+  let inspect =
+    Alcotest.testable
+      (fun ppf -> function
+        | `Contents -> Fmt.string ppf "contents"
+        | `Node `Hash -> Fmt.string ppf "hash"
+        | `Node `Map -> Fmt.string ppf "map"
+        | `Node `Value -> Fmt.string ppf "value"
+        | `Node `Pruned -> Fmt.string ppf "pruned")
+      ( = )
 end
 
 let check_exn_lwt ~exn_type pos f =
@@ -141,6 +151,36 @@ let test_diff _ () =
   >|= Alcotest.(check diffs)
         "Changed metadata"
         [ ([ "k" ], `Updated (("v", Left), ("v", Right))) ]
+
+let test_empty _ () =
+  let* () =
+    Alcotest.check_tree_lwt "The empty tree is empty" ~expected:(`Tree [])
+      (Lwt.return Tree.empty)
+  in
+
+  (* Ensure that different [empty] values have disjoint cache state.
+
+     This is a regression test for a bug in which all [Tree.empty] values had
+     shared cache state and any keys obtained from [export] were discarded (to
+     avoid sharing keys from different repositories). *)
+  let* () =
+    let* repo = Store.Repo.v (Irmin_mem.config ()) in
+    let empty_exported = Tree.empty and empty_not_exported = Tree.empty in
+    let+ () =
+      Store.Private.Repo.batch repo (fun c n _ ->
+          Store.save_tree repo c n empty_exported >|= ignore)
+    in
+    Alcotest.(check inspect)
+      "The exported empty tree is now in Key form"
+      (`Node `Hash)
+      (Tree.inspect empty_exported);
+    Alcotest.(check inspect)
+      "The non-exported empty tree should still be represented as a Map"
+      (`Node `Map)
+      (Tree.inspect empty_not_exported)
+  in
+
+  Lwt.return_unit
 
 let test_add _ () =
   let sample_tree ?(ab = "ab_v") ?ac () : Tree.concrete =
@@ -403,20 +443,7 @@ let persist_tree : Store.tree -> Store.tree Lwt.t =
   let* () = Store.set_tree_exn ~info:Irmin.Info.none store [] tree in
   Store.tree store
 
-let inspect =
-  Alcotest.testable
-    (fun ppf -> function
-      | `Contents -> Fmt.string ppf "contents"
-      | `Node `Hash -> Fmt.string ppf "hash"
-      | `Node `Map -> Fmt.string ppf "map"
-      | `Node `Value -> Fmt.string ppf "value"
-      | `Node `Pruned -> Fmt.string ppf "pruned")
-    ( = )
-
-type key = Store.Key.t [@@deriving irmin]
-
-let pp_key = Irmin.Type.pp key_t
-let equal_key = Irmin.Type.(unstage (equal key_t))
+type key = Store.Key.t [@@deriving irmin ~pp ~equal]
 
 let test_clear _ () =
   (* 1. Build a tree *)
@@ -771,6 +798,7 @@ let suite =
     Alcotest_lwt.test_case "bindings" `Quick test_bindings;
     Alcotest_lwt.test_case "paginated bindings" `Quick test_paginated_bindings;
     Alcotest_lwt.test_case "diff" `Quick test_diff;
+    Alcotest_lwt.test_case "empty" `Quick test_empty;
     Alcotest_lwt.test_case "add" `Quick test_add;
     Alcotest_lwt.test_case "remove" `Quick test_remove;
     Alcotest_lwt.test_case "update" `Quick test_update;


### PR DESCRIPTION
Backport for #1566 as this is needed for proper separation of env caches in #1625