### PR TITLE
irmin-pack: add a direct-addressing mode for internal pointers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -152,6 +152,9 @@
     (#1369, @samoht)
 
 - **irmin-pack**
+  - Changed the implementation of backend store keys to use direct pointers to
+    store contents (by offset in the pack file) when possible, rather than
+    querying the index on each lookup. (#1659, @CraigFe @ngoguey42 @icristescu)
   - The `Irmin_pack.Maker` module type now no longer takes a `Conf` argument.
     (#1641, @CraigFe)
   - The backend configuration type `Conf.S` requires a new parameter

--- a/src/irmin-pack/ext.ml
+++ b/src/irmin-pack/ext.ml
@@ -82,7 +82,21 @@ module Maker (Config : Conf.S) = struct
           Irmin.Commit.Generic_key.Store (Schema.Info) (Node) (CA) (H) (Value)
       end
 
-      module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.Value)
+      module Commit_portable = struct
+        module Hash_key = Irmin.Key.Of_hash (Hash)
+        include Schema.Commit (Hash_key) (Hash_key)
+
+        let of_commit : Commit.Value.t -> t =
+         fun t ->
+          let info = Commit.Value.info t
+          and node = Commit.Value.node t |> XKey.to_hash
+          and parents = Commit.Value.parents t |> List.map XKey.to_hash in
+          v ~info ~node ~parents
+
+        module Info = Schema.Info
+
+        type hash = Hash.t [@@deriving irmin]
+      end
 
       module Branch = struct
         module Key = B

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -19,15 +19,18 @@ include Inode_intf
 
 module Make_internal
     (Conf : Conf.S)
-    (H : Irmin.Hash.S)
-    (Key : Irmin.Key.S with type hash = H.t and type t = H.t)
+    (H : Irmin.Hash.S) (Key : sig
+      include Irmin.Key.S with type hash = H.t
+
+      val unfindable_of_hash : hash -> t
+    end)
     (Node : Irmin.Node.Generic_key.S
               with type hash = H.t
                and type contents_key = Key.t
                and type node_key = Key.t) =
 struct
   (** If [should_be_stable ~length ~root] is true for an inode [i], then [i]
-      hashes the same way as a [Node.t] containings the same entries. *)
+      hashes the same way as a [Node.t] containing the same entries. *)
   let should_be_stable ~length ~root =
     if length = 0 then true
     else if not root then false
@@ -43,12 +46,12 @@ struct
 
   module T = struct
     type hash = H.t [@@deriving irmin ~pp ~equal]
-    type key = Key.t
+    type key = Key.t [@@deriving irmin ~pp ~equal]
     type node_key = Node.node_key [@@deriving irmin]
     type contents_key = Node.contents_key [@@deriving irmin]
 
     type step = Node.step
-    [@@deriving irmin ~compare ~to_bin_string ~of_bin_string]
+    [@@deriving irmin ~compare ~to_bin_string ~of_bin_string ~short_hash]
 
     type metadata = Node.metadata [@@deriving irmin ~equal]
     type value = Node.value [@@deriving irmin ~equal]
@@ -66,31 +69,119 @@ struct
     let of_list l = List.fold_left (fun acc (k, v) -> add k v acc) empty l
   end
 
-  (* Binary representation, useful to compute hashes *)
+  module Val_ref : sig
+    open T
+
+    type t [@@deriving irmin]
+    type v = private Key of Key.t | Hash of hash Lazy.t
+
+    val inspect : t -> v
+    val of_key : key -> t
+    val of_hash : hash Lazy.t -> t
+    val promote_exn : t -> key -> unit
+    val to_hash : t -> hash
+    val to_key_exn : t -> key
+    val is_key : t -> bool
+  end = struct
+    open T
+
+    (** Nodes that have been persisted to an underlying store are referenced via
+        keys. Otherwise, when building in-memory inodes (e.g. via [Portable] or
+        [of_concrete_exn]) lazily-computed hashes are used instead. If such
+        values are persisted, the hash reference can be promoted to a key
+        reference (but [Key] values are never demoted to hashes).
+
+        NOTE: in future, we could reflect the case of this type in a type
+        parameter and refactor the [layout] types below to get static guarantees
+        that [Portable] nodes (with hashes for internal pointers) are not saved
+        without first saving their children. *)
+    type v = Key of Key.t | Hash of hash Lazy.t [@@deriving irmin ~pp_dump]
+
+    type t = v ref
+
+    let inspect t = !t
+    let of_key k = ref (Key k)
+    let of_hash h = ref (Hash h)
+
+    let promote_exn t k =
+      let existing_hash =
+        match !t with
+        | Key k' ->
+            (* NOTE: it's valid for [k'] to not be strictly equal to [k], because
+               of duplicate objects in the store. In this case, we preferentially
+               take the newer key. *)
+            Key.to_hash k'
+        | Hash h -> Lazy.force h
+      in
+      if not (equal_hash existing_hash (Key.to_hash k)) then
+        Fmt.failwith
+          "Attempted to promote existing reference %a to an inconsistent key %a"
+          pp_dump_v !t pp_key k;
+      t := Key k
+
+    let to_hash t =
+      match !t with Hash h -> Lazy.force h | Key k -> Key.to_hash k
+
+    let is_key t = match !t with Key _ -> true | _ -> false
+
+    let to_key_exn t =
+      match !t with
+      | Key k -> k
+      | Hash h ->
+          Fmt.failwith "Encountered unkeyed hash but expected key: %a" pp_hash
+            (Lazy.force h)
+
+    let t =
+      let pre_hash_hash = Irmin.Type.(unstage (pre_hash hash_t)) in
+      let pre_hash x f =
+        match !x with
+        | Key k -> pre_hash_hash (Key.to_hash k) f
+        | Hash h -> pre_hash_hash (Lazy.force h) f
+      in
+      Irmin.Type.map ~pre_hash v_t (fun x -> ref x) (fun x -> !x)
+  end
+
+  (* Binary representation. Used in two modes:
+
+      - with [key]s as pointers to child values, when encoding values to add
+        to the underlying store (or decoding values read from the store) –
+        interoperable with the [Compress]-ed binary representation.
+
+      - with either [key]s or [hash]es as pointers to child values, when
+        pre-computing the hash of a node with children that haven't yet been
+        written to the store. *)
   module Bin = struct
     open T
 
-    type ptr = { index : int; hash : H.t } [@@deriving irmin]
+    (** Distinguishes between the two possible modes of binary value. *)
+    type _ mode = Ptr_key : key mode | Ptr_any : Val_ref.t mode
 
-    type tree = { depth : int; length : int; entries : ptr list }
+    type 'vref with_index = { index : int; vref : 'vref } [@@deriving irmin]
+
+    type 'vref tree = {
+      depth : int;
+      length : int;
+      entries : 'vref with_index list;
+    }
     [@@deriving irmin]
 
-    type v = Values of (step * value) list | Tree of tree
+    type 'vref v = Values of (step * value) list | Tree of 'vref tree
     [@@deriving irmin ~pre_hash]
 
     module V =
       Irmin.Hash.Typed
         (H)
         (struct
-          type t = v
-
-          let t = v_t
+          type t = Val_ref.t v [@@deriving irmin]
         end)
 
-    type t = { hash : H.t Lazy.t; root : bool; v : v }
+    type 'vref t = { hash : H.t Lazy.t; root : bool; v : 'vref v }
 
-    let t : t Irmin.Type.t =
+    let t : type vref. vref Irmin.Type.t -> vref t Irmin.Type.t =
+     fun vref_t ->
       let open Irmin.Type in
+      let v_t = v_t vref_t in
+      let pre_hash_v = pre_hash_v vref_t in
       let pre_hash x = pre_hash_v x.v in
       record "Bin.t" (fun hash root v -> { hash = lazy hash; root; v })
       |+ field "hash" H.t (fun t -> Lazy.force t.hash)
@@ -431,12 +522,12 @@ struct
 
     type _ layout =
       | Total : total_ptr layout
-      | Partial : (hash -> partial_ptr t option) -> partial_ptr layout
+      | Partial : (key -> partial_ptr t option) -> partial_ptr layout
       | Truncated : truncated_ptr layout
 
     and partial_ptr_target =
       | Dirty of partial_ptr t
-      | Lazy of hash
+      | Lazy of key
       | Lazy_loaded of partial_ptr t
           (** A partial pointer differentiates the [Dirty] and [Lazy_loaded]
               cases in order to remember that only the latter should be
@@ -453,24 +544,47 @@ struct
 
     and total_ptr = Total_ptr of total_ptr t [@@unboxed]
 
-    and truncated_ptr = Broken of hash | Intact of truncated_ptr t
+    and truncated_ptr =
+      | Broken of Val_ref.t
+          (** Initially [Hash.t], then set to [Key.t] when we try to save the
+              parent and successfully index the hash. *)
+      | Intact of truncated_ptr t
 
     and 'ptr tree = { depth : int; length : int; entries : 'ptr option array }
 
     and 'ptr v = Values of value StepMap.t | Tree of 'ptr tree
 
-    and 'ptr t = { hash : hash Lazy.t; root : bool; v : 'ptr v }
+    and 'ptr t = {
+      root : bool;
+      v : 'ptr v;
+      v_ref : Val_ref.t;
+          (** Represents what is known about [v]'s presence in a corresponding
+              store. Will be a [hash] if [v] is purely in-memory, and a [key] if
+              [v] has been written to / loaded from a store. *)
+    }
 
     module Ptr = struct
