### PR TITLE
irmin: fix implementation of `Node.Generic_key.Make.index`

### DIFF
--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -349,7 +349,7 @@ struct
   let clear (_, t) = S.clear t
   let add (_, t) = S.add t
   let unsafe_add (_, t) = S.unsafe_add t
-  let index _ _ = Lwt.return_none
+  let index (_, t) h = S.index t h
   let batch (c, s) f = C.batch c (fun n -> S.batch s (fun s -> f (n, s)))
 
   let close (c, s) =


### PR DESCRIPTION
The function should proxy to the underlying store implementation, rather than just returning `None`. This bug was introduced by f20ea38945fcc6503d56c9994084108e1fb4e78c, and is exercised by Tezos' snapshot import process.