### PR TITLE
irmin: introduce an abstraction for portable commits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,8 +111,10 @@
     their hash. In particular, this includes:
     - New functions: `Store.{Commit,Contents,Tree}.of_key`.
     - Adds `Irmin.{Node,Commit}.Generic_key` modules.
-    - Adds a new type that must be provided by backends: `Node.Portable`.
+    - Adds new types that must be provided by backends: `Node.Portable` and
+      `Commit.Portable`.
     - Adds a new type of backend store: `Irmin.Indexable.S`.
+    (#1510 #1647, @CraigFe)
 
 - **irmin-containers**
   - Removed `Irmin_containers.Store_maker`; this is now equivalent to

--- a/src/irmin-git/backend.ml
+++ b/src/irmin-git/backend.ml
@@ -55,6 +55,8 @@ struct
     include Irmin.Commit.Store (Schema.Info) (Node) (S) (S.Hash) (S.Val)
   end
 
+  module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.S.Val)
+
   module Branch = struct
     module Key = Schema.Branch
     module Val = Commit_key

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -274,6 +274,7 @@ struct
       module Commit = struct
         module V = struct
           include Dummy.Commit.Val
+          module Info = Schema.Info
 
           type hash = Hash.t [@@deriving irmin]
         end
@@ -281,6 +282,8 @@ struct
         module CA = CA (Hash) (V)
         include Irmin.Commit.Store (Info) (Node) (CA) (Hash) (V)
       end
+
+      module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.V)
 
       module Branch = struct
         module Key = Dummy.Branch.Key

--- a/src/irmin-http/irmin_http.ml
+++ b/src/irmin-http/irmin_http.ml
@@ -493,6 +493,7 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
 
         module Val = struct
           include S.Backend.Commit.Val
+          module Info = S.Info
 
           type hash = S.Hash.t [@@deriving irmin]
         end
@@ -506,6 +507,7 @@ module Client (Client : HTTP_CLIENT) (S : Irmin.S) = struct
       let v ?ctx config = X.v ?ctx config "commit" "commits"
     end
 
+    module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.X.Val)
     module Slice = Irmin.Backend.Slice.Make (Contents) (Node) (Commit)
     module Remote = Irmin.Backend.Remote.None (Hash) (S.Branch)
 

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -70,22 +70,19 @@ module Maker (V : Version.S) (Config : Conf.S) = struct
       module Commit = struct
         module Value = struct
           include Schema.Commit (Node.Key) (XKey)
+          module Info = Schema.Info
 
           type hash = Hash.t [@@deriving irmin]
         end
 
-        module Pack_value =
-          Pack_value.Of_commit (H) (XKey)
-            (struct
-              module Info = Schema.Info
-              include Value
-            end)
-
+        module Pack_value = Pack_value.Of_commit (H) (XKey) (Value)
         module CA = Pack.Make (Pack_value)
 
         include
           Irmin.Commit.Generic_key.Store (Schema.Info) (Node) (CA) (H) (Value)
       end
+
+      module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.Value)
 
       module Branch = struct
         module Key = B

--- a/src/irmin-pack/layered/ext_layered.ml
+++ b/src/irmin-pack/layered/ext_layered.ml
@@ -81,16 +81,12 @@ module Maker' (Config : Conf.Pack.S) (Schema : Irmin.Schema.Extended) = struct
     module Commit = struct
       module Value = struct
         include Schema.Commit (XKey) (XKey)
+        module Info = Schema.Info
 
         type hash = Hash.t [@@deriving irmin]
       end
 
-      module Pack_value =
-        Irmin_pack.Pack_value.Of_commit (H) (XKey)
-          (struct
-            module Info = Schema.Info
-            include Value
-          end)
+      module Pack_value = Irmin_pack.Pack_value.Of_commit (H) (XKey) (Value)
 
       module CA = struct
         module CA = Pack.Make (Pack_value)
@@ -100,6 +96,8 @@ module Maker' (Config : Conf.Pack.S) (Schema : Irmin.Schema.Extended) = struct
       include
         Irmin.Commit.Generic_key.Store (Schema.Info) (Node) (CA) (H) (Value)
     end
+
+    module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.Value)
 
     module Branch = struct
       module Key = B

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -88,22 +88,19 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
       module Commit = struct
         module Value = struct
           include Schema.Commit (Node.Key) (XKey)
+          module Info = Schema.Info
 
           type hash = Hash.t [@@deriving irmin]
         end
 
-        module Pack_value =
-          Irmin_pack.Pack_value.Of_commit (H) (XKey)
-            (struct
-              module Info = Schema.Info
-              include Value
-            end)
-
+        module Pack_value = Irmin_pack.Pack_value.Of_commit (H) (XKey) (Value)
         module Indexable = Indexable_mem (H) (Pack_value)
 
         include
           Irmin.Commit.Generic_key.Store (Info) (Node) (Indexable) (H) (Value)
       end
+
+      module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.Value)
 
       module Branch = struct
         module Key = B

--- a/src/irmin/backend.ml
+++ b/src/irmin/backend.ml
@@ -19,6 +19,7 @@ open Store_properties
 
 open struct
   module type Node_portable = Node.Portable.S
+  module type Commit_portable = Commit.Portable.S
 end
 
 module type S = sig
@@ -54,6 +55,12 @@ module type S = sig
     Commit.Store
       with type hash = Hash.t
        and type Val.node_key = Node.key
+       and module Info = Schema.Info
+
+  module Commit_portable :
+    Commit_portable
+      with type commit := Commit.value
+       and type hash := Hash.t
        and module Info = Schema.Info
 
   (** Backend branch store. *)

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -81,10 +81,14 @@ module Maker_generic_key (Backend : Maker_generic_key_args) = struct
 
       module Commit = struct
         module Commit_maker = Commit.Generic_key.Maker (Schema.Info)
-        module C = Commit_maker.Make (S.Hash) (Node_key) (Commit_key)
-        module Backend = Backend.Commit_store.Make (S.Hash) (C)
-        include Commit.Generic_key.Store (S.Info) (Node) (Backend) (S.Hash) (C)
+        module Value = Commit_maker.Make (S.Hash) (Node_key) (Commit_key)
+        module Backend = Backend.Commit_store.Make (S.Hash) (Value)
+
+        include
+          Commit.Generic_key.Store (S.Info) (Node) (Backend) (S.Hash) (Value)
       end
+
+      module Commit_portable = Commit.Value.Portable
 
       module Branch = struct
         module Val = Commit.Key

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -354,6 +354,7 @@ module type Sigs = sig
     module Of_node (S : S) :
       Portable
         with type node := S.t
+         and type t = S.t
          and type step = S.step
          and type metadata = S.metadata
          and type hash = S.hash


### PR DESCRIPTION
This is needed by users of generic-keyed backends in order to compute the hash of purely in-memory commits.

I'm not so happy with the extra boilerplate that this requires of the backends. That could be avoided by providing a helper functor such as `Irmin.Of_hash_keyed_backend`, but I'll leave it for a different PR as this is already the case for the `Node_portable` module.

Extracted from https://github.com/mirage/irmin/pull/1534.