### PR TITLE
irmin-pack: use relative addressing for internal inode addresses

### DIFF
--- a/irmin.opam
+++ b/irmin.opam
@@ -50,6 +50,6 @@ depend on external C stubs; it aims to run everywhere, from Linux,
 to browsers and Xen unikernels.
 """
 pin-depends: [
-  [ "repr.dev" "git+https://github.com/mirage/repr#031cbb3728c3394e46b25a5e77aa5ceaa674c235" ]
-  [ "ppx_repr.dev" "git+https://github.com/mirage/repr#031cbb3728c3394e46b25a5e77aa5ceaa674c235" ]
+  [ "repr.dev" "git+https://github.com/mirage/repr#ca119f83baf2a948ef87f3a5702b5a790e29c3b9" ]
+  [ "ppx_repr.dev" "git+https://github.com/mirage/repr#ca119f83baf2a948ef87f3a5702b5a790e29c3b9" ]
 ]

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -115,10 +115,10 @@ struct
   let encode_value = Irmin.Type.(unstage (encode_bin value))
   let decode_value = Irmin.Type.(unstage (decode_bin value))
 
-  let encode_bin ~dict:_ ~offset_of_key:_ hash v f =
+  let encode_bin ~dict:_ ~offset_of_key:_ ~pack_offset:_ hash v f =
     encode_value { kind; hash; v } f
 
-  let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ s off =
+  let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ ~pack_offset:_ s off =
     let t = decode_value s off in
     t.v
 
@@ -174,7 +174,7 @@ struct
     `Sometimes
       (function Kind.Contents -> assert false | x -> Kind.length_header_exn x)
 
-  let encode_bin ~dict:_ ~offset_of_key hash v f =
+  let encode_bin ~dict:_ ~offset_of_key ~pack_offset:_ hash v f =
     let address_of_key k : Commit_direct.address =
       match offset_of_key k with
       | None -> Hash (Key.to_hash k)
@@ -189,7 +189,7 @@ struct
     let length = Commit_direct.size_of v in
     Entry.V1.encode_bin { hash; kind = Commit_v1; v = { length; v } } f
 
-  let decode_bin ~dict:_ ~key_of_offset ~key_of_hash s off =
+  let decode_bin ~dict:_ ~key_of_offset ~key_of_hash ~pack_offset:_ s off =
     let key_of_address : Commit_direct.address -> Key.t = function
       | Offset x -> key_of_offset x
       | Hash x -> key_of_hash x

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -16,6 +16,7 @@ module type S = sig
   val encode_bin :
     dict:(string -> int option) ->
     offset_of_key:(key -> int63 option) ->
+    pack_offset:int63 ->
     hash ->
     t Irmin.Type.encode_bin
 
@@ -23,6 +24,7 @@ module type S = sig
     dict:(int -> string option) ->
     key_of_offset:(int63 -> key) ->
     key_of_hash:(hash -> key) ->
+    pack_offset:int63 ->
     t Irmin.Type.decode_bin
 
   val decode_bin_length : string -> int -> int

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -60,9 +60,10 @@ module Contents = struct
   let encode_pair = Irmin.Type.(unstage (encode_bin (pair H.t t)))
   let decode_pair = Irmin.Type.(unstage (decode_bin (pair H.t t)))
   let length_header = `Sometimes (Fun.const (Some `Varint))
-  let encode_bin ~dict:_ ~offset_of_key:_ k x = encode_pair (k, x)
+  let encode_bin ~dict:_ ~offset_of_key:_ ~pack_offset:_ k x = encode_pair (k, x)
 
-  let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ x pos_ref =
+  let decode_bin ~dict:_ ~key_of_offset:_ ~key_of_hash:_ ~pack_offset:_ x
+      pos_ref =
     let _, v = decode_pair x pos_ref in
     v
 

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -579,7 +579,7 @@ module Inode_tezos = struct
     S.Inter.Raw.encode_bin
       ~dict:(fun _ -> None)
       ~offset_of_key:(fun _ -> None)
-      h v1
+      ~pack_offset:Int63.zero h v1
 
   let hex_encode s = Hex.of_string s |> Hex.show
 


### PR DESCRIPTION
Resolves https://github.com/mirage/irmin/issues/1657. Depends on https://github.com/mirage/repr/pull/88.

I measured the impact of this change by importing a recent (post-flattening, mainnet block 1929566) snapshot.

```bash
; du ./current-main/context/store.pack
1846840 /mnt/ssd/data/current-main/context/store.pack

; du ./varint-offsets/context/store.pack
1826572 /mnt/ssd/data/varint-offsets/context/store.pack
```

This is a 1.1% space saving. Given the relatively small improvement, I'm not sure this change is worthwhile, but I'd like opinions either way.