-      let hash : type ptr. ptr layout -> ptr -> _ = function
-        | Total -> fun (Total_ptr ptr) -> Lazy.force ptr.hash
+      let val_ref : type ptr. ptr layout -> ptr -> Val_ref.t = function
+        | Total -> fun (Total_ptr ptr) -> ptr.v_ref
         | Partial _ -> (
             fun { target } ->
               match target with
-              | Lazy hash -> hash
-              | Dirty { hash; _ } | Lazy_loaded { hash; _ } -> Lazy.force hash)
+              | Lazy key -> Val_ref.of_key key
+              | Lazy_loaded { v_ref; _ } | Dirty { v_ref; _ } -> v_ref)
+        | Truncated -> ( function Broken v -> v | Intact ptr -> ptr.v_ref)
+
+      let key_exn : type ptr. ptr layout -> ptr -> key = function
+        | Total -> fun (Total_ptr ptr) -> Val_ref.to_key_exn ptr.v_ref
+        | Partial _ -> (
+            fun { target } ->
+              match target with
+              | Lazy key -> key
+              | Lazy_loaded { v_ref; _ } | Dirty { v_ref; _ } ->
+                  Val_ref.to_key_exn v_ref)
         | Truncated -> (
-            function Broken h -> h | Intact ptr -> Lazy.force ptr.hash)
+            function
+            | Broken h -> Val_ref.to_key_exn h
+            | Intact ptr -> Val_ref.to_key_exn ptr.v_ref)
 
       let target : type ptr. cache:bool -> ptr layout -> ptr -> ptr t =
        fun ~cache layout ->
@@ -483,10 +597,9 @@ struct
                    new cache entries, not the older ones for which the irmin
                    users can discard using [clear]. *)
                 entry
-            | { target = Lazy _ } as t -> (
-                let h = hash layout t in
-                match find h with
-                | None -> Fmt.failwith "%a: unknown key" pp_hash h
+            | { target = Lazy key } as t -> (
+                match find key with
+                | None -> Fmt.failwith "%a: unknown key" pp_key key
                 | Some x ->
                     if cache then t.target <- Lazy_loaded x;
                     x))
@@ -503,38 +616,53 @@ struct
         | Partial _ -> fun target -> { target = Dirty target }
         | Truncated -> fun target -> Intact target
 
-      let of_hash : type ptr. ptr layout -> hash -> ptr = function
+      let of_key : type ptr. ptr layout -> key -> ptr = function
         | Total -> assert false
-        | Partial _ -> fun hash -> { target = Lazy hash }
-        | Truncated -> fun hash -> Broken hash
+        | Partial _ -> fun key -> { target = Lazy key }
+        | Truncated -> fun key -> Broken (Val_ref.of_key key)
+
+      type ('input, 'output) cps = { f : 'r. 'input -> ('output -> 'r) -> 'r }
+      [@@ocaml.unboxed]
 
       let save :
           type ptr.
-          broken:(hash -> unit) ->
-          save_dirty:(ptr t -> unit) ->
+          broken:(hash, key) cps ->
+          save_dirty:(ptr t, key) cps ->
           clear:bool ->
           ptr layout ->
           ptr ->
           unit =
        fun ~broken ~save_dirty ~clear -> function
-        | Total -> fun (Total_ptr entry) -> (save_dirty [@tailcall]) entry
+        (* Invariant: after returning, we can recover the key from the saved
+           pointer (i.e. [key_exn] does not raise an exception). This is necessary
+           in order to be able to serialise a parent inode (for export) after
+           having saved its children. *)
+        | Total ->
+            fun (Total_ptr entry) ->
+              save_dirty.f entry (fun key ->
+                  Val_ref.promote_exn entry.v_ref key)
         | Partial _ -> (
             function
             | { target = Dirty entry } as box ->
-                if clear then box.target <- Lazy (Lazy.force entry.hash)
-                else
-                  (* Promote from dirty to lazy as it will be saved during
-                     [save_dirty]. *)
-                  box.target <- Lazy_loaded entry;
-                (save_dirty [@tailcall]) entry
+                save_dirty.f entry (fun key ->
+                    if clear then box.target <- Lazy key
+                    else (
+                      box.target <- Lazy_loaded entry;
+                      Val_ref.promote_exn entry.v_ref key))
             | { target = Lazy_loaded entry } as box ->
-                if clear then box.target <- Lazy (Lazy.force entry.hash);
-                (save_dirty [@tailcall]) entry
+                (* TODO(craigfe): document why we save in this case. *)
+                save_dirty.f entry (fun key ->
+                    if clear then box.target <- Lazy key)
             | { target = Lazy _ } -> ())
         | Truncated -> (
             function
-            | Broken h -> (broken [@tailcall]) h
-            | Intact entry -> (save_dirty [@tailcall]) entry)
+            | Intact entry ->
+                save_dirty.f entry (fun key ->
+                    Val_ref.promote_exn entry.v_ref key)
+            | Broken vref ->
+                if not (Val_ref.is_key vref) then
+                  broken.f (Val_ref.to_hash vref) (fun key ->
+                      Val_ref.promote_exn vref key))
 
       let clear :
           type ptr.
@@ -547,21 +675,21 @@ struct
             | { target = Lazy _ } -> ()
             | { target = Dirty ptr } -> iter_dirty layout ptr
             | { target = Lazy_loaded ptr } as box ->
-                let hash = Lazy.force ptr.hash in
-                (* Since a [Lazy_loaded] used to be a [Lazy], the hash is always
+                (* Since a [Lazy_loaded] used to be a [Lazy], the key is always
                    available. *)
-                box.target <- Lazy hash)
+                let key = Val_ref.to_key_exn ptr.v_ref in
+                box.target <- Lazy key)
         | Total | Truncated -> ()
     end
 
     let pred layout t =
       match t.v with
       | Tree i ->
-          let hash_of_ptr = Ptr.hash layout in
+          let key_of_ptr = Ptr.key_exn layout in
           Array.fold_left
             (fun acc -> function
               | None -> acc
-              | Some ptr -> (None, `Inode (hash_of_ptr ptr)) :: acc)
+              | Some ptr -> (None, `Inode (key_of_ptr ptr)) :: acc)
             [] i.entries
       | Values l ->
           StepMap.fold
@@ -667,21 +795,27 @@ struct
       let len = Int.max_int in
       fun () -> seq_v layout v ~cache empty_continuation ~off ~len
 
-    let to_bin_v layout v =
+    let to_bin_v :
+        type ptr vref. ptr layout -> vref Bin.mode -> ptr v -> vref Bin.v =
+     fun layout mode node ->
       Stats.incr_inode_to_binv ();
-      match v with
+      match node with
       | Values vs ->
           let vs = StepMap.bindings vs in
           Bin.Values vs
       | Tree t ->
-          let hash_of_ptr = Ptr.hash layout in
+          let vref_of_ptr : ptr -> vref =
+            match mode with
+            | Bin.Ptr_any -> Ptr.val_ref layout
+            | Bin.Ptr_key -> Ptr.key_exn layout
+          in
           let _, entries =
             Array.fold_left
               (fun (i, acc) -> function
                 | None -> (i + 1, acc)
                 | Some ptr ->
-                    let hash = hash_of_ptr ptr in
-                    (i + 1, { Bin.index = i; hash } :: acc))
+                    let vref = vref_of_ptr ptr in
+                    (i + 1, { Bin.index = i; vref } :: acc))
               (0, []) t.entries
           in
           let entries = List.rev entries in
@@ -690,13 +824,18 @@ struct
     let is_root t = t.root
     let is_stable t = should_be_stable ~length:(length t) ~root:(is_root t)
 
-    let to_bin layout t =
-      let v = to_bin_v layout t.v in
-      Bin.v ~root:(is_root t) ~hash:t.hash v
+    let to_bin layout mode t =
+      let v = to_bin_v layout mode t.v in
+      Bin.v ~root:(is_root t) ~hash:(lazy (Val_ref.to_hash t.v_ref)) v
 
     module Concrete = struct
-      type kind = Contents | Contents_x of metadata | Node [@@deriving irmin]
-      type entry = { name : step; kind : kind; hash : hash } [@@deriving irmin]
+      type kinded_key =
+        | Contents of contents_key
+        | Contents_x of metadata * contents_key
+        | Node of node_key
+      [@@deriving irmin]
+
+      type entry = { name : step; key : kinded_key } [@@deriving irmin]
 
       type 'a pointer = { index : int; pointer : hash; tree : 'a }
       [@@deriving irmin]
@@ -708,18 +847,18 @@ struct
 
       let to_entry (name, v) =
         match v with
-        | `Contents (hash, m) ->
+        | `Contents (contents_key, m) ->
             if T.equal_metadata m Metadata.default then
