### PR TITLE
[2.10] irmin-pack: fix proofs for large inodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - *irmin*
   - Conversion between proofs and trees are now done in CPS (#1624, @samoht)
 
+- *irmin-pack*
+  - Fix proofs for large inodes by tracking side-effects reads inside the
+    inode implementation (#1670, @samoht, @Ngoguey42)
+
 ### Added
 
 - **irmin**

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -352,7 +352,11 @@ struct
       type proof = N.proof [@@deriving irmin]
 
       let to_proof t = N.to_proof (to_n t)
-      let of_proof p = of_n (N.of_proof p)
+      let of_proof p = Option.map of_n (N.of_proof p)
+
+      exception Dangling_hash of { context : string; hash : hash }
+
+      let with_handler _ n = n
     end
 
     include Content_addressable (struct

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -59,8 +59,6 @@ module type Internal = sig
 
   val pp_hash : hash Fmt.t
 
-  exception Dangling_hash of { context : string; hash : hash }
-
   module Raw : sig
     include Pack_value.S with type hash = hash
 

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
 include Proof_intf
 
 module Make
@@ -52,3 +53,113 @@ end
 exception Bad_proof of { context : string }
 
 let bad_proof_exn context = raise (Bad_proof { context })
+
+module Env (H : Hash.S) (C : Contents.S) (N : Node.S with type hash = H.t) =
+struct
+  module Hashes = struct
+    include Hashtbl.Make (struct
+      type t = H.t
+
+      let hash = H.short_hash
+      let equal = Type.(unstage (equal H.t))
+    end)
+
+    let of_list l = of_seq (List.to_seq l)
+    let to_list t = List.of_seq (to_seq t)
+    let t elt_t = Type.map [%typ: (H.t * elt) list] of_list to_list
+  end
+
+  (* Keep track of read effects happening during a computation using
+     sets. This does not keep track of the ordering of the reads. *)
+  type read_set = { nodes : N.t Hashes.t; contents : C.t Hashes.t }
+  [@@deriving irmin]
+
+  type mode = Produce | Consume [@@deriving irmin]
+  type set_effects = { mode : mode; set : read_set } [@@deriving irmin]
+  type v = Empty | Set of set_effects [@@deriving irmin]
+  type t = v ref
+
+  let t = Type.map v_t ref ( ! )
+  let empty () : t = ref Empty
+  let is_empty t = !t = Empty
+  let empty_set () = { contents = Hashes.create 13; nodes = Hashes.create 13 }
+  let copy ~into t = into := !t
+  let mode t = match !t with Empty -> None | Set { mode; _ } -> Some mode
+
+  let reads_as_set mode =
+    let set = empty_set () in
+    ref (Set { mode; set })
+
+  let track_reads_as_sets_lwt mode f =
+    let t = reads_as_set mode in
+    let+ res = f t in
+    t := Empty;
+    res
+
+  let track_reads_as_sets mode f =
+    let t = reads_as_set mode in
+    let res = f t in
+    t := Empty;
+    res
+
+  let find_contents t h =
+    match !t with
+    | Set { set; _ } -> Hashes.find_opt set.contents h
+    | Empty -> None
+
+  let add_contents t h v =
+    match !t with Set { set; _ } -> Hashes.add set.contents h v | Empty -> ()
+
+  let add_contents_opt t h = function
+    | Some v -> add_contents t h v
+    | None -> ()
+
+  let add_node_to_set t h v =
+    match !t with Set { set; _ } -> Hashes.add set.nodes h v | _ -> ()
+
+  let find_node t ?depth:_ h =
+    match !t with
+    | Set { set; _ } -> Hashes.find_opt set.nodes h
+    | Empty -> None
+
+  (* Wrap backend's [find] function in order to handle its side effects *)
+  let rec handle : t -> 'a -> 'a =
+   fun t find ->
+    let find' ~expected_depth h =
+      match !t with
+      | Empty -> find ~expected_depth h
+      | Set { mode = Consume; _ } ->
+          (* [find'] should never hit the storage in [Consume] mode, it should
+             only hit the env. *)
+          find_node ~depth:expected_depth t h
+      | Set { mode = Produce; _ } ->
+          (* Call the backend's [find] function and push the result into the
+             env before returning the value back to the backend. *)
+          find ~expected_depth h |> add_node_opt t h
+    in
+    find'
+
+  and add_node (t : t) h v =
+    let tracked_v = N.with_handler (handle t) v in
+    add_node_to_set t h tracked_v;
+    tracked_v
+
+  and add_node_opt t h = function
+    | None -> None
+    | Some v -> Some (add_node t h v)
+
+  let find_contents_opt t = function
+    | None -> None
+    | Some h -> find_contents t h
+
+  let find_node_opt t = function None -> None | Some h -> find_node t h
+
+  (* x' = y' <- x union y *)
+  let merge (x : t) (y : t) =
+    match (!x, !y) with
+    | Empty, Empty -> ()
+    | Empty, y -> x := y
+    | x, Empty -> y := x
+    | Set _, Set _ ->
+        failwith "Merging two non-empty [Proof.Env.t] is forbidden"
+end

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -336,8 +336,8 @@ module type S = sig
     type irmin_tree
 
     val to_tree : t -> irmin_tree
-    (** [to_tree p] is the tree representing the tree proof [p]. Blinded parts
-        of the proof will raise [Dangling_hash] when traversed. *)
+    (** [to_tree p] is the tree [t] representing the tree proof [p]. Blinded
+        parts of the proof will raise [Dangling_hash] when traversed. *)
   end
   with type irmin_tree := t
 
@@ -377,11 +377,8 @@ module type S = sig
 
   module Env : sig
     type t [@@deriving irmin]
-    type read_set
 
     val is_empty : t -> bool
-    val read_set : t -> read_set option
-    val length : t -> int
   end
 
   val get_env : t -> Env.t

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -377,7 +377,7 @@ let test_truncated_inodes () =
     try
       ignore (f ());
       Alcotest.fail "was expecting a dangling hash failure, but got nothing"
-    with Inter.Dangling_hash _ -> ()
+    with Inode.Val.Dangling_hash _ -> ()
   in
   let s00, s01, s11, s10 =
     Inode_permutations_generator.


### PR DESCRIPTION
This is more involved that I initially thought, as we also need to track effects inside inodes (hence the new `map_env` function).