### PR TITLE
[2.10] Simplfify the proof API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
     proofs from complex computations. `produce_proof` and `verify_proof`
     takes a callback over tree and instead of a static list of operations
     -- this now means that the full `Tree` API can now be used in proofs,
-    including sub-tree operations, folds and paginated lists (#1625, @samoht)
+    including sub-tree operations, folds and paginated lists
+    (#1625, #1663, @samoht)
 
 ### Changed
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1616,16 +1616,15 @@ module Make (S : S) = struct
       in
       let* p0 = S.Tree.produce_proof repo hash f0 in
       let proof ?(before = S.Tree.Proof.before p0)
-          ?(after = S.Tree.Proof.after p0) ?(contents = S.Tree.Proof.proof p0)
-          () =
-        S.Tree.Proof.v ~before ~after contents
+          ?(after = S.Tree.Proof.after p0) ?(state = S.Tree.Proof.state p0) () =
+        S.Tree.Proof.v ~before ~after state
       in
       let wrong_hash = P.Contents.Key.hash "not the right hash!" in
       let wrong_kinded_hash = `Node wrong_hash in
       let* () = check_bad_proof (proof ~before:wrong_kinded_hash ()) in
       let* () = check_bad_proof (proof ~after:wrong_kinded_hash ()) in
       let* _ = S.Tree.verify_proof (proof ()) f0 in
-      let some_contents : S.Tree.Proof.tree_proof list =
+      let some_contents : S.Tree.Proof.tree list =
         [
           Blinded_node wrong_hash;
           Node [];
@@ -1636,7 +1635,7 @@ module Make (S : S) = struct
       in
       let* () =
         Lwt_list.iter_s
-          (fun c -> check_bad_proof (proof ~contents:c ()))
+          (fun c -> check_bad_proof (proof ~state:c ()))
           some_contents
       in
       P.Repo.close repo

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -16,35 +16,6 @@
 
 include Proof_intf
 
-type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
-
-type ('contents, 'hash, 'step, 'metadata) tree =
-  | Blinded_node of 'hash
-  | Node of ('step * ('contents, 'hash, 'step, 'metadata) tree) list
-  | Inode of ('contents, 'hash, 'step, 'metadata) tree inode
-  | Blinded_contents of 'hash * 'metadata
-  | Contents of 'contents * 'metadata
-
-(* TODO(craigfe): fix [ppx_irmin] for inline parameters. *)
-let tree_t contents_t hash_t step_t metadata_t =
-  let open Type in
-  mu (fun t ->
-      variant "proof" (fun blinded_node node inode blinded_contents contents ->
-        function
-        | Blinded_node x1 -> blinded_node x1
-        | Node x1 -> node x1
-        | Inode i -> inode i
-        | Blinded_contents (x1, x2) -> blinded_contents (x1, x2)
-        | Contents (c, m) -> contents (c, m))
-      |~ case1 "Blinded_node" hash_t (fun x1 -> Blinded_node x1)
-      |~ case1 "Node" [%typ: (step * t) list] (fun x1 -> Node x1)
-      |~ case1 "Inode" [%typ: t inode] (fun i -> Inode i)
-      |~ case1 "Blinded_contents" [%typ: hash * metadata] (fun (x1, x2) ->
-             Blinded_contents (x1, x2))
-      |~ case1 "Contents" [%typ: contents * metadata] (fun (x1, x2) ->
-             Contents (x1, x2))
-      |> Type.sealv)
-
 module Make
     (C : Type.S)
     (H : Type.S) (S : sig
@@ -56,20 +27,26 @@ struct
   type hash = H.t [@@deriving irmin]
   type step = S.step [@@deriving irmin]
   type metadata = M.t [@@deriving irmin]
+  type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
 
-  type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
+  type kinded_hash = [ `Node of hash | `Contents of hash * metadata ]
   [@@deriving irmin]
 
-  type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
-  type tree_proof = (contents, hash, step, metadata) tree [@@deriving irmin]
+  type tree =
+    | Blinded_node of hash
+    | Node of (step * tree) list
+    | Inode of tree inode
+    | Blinded_contents of hash * metadata
+    | Contents of contents * metadata
+  [@@deriving irmin]
 
-  type t = { before : kinded_hash; after : kinded_hash; proof : tree_proof }
+  type t = { before : kinded_hash; after : kinded_hash; state : tree }
   [@@deriving irmin]
 
   let before t = t.before
   let after t = t.after
-  let proof t = t.proof
-  let v ~before ~after proof = { after; before; proof }
+  let state t = t.state
+  let v ~before ~after state = { after; before; state }
 end
 
 exception Bad_proof of { context : string }

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -353,7 +353,6 @@ module type S = sig
          and type contents := contents
          and type node := node
          and type hash := hash
-         and type Proof.tree_proof = (contents, hash, step, metadata) Proof.tree
 
     (** {1 Import/Export} *)
 

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -332,15 +332,14 @@ module type S = sig
          and type hash := hash
          and type step := step
          and type metadata := metadata
-         and type tree_proof = (contents, hash, step, metadata) Proof.tree
 
-    type tree
+    type irmin_tree
 
-    val to_tree : t -> tree
+    val to_tree : t -> irmin_tree
     (** [to_tree p] is the tree representing the tree proof [p]. Blinded parts
         of the proof will raise [Dangling_hash] when traversed. *)
   end
-  with type tree := t
+  with type irmin_tree := t
 
   (** {1 Caches} *)
 
@@ -402,12 +401,6 @@ module type Tree = sig
          and type metadata = P.Node.Metadata.t
          and type contents = P.Contents.value
          and type hash = P.Hash.t
-         and type Proof.tree_proof =
-              ( P.Contents.value,
-                P.Hash.t,
-                P.Node.Path.step,
-                P.Node.Metadata.t )
-              Proof.tree
 
     type kinded_hash := [ `Contents of hash * metadata | `Node of hash ]
 


### PR DESCRIPTION
Do not use ground types with lots of parameters anymore. We loose type
equalities between proofs of different stores, but we gain better error
messages, tooling support (including merlin and odoc).

It's a good tradeoff for now.