-              { name; kind = Contents; hash }
-            else { name; kind = Contents_x m; hash }
-        | `Node hash -> { name; kind = Node; hash }
+              { name; key = Contents contents_key }
+            else { name; key = Contents_x (m, contents_key) }
+        | `Node node_key -> { name; key = Node node_key }
 
       let of_entry e =
         ( e.name,
-          match e.kind with
-          | Contents -> `Contents (e.hash, Metadata.default)
-          | Contents_x m -> `Contents (e.hash, m)
-          | Node -> `Node e.hash )
+          match e.key with
+          | Contents key -> `Contents (key, Metadata.default)
+          | Contents_x (m, key) -> `Contents (key, m)
+          | Node key -> `Node key )
 
       type error =
         [ `Invalid_hash of hash * hash * t
@@ -761,7 +900,7 @@ struct
       let rec aux t =
         match t.v with
         | Tree tr ->
-            ( Lazy.force t.hash,
+            ( Val_ref.to_hash t.v_ref,
               Concrete.Tree
                 {
                   depth = tr.depth;
@@ -781,7 +920,7 @@ struct
                     |> List.rev;
                 } )
         | Values l ->
-            ( Lazy.force t.hash,
+            ( Val_ref.to_hash t.v_ref,
               Concrete.Value (List.map Concrete.to_entry (StepMap.bindings l))
             )
       in
@@ -815,7 +954,7 @@ struct
         if List.length s <> List.length ps then raise (Duplicated_pointers t);
         if s <> ps then raise (Unsorted_pointers t)
       in
-      let hash v = Bin.V.hash (to_bin_v Total v) in
+      let hash v = Bin.V.hash (to_bin_v Total Bin.Ptr_any v) in
       let rec aux depth t =
         match t with
         | Concrete.Value l ->
@@ -830,7 +969,9 @@ struct
                 let hash = hash v in
                 if not (equal_hash hash pointer) then
                   raise (Invalid_hash (hash, pointer, t));
-                let t = { hash = lazy pointer; root = false; v } in
+                let t =
+                  { v_ref = Val_ref.of_hash (lazy pointer); root = false; v }
+                in
                 entries.(index) <- Some (Ptr.of_target Total t))
               tr.pointers;
             let length = Concrete.length t in
@@ -847,7 +988,7 @@ struct
           Node.hash node
         else hash v
       in
-      { hash = lazy hash; root = true; v }
+      { v_ref = Val_ref.of_hash (lazy hash); root = true; v }
 
     let of_concrete t =
       try Ok (of_concrete_exn t) with
@@ -860,7 +1001,7 @@ struct
       | Unsorted_entries t -> Error (`Unsorted_entries t)
       | Unsorted_pointers t -> Error (`Unsorted_pointers t)
 
-    let hash t = Lazy.force t.hash
+    let hash t = Val_ref.to_hash t.v_ref
 
     let check_write_op_supported t =
       if not @@ is_root t then
@@ -871,20 +1012,21 @@ struct
       (* If [t] is the empty inode (i.e. [n = 0]) then is is already stable *)
       if n > Conf.stable_hash then { t with root = true }
       else
-        let hash =
-          lazy
-            (let vs = seq layout t in
-             Node.hash (Node.of_seq vs))
+        let v_ref =
+          Val_ref.of_hash
+            (lazy
+              (let vs = seq layout t in
+               Node.hash (Node.of_seq vs)))
         in
-        { hash; v = t.v; root = true }
+        { v_ref; v = t.v; root = true }
 
-    let hash_key = Irmin.Type.(unstage (short_hash step_t))
+    let hash_key = short_hash_step
     let index ~depth k = abs (hash_key ~seed:depth k) mod Conf.entries
 
     (** This function shouldn't be called with the [Total] layout. In the
         future, we could add a polymorphic variant to the GADT parameter to
         enfoce that. *)
-    let of_bin layout t =
+    let of_bin layout (t : key Bin.t) =
       let v =
         match t.Bin.v with
         | Bin.Values vs ->
@@ -892,32 +1034,36 @@ struct
             Values vs
         | Tree t ->
             let entries = Array.make Conf.entries None in
-            let ptr_of_hash = Ptr.of_hash layout in
+            let ptr_of_key = Ptr.of_key layout in
             List.iter
-              (fun { Bin.index; hash } ->
-                entries.(index) <- Some (ptr_of_hash hash))
+              (fun { Bin.index; vref } ->
+                entries.(index) <- Some (ptr_of_key vref))
               t.entries;
             Tree { depth = t.Bin.depth; length = t.length; entries }
       in
-      { hash = t.Bin.hash; v; root = t.root }
+      { v_ref = Val_ref.of_hash t.Bin.hash; root = t.Bin.root; v }
 
     let empty : 'a. 'a layout -> 'a t =
      fun _ ->
-      let hash = lazy (Node.hash (Node.empty ())) in
-      { hash; root = false; v = Values StepMap.empty }
+      let v_ref = Val_ref.of_hash (lazy (Node.hash (Node.empty ()))) in
+      { root = false; v_ref; v = Values StepMap.empty }
 
     let values layout vs =
       let length = StepMap.cardinal vs in
       if length = 0 then empty layout
       else
         let v = Values vs in
-        let hash = lazy (Bin.V.hash (to_bin_v layout v)) in
-        { hash; root = false; v }
+        let v_ref =
+          Val_ref.of_hash (lazy (Bin.V.hash (to_bin_v layout Bin.Ptr_any v)))
+        in
+        { v_ref; root = false; v }
 
     let tree layout is =
       let v = Tree is in
-      let hash = lazy (Bin.V.hash (to_bin_v layout v)) in
-      { hash; root = false; v }
+      let v_ref =
+        Val_ref.of_hash (lazy (Bin.V.hash (to_bin_v layout Bin.Ptr_any v)))
+      in
+      { v_ref; root = false; v }
 
     let is_empty t =
       match t.v with Values vs -> StepMap.is_empty vs | Tree _ -> false
@@ -1068,7 +1214,7 @@ struct
       in
       stabilize_root Total t
 
-    let save layout ~add ~mem t =
+    let save layout ~add ~index ~mem t =
       let clear =
         (* When set to [true], collect the loaded inodes as soon as they're
            saved.
@@ -1076,39 +1222,82 @@ struct
            This parameter is not exposed yet. Ideally it would be exposed and
            be forwarded from [Tree.export ?clear] through [P.Node.add].
 
-           It is currently set to true in order to preserve behaviour *)
+           It is currently set to false in order to preserve behaviour *)
         false
       in
       let iter_entries =
-        let broken h =
+        let broken h k =
           (* This function is called when we encounter a Broken pointer with
              Truncated layouts. *)
-          if not @@ mem h then
-            Fmt.failwith
-              "You are trying to save to the backend an inode deserialized \
-               using [Irmin.Type] that used to contain pointer(s) to inodes \
-               which are unknown to the backend. Hash: %a"
-              pp_hash h
-          else
-            (* The backend already knows this target inode, there is no need to
-               traverse further down. This happens during the unit tests. *)
-            ()
+          match index h with
+          | None ->
+              Fmt.failwith
+                "You are trying to save to the backend an inode deserialized \
+                 using [Irmin.Type] that used to contain pointer(s) to inodes \
+                 which are unknown to the backend. Hash: %a"
+                pp_hash h
+          | Some key ->
+              (* The backend already knows this target inode, there is no need to
+                 traverse further down. This happens during the unit tests. *)
+              k key
         in
-        fun save_dirty arr ->
-          let iter_ptr = Ptr.save ~broken ~save_dirty ~clear layout in
+        fun ~save_dirty arr ->
+          let iter_ptr =
+            Ptr.save ~broken:{ f = broken } ~save_dirty ~clear layout
+          in
           Array.iter (Option.iter iter_ptr) arr
       in
       let rec aux ~depth t =
         [%log.debug "save depth:%d" depth];
         match t.v with
-        | Values _ -> add (Lazy.force t.hash) (to_bin layout t)
+        | Values _ -> (
+            let unguarded_add hash =
+              let value =
+                (* NOTE: the choice of [Bin.mode] is irrelevant (and this
+                   conversion is always safe), since nodes of kind [Values _]
+                   contain no internal pointers. *)
+                to_bin layout Bin.Ptr_key t
+              in
+              let key = add hash value in
+              Val_ref.promote_exn t.v_ref key;
+              key
+            in
+            match Val_ref.inspect t.v_ref with
+            | Key key ->
+                if mem key then key else unguarded_add (Key.to_hash key)
+            | Hash hash -> unguarded_add (Lazy.force hash))
         | Tree n ->
-            iter_entries
-              (fun t ->
-                let hash = Lazy.force t.hash in
-                if mem hash then () else aux ~depth:(depth + 1) t)
-              n.entries;
-            add (Lazy.force t.hash) (to_bin layout t)
+            let save_dirty t k =
+              let key =
+                match Val_ref.inspect t.v_ref with
+                | Key key -> if mem key then key else aux ~depth:(depth + 1) t
+                | Hash hash -> (
+                    match index (Lazy.force hash) with
+                    | Some key ->
+                        if mem key then key
+                        else
+                          (* In this case, [index] has returned a key that is
+                             not present in the underlying store. This is
+                             permitted by the contract on index functions (and
+                             required by [irmin-pack.mem]), but never happens
+                             with the persistent {!Pack_store} backend (provided
+                             the store is not corrupted). *)
+                          aux ~depth:(depth + 1) t
+                    | None -> aux ~depth:(depth + 1) t)
+              in
+              Val_ref.promote_exn t.v_ref key;
+              k key
+            in
+            iter_entries ~save_dirty:{ f = save_dirty } n.entries;
+            let bin =
+              (* Serialising with [Bin.Ptr_key] is safe here because just called
+                 [Ptr.save] on any dirty children (and we never try to save
+                 [Portable] nodes). *)
+              to_bin layout Bin.Ptr_key t
+            in
+            let key = add (Val_ref.to_hash t.v_ref) bin in
+            Val_ref.promote_exn t.v_ref key;
+            key
       in
       aux ~depth:0 t
 
@@ -1150,9 +1339,7 @@ struct
   module Raw = struct
     type hash = H.t
     type key = Key.t
-    type t = Bin.t
-
-    let t = Bin.t
+    type t = T.key Bin.t [@@deriving irmin]
 
     let kind (t : t) =
       (* This is the kind of newly appended values, let's use v1 then *)
@@ -1164,14 +1351,29 @@ struct
     let step_of_bin = T.step_of_bin_string
     let encode_compress = Irmin.Type.(unstage (encode_bin Compress.t))
     let decode_compress = Irmin.Type.(unstage (decode_bin Compress.t))
-    let length_header = `Never
+
+    let length_header =
+      `Sometimes
+        (function
+        | Pack_value.Kind.Contents ->
+            (* NOTE: the Node instantiation of the pack store must have access to
+               the header format used by contents values in order to eagerly
+               construct contents keys with length information during
+               [key_of_offset]. *)
+            Conf.contents_length_header
+        | k -> Pack_value.Kind.length_header_exn k)
 
     let decode_compress_length =
       match Irmin.Type.Size.of_encoding Compress.t with
       | Unknown | Static _ -> assert false
       | Dynamic f -> f
 
-    let encode_bin ~dict ~offset_of_key hash (t : t) =
+    let encode_bin :
+        dict:(string -> int option) ->
+        offset_of_key:(Key.t -> int63 option) ->
+        hash ->
+        t Irmin.Type.encode_bin =
+     fun ~dict ~offset_of_key hash t ->
       Stats.incr_inode_encode_bin ();
       let step s : Compress.name =
         let str = step_to_bin s in
@@ -1180,12 +1382,15 @@ struct
       in
       let address_of_key key : Compress.address =
         match offset_of_key key with
-        | None -> Compress.Direct (Key.to_hash key)
         | Some off -> Compress.Indirect off
+        | None ->
+            (* The key references an inode/contents that is not in the pack
+                file. This is highly unusual but not forbidden. *)
+            Compress.Direct (Key.to_hash key)
       in
-      let ptr : Bin.ptr -> Compress.ptr =
+      let ptr : T.key Bin.with_index -> Compress.ptr =
        fun n ->
-        let hash = address_of_key n.hash in
+        let hash = address_of_key n.vref in
         { index = n.index; hash }
       in
       let value : T.step * T.value -> Compress.value = function
@@ -1199,7 +1404,7 @@ struct
             Compress.Node (s, v)
       in
       (* List.map is fine here as the number of entries is small *)
-      let v : Bin.v -> Compress.v = function
+      let v : T.key Bin.v -> Compress.v = function
         | Values vs -> Values (List.map value vs)
         | Tree { depth; length; entries } ->
             let entries = List.map ptr entries in
@@ -1210,9 +1415,14 @@ struct
 
     exception Exit of [ `Msg of string ]
 
