### PR TITLE
irmin-pack: fix binary encoding of new inode values

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1180,7 +1180,7 @@ struct
       in
       let address_of_key key : Compress.address =
         match offset_of_key key with
-        | None -> Compress.Direct hash
+        | None -> Compress.Direct (Key.to_hash key)
         | Some off -> Compress.Indirect off
       in
       let ptr : Bin.ptr -> Compress.ptr =


### PR DESCRIPTION
The automatic merge of https://github.com/mirage/irmin/pull/1633 and https://github.com/mirage/irmin/pull/1649 introduced a bug to `main` that is resolved by this diff.

(I think we should consider altering our GitHub workflow to prevent this from happening in future.)