### PR TITLE
irmin-pack: split metrics for `find` according to key type

### DIFF
--- a/bench/irmin-pack/trace_collection.ml
+++ b/bench/irmin-pack/trace_collection.ml
@@ -47,7 +47,8 @@ module Make_stat (Store : Irmin.Generic_key.KV) = struct
             total = v.finds.total;
             from_staging = v.finds.from_staging;
             from_lru = v.finds.from_lru;
-            from_pack = v.finds.from_pack;
+            from_pack_direct = v.finds.from_pack_direct;
+            from_pack_indexed = v.finds.from_pack_indexed;
           }
       in
       Def.

--- a/bench/irmin-pack/trace_definitions.ml
+++ b/bench/irmin-pack/trace_definitions.ml
@@ -362,7 +362,8 @@ module Stat_trace = struct
       total : int;
       from_staging : int;
       from_lru : int;
-      from_pack : int;
+      from_pack_direct : int;
+      from_pack_indexed : int;
     }
     [@@deriving repr]
     (** Stats extracted from [Irmin_pack.Stats.get ()]. *)
@@ -393,7 +394,13 @@ module Stat_trace = struct
     let v1pack_of_v0pack (v0 : V0.pack) : pack =
       {
         finds =
-          { total = v0.finds; from_staging = 0; from_lru = 0; from_pack = 0 };
+          {
+            total = v0.finds;
+            from_staging = 0;
+            from_lru = 0;
+            from_pack_direct = 0;
+            from_pack_indexed = 0;
+          };
         appended_hashes = v0.appended_hashes;
         appended_offsets = v0.appended_offsets;
         inode_add = 0;

--- a/bench/irmin-pack/trace_stat_summary_cb.ml
+++ b/bench/irmin-pack/trace_stat_summary_cb.ml
@@ -160,7 +160,8 @@ let create_raw_results2 s : result list =
       ("finds", s.pack.finds.total);
       ("finds.from_staging", s.pack.finds.from_staging);
       ("finds.from_lru", s.pack.finds.from_lru);
-      ("finds.from_pack", s.pack.finds.from_pack);
+      ("finds.from_pack_direct", s.pack.finds.from_pack_direct);
+      ("finds.from_pack_indexed", s.pack.finds.from_pack_indexed);
       ("finds.missing", s.pack.finds.missing);
       ("finds.cache_miss", s.pack.finds.cache_miss);
       ("appended_hashes", s.pack.appended_hashes);

--- a/bench/irmin-pack/trace_stat_summary_pp.ml
+++ b/bench/irmin-pack/trace_stat_summary_pp.ml
@@ -394,7 +394,9 @@ module Table2 = struct
       pb "pack.finds" (fun s -> s.pack.finds.total);
       pb "pack.finds.from_staging" (fun s -> s.pack.finds.from_staging);
       pb "pack.finds.from_lru" (fun s -> s.pack.finds.from_lru);
-      pb "pack.finds.from_pack" (fun s -> s.pack.finds.from_pack);
+      pb "pack.finds.from_pack_direct" (fun s -> s.pack.finds.from_pack_direct);
+      pb "pack.finds.from_pack_indexed" (fun s ->
+          s.pack.finds.from_pack_indexed);
       pb "pack.finds.missing" (fun s -> s.pack.finds.missing);
       pb "pack.finds.cache_miss" (fun s -> s.pack.finds.cache_miss);
       pb "pack.appended_hashes" (fun s -> s.pack.appended_hashes);
@@ -887,7 +889,10 @@ module Table4 = struct
       pb "pack.finds.from_staging per block *LA" (fun s ->
           s.pack.finds.from_staging);
       pb "pack.finds.from_lru per block *LA" (fun s -> s.pack.finds.from_lru);
-      pb "pack.finds.from_pack per block *LA" (fun s -> s.pack.finds.from_pack);
+      pb "pack.finds.from_pack_direct per block *LA" (fun s ->
+          s.pack.finds.from_pack_direct);
+      pb "pack.finds.from_pack_indexed per block *LA" (fun s ->
+          s.pack.finds.from_pack_indexed);
       pb "pack.finds.missing per block *LA" (fun s -> s.pack.finds.missing);
       pb "pack.finds.cache_miss per block *LA" (fun s ->
           s.pack.finds.cache_miss);

--- a/src/irmin-pack/pack_store.ml
+++ b/src/irmin-pack/pack_store.ml
@@ -338,13 +338,14 @@ module Maker (Index : Pack_index.S) (K : Irmin.Hash.S with type t = Index.key) :
     let find_in_pack_file ~check_integrity t key hash =
       let loc, { offset; length } =
         match Pack_key.inspect key with
-        | Direct { offset; length; _ } -> (Stats.Find.Pack, { offset; length })
+        | Direct { offset; length; _ } ->
+            (Stats.Find.Pack_direct, { offset; length })
         | Indexed hash ->
             let entry_span = get_entry_span_from_index_exn t hash in
             (* Cache the offset and length information in the existing key: *)
             Pack_key.promote_exn key ~offset:entry_span.offset
               ~length:entry_span.length;
-            (Stats.Find.Pack, entry_span)
+            (Stats.Find.Pack_indexed, entry_span)
       in
       let io_offset = IO.offset t.pack.block in
       if Int63.add offset (Int63.of_int length) > io_offset then (

--- a/src/irmin-pack/stats.ml
+++ b/src/irmin-pack/stats.ml
@@ -15,23 +15,33 @@
  *)
 
 module Find = struct
-  type location = Staging | Lru | Pack | Not_found [@@deriving irmin]
+  type location = Staging | Lru | Pack_direct | Pack_indexed | Not_found
+  [@@deriving irmin]
 
   type t = {
     mutable total : int;
     mutable from_staging : int;
     mutable from_lru : int;
-    mutable from_pack : int;
+    mutable from_pack_direct : int;
+    mutable from_pack_indexed : int;
   }
   [@@deriving irmin]
 
-  let create () = { total = 0; from_staging = 0; from_lru = 0; from_pack = 0 }
+  let create () =
+    {
+      total = 0;
+      from_staging = 0;
+      from_lru = 0;
+      from_pack_direct = 0;
+      from_pack_indexed = 0;
+    }
 
   let clear t =
     t.total <- 0;
     t.from_staging <- 0;
     t.from_lru <- 0;
-    t.from_pack <- 0
+    t.from_pack_direct <- 0;
+    t.from_pack_indexed <- 0
 
   let cache_misses
       {
@@ -40,7 +50,8 @@ module Find = struct
         (* In-memory hits: *)
         from_staging;
         from_lru;
-        from_pack = _;
+        from_pack_direct = _;
+        from_pack_indexed = _;
       } =
     total - (from_staging + from_lru)
 end
@@ -102,7 +113,8 @@ let report_find ~(location : Find.location) =
   match location with
   | Staging -> finds.from_staging <- succ finds.from_staging
   | Lru -> finds.from_lru <- succ finds.from_lru
-  | Pack -> finds.from_pack <- succ finds.from_pack
+  | Pack_direct -> finds.from_pack_direct <- succ finds.from_pack_direct
+  | Pack_indexed -> finds.from_pack_indexed <- succ finds.from_pack_indexed
   | Not_found -> ()
 
 let incr_appended_hashes () = s.appended_hashes <- succ s.appended_hashes

--- a/src/irmin-pack/stats.mli
+++ b/src/irmin-pack/stats.mli
@@ -15,7 +15,15 @@
  *)
 
 module Find : sig