-    let decode_bin ~dict ~key_of_offset ~key_of_hash:_ t off =
+    let decode_bin :
+        dict:(int -> string option) ->
+        key_of_offset:(int63 -> key) ->
+        key_of_hash:(hash -> key) ->
+        t Irmin.Type.decode_bin =
+     fun ~dict ~key_of_offset ~key_of_hash t pos_ref ->
       Stats.incr_inode_decode_bin ();
-      let i = decode_compress t off in
+      let i = decode_compress t pos_ref in
       let step : Compress.name -> T.step = function
         | Direct n -> n
         | Indirect s -> (
@@ -1223,26 +1433,26 @@ struct
                 | Error e -> raise_notrace (Exit e)
                 | Ok v -> v))
       in
-      let hash : Compress.address -> H.t = function
+      let key : Compress.address -> T.key = function
         | Indirect off -> key_of_offset off
-        | Direct n -> n
+        | Direct n -> key_of_hash n
       in
-      let ptr : Compress.ptr -> Bin.ptr =
+      let ptr : Compress.ptr -> T.key Bin.with_index =
        fun n ->
-        let hash = hash n.hash in
-        { index = n.index; hash }
+        let vref = key n.hash in
+        { index = n.index; vref }
       in
       let value : Compress.value -> T.step * T.value = function
         | Contents (n, h, metadata) ->
             let name = step n in
-            let hash = hash h in
+            let hash = key h in
             (name, `Contents (hash, metadata))
         | Node (n, h) ->
             let name = step n in
-            let hash = hash h in
+            let hash = key h in
             (name, `Node hash)
       in
-      let t : Compress.tagged_v -> Bin.v =
+      let t : Compress.tagged_v -> T.key Bin.v =
        fun tv ->
         let v =
           match tv with
@@ -1338,40 +1548,60 @@ struct
       in
       map t { f }
 
-    let pre_hash_binv = Irmin.Type.(unstage (pre_hash Bin.v_t))
-    let pre_hash_node = Irmin.Type.(unstage (pre_hash Node.t))
-
     let t : t Irmin.Type.t =
+      let pre_hash_binv = Irmin.Type.(unstage (pre_hash (Bin.v_t Val_ref.t))) in
+      let pre_hash_node = Irmin.Type.(unstage (pre_hash Node.t)) in
       let pre_hash x =
         let stable = apply x { f = (fun _ v -> I.is_stable v) } in
         if not stable then
-          let bin = apply x { f = (fun layout v -> I.to_bin layout v) } in
+          let bin =
+            apply x { f = (fun layout v -> I.to_bin layout Bin.Ptr_any v) }
+          in
           pre_hash_binv bin.v
         else
           let vs = seq x in
           pre_hash_node (Node.of_seq vs)
       in
-      Irmin.Type.map ~pre_hash Bin.t
+      let module Ptr_any = struct
+        let t =
+          Irmin.Type.map (Bin.t Val_ref.t)
+            (fun _ -> assert false)
+            (fun x ->
+              apply x { f = (fun layout v -> I.to_bin layout Bin.Ptr_any v) })
+
+        type nonrec t = t [@@deriving irmin ~equal ~compare ~pp]
+
+        (* TODO(repr): add these to [ppx_repr] meta-deriving *)
+        (* TODO(repr): why is there no easy way to get a decoder value to pass to [map ~json]? *)
+        let encode_json = Irmin.Type.encode_json t
+        let decode_json _ = failwith "TODO"
+      end in
+      Irmin.Type.map ~pre_hash ~pp:Ptr_any.pp
+        ~json:(Ptr_any.encode_json, Ptr_any.decode_json)
+        ~equal:Ptr_any.equal ~compare:Ptr_any.compare (Bin.t T.key_t)
         (fun bin -> Truncated (I.of_bin I.Truncated bin))
-        (fun x -> apply x { f = (fun layout v -> I.to_bin layout v) })
+        (fun x ->
+          apply x { f = (fun layout v -> I.to_bin layout Bin.Ptr_key v) })
 
     let hash t = apply t { f = (fun _ v -> I.hash v) }
 
-    let save ~add ~mem t =
+    let save ~add ~index ~mem t =
       let f layout v =
         I.check_write_op_supported v;
-        I.save layout ~add ~mem v
+        I.save layout ~add ~index ~mem v
       in
       apply t { f }
 
-    let of_raw find' v =
+    let of_raw (find' : key -> key Bin.t option) v =
       Stats.incr_inode_of_raw ();
       let rec find h =
         match find' h with None -> None | Some v -> Some (I.of_bin layout v)
       and layout = I.Partial find in
       Partial (layout, I.of_bin layout v)
 
-    let to_raw t = apply t { f = (fun layout v -> I.to_bin layout v) }
+    let to_raw t =
+      apply t { f = (fun layout v -> I.to_bin layout Bin.Ptr_key v) }
+
     let stable t = apply t { f = (fun _ v -> I.is_stable v) }
     let length t = apply t { f = (fun _ v -> I.length v) }
     let clear t = apply t { f = (fun layout v -> I.clear layout v) }
@@ -1410,7 +1640,54 @@ struct
     module Portable = struct
       include Val_portable
 
+      type node_key = hash [@@deriving irmin]
+      type contents_key = hash [@@deriving irmin]
+
+      type value = [ `Contents of hash * metadata | `Node of hash ]
+      [@@deriving irmin]
+
       let of_node t = t
+
+      let keyvalue_of_hashvalue = function
+        | `Contents (h, m) -> `Contents (Key.unfindable_of_hash h, m)
+        | `Node h -> `Node (Key.unfindable_of_hash h)
+
+      let hashvalue_of_keyvalue = function
+        | `Contents (k, m) -> `Contents (Key.to_hash k, m)
+        | `Node k -> `Node (Key.to_hash k)
+
+      let of_list bindings =
+        bindings
+        |> List.map (fun (k, v) -> (k, keyvalue_of_hashvalue v))
+        |> of_list
+
+      let of_seq bindings =
+        bindings
+        |> Seq.map (fun (k, v) -> (k, keyvalue_of_hashvalue v))
+        |> of_seq
+
+      let seq ?offset ?length ?cache t =
+        seq ?offset ?length ?cache t
+        |> Seq.map (fun (k, v) -> (k, hashvalue_of_keyvalue v))
+
+      let add : t -> step -> value -> t =
+       fun t s v -> add t s (keyvalue_of_hashvalue v)
+
+      let list ?offset ?length ?cache t =
+        list ?offset ?length ?cache t
+        |> List.map (fun (s, v) -> (s, hashvalue_of_keyvalue v))
+
+      let find ?cache t s = find ?cache t s |> Option.map hashvalue_of_keyvalue
+
+      let merge =
+        let promote_merge :
+            hash option Irmin.Merge.t -> key option Irmin.Merge.t =
+         fun t ->
+          Irmin.Merge.like [%typ: key option] t (Option.map Key.to_hash)
+            (Option.map Key.unfindable_of_hash)
+        in
+        fun ~contents ~node ->
+          merge ~contents:(promote_merge contents) ~node:(promote_merge node)
     end
 
     let to_concrete t = apply t { f = (fun la v -> I.to_concrete la v) }
@@ -1422,7 +1699,7 @@ end
 
 module Make
     (H : Irmin.Hash.S)
-    (Key : Irmin.Key.S with type hash = H.t and type t = H.t)
+    (Key : Irmin.Key.S with type hash = H.t)
     (Node : Irmin.Node.Generic_key.S
               with type hash = H.t
                and type contents_key = Key.t
@@ -1442,12 +1719,12 @@ struct
   module Val = Inter.Val
 
   type 'a t = 'a Pack.t
-  type key = Key.t
+  type key = Key.t [@@deriving irmin ~equal]
   type hash = Hash.t
   type value = Inter.Val.t
 
   let mem t k = Pack.mem t k
-  let index _ k = Lwt.return_some k
+  let index t k = Pack.index t k
 
   let find t k =
     Pack.find t k >|= function
@@ -1459,17 +1736,12 @@ struct
 
   let save t v =
     let add k v =
-      ignore
-        (Pack.unsafe_append ~ensure_unique:true ~overcommit:false t k v : hash)
+      Pack.unsafe_append ~ensure_unique:true ~overcommit:false t k v
     in
-    Val.save ~add ~mem:(Pack.unsafe_mem t) v
+    Val.save ~add ~index:(Pack.index_direct t) ~mem:(Pack.unsafe_mem t) v
 
   let hash v = Val.hash v
-
-  let add t v =
-    save t v;
-    Lwt.return (hash v)
-
+  let add t v = Lwt.return (save t v)
   let equal_hash = Irmin.Type.(unstage (equal H.t))
 
   let check_hash expected got =
@@ -1480,8 +1752,7 @@ struct
 
   let unsafe_add t k v =
     check_hash k (hash v);
-    save t v;
-    Lwt.return k
+    Lwt.return (save t v)
 
   let batch = Pack.batch
   let close = Pack.close

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -650,7 +650,12 @@ struct
                       box.target <- Lazy_loaded entry;
                       Val_ref.promote_exn entry.v_ref key))
             | { target = Lazy_loaded entry } as box ->
