### PR TITLE
irmin-pack: bump version header when appending new pack values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,7 +158,7 @@
   - Upgraded on-disk format of pack files to support more efficient lookups and
     reduce indexing overhead.  This change is fully backwards-compatible with
     existing stores using `irmin-pack.2.x` versions, but not
-    forwards compatible. (#1649, @CraigFe @Ngoguey42)
+    forwards compatible. (#1649 #1655, @CraigFe @Ngoguey42)
 
 - **irmin-unix**
   - Clean up command line interface. Allow config file to be specified when

--- a/src/irmin-pack/IO_intf.ml
+++ b/src/irmin-pack/IO_intf.ml
@@ -29,7 +29,6 @@ module type S = sig
   val offset : t -> int63
   val force_offset : t -> int63
   val readonly : t -> bool
-  val version : t -> Version.t
   val flush : t -> unit
   val close : t -> unit
   val exists : string -> bool
@@ -38,6 +37,11 @@ module type S = sig
   val truncate : t -> unit
   (** Sets the length of the underlying IO to be 0, without actually purging the
       associated data. *)
+
+  (* {2 Versioning} *)
+
+  val version : t -> Version.t
+  val set_version : t -> Version.t -> unit
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -60,6 +60,10 @@ module Kind = struct
       | Inode_v1_root -> "Inode_v1_root"
       | Inode_v1_nonroot -> "Inode_v1_nonroot")
 
+  let version : t -> Version.t = function
+    | Contents | Commit_v0 | Inode_v0_unstable | Inode_v0_stable -> `V1
+    | Commit_v1 | Inode_v1_root | Inode_v1_nonroot -> `V2
+
   let length_header_exn : t -> length_header =
     let some_varint = Some `Varint in
     function

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -54,6 +54,7 @@ module type Sigs = sig
     val to_enum : t -> int
     val to_magic : t -> char
     val of_magic_exn : char -> t
+    val version : t -> Version.t
     val pp : t Fmt.t
   end
 

--- a/src/irmin-pack/version.ml
+++ b/src/irmin-pack/version.ml
@@ -17,12 +17,14 @@
 (* For every new version, update the [version] type and [versions]
    headers. *)
 
-type t = [ `V1 ] [@@deriving irmin]
+type t = [ `V1 | `V2 ] [@@deriving irmin]
 
-let latest = `V1
-let enum = [ (`V1, "00000001") ]
-let pp = Fmt.of_to_string (function `V1 -> "v1")
+let latest = `V2
+let enum = [ (`V1, "00000001"); (`V2, "00000002") ]
+let pp = Fmt.of_to_string (function `V1 -> "v1" | `V2 -> "v2")
 let to_bin v = List.assoc v enum
+let to_int = function `V1 -> 1 | `V2 -> 2
+let compare a b = Int.compare (to_int a) (to_int b)
 
 let invalid_arg v =
   let pp_full_version ppf v = Fmt.pf ppf "%a (%S)" pp v (to_bin v) in

--- a/src/irmin-pack/version.mli
+++ b/src/irmin-pack/version.mli
@@ -16,9 +16,10 @@
 
 (** Management of disk-format versions. *)
 
-type t = [ `V1 ] [@@deriving irmin]
+type t = [ `V1 | `V2 ] [@@deriving irmin]
 (** The type for version numbers. *)
 
+val compare : t -> t -> int
 val latest : t
 
 val pp : t Fmt.t


### PR DESCRIPTION
Based on https://github.com/mirage/irmin/pull/1654.  Still needs tests.