-  type location = Staging | Lru | Pack_direct | Pack_indexed | Not_found
+  type location =
+    | Staging  (** Found in the store's write buffer. *)
+    | Lru  (** Found in the store's LRU of recent [find] results. *)
+    | Pack_direct
+        (** Decoded directly from the pack file (via a direct key). *)
+    | Pack_indexed
+        (** Binding recovered from the pack file after first checking the index
+            for its offset and length (via an indexed key). *)
+    | Not_found  (** Find returned [None]. *)
   [@@deriving irmin]
 
   type t = {

--- a/src/irmin-pack/stats.mli
+++ b/src/irmin-pack/stats.mli
@@ -15,13 +15,15 @@
  *)
 
 module Find : sig
-  type location = Staging | Lru | Pack | Not_found [@@deriving irmin]
+  type location = Staging | Lru | Pack_direct | Pack_indexed | Not_found
+  [@@deriving irmin]
 
   type t = {
     mutable total : int;
     mutable from_staging : int;
     mutable from_lru : int;
-    mutable from_pack : int;
+    mutable from_pack_direct : int;
+    mutable from_pack_indexed : int;
   }
   [@@deriving irmin]
 

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -82,7 +82,14 @@ let replay_1_commit () =
   let expected =
     Irmin_pack.Stats.
       {
-        finds = { total = 2; from_staging = 0; from_lru = 2; from_pack = 0 };
+        finds =
+          {
+            total = 2;
+            from_staging = 0;
+            from_lru = 2;
+            from_pack_direct = 0;
+            from_pack_indexed = 0;
+          };
         appended_hashes = 0;
         appended_offsets = 5;
         inode_add = 0;


### PR DESCRIPTION
Extracted from https://github.com/mirage/irmin/pull/1534.

Finds via `Direct` keys are much more efficient than finds via `Indexed` keys, and our metrics should keep track of which are which.