-                (* TODO(craigfe): document why we save in this case. *)
+                (* In this case, [entry.v_ref] is a [Hash h] such that [mem t
+                   (index t h) = true]. We "save" the entry in order to trigger
+                   the [index] lookup and recover the key, in order to meet the
+                   return invariant above.
+
+                   TODO: refactor this case to be more precise. *)
                 save_dirty.f entry (fun key ->
                     if clear then box.target <- Lazy key)
             | { target = Lazy _ } -> ())

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1352,16 +1352,14 @@ struct
     let encode_compress = Irmin.Type.(unstage (encode_bin Compress.t))
     let decode_compress = Irmin.Type.(unstage (decode_bin Compress.t))
 
-    let length_header =
-      `Sometimes
-        (function
-        | Pack_value.Kind.Contents ->
-            (* NOTE: the Node instantiation of the pack store must have access to
-               the header format used by contents values in order to eagerly
-               construct contents keys with length information during
-               [key_of_offset]. *)
-            Conf.contents_length_header
-        | k -> Pack_value.Kind.length_header_exn k)
+    let length_header = function
+      | Pack_value.Kind.Contents ->
+          (* NOTE: the Node instantiation of the pack store must have access to
+             the header format used by contents values in order to eagerly
+             construct contents keys with length information during
+             [key_of_offset]. *)
+          Conf.contents_length_header
+      | k -> Pack_value.Kind.length_header_exn k
 
     let decode_compress_length =
       match Irmin.Type.Size.of_encoding Compress.t with

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -661,6 +661,8 @@ struct
             | { target = Lazy _ } -> ())
         | Truncated -> (
             function
+            (* TODO: this branch is currently untested: we never attempt to
+               save a truncated node as part of the unit tests. *)
             | Intact entry ->
                 save_dirty.f entry (fun key ->
                     Val_ref.promote_exn entry.v_ref key)

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -49,7 +49,12 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
     module M = Schema.Metadata
     module B = Schema.Branch
     module Pack = Indexable.Maker (H)
-    module XKey = Irmin.Key.Of_hash (H)
+
+    module XKey = struct
+      include Irmin.Key.Of_hash (H)
+
+      let unfindable_of_hash x = x
+    end
 
     module X = struct
       module Schema = Schema

--- a/src/irmin-pack/pack_key.ml
+++ b/src/irmin-pack/pack_key.ml
@@ -17,17 +17,107 @@
 open! Import
 include Pack_key_intf
 
-type 'hash t = 'hash
+type 'hash state =
+  | Direct of { hash : 'hash; offset : int63; length : int }
+  | Indexed of 'hash
+
+type 'hash t = { mutable state : 'hash state }
+
+let inspect t = t.state
+let to_hash t = match t.state with Direct t -> t.hash | Indexed h -> h
+
+let promote_exn t ~offset ~length =
+  let () =
+    match t.state with
+    | Direct _ ->
+        Fmt.failwith "Attempted to promote a key that is already Direct"
+    | Indexed _ -> ()
+  in
+  t.state <- Direct { hash = to_hash t; offset; length }
+
+let t : type h. h Irmin.Type.t -> h t Irmin.Type.t =
+ fun hash_t ->
+  let open Irmin.Type in
+  variant "t" (fun direct indexed t ->
+      match t.state with
+      | Direct { hash; offset; length } -> direct (hash, offset, length)
+      | Indexed x1 -> indexed x1)
+  |~ case1 "Direct" [%typ: hash * int63 * int] (fun (hash, offset, length) ->
+         { state = Direct { hash; offset; length } })
+  |~ case1 "Indexed" [%typ: hash] (fun x1 -> { state = Indexed x1 })
+  |> sealv
+
+let t (type hash) (hash_t : hash Irmin.Type.t) =
+  let module Hash = struct
+    type t = hash
+    [@@deriving irmin ~equal ~compare ~pre_hash ~encode_bin ~decode_bin]
+
+    let unboxed_encode_bin = Irmin.Type.(unstage (Unboxed.encode_bin t))
+    let unboxed_decode_bin = Irmin.Type.(unstage (Unboxed.decode_bin t))
+
+    let encoded_size =
+      match Irmin.Type.Size.of_value t with
+      | Static n -> n
+      | Dynamic _ | Unknown ->
+          Fmt.failwith "Hash must have a fixed-width binary encoding"
+  end in
+  (* The pre-hash image of a key is just the hash of the corresponding value.
+
+     NOTE: it's particularly important that we discard the file offset when
+     computing hashes of structured values (e.g. inodes), so that this hashing
+     process is reproducible in different stores (w/ different offsets for the
+     values). *)
+  let equal a b =
+    let result = Hash.equal (to_hash a) (to_hash b) in
+    assert (
+      if not result then true
+      else
+        match (a.state, b.state) with
+        | Direct a, Direct b -> a.length = b.length
+        | _, _ -> true);
+    result
+  in
+  let compare a b = Hash.compare (to_hash a) (to_hash b) in
+  let pre_hash t f = Hash.pre_hash (to_hash t) f in
+  let encode_bin t f = Hash.encode_bin (to_hash t) f in
+  let unboxed_encode_bin t f = Hash.unboxed_encode_bin (to_hash t) f in
+  let decode_bin buf pos_ref =
+    { state = Indexed (Hash.decode_bin buf pos_ref) }
+  in
+  let unboxed_decode_bin buf pos_ref =
+    { state = Indexed (Hash.unboxed_decode_bin buf pos_ref) }
+  in
+  let size_of = Irmin.Type.Size.custom_static Hash.encoded_size in
+  Irmin.Type.like (t hash_t) ~pre_hash ~equal ~compare
+    ~bin:(encode_bin, decode_bin, size_of)
+    ~unboxed_bin:(unboxed_encode_bin, unboxed_decode_bin, size_of)
+
+let v_direct ~hash ~offset ~length = { state = Direct { hash; offset; length } }
+let v_indexed hash = { state = Indexed hash }
+
+module type S = sig
+  type hash
+
+  include S with type t = hash t and type hash := hash
+end
 
 module Make (Hash : Irmin.Hash.S) = struct
-  include Irmin.Key.Of_hash (Hash)
+  type nonrec t = Hash.t t [@@deriving irmin]
+  type hash = Hash.t [@@deriving irmin ~of_bin_string]
 
-  type nonrec t = t [@@deriving irmin ~of_bin_string]
+  let to_hash = to_hash
+  let null_offset = Int63.minus_one
+  let null_length = -1
 
   let null =
-    match of_bin_string (String.make Hash.hash_size '\000') with
-    | Ok x -> x
-    | Error _ -> assert false
+    let buf = String.make Hash.hash_size '\000' in
+    let hash =
+      match hash_of_bin_string buf with Ok x -> x | Error _ -> assert false
+    in
+    v_direct ~hash ~offset:null_offset ~length:null_length
+
+  let unfindable_of_hash hash =
+    v_direct ~hash ~offset:null_offset ~length:null_length
 end
 
 module type Store_spec = sig

--- a/src/irmin-pack/pack_key_intf.ml
+++ b/src/irmin-pack/pack_key_intf.ml
@@ -17,19 +17,60 @@
 open! Import
 
 module type S = sig
-  type hash
-
-  include Irmin.Key.S with type t = hash and type hash := hash
+  include Irmin.Key.S
 
   val null : t
+
+  val unfindable_of_hash : hash -> t
+  (** [unfindable_of_hash h] is a key [k] such that [to_hash k = h], with an
+      unspecified internal representation. This function enables an efficient
+      implmentation of "portable" inodes, but is otherwise unused. Attempting to
+      dereference a key constructed in this way results in undefined behaviour. *)
 end
 
 module type Sigs = sig
-  type 'hash t = 'hash
+  type 'hash t
   (** The type of {i keys} referencing values stored in the [irmin-pack]
       backend. *)
 
-  module type S = S
+  (** The internal state of a key (read with {!inspect}).
+
+      Invariant: keys of the form {!Indexed} always reference values that have
+      entries in the index (as otherwise these keys could not be dereferenced). *)
+  type 'hash state = private
+    | Direct of { hash : 'hash; offset : int63; length : int }
+        (** A "direct" pointer to a value stored at [offset] in the pack-file
+            (with hash [hash] and length [length]). Such keys can be
+            dereferenced from the store with a single IO read, without needing
+            to consult the index.
+
+            They are built in-memory (e.g. after adding a fresh value to the
+            pack file), but have no corresponding encoding format, as the pack
+            format keeps length information with the values themselves.
+
+            When decoding a inode, which references its children as single
+            offsets, we fetch the length information of the child at the same
+            time as fetching its hash (which we must do anyway in order to do an
+            integrity check), creating keys of this form. *)
+    | Indexed of 'hash
+        (** A pointer to an object in the pack file that is indexed. Reading the
+            object necessitates consulting the index, after which the key can be
+            promoted to {!Direct}.
+
+            Such keys result from decoding pointers to other store objects
+            (nodes or commits) from commits or from the branch store. *)
+
+  val inspect : 'hash t -> 'hash state
+  val v_direct : hash:'h -> offset:int63 -> length:int -> 'h t
+  val v_indexed : 'h -> 'h t
+  val promote_exn : 'h t -> offset:int63 -> length:int -> unit
+
+  module type S = sig
+    type hash
+
+    (** @inline *)
+    include S with type t = hash t and type hash := hash
+  end
 
   module Make (Hash : Irmin.Hash.S) : S with type hash = Hash.t
 

--- a/src/irmin-pack/pack_key_intf.ml
+++ b/src/irmin-pack/pack_key_intf.ml
@@ -60,6 +60,27 @@ module type Sigs = sig
             Such keys result from decoding pointers to other store objects
             (nodes or commits) from commits or from the branch store. *)
 
+  (** {2 Undereferencable keys}
+
+      A key [k] is "undereferencable" with respect to some store handle [t] if
+      [find t k <> Some _]. Such keys should not arise during regular operation
+      of a single Irmin repository, but are still technically constructible in
+      the following ways:
+
+      - {b storage corruption}. When decoding a key from disk, we may not
+        immediately check that it is dereferenceable for performance reasons. In
+        this case, any corruption to the key (or the referenced section of the
+        store) will be discovered on attempted [find] (or [mem]).
+
+      - {b passing keys between store handles}. Read-only handles on a pack
+        store must explicitly {i sync} to observe recent writes to the store.
+        This means that any keys built by a read-write instance and passed to a
+        read-only instance will be undereferencable until that reader has
+        synced.
+
+      - {b passing keys between repositories}. Keys created for one Irmin
+        repository may not be dereferenced with respect to another by design. *)
+
   val inspect : 'hash t -> 'hash state
   val v_direct : hash:'h -> offset:int63 -> length:int -> 'h t
   val v_indexed : 'h -> 'h t

--- a/src/irmin-pack/pack_store.ml
+++ b/src/irmin-pack/pack_store.ml
@@ -8,6 +8,20 @@ module Table (K : Irmin.Hash.S) = Hashtbl.Make (struct
   let equal = Irmin.Type.(unstage (equal K.t))
 end)
 
+exception Invalid_read of string
+exception Corrupted_store of string
+
+let invalid_read fmt = Fmt.kstr (fun s -> raise (Invalid_read s)) fmt
+let corrupted_store fmt = Fmt.kstr (fun s -> raise (Corrupted_store s)) fmt
+
+module Varint = struct
+  type t = int [@@deriving irmin ~decode_bin]
+
+  (** LEB128 stores 7 bits per byte. An OCaml [int] has at most 63 bits.
+      [63 / 7] equals [9]. *)
+  let max_encoded_size = 9
+end
+
 let selected_version = `V2
 
 module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
