### PR TITLE
irmin-pack: add new pack entries with length headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,10 @@
   - The backend configuration type `Conf.S` requires a new parameter
     `contents_length_header` that (optionally) further specifies the encoding
     format used for commits in order to improve performance. (#1644, @CraigFe)
+  - Upgraded on-disk format of pack files to support more efficient lookups and
+    reduce indexing overhead.  This change is fully backwards-compatible with
+    existing stores using `irmin-pack.2.x` versions, but not
+    forwards compatible. (#1649, @CraigFe @Ngoguey42)
 
 - **irmin-unix**
   - Clean up command line interface. Allow config file to be specified when

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -124,7 +124,9 @@ module Make (M : Maker) = struct
       let f _ (_, _, (kind : Pack_value.Kind.t)) =
         match kind with
         | Contents -> progress_contents ()
-        | Inode_v0_stable | Inode_v0_unstable -> progress_nodes ()
+        | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
+          ->
+            progress_nodes ()
         | Commit -> progress_commits ()
       in
       Index.iter f index;
@@ -434,7 +436,8 @@ module Index (Index : Pack_index.S) = struct
       | Contents ->
           progress_contents ();
           check ~kind:`Contents ~offset ~length k
-      | Inode_v0_stable | Inode_v0_unstable ->
+      | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
+        ->
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
       | Commit ->

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -127,7 +127,7 @@ module Make (M : Maker) = struct
         | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
           ->
             progress_nodes ()
-        | Commit -> progress_commits ()
+        | Commit_v0 | Commit_v1 -> progress_commits ()
       in
       Index.iter f index;
       let nb_commits, nb_nodes, nb_contents =
@@ -440,7 +440,7 @@ module Index (Index : Pack_index.S) = struct
         ->
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
-      | Commit ->
+      | Commit_v0 | Commit_v1 ->
           progress_commits ();
           check ~kind:`Commit ~offset ~length k
     in

--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -124,7 +124,7 @@ module Make (M : Maker) = struct
       let f _ (_, _, (kind : Pack_value.Kind.t)) =
         match kind with
         | Contents -> progress_contents ()
-        | Node | Inode -> progress_nodes ()
+        | Inode_v0_stable | Inode_v0_unstable -> progress_nodes ()
         | Commit -> progress_commits ()
       in
       Index.iter f index;
@@ -434,7 +434,7 @@ module Index (Index : Pack_index.S) = struct
       | Contents ->
           progress_contents ();
           check ~kind:`Contents ~offset ~length k
-      | Node | Inode ->
+      | Inode_v0_stable | Inode_v0_unstable ->
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
       | Commit ->

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -281,7 +281,8 @@ struct
           assert (is_real_length length);
           let v = decode_bin_v s off in
           V1_nonroot { length; v }
-      | Commit | Contents -> assert false
+      | Commit_v0 | Commit_v1 -> assert false
+      | Contents -> assert false
 
     let size_of_tv =
       let of_value tv =
@@ -308,7 +309,7 @@ struct
         | Inode_v1_root | Inode_v1_nonroot ->
             let len = decode_bin_int s offref in
             len - H.hash_size
-        | Commit | Contents -> assert false
+        | Commit_v0 | Commit_v1 | Contents -> assert false
       in
       Irmin.Type.Size.custom_dynamic ~of_value ~of_encoding ()
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -27,8 +27,17 @@ module Make_internal
                and type node_key = Key.t) =
 struct
   let () =
+    (* TODO: REMOVE *)
     if Conf.entries > Conf.stable_hash then
       invalid_arg "entries should be lower or equal to stable_hash"
+
+  (** If [should_be_stable ~length ~root] is true for an inode [i], then [i]
+      hashes the same way as a [Node.t] containings the same entries. *)
+  let should_be_stable ~length ~root =
+    if length = 0 then true
+    else if not root then false
+    else if length <= Conf.stable_hash then true
+    else false
 
   module Node = struct
     include Node
@@ -83,19 +92,19 @@ struct
           let t = v_t
         end)
 
-    type t = { hash : H.t Lazy.t; stable : bool; v : v }
+    type t = { hash : H.t Lazy.t; root : bool; v : v }
 
     let t : t Irmin.Type.t =
       let open Irmin.Type in
       let pre_hash x = pre_hash_v x.v in
-      record "Bin.t" (fun hash stable v -> { hash = lazy hash; stable; v })
+      record "Bin.t" (fun hash root v -> { hash = lazy hash; root; v })
       |+ field "hash" H.t (fun t -> Lazy.force t.hash)
-      |+ field "stable" bool (fun t -> t.stable)
+      |+ field "root" bool (fun t -> t.root)
       |+ field "v" v_t (fun t -> t.v)
       |> sealr
       |> like ~pre_hash
 
-    let v ~stable ~hash v = { stable; hash; v }
+    let v ~hash ~root v = { hash; root; v }
     let hash t = Lazy.force t.hash
   end
 
@@ -254,13 +263,21 @@ struct
 
     type t = { hash : H.t; v : tagged_v }
 
-    let v ~stable ~hash v =
+    let v ~root ~hash v =
+      (* TODO: Deprecate creation of V0 [Compress.t] *)
+      let length =
+        match v with Values v -> List.length v | Tree { length; _ } -> length
+      in
+      let stable = should_be_stable ~length ~root in
       let v = if stable then V0_stable v else V0_unstable v in
       { hash; v }
 
-    let is_stable = function
-      | { v = V0_stable _; _ } -> true
-      | { v = V0_unstable _; _ } -> false
+    let is_root = function
+      | { v = V0_stable (Values _); _ } -> true
+      | { v = V0_unstable (Values _); _ } -> false
+      | { v = V0_stable (Tree { depth; _ }); _ }
+      | { v = V0_unstable (Tree { depth; _ }); _ } ->
+          depth = 0
 
     let t =
       let open Irmin.Type in
@@ -368,7 +385,7 @@ struct
 
     and 'ptr v = Values of value StepMap.t | Tree of 'ptr tree
 
-    and 'ptr t = { hash : hash Lazy.t; stable : bool; v : 'ptr v }
+    and 'ptr t = { hash : hash Lazy.t; root : bool; v : 'ptr v }
 
     module Ptr = struct
       let hash : type ptr. ptr layout -> ptr -> _ = function
@@ -505,8 +522,6 @@ struct
             0 i.entries
       | Values vs -> StepMap.cardinal vs
 
-    let stable t = t.stable
-
     type cont = off:int -> len:int -> (step * value) Seq.node
 
     let rec seq_tree layout bucket_seq ~cache : cont -> cont =
@@ -598,9 +613,12 @@ struct
           let entries = List.rev entries in
           Bin.Tree { depth = t.depth; length = t.length; entries }
 
+    let is_root t = t.root
+    let is_stable t = should_be_stable ~length:(length t) ~root:(is_root t)
+
     let to_bin layout t =
       let v = to_bin_v layout t.v in
-      Bin.v ~stable:t.stable ~hash:t.hash v
+      Bin.v ~root:(is_root t) ~hash:t.hash v
 
     module Concrete = struct
       type kind = Contents | Contents_x of metadata | Node [@@deriving irmin]
@@ -738,7 +756,7 @@ struct
                 let hash = hash v in
                 if not (equal_hash hash pointer) then
                   raise (Invalid_hash (hash, pointer, t));
-                let t = { hash = lazy pointer; stable = false; v } in
+                let t = { hash = lazy pointer; root = false; v } in
                 entries.(index) <- Some (Ptr.of_target Total t))
               tr.pointers;
             let length = Concrete.length t in
@@ -749,13 +767,13 @@ struct
       in
       let v = aux 0 t in
       let length = length_of_v v in
-      let stable, hash =
-        if length > Conf.stable_hash then (false, hash v)
-        else
+      let hash =
+        if should_be_stable ~length ~root:true then
           let node = Node.of_seq (seq_v Total v) in
-          (true, Node.hash node)
+          Node.hash node
+        else hash v
       in
-      { hash = lazy hash; stable; v }
+      { hash = lazy hash; root = true; v }
 
     let of_concrete t =
       try Ok (of_concrete_exn t) with
@@ -770,43 +788,21 @@ struct
 
     let hash t = Lazy.force t.hash
 
-    let is_root t =
-      match t.v with
-      | Tree { depth; _ } -> depth = 0
-      | Values _ ->
-          (* When [t] is of tag [Values], then [t] is root iff [t] is stable. It
-             is implied by the following.
-
-             When [t] is stable, then [t] is a root, because:
-              - Only 2 functions produce stable inodes: [stabilize] and [empty].
-              - Only the roots are output of [stabilize].
-              - An empty map can only be located at the root.
-
-             When [t] is a root of tag [Value], then [t] is stable, because:
-             - All the roots are output of [stabilize].
-             - When an unstable inode enters [stabilize], it becomes stable if
-               it has at most [Conf.stable_hash] leaves.
-             - A [Value] has at most [Conf.stable_hash] leaves because
-               [Conf.entries <= Conf.stable_hash] is enforced.
-          *)
-          t.stable
-
     let check_write_op_supported t =
       if not @@ is_root t then
         failwith "Cannot perform operation on non-root inode value."
 
-    let stabilize layout t =
-      if t.stable then t
+    let stabilize_root layout t =
+      let n = length t in
+      (* If [t] is the empty inode (i.e. [n = 0]) then is is already stable *)
+      if n > Conf.stable_hash then { t with root = true }
       else
-        let n = length t in
-        if n > Conf.stable_hash then t
-        else
-          let hash =
-            lazy
-              (let vs = seq layout t in
-               Node.hash (Node.of_seq vs))
-          in
-          { hash; stable = true; v = t.v }
+        let hash =
+          lazy
+            (let vs = seq layout t in
+             Node.hash (Node.of_seq vs))
+        in
+        { hash; v = t.v; root = true }
 
     let hash_key = Irmin.Type.(unstage (short_hash step_t))
     let index ~depth k = abs (hash_key ~seed:depth k) mod Conf.entries
@@ -829,12 +825,12 @@ struct
               t.entries;
             Tree { depth = t.Bin.depth; length = t.length; entries }
       in
-      { hash = t.Bin.hash; stable = t.Bin.stable; v }
+      { hash = t.Bin.hash; v; root = t.root }
 
     let empty : 'a. 'a layout -> 'a t =
      fun _ ->
       let hash = lazy (Node.hash (Node.empty ())) in
-      { stable = true; hash; v = Values StepMap.empty }
+      { hash; root = false; v = Values StepMap.empty }
 
     let values layout vs =
       let length = StepMap.cardinal vs in
@@ -842,12 +838,12 @@ struct
       else
         let v = Values vs in
         let hash = lazy (Bin.V.hash (to_bin_v layout v)) in
-        { hash; stable = false; v }
+        { hash; root = false; v }
 
     let tree layout is =
       let v = Tree is in
       let hash = lazy (Bin.V.hash (to_bin_v layout v)) in
-      { hash; stable = false; v }
+      { hash; root = false; v }
 
     let is_empty t =
       match t.v with Values vs -> StepMap.is_empty vs | Tree _ -> false
@@ -914,13 +910,13 @@ struct
     let add layout ~copy t s v =
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
       match find_value ~cache:true ~depth:0 layout t s with
-      | Some v' when equal_value v v' -> stabilize layout t
+      | Some v' when equal_value v v' -> t
       | Some _ ->
           add ~depth:0 layout ~copy ~replace:true t s v Fun.id
-          |> stabilize layout
+          |> stabilize_root layout
       | None ->
           add ~depth:0 layout ~copy ~replace:false t s v Fun.id
-          |> stabilize layout
+          |> stabilize_root layout
 
     let rec remove layout ~depth t s k =
       Stats.incr_inode_rec_remove ();
@@ -960,8 +956,8 @@ struct
     let remove layout t s =
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
       match find_value ~cache:true layout ~depth:0 t s with
-      | None -> stabilize layout t
-      | Some _ -> remove layout ~depth:0 t s Fun.id |> stabilize layout
+      | None -> t
+      | Some _ -> remove layout ~depth:0 t s Fun.id |> stabilize_root layout
 
     let of_seq l =
       let t =
@@ -996,7 +992,7 @@ struct
         in
         aux_small l StepMap.empty
       in
-      stabilize Total t
+      stabilize_root Total t
 
     let save layout ~add ~mem t =
       let clear =
@@ -1045,7 +1041,7 @@ struct
     let check_stable layout t =
       let target_of_ptr = Ptr.target ~cache:true layout in
       let rec check t any_stable_ancestor =
-        let stable = t.stable || any_stable_ancestor in
+        let stable = is_stable t || any_stable_ancestor in
         match t.v with
         | Values _ -> true
         | Tree tree ->
@@ -1054,10 +1050,11 @@ struct
                 | None -> true
                 | Some t ->
                     let t = target_of_ptr t in
-                    (if stable then not t.stable else true) && check t stable)
+                    (if stable then not (is_stable t) else true)
+                    && check t stable)
               tree.entries
       in
-      check t t.stable
+      check t (is_stable t)
 
     let contains_empty_map layout t =
       let target_of_ptr = Ptr.target ~cache:true layout in
@@ -1085,7 +1082,14 @@ struct
 
     let kind (t : t) =
       (* This is the kind of newly appended values, let's use v1 then *)
-      if t.stable then Pack_value.Kind.Inode_v0_stable
+      (* TODO: Use v1 *)
+      let length =
+        match t.v with
+        | Bin.Values l -> List.length l
+        | Tree { length; _ } -> length
+      in
+      if should_be_stable ~length ~root:t.root then
+        Pack_value.Kind.Inode_v0_stable
       else Pack_value.Kind.Inode_v0_unstable
 
     let hash t = Bin.hash t
@@ -1134,14 +1138,14 @@ struct
             let entries = List.map ptr entries in
             Tree { Compress.depth; length; entries }
       in
-      let t = Compress.v ~stable:t.stable ~hash:k (v t.v) in
+      let t = Compress.v ~root:t.root ~hash:k (v t.v) in
       encode_compress t
 
     exception Exit of [ `Msg of string ]
 
-    let decode_bin ~dict ~hash t pos_ref : t =
+    let decode_bin ~dict ~hash t off =
       Stats.incr_inode_decode_bin ();
-      let i = decode_compress t pos_ref in
+      let i = decode_compress t off in
       let step : Compress.name -> T.step = function
         | Direct n -> n
         | Indirect s -> (
@@ -1180,8 +1184,8 @@ struct
             let entries = List.map ptr entries in
             Tree { depth; length; entries }
       in
-      let stable = Compress.is_stable i in
-      Bin.v ~stable ~hash:(lazy i.hash) (t i.v)
+      let root = Compress.is_root i in
+      Bin.v ~root ~hash:(lazy i.hash) (t i.v)
 
     let decode_bin_length = decode_compress_length
   end
@@ -1265,7 +1269,7 @@ struct
 
     let t : t Irmin.Type.t =
       let pre_hash x =
-        let stable = apply x { f = (fun _ v -> I.stable v) } in
+        let stable = apply x { f = (fun _ v -> I.is_stable v) } in
         if not stable then
           let bin = apply x { f = (fun layout v -> I.to_bin layout v) } in
           pre_hash_binv bin.v
@@ -1294,7 +1298,7 @@ struct
       Partial (layout, I.of_bin layout v)
 
     let to_raw t = apply t { f = (fun layout v -> I.to_bin layout v) }
-    let stable t = apply t { f = (fun _ v -> I.stable v) }
+    let stable t = apply t { f = (fun _ v -> I.is_stable v) }
     let length t = apply t { f = (fun _ v -> I.length v) }
     let clear t = apply t { f = (fun layout v -> I.clear layout v) }
     let nb_children t = apply t { f = (fun _ v -> I.nb_children v) }

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -196,36 +196,77 @@ struct
       |> sealv
 
     type v = Values of value list | Tree of tree
+    [@@deriving irmin ~encode_bin ~decode_bin ~size_of]
 
-    let v_t : v Irmin.Type.t =
-      let open Irmin.Type in
-      variant "Compress.v" (fun values tree -> function
-        | Values x -> values x | Tree x -> tree x)
-      |~ case1 "Values" (list value_t) (fun x -> Values x)
-      |~ case1 "Tree" tree_t (fun x -> Tree x)
-      |> sealv
+    let dynamic_size_of_v_encoding =
+      match Irmin.Type.Size.of_encoding v_t with
+      | Irmin.Type.Size.Dynamic f -> f
+      | _ -> assert false
 
-    type t = { hash : H.t; stable : bool; v : v }
+    let dynamic_size_of_v =
+      match Irmin.Type.Size.of_value v_t with
+      | Irmin.Type.Size.Dynamic f -> f
+      | _ -> assert false
 
-    let v ~stable ~hash v = { hash; stable; v }
-    let to_magic = Pack_value.Kind.to_magic
-    let kind_inode_v0_stable = Pack_value.Kind.Inode_v0_stable
-    let kind_inode_v0_unstable = Pack_value.Kind.Inode_v0_unstable
-    let magic_inode_v0_stable = to_magic kind_inode_v0_stable
-    let magic_inode_v0_unstable = to_magic kind_inode_v0_unstable
+    type kind = Pack_value.Kind.t
+    [@@deriving irmin ~encode_bin ~decode_bin ~size_of]
 
-    let stable_t : bool Irmin.Type.t =
-      Irmin.Type.(map char)
-        (fun n -> n = magic_inode_v0_stable)
-        (function
-          | true -> magic_inode_v0_stable | false -> magic_inode_v0_unstable)
+    (** [tagged_v] sits between [v] and [t]. It is a variant with the header
+        binary encoded as the magic. *)
+    type tagged_v = V0_stable of v | V0_unstable of v [@@deriving irmin]
+
+    let encode_bin_tv vt f =
+      (* TODO: Deprecate v0 at encode_time *)
+      match vt with
+      | V0_stable v ->
+          encode_bin_kind Pack_value.Kind.Inode_v0_stable f;
+          encode_bin_v v f
+      | V0_unstable v ->
+          encode_bin_kind Pack_value.Kind.Inode_v0_unstable f;
+          encode_bin_v v f
+
+    let decode_bin_tv s off =
+      let kind = decode_bin_kind s off in
+      match kind with
+      | Pack_value.Kind.Inode_v0_unstable ->
+          let v = decode_bin_v s off in
+          V0_unstable v
+      | Inode_v0_stable ->
+          let v = decode_bin_v s off in
+          V0_stable v
+      | Commit | Contents -> assert false
+
+    let size_of_tv =
+      let of_value vt =
+        match vt with V0_stable v | V0_unstable v -> dynamic_size_of_v v + 1
+      in
+      let of_encoding s off =
+        let kind = decode_bin_kind s (ref off) in
+        match kind with
+        | Pack_value.Kind.Inode_v0_unstable | Inode_v0_stable ->
+            dynamic_size_of_v_encoding s (off + 1) + 1
+        | Commit | Contents -> assert false
+      in
+      Irmin.Type.Size.custom_dynamic ~of_value ~of_encoding ()
+
+    let tagged_v_t =
+      Irmin.Type.like ~bin:(encode_bin_tv, decode_bin_tv, size_of_tv) tagged_v_t
+
+    type t = { hash : H.t; v : tagged_v }
+
+    let v ~stable ~hash v =
+      let v = if stable then V0_stable v else V0_unstable v in
+      { hash; v }
+
+    let is_stable = function
+      | { v = V0_stable _; _ } -> true
+      | { v = V0_unstable _; _ } -> false
 
     let t =
       let open Irmin.Type in
-      record "Compress.t" (fun hash stable v -> { hash; stable; v })
+      record "Compress.t" (fun hash v -> { hash; v })
       |+ field "hash" H.t (fun t -> t.hash)
-      |+ field "stable" stable_t (fun t -> t.stable)
-      |+ field "v" v_t (fun t -> t.v)
+      |+ field "tagged_v" tagged_v_t (fun t -> t.v)
       |> sealr
   end
 
@@ -1043,8 +1084,9 @@ struct
     let t = Bin.t
 
     let kind (t : t) =
-      if t.stable then Compress.kind_inode_v0_stable
-      else Compress.kind_inode_v0_unstable
+      (* This is the kind of newly appended values, let's use v1 then *)
+      if t.stable then Pack_value.Kind.Inode_v0_stable
+      else Pack_value.Kind.Inode_v0_unstable
 
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string
@@ -1129,13 +1171,17 @@ struct
             let hash = hash h in
             (name, `Node hash)
       in
-      let t : Compress.v -> Bin.v = function
+      let t : Compress.tagged_v -> Bin.v =
+       fun tv ->
+        let v = match tv with V0_stable v -> v | V0_unstable v -> v in
+        match v with
         | Values vs -> Values (List.rev_map value (List.rev vs))
         | Tree { depth; length; entries } ->
             let entries = List.map ptr entries in
             Tree { depth; length; entries }
       in
-      Bin.v ~stable:i.stable ~hash:(lazy i.hash) (t i.v)
+      let stable = Compress.is_stable i in
+      Bin.v ~stable ~hash:(lazy i.hash) (t i.v)
 
     let decode_bin_length = decode_compress_length
   end

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -208,15 +208,17 @@ struct
     type t = { hash : H.t; stable : bool; v : v }
 
     let v ~stable ~hash v = { hash; stable; v }
-    let kind_node = Pack_value.Kind.Node
-    let kind_inode = Pack_value.Kind.Inode
-    let magic_node = Pack_value.Kind.to_magic kind_node
-    let magic_inode = Pack_value.Kind.to_magic kind_inode
+    let to_magic = Pack_value.Kind.to_magic
+    let kind_inode_v0_stable = Pack_value.Kind.Inode_v0_stable
+    let kind_inode_v0_unstable = Pack_value.Kind.Inode_v0_unstable
+    let magic_inode_v0_stable = to_magic kind_inode_v0_stable
+    let magic_inode_v0_unstable = to_magic kind_inode_v0_unstable
 
     let stable_t : bool Irmin.Type.t =
       Irmin.Type.(map char)
-        (fun n -> n = magic_node)
-        (function true -> magic_node | false -> magic_inode)
+        (fun n -> n = magic_inode_v0_stable)
+        (function
+          | true -> magic_inode_v0_stable | false -> magic_inode_v0_unstable)
 
     let t =
       let open Irmin.Type in
@@ -1041,7 +1043,8 @@ struct
     let t = Bin.t
 
     let kind (t : t) =
-      if t.stable then Compress.kind_node else Compress.kind_inode
+      if t.stable then Compress.kind_inode_v0_stable
+      else Compress.kind_inode_v0_unstable
 
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -2,30 +2,35 @@ open! Import
 include Pack_value_intf
 
 module Kind = struct
-  type t = Commit | Contents | Inode | Node
+  type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable
 
   let to_magic = function
     | Commit -> 'C'
     | Contents -> 'B'
-    | Inode -> 'I'
-    | Node -> 'N'
+    | Inode_v0_unstable -> 'I'
+    | Inode_v0_stable -> 'N'
 
   let of_magic_exn = function
     | 'C' -> Commit
     | 'B' -> Contents
-    | 'I' -> Inode
-    | 'N' -> Node
+    | 'I' -> Inode_v0_unstable
+    | 'N' -> Inode_v0_stable
     | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
 
-  let all = [ Commit; Contents; Inode; Node ]
-  let to_enum = function Commit -> 0 | Contents -> 1 | Inode -> 2 | Node -> 3
+  let all = [ Commit; Contents; Inode_v0_unstable; Inode_v0_stable ]
+
+  let to_enum = function
+    | Commit -> 0
+    | Contents -> 1
+    | Inode_v0_unstable -> 2
+    | Inode_v0_stable -> 3
 
   let pp =
     Fmt.of_to_string (function
       | Commit -> "Commit"
       | Contents -> "Contents"
-      | Inode -> "Inode"
-      | Node -> "Node")
+      | Inode_v0_unstable -> "Inode_v0_unstable"
+      | Inode_v0_stable -> "Inode_v0_stable")
 
   let t = Irmin.Type.map ~pp Irmin.Type.char of_magic_exn to_magic
 end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -3,7 +3,8 @@ include Pack_value_intf
 
 module Kind = struct
   type t =
-    | Commit
+    | Commit_v0
+    | Commit_v1
     | Contents
     | Inode_v0_unstable
     | Inode_v0_stable
@@ -11,7 +12,8 @@ module Kind = struct
     | Inode_v1_nonroot
 
   let to_magic = function
-    | Commit -> 'C'
+    | Commit_v0 -> 'C'
+    | Commit_v1 -> 'D'
     | Contents -> 'B'
     | Inode_v0_unstable -> 'I'
     | Inode_v0_stable -> 'N'
@@ -19,7 +21,8 @@ module Kind = struct
     | Inode_v1_nonroot -> 'O'
 
   let of_magic_exn = function
-    | 'C' -> Commit
+    | 'C' -> Commit_v0
+    | 'D' -> Commit_v1
     | 'B' -> Contents
     | 'I' -> Inode_v0_unstable
     | 'N' -> Inode_v0_stable
@@ -29,7 +32,8 @@ module Kind = struct
 
   let all =
     [
-      Commit;
+      Commit_v0;
+      Commit_v1;
       Contents;
       Inode_v0_unstable;
       Inode_v0_stable;
@@ -38,21 +42,32 @@ module Kind = struct
     ]
 
   let to_enum = function
-    | Commit -> 0
-    | Contents -> 1
-    | Inode_v0_unstable -> 2
-    | Inode_v0_stable -> 3
-    | Inode_v1_root -> 4
-    | Inode_v1_nonroot -> 5
+    | Commit_v0 -> 0
+    | Commit_v1 -> 1
+    | Contents -> 2
+    | Inode_v0_unstable -> 3
+    | Inode_v0_stable -> 4
+    | Inode_v1_root -> 5
+    | Inode_v1_nonroot -> 6
 
   let pp =
     Fmt.of_to_string (function
-      | Commit -> "Commit"
+      | Commit_v0 -> "Commit_v0"
+      | Commit_v1 -> "Commit_v1"
       | Contents -> "Contents"
       | Inode_v0_unstable -> "Inode_v0_unstable"
       | Inode_v0_stable -> "Inode_v0_stable"
       | Inode_v1_root -> "Inode_v1_root"
       | Inode_v1_nonroot -> "Inode_v1_nonroot")
+
+  let length_header_exn : t -> length_header =
+    let some_varint = Some `Varint in
+    function
+    | Commit_v0 | Inode_v0_unstable | Inode_v0_stable -> None
+    | Commit_v1 | Inode_v1_root | Inode_v1_nonroot -> some_varint
+    | Contents ->
+        Fmt.failwith
+          "Can't determine length header for user-defined codec Contents"
 
   let t = Irmin.Type.map ~pp Irmin.Type.char of_magic_exn to_magic
 end
@@ -62,9 +77,17 @@ type ('h, 'a) value = { hash : 'h; kind : Kind.t; v : 'a } [@@deriving irmin]
 module type S = S with type kind := Kind.t
 module type Persistent = Persistent with type kind := Kind.t
 
-module Make (Config : sig
-  val selected_kind : Kind.t
-  val length_header : length_header
+let get_dynamic_sizer_exn : type a. a Irmin.Type.t -> string -> int -> int =
+ fun typ ->
+  match Irmin.Type.(Size.of_encoding typ) with
+  | Unknown ->
+      Fmt.failwith "Type must have a recoverable encoded length: %a"
+        Irmin.Type.pp_ty typ
+  | Static n -> fun _ _ -> n
+  | Dynamic f -> f
+
+module Of_contents (Conf : sig
+  val contents_length_header : length_header
 end)
 (Hash : Irmin.Hash.S)
 (Key : T)
@@ -77,10 +100,10 @@ struct
   type hash = Hash.t
 
   let hash = Hash.hash
-  let kind = Config.selected_kind
+  let kind = Kind.Contents
 
   let length_header =
-    match Config.length_header with
+    match Conf.contents_length_header with
     | None -> `Never
     | Some _ as x -> `Sometimes (Fun.const x)
 
@@ -95,28 +118,94 @@ struct
     let t = decode_value s off in
     t.v
 
-  type nonrec int = int [@@deriving irmin ~decode_bin]
-
-  let decode_bin_length =
-    match Irmin.Type.(Size.of_encoding value) with
-    | Unknown ->
-        Fmt.failwith "Type must have a recoverable encoded length: %a"
-          Irmin.Type.pp_ty t
-    | Static n -> fun _ _ -> n
-    | Dynamic f -> f
-
-  let kind _ = Config.selected_kind
+  let decode_bin_length = get_dynamic_sizer_exn value
+  let kind _ = kind
 end
 
-module Of_contents (Conf : sig
-  val contents_length_header : length_header
-end) =
-Make (struct
-  let selected_kind = Kind.Contents
-  let length_header = Conf.contents_length_header
-end)
+module Of_commit
+    (Hash : Irmin.Hash.S)
+    (Key : Irmin.Key.S with type hash = Hash.t)
+    (Commit : Irmin.Commit.Generic_key.S
+                with type node_key = Key.t
+                 and type commit_key = Key.t) =
+struct
+  module Hash = Irmin.Hash.Typed (Hash) (Commit)
 
-module Of_commit = Make (struct
-  let selected_kind = Kind.Commit
-  let length_header = None
-end)
+  type t = Commit.t [@@deriving irmin]
+  type key = Key.t
+  type hash = Hash.t [@@deriving irmin ~encode_bin ~decode_bin]
+
+  let hash = Hash.hash
+  let kind _ = Kind.Commit_v1
+
+  (* A commit implementation that uses integer offsets for addresses where possible. *)
+  module Commit_direct = struct
+    type address = Offset of int63 | Hash of Hash.t [@@deriving irmin]
+
+    type t = {
+      node_offset : address;
+      parent_offsets : address list;
+      info : Commit.Info.t;
+    }
+    [@@deriving irmin ~encode_bin ~to_bin_string ~decode_bin]
+
+    let size_of =
+      match Irmin.Type.Size.of_value t with
+      | Dynamic f -> f
+      | Static _ | Unknown -> assert false
+  end
+
+  module Entry = struct
+    module V0 = struct
+      type t = (hash, Commit.t) value [@@deriving irmin ~decode_bin]
+    end
+
+    module V1 = struct
+      type data = { length : int; v : Commit_direct.t } [@@deriving irmin]
+      type t = (hash, data) value [@@deriving irmin ~encode_bin ~decode_bin]
+    end
+  end
+
+  let length_header =
+    `Sometimes
+      (function Kind.Contents -> assert false | x -> Kind.length_header_exn x)
+
+  let encode_bin ~dict:_ ~offset_of_key hash v f =
+    let address_of_key k : Commit_direct.address =
+      match offset_of_key k with
+      | None -> Hash (Key.to_hash k)
+      | Some k -> Offset k
+    in
+    let v =
+      let info = Commit.info v in
+      let node_offset = address_of_key (Commit.node v) in
+      let parent_offsets = List.map address_of_key (Commit.parents v) in
+      { Commit_direct.node_offset; parent_offsets; info }
+    in
+    let length = Commit_direct.size_of v in
+    Entry.V1.encode_bin { hash; kind = Commit_v1; v = { length; v } } f
+
+  let decode_bin ~dict:_ ~key_of_offset ~key_of_hash s off =
+    let key_of_address : Commit_direct.address -> Key.t = function
+      | Offset x -> key_of_offset x
+      | Hash x -> key_of_hash x
+    in
+    match Kind.of_magic_exn s.[!off + Hash.hash_size] with
+    | Commit_v0 -> (Entry.V0.decode_bin s off).v
+    | Commit_v1 ->
+        let { v = { Entry.V1.v = commit; _ }; _ } = Entry.V1.decode_bin s off in
+        let info = commit.info in
+        let node = key_of_address commit.node_offset in
+        let parents = List.map key_of_address commit.parent_offsets in
+        Commit.v ~info ~node ~parents
+    | _ -> assert false
+
+  let decode_bin_length =
+    let of_v0_entry = get_dynamic_sizer_exn Entry.V0.t
+    and of_v1_entry = get_dynamic_sizer_exn Entry.V1.t in
+    fun s off ->
+      match Kind.of_magic_exn s.[off + Hash.hash_size] with
+      | Commit_v0 -> of_v0_entry s off
+      | Commit_v1 -> of_v1_entry s off
+      | _ -> assert false
+end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -2,35 +2,57 @@ open! Import
 include Pack_value_intf
 
 module Kind = struct
-  type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable
+  type t =
+    | Commit
+    | Contents
+    | Inode_v0_unstable
+    | Inode_v0_stable
+    | Inode_v1_root
+    | Inode_v1_nonroot
 
   let to_magic = function
     | Commit -> 'C'
     | Contents -> 'B'
     | Inode_v0_unstable -> 'I'
     | Inode_v0_stable -> 'N'
+    | Inode_v1_root -> 'R'
+    | Inode_v1_nonroot -> 'O'
 
   let of_magic_exn = function
     | 'C' -> Commit
     | 'B' -> Contents
     | 'I' -> Inode_v0_unstable
     | 'N' -> Inode_v0_stable
+    | 'R' -> Inode_v1_root
+    | 'O' -> Inode_v1_nonroot
     | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
 
-  let all = [ Commit; Contents; Inode_v0_unstable; Inode_v0_stable ]
+  let all =
+    [
+      Commit;
+      Contents;
+      Inode_v0_unstable;
+      Inode_v0_stable;
+      Inode_v1_root;
+      Inode_v1_nonroot;
+    ]
 
   let to_enum = function
     | Commit -> 0
     | Contents -> 1
     | Inode_v0_unstable -> 2
     | Inode_v0_stable -> 3
+    | Inode_v1_root -> 4
+    | Inode_v1_nonroot -> 5
 
   let pp =
     Fmt.of_to_string (function
       | Commit -> "Commit"
       | Contents -> "Contents"
       | Inode_v0_unstable -> "Inode_v0_unstable"
-      | Inode_v0_stable -> "Inode_v0_stable")
+      | Inode_v0_stable -> "Inode_v0_stable"
+      | Inode_v1_root -> "Inode_v1_root"
+      | Inode_v1_nonroot -> "Inode_v1_nonroot")
 
   let t = Irmin.Type.map ~pp Irmin.Type.char of_magic_exn to_magic
 end

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -87,9 +87,11 @@ struct
   let value = [%typ: (Hash.t, Data.t) value]
   let encode_value = Irmin.Type.(unstage (encode_bin value))
   let decode_value = Irmin.Type.(unstage (decode_bin value))
-  let encode_bin ~dict:_ ~offset:_ v hash = encode_value { kind; hash; v }
 
-  let decode_bin ~dict:_ ~hash:_ s off =
+  let encode_bin ~dict:_ ~offset_of_key:_ hash v f =
+    encode_value { kind; hash; v } f
+
+  let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ s off =
     let t = decode_value s off in
     t.v
 

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -39,7 +39,13 @@ end
 
 module type Sigs = sig
   module Kind : sig
-    type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable
+    type t =
+      | Commit
+      | Contents
+      | Inode_v0_unstable
+      | Inode_v0_stable
+      | Inode_v1_root
+      | Inode_v1_nonroot
     [@@deriving irmin]
 
     val all : t list

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -41,7 +41,8 @@ end
 module type Sigs = sig
   module Kind : sig
     type t =
-      | Commit
+      | Commit_v0
+      | Commit_v1
       | Contents
       | Inode_v0_unstable
       | Inode_v0_stable
@@ -59,14 +60,6 @@ module type Sigs = sig
   module type S = S with type kind := Kind.t
   module type Persistent = Persistent with type kind := Kind.t
 
-  module Make (_ : sig
-    val selected_kind : Kind.t
-    val length_header : length_header
-  end)
-  (Hash : Irmin.Hash.S)
-  (Key : T)
-  (Data : Irmin.Type.S) : S with type hash = Hash.t and type key = Key.t
-
   module Of_contents (_ : sig
     val contents_length_header : length_header
   end)
@@ -75,6 +68,11 @@ module type Sigs = sig
   (Contents : Irmin.Contents.S) :
     S with type t = Contents.t and type hash = Hash.t and type key = Key.t
 
-  module Of_commit (Hash : Irmin.Hash.S) (Key : T) (Commit : Irmin.Commit.S) :
+  module Of_commit
+      (Hash : Irmin.Hash.S)
+      (Key : Irmin.Key.S with type hash = Hash.t)
+      (Commit : Irmin.Commit.Generic_key.S
+                  with type node_key = Key.t
+                   and type commit_key = Key.t) :
     S with type t = Commit.t and type hash = Hash.t and type key = Key.t
 end

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -15,14 +15,15 @@ module type S = sig
 
   val encode_bin :
     dict:(string -> int option) ->
-    offset:(key -> int63 option) ->
-    t ->
+    offset_of_key:(key -> int63 option) ->
     hash ->
-    (string -> unit) ->
-    unit
+    t Irmin.Type.encode_bin
 
   val decode_bin :
-    dict:(int -> string option) -> hash:(int63 -> key) -> string -> int ref -> t
+    dict:(int -> string option) ->
+    key_of_offset:(int63 -> key) ->
+    key_of_hash:(hash -> key) ->
+    t Irmin.Type.decode_bin
 
   val decode_bin_length : string -> int -> int
 end

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -39,7 +39,8 @@ end
 
 module type Sigs = sig
   module Kind : sig
-    type t = Commit | Contents | Inode | Node [@@deriving irmin]
+    type t = Commit | Contents | Inode_v0_unstable | Inode_v0_stable
+    [@@deriving irmin]
 
     val all : t list
     val to_enum : t -> int

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -165,7 +165,7 @@ end = struct
 
   let decode_entry_length = function
     | Pack_value.Kind.Contents -> Contents.decode_bin_length
-    | Commit -> Commit.decode_bin_length
+    | Commit_v0 | Commit_v1 -> Commit.decode_bin_length
     | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot ->
         Inode.decode_bin_length
 

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -166,7 +166,8 @@ end = struct
   let decode_entry_length = function
     | Pack_value.Kind.Contents -> Contents.decode_bin_length
     | Commit -> Commit.decode_bin_length
-    | Inode_v0_stable | Inode_v0_unstable -> Inode.decode_bin_length
+    | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot ->
+        Inode.decode_bin_length
 
   let decode_entry_exn ~off ~buffer ~buffer_off =
     try

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -166,7 +166,7 @@ end = struct
   let decode_entry_length = function
     | Pack_value.Kind.Contents -> Contents.decode_bin_length
     | Commit -> Commit.decode_bin_length
-    | Node | Inode -> Inode.decode_bin_length
+    | Inode_v0_stable | Inode_v0_unstable -> Inode.decode_bin_length
 
   let decode_entry_exn ~off ~buffer ~buffer_off =
     try

--- a/src/irmin-test/helpers.ml
+++ b/src/irmin-test/helpers.ml
@@ -1,0 +1,3 @@
+let init_logs () =
+  Logs.set_level (Some Debug);
+  Logs.set_reporter (Common.reporter ())

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -84,7 +84,7 @@ let replay_1_commit () =
       {
         finds = { total = 2; from_staging = 0; from_lru = 2; from_pack = 0 };
         appended_hashes = 0;
-        appended_offsets = 4;
+        appended_offsets = 5;
         inode_add = 0;
         inode_remove = 0;
         inode_of_seq = 2;

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -60,9 +60,9 @@ module Contents = struct
   let encode_pair = Irmin.Type.(unstage (encode_bin (pair H.t t)))
   let decode_pair = Irmin.Type.(unstage (decode_bin (pair H.t t)))
   let length_header = `Sometimes (Fun.const (Some `Varint))
-  let encode_bin ~dict:_ ~offset:_ x k = encode_pair (k, x)
+  let encode_bin ~dict:_ ~offset_of_key:_ k x = encode_pair (k, x)
 
-  let decode_bin ~dict:_ ~hash:_ x pos_ref =
+  let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ x pos_ref =
     let _, v = decode_pair x pos_ref in
     v
 


### PR DESCRIPTION
This PR adds three new types of pack entry:

- **`Inode_v1_root`** / **`Inode_v1_nonroot`** (taken from https://github.com/mirage/irmin/pull/1601). These are similar to the existing `Node` and `Inode` except:
  - the discriminator between types of node is now `is_root` rather than `is_stable`;
  - the pack entry has a varint length header after the kind (and before the data).

- **`Commit_v1`**. These are similar to the existing `Commit`, except:
  - references to other values (parent commits and root nodes) are serialised as direct offsets when possible (i.e. when the value being referenced already exists in the store). (_I was hoping that this would always be possible, but the upper layered store relies on serialising an orphan commit_.)
  - the pack entry has a varint length header after the kind (and before the data).

All of these changes (except the change in discriminator for inodes) exist to support adding direct pointers to `irmin-pack`, but are currently unused.

Some TODOs:
- write some tests of the encoder / decoder for commits;
- we should probably bump the version number in the pack file, but haven't looked into implementing this yet.

Extracted from https://github.com/mirage/irmin/pull/1534.