@@ -81,10 +95,16 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
     }
 
     type hash = K.t [@@deriving irmin ~pp ~equal ~decode_bin]
-    type key = Key.t [@@deriving irmin ~pp ~equal]
+    type key = Key.t [@@deriving irmin ~pp]
     type value = Val.t [@@deriving irmin ~pp]
 
-    let index_direct _ hash = Some hash
+    let index_direct t hash =
+      [%log.debug "index %a" pp_hash hash];
+      match Index.find t.pack.index hash with
+      | None -> None
+      | Some (offset, length, _) ->
+          Some (Pack_key.v_direct ~hash ~offset ~length)
+
     let index t hash = Lwt.return (index_direct t hash)
 
     let clear t =
@@ -147,9 +167,112 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
       assert (n = K.hash_size);
       decode_bin_hash (Bytes.unsafe_to_string buf) (ref 0)
 
+    type span = { offset : int63; length : int }
+    (** The type of contiguous ranges of bytes in the pack file. *)
+
+    (** Refer to the index for the position of a pack entry, assuming it is
+        indexed: *)
+    let get_entry_span_from_index_exn t hash : span =
+      match index_direct t hash with
+      | Some key' -> (
+          match Pack_key.inspect key' with
+          | Direct { offset; length; _ } -> { offset; length }
+          | Indexed _ ->
+              (* [index_direct] returns only [Direct] keys. *)
+              assert false)
+      | None ->
+          corrupted_store "Unexpected object %a missing from index" pp_hash hash
+
+    module Entry_prefix = struct
+      type t = {
+        hash : hash;
+        kind : Pack_value.Kind.t;
+        value_length : int option;
+            (** Length of the value segment including the length header (if it
+                exists). *)
+      }
+      [@@deriving irmin ~pp_dump]
+
+      let min_length = K.hash_size + 1
+      let max_length = K.hash_size + 1 + Varint.max_encoded_size
+    end
+
+    let io_read_and_decode_entry_prefix ~off t =
+      let buf = Bytes.create Entry_prefix.max_length in
+      let bytes_read = IO.read t.pack.block ~off buf in
+      (* We may read fewer then [Entry_prefix.max_length] bytes when reading the
+         final entry in the pack file (if the data section of the entry is
+         shorter than [Varint.max_encoded_size]. In this case, an invalid read
+         may be discovered below when attempting to decode the length header. *)
+      if bytes_read < Entry_prefix.min_length then
+        invalid_read
+          "Attempted to read an entry at offset %a in the pack file, but got \
+           only %d bytes"
+          Int63.pp off bytes_read;
+      let hash = decode_bin_hash (Bytes.unsafe_to_string buf) (ref 0) in
+      let kind = Pack_value.Kind.of_magic_exn (Bytes.get buf Hash.hash_size) in
+      let value_length =
+        match Val.length_header with
+        | `Never -> None
+        | `Sometimes has_length_header -> (
+            let length_header_start = Entry_prefix.min_length in
+            match has_length_header kind with
+            | None -> None
+            | Some `Varint ->
+                (* The bytes starting at [length_header_start] are a
+                   variable-length length field (if they exist / were read
+                   correctly): *)
+                let pos_ref = ref length_header_start in
+                let length_header =
+                  Varint.decode_bin (Bytes.unsafe_to_string buf) pos_ref
+                in
+                let length_header_length = !pos_ref - length_header_start in
+                Some (length_header_length + length_header))
+      in
+      { Entry_prefix.hash; kind; value_length }
+
+    let pack_file_contains_key t k =
+      let key = Pack_key.inspect k in
+      match key with
+      | Indexed hash -> Index.mem t.pack.index hash
+      | Direct { offset; _ } ->
+          let minimal_entry_length = Hash.hash_size + 1 in
+          let io_offset = IO.offset t.pack.block in
+          if
+            Int63.compare
+              (Int63.add offset (Int63.of_int minimal_entry_length))
+              io_offset
+            > 0
+          then (
+            (* Can't fit an entry into this suffix of the store, so this key
+               isn't (yet) valid. If we're a read-only instance, the key may
+               become valid on [sync]; otherwise we know that this key wasn't
+               constructed for this store. *)
+            if not t.readonly then
+              invalid_read
+                "invalid key %a checked for membership (IO offset = %a)" pp_key
+                k Int63.pp io_offset;
+            false)
+          else
+            (* Read the hash explicitly as an integrity check: *)
+            let hash = io_read_and_decode_hash ~off:offset t in
+            let expected_hash = Key.to_hash k in
+            if not (Hash.equal hash expected_hash) then
+              invalid_read
+                "invalid key %a checked for membership (read hash %a at this \
+                 offset instead)"
+                pp_key k pp_hash hash;
+            (* At this point we consider the key to be contained in the pack
+               file. However, we could also be in the presence of a forged (or
+               unlucky) key that points to an offset that mimics a real pack
+               entry (e.g. in the middle of a blob). *)
+            true
+
     let unsafe_mem t k =
-      [%log.debug "[pack] mem %a" pp_hash k];
-      Tbl.mem t.staging k || Lru.mem t.lru k || Index.mem t.pack.index k
+      [%log.debug "[pack] mem %a" pp_key k];
+      Tbl.mem t.staging (Key.to_hash k)
+      || Lru.mem t.lru (Key.to_hash k)
+      || pack_file_contains_key t k
 
     let mem t k =
       let b = unsafe_mem t k in
@@ -159,16 +282,45 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
       let h' = Val.hash v in
       if equal_hash h h' then Ok () else Error (h, h')
 
-    exception Invalid_read
+    let check_key k v = check_hash (Key.to_hash k) v
 
     let io_read_and_decode ~off ~len t =
-      if (not (IO.readonly t.pack.block)) && off > IO.offset t.pack.block then
-        raise Invalid_read;
+      let () =
+        if not (IO.readonly t.pack.block) then
+          let io_offset = IO.offset t.pack.block in
+          if Int63.add off (Int63.of_int len) > io_offset then
+            (* This is likely a store corruption. We raise [Invalid_read]
+               specifically so that [integrity_check] below can handle it. *)
+            invalid_read
+              "Got request to read %d bytes (at offset %a), but max IO offset \
+               is %a"
+              len Int63.pp off Int63.pp io_offset
+      in
       let buf = Bytes.create len in
       let n = IO.read t.pack.block ~off buf in
-      if n <> len then raise Invalid_read;
-      let key_of_offset off = io_read_and_decode_hash ~off t in
-      let key_of_hash hash = hash in
+      if n <> len then
+        invalid_read "Read %d bytes (at offset %a) but expected %d" n Int63.pp
+          off len;
+      let key_of_offset offset =
+        [%log.debug "key_of_offset: %a" Int63.pp offset];
+        (* Attempt to eagerly read the length at the same time as reading the
+           hash in order to save an extra IO read when dereferencing the key: *)
+        let { Entry_prefix.hash; value_length; _ } =
+          io_read_and_decode_entry_prefix ~off:offset t
+        in
+        match value_length with
+        | Some value_length ->
+            let length = Hash.hash_size + 1 + value_length in
+            Pack_key.v_direct ~hash ~offset ~length
+        | None ->
+            (* NOTE: we could store [offset] in this key, but since we know the
+               entry doesn't have a length header we'll need to check the index
+               when dereferencing this key anyway. {i Not} storing the offset
+               avoids doing another failed check in the pack file for the length
+               header during [find]. *)
+            Pack_key.v_indexed hash
+      in
+      let key_of_hash = Pack_key.v_indexed in
       let dict = Dict.find t.pack.dict in
       Val.decode_bin ~key_of_offset ~key_of_hash ~dict
         (Bytes.unsafe_to_string buf)
@@ -179,29 +331,58 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
       let mode = if t.readonly then ":RO" else "" in
       Fmt.pf ppf "%s%s" name mode
 
+    let find_in_pack_file ~check_integrity t key hash =
+      let loc, { offset; length } =
+        match Pack_key.inspect key with
+        | Direct { offset; length; _ } -> (Stats.Find.Pack, { offset; length })
+        | Indexed hash ->
+            let entry_span = get_entry_span_from_index_exn t hash in
+            (* Cache the offset and length information in the existing key: *)
+            Pack_key.promote_exn key ~offset:entry_span.offset
+              ~length:entry_span.length;
+            (Stats.Find.Pack, entry_span)
+      in
+      let io_offset = IO.offset t.pack.block in
+      if Int63.add offset (Int63.of_int length) > io_offset then (
+        (* Can't fit an entry into this suffix of the store, so this key
+           isn't (yet) valid. If we're a read-only instance, the key may
+           become valid on [sync]; otherwise we know that this key wasn't
+           constructed for this store. *)
+        match t.readonly with
+        | false ->
+            invalid_read
+              "attempt to dereference invalid key %a (IO offset = %a)" pp_key
+              key Int63.pp io_offset
+        | true ->
+            [%log.debug
+              "Direct store key references an unknown starting offset %a \
+               (length = %d, IO offset = %a)"
+              Int63.pp offset length Int63.pp io_offset];
+            (Stats.Find.Not_found, None))
+      else
+        let v = io_read_and_decode ~off:offset ~len:length t in
+        Lru.add t.lru hash v;
+        (if check_integrity then
+         check_key key v |> function
+         | Ok () -> ()
+         | Error (expected, got) ->
+             corrupted_store "Got hash %a, expecting %a (for val: %a)." pp_hash
+               got pp_hash expected pp_value v);
+        (loc, Some v)
+
     let unsafe_find ~check_integrity t k =
-      [%log.debug "[pack:%a] find %a" pp_io t pp_hash k];
+      [%log.debug "[pack:%a] find %a" pp_io t pp_key k];
+      let hash = Key.to_hash k in
       let location, value =
-        match Tbl.find t.staging k with
+        match Tbl.find t.staging hash with
         | v ->
-            Lru.add t.lru k v;
+            Lru.add t.lru hash v;
             (Stats.Find.Staging, Some v)
         | exception Not_found -> (
-            match Lru.find t.lru k with
+            match Lru.find t.lru hash with
             | v -> (Stats.Find.Lru, Some v)
-            | exception Not_found -> (
-                match Index.find t.pack.index k with
-                | None -> (Stats.Find.Not_found, None)
-                | Some (off, len, _) ->
-                    let v = io_read_and_decode ~off ~len t in
-                    (if check_integrity then
-                     check_hash k v |> function
-                     | Ok () -> ()
-                     | Error (expected, got) ->
-                         Fmt.failwith "corrupted value: got %a, expecting %a."
-                           pp_hash got pp_hash expected);
-                    Lru.add t.lru k v;
-                    (Stats.Find.Pack, Some v)))
+            | exception Not_found -> find_in_pack_file ~check_integrity t k hash
+            )
       in
       Stats.report_find ~location;
       value
@@ -218,7 +399,7 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
         match check_hash hash value with
         | Ok () -> Ok ()
         | Error _ -> Error `Wrong_hash
-      with Invalid_read -> Error `Absent_value
+      with Invalid_read _ -> Error `Absent_value
 
     let batch t f =
       let* r = f (cast t) in
@@ -229,18 +410,22 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
 
     let auto_flush = 1024
 
-    let unsafe_append ~ensure_unique ~overcommit t k v =
-      if ensure_unique && unsafe_mem t k then k
-      else (
-        [%log.debug "[pack] append %a" pp_hash k];
+    let unsafe_append ~ensure_unique ~overcommit t hash v =
+      let unguarded_append () =
+        [%log.debug "[pack] append %a" pp_hash hash];
         let offset_of_key k =
-          match Index.find t.pack.index k with
-          | None ->
-              Stats.incr_appended_hashes ();
-              None
-          | Some (off, _, _) ->
+          match Pack_key.inspect k with
+          | Direct { offset; _ } ->
               Stats.incr_appended_offsets ();
-              Some off
+              Some offset
+          | Indexed hash -> (
+              match Index.find t.pack.index hash with
+              | None ->
+                  Stats.incr_appended_hashes ();
+                  None
+              | Some (offset, _, _) ->
+                  Stats.incr_appended_offsets ();
+                  Some offset)
         in
         let kind = Val.kind v in
         let () =
@@ -252,20 +437,27 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
         in
         let dict = Dict.index t.pack.dict in
         let off = IO.offset t.pack.block in
-        Val.encode_bin ~offset_of_key ~dict k v (IO.append t.pack.block);
+        Val.encode_bin ~offset_of_key ~dict hash v (IO.append t.pack.block);
         let len = Int63.to_int (IO.offset t.pack.block -- off) in
-        Index.add ~overcommit t.pack.index k (off, len, kind);
+        let key = Pack_key.v_direct ~hash ~offset:off ~length:len in
+        Index.add ~overcommit t.pack.index hash (off, len, kind);
         if Tbl.length t.staging >= auto_flush then flush t
-        else Tbl.add t.staging k v;
-        Lru.add t.lru k v;
-        k)
+        else Tbl.add t.staging hash v;
+        Lru.add t.lru hash v;
+        [%log.debug "[pack] append done %a <- %a" pp_hash hash pp_key key];
+        key
+      in
+      match ensure_unique with
+      | false -> unguarded_append ()
+      | true -> (
+          match index_direct t hash with
+          | None -> unguarded_append ()
+          | Some key -> key)
 
-    let add t v =
-      let k = Val.hash v in
-      unsafe_append ~ensure_unique:true ~overcommit:false t k v |> Lwt.return
+    let unsafe_add t hash v =
+      unsafe_append ~ensure_unique:true ~overcommit:false t hash v |> Lwt.return
 
-    let unsafe_add t k v =
-      unsafe_append ~ensure_unique:true ~overcommit:false t k v |> Lwt.return
+    let add t v = unsafe_add t (Val.hash v) v
 
     let unsafe_close t =
       t.open_instances <- t.open_instances - 1;

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -104,12 +104,7 @@ struct
 
   let hash = Hash.hash
   let kind = Kind.Contents
-
-  let length_header =
-    match Conf.contents_length_header with
-    | None -> `Never
-    | Some _ as x -> `Sometimes (Fun.const x)
-
+  let length_header = Fun.const Conf.contents_length_header
   let value = [%typ: (Hash.t, Data.t) value]
   let encode_value = Irmin.Type.(unstage (encode_bin value))
   let decode_value = Irmin.Type.(unstage (decode_bin value))
@@ -169,9 +164,9 @@ struct
     end
   end
 
-  let length_header =
-    `Sometimes
-      (function Kind.Contents -> assert false | x -> Kind.length_header_exn x)
+  let length_header = function
+    | Kind.Contents -> assert false
+    | x -> Kind.length_header_exn x
 
   let encode_bin ~dict:_ ~offset_of_key hash v f =
     let address_of_key k : Commit_direct.address =

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -90,12 +90,11 @@ let get_dynamic_sizer_exn : type a. a Irmin.Type.t -> string -> int -> int =
   | Static n -> fun _ _ -> n
   | Dynamic f -> f
 
-module Of_contents (Conf : sig
-  val contents_length_header : length_header
-end)
-(Hash : Irmin.Hash.S)
-(Key : T)
-(Data : Irmin.Type.S) =
+module Of_contents
+    (Conf : Config)
+    (Hash : Irmin.Hash.S)
+    (Key : T)
+    (Data : Irmin.Type.S) =
 struct
   module Hash = Irmin.Hash.Typed (Hash) (Data)
 

--- a/src/irmin-pack/pack_value.mli
+++ b/src/irmin-pack/pack_value.mli
@@ -1,2 +1,30 @@
+(** This module defines abstractions over entries in the pack file, which are
+    encoded as follows:
+
+    {v
+      ┌────────┬────────┬──────────────┬─────────┐
+      │  Hash  │  Kind  │  Len(Value)? │  Value  │
+      └────────┴────────┴──────────────┴─────────┘
+      ┆<┄ H ┄┄>┆<┄ K ┄┄>┆<┄┄┄┄ L? ┄┄┄┄>┆<┄┄ V ┄┄>┆
+      ┆<┄┄┄┄┄┄┄┄┄┄┄ entry length, E ┄┄┄┄┄┄┄┄┄┄┄┄>┆
+    v}
+
+    The fields are as follows:
+
+    - [Hash]: the (fixed-length) hash of the data stored in this entry;
+
+    - [Kind]: the {i kind} of data being stored (contents, nodes, commits etc.),
+      encoded as a single "magic" character;
+
+    - [Len(Value)]: an optional length header for the [Value] section of the
+      entry ({i not} including the length of the length header itself), encoded
+      using a variable-length encoding (LEB128). The presence of a length header
+      is determined by the [Kind] character.
+
+    - [Value]: the data itself.
+
+    The length of the overall pack {i entry}, as referenced in the {!Pack_index}
+    or in a direct {!Pack_key.t}, is equal to [E = H + K + L + V]. *)
+
 include Pack_value_intf.Sigs
 (** @inline *)

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -20,12 +20,9 @@ module type S = sig
   val hash : t -> hash
   val kind : t -> kind
 
-  val length_header : [ `Never | `Sometimes of kind -> [ `Varint ] option ]
+  val length_header : kind -> length_header
   (** Describes the length header formats for the {i data} sections of pack
-      entries.
-
-      NOTE: [`Never] is equivalent to [`Sometimes (Fun.const None)], but enables
-      a more efficient store implementation. *)
+      entries. *)
 
   val encode_bin :
     dict:(string -> int option) ->

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -1,13 +1,5 @@
 open! Import
 
-(** This module defines abstractions over entries in the pack file, which are
-    encoded as the following sequence:
-
-    - the (fixed-length) hash of the data stored in this entry;
-    - the {i kind} of data being stored (contents, nodes, blob etc.);
-    - the data itself, optionally with a length header that contains the encoded
-      size of the data section (excluding the header itself). *)
-
 type length_header = [ `Varint ] option
 
 module type S = sig

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -57,6 +57,9 @@ module Suite : sig
 end
 
 val line : string -> unit
+
+module Schema = Common.Schema
+
 val store : (module Irmin.Maker) -> (module Irmin.Metadata.S) -> (module S)
 
 val layered_store :

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -145,8 +145,12 @@ module Make (S : Generic_key) = struct
         check_val "find xx" None (B.Node.Val.find u "xx")
       in
       check_values u;
-      let w = B.Node.Val.of_list [ ("y", k); ("z", k); ("x", k) ] in
-      check B.Node.Val.t "v" u w;
+      let () =
+        let _w = B.Node.Val.of_list [ ("y", k); ("z", k); ("x", k) ] in
+        (* XXX: this isn't a valid check. [u] is not concrete, and [w] is. *)
+        (* check B.Node.Val.t "v" u w; *)
+        ()
+      in
       let l = B.Node.Val.list u in
       check_list "list all" [ ("x", k); ("y", k); ("z", k) ] l;
       let l = B.Node.Val.list ~length:1 u in

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -59,7 +59,7 @@ module Contents = struct
   let hash = H.hash
   let encode_pair = Irmin.Type.(unstage (encode_bin (pair H.t t)))
   let decode_pair = Irmin.Type.(unstage (decode_bin (pair H.t t)))
-  let length_header = `Sometimes (Fun.const (Some `Varint))
+  let length_header = Fun.const (Some `Varint)
   let encode_bin ~dict:_ ~offset_of_key:_ k x = encode_pair (k, x)
 
   let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ x pos_ref =

--- a/test/irmin-pack/test_hashes.ml
+++ b/test/irmin-pack/test_hashes.ml
@@ -76,7 +76,9 @@ struct
     let* init_commit = Commit.v ~parents:[] ~info:Info.empty repo empty in
     let h = Commit.hash init_commit in
     let info = Info.v ~author:"Tezos" 0L in
-    let* commit = Commit.v ~parents:[ h ] ~info repo tree in
+    let* commit =
+      Commit.v ~parents:[ Irmin_pack.Pack_key.v_indexed h ] ~info repo tree
+    in
     let tree = Commit.tree commit in
     Lwt.return (repo, tree, commit)
 

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -198,7 +198,9 @@ module Inode_permutations_generator = struct
     let ( ** ) a b = float_of_int a ** float_of_int b |> int_of_float in
     let steps = gen_steps entries maxdepth_of_test in
     let content_per_step =
-      List.map (fun s -> (s, H_contents.hash s |> normal)) steps
+      List.map
+        (fun s -> (s, H_contents.hash s |> Key.unfindable_of_hash |> normal))
+        steps
       |> List.to_seq
       |> StepMap.of_seq
     in
@@ -663,6 +665,10 @@ let tests =
   let tc name f =
     Alcotest.test_case name `Quick (fun () -> Lwt_main.run (f ()))
   in
+  (* Test disabled because it relies on being able to serialise concrete inodes,
+     which is not possible following the introduction of structured keys. *)
+  let _ = tc "test truncated inodes" test_truncated_inodes in
+  let _ = tc "test encode bin of trees" Inode_tezos.test_encode_bin_tree in
   [
     tc "add values" test_add_values;
     tc "add values to inodes" test_add_inodes;
@@ -672,7 +678,5 @@ let tests =
     tc "test representation uniqueness"
       test_representation_uniqueness_maxdepth_3;
     tc "test encode bin of values" Inode_tezos.test_encode_bin_values;
-    tc "test encode bin of trees" Inode_tezos.test_encode_bin_tree;
-    tc "test truncated inodes" test_truncated_inodes;
     tc "test intermediate inode as root" test_intermediate_inode_as_root;
   ]

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -17,6 +17,11 @@
 open! Import
 open Common
 
+(* XXX(craigfe): these tests previously use hashes as addresses. I've changed
+   them to use keys instead, which means that they're mostly reading direct offsets
+   and not going via the index anymore. TODO: ensure the indexing mechanism is
+   still properly tested. *)
+
 module Config = struct
   let entries = 2
   let stable_hash = 3
@@ -25,10 +30,22 @@ end
 
 let test_dir = Filename.concat "_build" "test-db-pack"
 
-module Irmin_pack_maker : Irmin.Maker = struct
-  include Irmin_pack.Maker (Config)
+module Schema = struct
+  (* TODO: expose Irmin_test.Metadata, or something like it *)
+  module Hash = Irmin.Hash.SHA1
+  module Commit = Irmin.Commit.Make (Hash)
+  module Path = Irmin.Path.String_list
+  module Metadata = Irmin.Metadata.None
+  module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
+  module Branch = Irmin.Branch.String
+  module Info = Irmin.Info.Default
+  module Contents = Irmin.Contents.String
+end
 
-  module Make (Schema : Irmin.Schema.S) = Make (struct
+module Irmin_pack_store : Irmin_test.Generic_key = struct
+  open Irmin_pack.Maker (Config)
+
+  include Make (struct
     include Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
     module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
@@ -37,9 +54,7 @@ module Irmin_pack_maker : Irmin.Maker = struct
 end
 
 let suite_pack =
-  let store =
-    Irmin_test.store (module Irmin_pack_maker) (module Irmin.Metadata.None)
-  in
+  let store = (module Irmin_pack_store : Irmin_test.Generic_key) in
   let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_dir in
   let init () =
     rm_dir test_dir;
@@ -49,13 +64,13 @@ let suite_pack =
     rm_dir test_dir;
     Lwt.return_unit
   in
-  Irmin_test.Suite.create ~name:"PACK" ~clear_supported:false ~init ~store
-    ~config ~clean ~layered_store:None ()
+  Irmin_test.Suite.create_generic_key ~name:"PACK" ~clear_supported:false
+    ~import_supported:false ~init ~store ~config ~clean ~layered_store:None ()
 
-module Irmin_pack_mem_maker = struct
-  include Irmin_pack_mem.Maker (Config)
+module Irmin_pack_mem_maker : Irmin_test.Generic_key = struct
+  open Irmin_pack_mem.Maker (Config)
 
-  module Make (Schema : Irmin.Schema.S) = Make (struct
+  include Make (struct
     include Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
     module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
@@ -64,11 +79,10 @@ module Irmin_pack_mem_maker = struct
 end
 
 let suite_mem =
-  let store =
-    Irmin_test.store (module Irmin_pack_mem_maker) (module Irmin.Metadata.None)
-  in
+  let store = (module Irmin_pack_mem_maker : Irmin_test.Generic_key) in
   let config = Irmin_pack.config ~fresh:false ~lru_size:0 test_dir in
-  Irmin_test.Suite.create ~name:"PACK MEM" ~store ~config ~layered_store:None ()
+  Irmin_test.Suite.create_generic_key ~import_supported:false ~name:"PACK MEM"
+    ~store ~config ~layered_store:None ()
 
 let suite = [ suite_pack; suite_mem ]
 
@@ -316,11 +330,9 @@ module Pack = struct
     (*close index while in use*)
     let* i, r = t.clone_index_pack ~readonly:false in
     Index.close i;
-    Lwt.catch
-      (fun () ->
-        let* _ = Pack.find r h1 in
-        Alcotest.fail "Add after closing the index should not be allowed")
-      (function I.Closed -> Lwt.return_unit | exn -> Lwt.fail exn)
+    (* [find] after Index [close] is OK, provided we still have the key *)
+    let* () = Pack.find r k1 >|= get >|= Alcotest.(check string) "x1.2" x1 in
+    Lwt.return_unit
 
   (** Index can be flushed to disk independently of pack, we simulate this in
       the tests using [Index.filter] and [Index.flush]. Regression test for PR

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -17,11 +17,6 @@
 open! Import
 open Common
 
-(* XXX(craigfe): these tests previously use hashes as addresses. I've changed
-   them to use keys instead, which means that they're mostly reading direct offsets
-   and not going via the index anymore. TODO: ensure the indexing mechanism is
-   still properly tested. *)
-
 module Config = struct
   let entries = 2
   let stable_hash = 3
@@ -30,23 +25,11 @@ end
 
 let test_dir = Filename.concat "_build" "test-db-pack"
 
-module Schema = struct
-  (* TODO: expose Irmin_test.Metadata, or something like it *)
-  module Hash = Irmin.Hash.SHA1
-  module Commit = Irmin.Commit.Make (Hash)
-  module Path = Irmin.Path.String_list
-  module Metadata = Irmin.Metadata.None
-  module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
-  module Branch = Irmin.Branch.String
-  module Info = Irmin.Info.Default
-  module Contents = Irmin.Contents.String
-end
-
 module Irmin_pack_store : Irmin_test.Generic_key = struct
   open Irmin_pack.Maker (Config)
 
   include Make (struct
-    include Schema
+    include Irmin_test.Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
     module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
     module Commit = Commit_maker.Make (Hash)
@@ -71,7 +54,7 @@ module Irmin_pack_mem_maker : Irmin_test.Generic_key = struct
   open Irmin_pack_mem.Maker (Config)
 
   include Make (struct
-    include Schema
+    include Irmin_test.Schema
     module Node = Irmin.Node.Generic_key.Make (Hash) (Path) (Metadata)
     module Commit_maker = Irmin.Commit.Generic_key.Maker (Info)
     module Commit = Commit_maker.Make (Hash)


### PR DESCRIPTION
Extracted from https://github.com/mirage/irmin/pull/1534.

Contains the minimal changes necessary to introduce direct pointers to `irmin-pack`, without changing the indexing strategy (or allowing the user to do the same).