### PR TITLE
[2.10] irmin-pack: add an option to configure the index function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
   - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
   - `Tree.length` now takes a tree as argument (#1676, @samoht)
 
+- **irmin-pack**
+  - irmin-pack: add an option to configure the index function and pick
+    the relevant bits in cryptographic a hash by default (#1677, @samoht)
+
 ## 2.9.0 (2021-11-15)
 
 ### Fixed

--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -75,6 +75,7 @@ let with_progress_bar ~message ~n ~unit =
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Hash_bits
 end
 
 let info () =

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -10,10 +10,7 @@ val with_progress_bar :
 val info : unit -> Irmin.Info.t
 val random_blob : unit -> string
 
-module Conf : sig
-  val entries : int
-  val stable_hash : int
-end
+module Conf : Irmin_pack.Conf.S
 
 module FSHelper : sig
   val rm_dir : string -> unit

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -19,6 +19,7 @@ let config ~root = Irmin_pack.config ~fresh:false root
 module Config = struct
   let entries = 2
   let stable_hash = 3
+  let inode_child_order = `Hash_bits
 end
 
 module KV =

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -323,11 +323,7 @@ end
 
 module Hash = Irmin.Hash.SHA1
 
-module Bench_suite (Conf : sig
-  val entries : int
-  val stable_hash : int
-end) =
-struct
+module Bench_suite (Conf : Irmin_pack.Conf.S) = struct
   module Store =
     Irmin_pack.Make (Irmin_pack.Version.V1) (Conf) (Irmin.Metadata.None)
       (Irmin.Contents.String)
@@ -436,6 +432,7 @@ module Bench_inodes_32 = Bench_suite (Conf)
 module Bench_inodes_2 = Bench_suite (struct
   let entries = 2
   let stable_hash = 5
+  let inode_child_order = `Hash_bits
 end)
 
 type mode_elt = [ `Read_trace | `Chains | `Large ]

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -17,6 +17,11 @@
 module type S = sig
   val entries : int
   val stable_hash : int
+
+  type inode_child_order :=
+    [ `Seeded_hash | `Hash_bits | `Custom of depth:int -> bytes -> int ]
+
+  val inode_child_order : inode_child_order
 end
 
 module Default = struct

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -17,6 +17,13 @@
 module type S = sig
   val entries : int
   val stable_hash : int
+
+  type inode_child_order :=
+    [ `Seeded_hash  (** use a non-crypto seeded-hash of the step *)
+    | `Hash_bits  (** crypto hash the step and extract the relevant bits. *)
+    | `Custom of depth:int -> bytes -> int  (** use a custom index *) ]
+
+  val inode_child_order : inode_child_order
 end
 
 val fresh_key : bool Irmin.Private.Conf.key

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -37,18 +37,87 @@ struct
   let max_depth = int_of_float (log (2. ** 50.) /. log (float Conf.entries))
 
   module T = struct
-    type hash = H.t [@@deriving irmin]
-    type step = Node.step [@@deriving irmin]
+    type hash = H.t [@@deriving irmin ~pp ~to_bin_string]
+    type step = Node.step [@@deriving irmin ~to_bin_string]
     type metadata = Node.metadata [@@deriving irmin]
+    type value = Node.value [@@deriving irmin]
 
     let default = Node.default
 
-    type value = Node.value
-
-    let value_t = Node.value_t
-    let pp_hash = Irmin.Type.(pp hash_t)
-
     exception Dangling_hash = Node.Dangling_hash
+  end
+
+  module Step =
+    Irmin.Hash.Typed
+      (H)
+      (struct
+        type t = T.step
+
+        let t = T.step_t
+      end)
+
+  exception Max_depth of int
+
+  module Index : sig
+    type key
+
+    val key : T.step -> key
+    val index : depth:int -> key -> int
+  end = struct
+    open T
+
+    type key = bytes
+
+    let log_entry = int_of_float (log (float Conf.entries) /. log 2.)
+
+    let () =
+      assert (log_entry <> 0);
+      assert (Conf.entries = int_of_float (2. ** float log_entry))
+
+    let key =
+      match Conf.inode_child_order with
+      | `Hash_bits ->
+          fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s))
+      | `Seeded_hash | `Custom _ ->
+          fun s -> Bytes.unsafe_of_string (step_to_bin_string s)
+
+    (* Assume [k = cryto_hash(step)] (see {!key}) and [Conf.entry] can
+       can represented with [n] bits. Then, [hash_bits ~depth k] is
+       the [n]-bits integer [i] with the following binary representation:
+
+         [k(n*depth) ... k(n*depth+n-1)]
+
+       When [n] is not a power of 2, [hash_bits] needs to handle
+       unaligned reads properly. *)
+    let hash_bits ~depth k =
+      let byte = 8 in
+      let n = depth * log_entry / byte in
+      let r = depth * log_entry mod byte in
+      if n >= Bytes.length k then raise (Max_depth depth);
+      if r + log_entry <= byte then
+        let i = Bytes.get_uint8 k n in
+        let e0 = i lsr (byte - log_entry - r) in
+        let r0 = e0 land (Conf.entries - 1) in
+        r0
+      else
+        let i0 = Bytes.get_uint8 k n in
+        let to_read = byte - r in
+        let rest = log_entry - to_read in
+        let mask = (1 lsl to_read) - 1 in
+        let r0 = (i0 land mask) lsl rest in
+        if n + 1 >= Bytes.length k then raise (Max_depth depth);
+        let i1 = Bytes.get_uint8 k (n + 1) in
+        let r1 = i1 lsr (byte - rest) in
+        r0 + r1
+
+    let short_hash = Irmin.Type.(unstage (short_hash bytes))
+    let seeded_hash ~depth k = abs (short_hash ~seed:depth k) mod Conf.entries
+
+    let index =
+      match Conf.inode_child_order with
+      | `Seeded_hash -> seeded_hash
+      | `Hash_bits -> hash_bits
+      | `Custom f -> f
   end
 
   module StepMap = struct
@@ -60,8 +129,6 @@ struct
 
     let of_list l = List.fold_left (fun acc (k, v) -> add k v acc) empty l
   end
-
-  exception Max_depth of int
 
   (* Binary representation, useful to compute hashes *)
   module Bin = struct
@@ -821,11 +888,9 @@ struct
           in
           { hash; stable = true; v = t.v }
 
-    let hash_key = Irmin.Type.(unstage (short_hash step_t))
-
     let index ~depth k =
       if depth >= max_depth then raise (Max_depth depth);
-      abs (hash_key ~seed:depth k) mod Conf.entries
+      Index.index ~depth k
 
     (** This function shouldn't be called with the [Total] layout. In the
         future, we could add a polymorphic variant to the GADT parameter to
@@ -870,10 +935,11 @@ struct
 
     let find_value ~cache layout ~depth t s =
       let target_of_ptr = Ptr.target ~cache ~force:true "find_value" layout in
+      let key = Index.key s in
       let rec aux ~depth = function
         | Values vs -> ( try Some (StepMap.find s vs) with Not_found -> None)
         | Tree t -> (
-            let i = index ~depth s in
+            let i = index ~depth key in
             let x = t.entries.(i) in
             match x with
             | None -> None
@@ -885,7 +951,7 @@ struct
 
     let find ?(cache = true) layout t s = find_value ~cache ~depth:0 layout t s
 
-    let rec add layout ~depth ~copy ~replace t s v k =
+    let rec add layout ~depth ~copy ~replace t (s, key) v k =
       match t.v with
       | Values vs ->
           let length =
@@ -899,9 +965,10 @@ struct
                 tree layout
                   { length = 0; depth; entries = Array.make Conf.entries None }
               in
-              let aux t (s, v) =
-                (add [@tailcall]) layout ~depth ~copy:false ~replace t s v
-                  (fun x -> x)
+              let aux t (s', v) =
+                let key' = Index.key s' in
+                (add [@tailcall]) layout ~depth ~copy:false ~replace t
+                  (s', key') v (fun x -> x)
               in
               List.fold_left aux empty vs
           in
@@ -909,7 +976,7 @@ struct
       | Tree t -> (
           let length = if replace then t.length else t.length + 1 in
           let entries = if copy then Array.copy t.entries else t.entries in
-          let i = index ~depth s in
+          let i = index ~depth key in
           match entries.(i) with
           | None ->
               let target = values layout (StepMap.singleton s v) in
@@ -922,24 +989,25 @@ struct
                    [find_value] for that path.*)
                 Ptr.target ~depth ~cache:true ~force:true "add" layout n
               in
-              (add [@tailcall]) layout ~depth:(depth + 1) ~copy ~replace t s v
-                (fun target ->
+              (add [@tailcall]) layout ~depth:(depth + 1) ~copy ~replace t
+                (s, key) v (fun target ->
                   entries.(i) <- Some (Ptr.of_target layout target);
                   let t = tree layout { depth; length; entries } in
                   k t))
 
     let add layout ~copy t s v =
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
+      let k = Index.key s in
       match find_value ~cache:true ~depth:0 layout t s with
       | Some v' when equal_value v v' -> stabilize layout t
       | Some _ ->
-          add ~depth:0 layout ~copy ~replace:true t s v Fun.id
+          add ~depth:0 layout ~copy ~replace:true t (s, k) v Fun.id
           |> stabilize layout
       | None ->
-          add ~depth:0 layout ~copy ~replace:false t s v Fun.id
+          add ~depth:0 layout ~copy ~replace:false t (s, k) v Fun.id
           |> stabilize layout
 
-    let rec remove layout ~depth t s k =
+    let rec remove layout ~depth t (s, key) k =
       match t.v with
       | Values vs ->
           let t = values layout (StepMap.remove s vs) in
@@ -954,7 +1022,7 @@ struct
             k t
           else
             let entries = Array.copy t.entries in
-            let i = index ~depth s in
+            let i = index ~depth key in
             match entries.(i) with
             | None -> assert false
             | Some t ->
@@ -968,16 +1036,17 @@ struct
                   let t = tree layout { depth; length = len; entries } in
                   k t)
                 else
-                  remove ~depth:(depth + 1) layout t s @@ fun target ->
+                  remove ~depth:(depth + 1) layout t (s, key) @@ fun target ->
                   entries.(i) <- Some (Ptr.of_target layout target);
                   let t = tree layout { depth; length = len; entries } in
                   k t)
 
     let remove layout t s =
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
+      let k = Index.key s in
       match find_value ~cache:true layout ~depth:0 t s with
       | None -> stabilize layout t
-      | Some _ -> remove layout ~depth:0 t s Fun.id |> stabilize layout
+      | Some _ -> remove layout ~depth:0 t (s, k) Fun.id |> stabilize layout
 
     let of_seq l =
       let t =
@@ -1383,7 +1452,7 @@ struct
     let stable t = apply t { f = (fun _ v -> I.stable v) }
     let length t = apply t { f = (fun _ v -> I.length v) }
     let clear t = apply t { f = (fun layout v -> I.clear layout v) }
-    let index = I.index
+    let index ~depth s = I.index ~depth (Index.key s)
 
     let integrity_check t =
       let f layout v =

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -146,14 +146,14 @@ module Make (S : S) = struct
       check_values u;
       let w = P.Node.Val.of_list [ ("y", k); ("z", k); ("x", k) ] in
       check P.Node.Val.t "v" u w;
-      let l = P.Node.Val.list u in
-      check_list "list all" [ ("x", k); ("y", k); ("z", k) ] l;
+      let all = P.Node.Val.list u in
+      check_list "list all" [ ("x", k); ("y", k); ("z", k) ] all;
       let l = P.Node.Val.list ~length:1 u in
       check_list "list length=1" [ ("x", k) ] l;
       let l = P.Node.Val.list ~offset:1 u in
       check_list "list offset=1" [ ("y", k); ("z", k) ] l;
       let l = P.Node.Val.list ~offset:1 ~length:1 u in
-      check_list "list offset=1 length=1" [ ("y", k) ] l;
+      check_list "list offset=1 length=1" [ List.nth all 1 ] l;
       let u = P.Node.Val.add u "a" k in
       check_node "node: x+y+z+a" u >>= fun () ->
       let u = P.Node.Val.add u "b" k in

--- a/src/irmin-tezos/irmin_tezos.ml
+++ b/src/irmin-tezos/irmin_tezos.ml
@@ -24,6 +24,7 @@ end
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Seeded_hash
 end
 
 module Maker = Irmin_pack.Make_ext (V1) (Conf) (Node) (Commit)

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -277,6 +277,7 @@ module Store = struct
   module Inode_config = struct
     let entries = 32
     let stable_hash = 256
+    let inode_child_order = `Hash_bits
   end
 
   let pack = create (module Irmin_pack.V1 (Inode_config))

--- a/test/irmin-pack/cli/generate.ml
+++ b/test/irmin-pack/cli/generate.ml
@@ -28,6 +28,7 @@ let rm_dir () =
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Hash_bits
 end
 
 module Store =

--- a/test/irmin-pack/cli/irmin_fsck.ml
+++ b/test/irmin-pack/cli/irmin_fsck.ml
@@ -23,6 +23,7 @@ module Commit = Irmin.Private.Commit.Make
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Hash_bits
 end
 
 module Maker (V : Irmin_pack.Version.S) =

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -38,6 +38,7 @@ let random_letters n = String.init n (fun _i -> random_letter ())
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Hash_bits
 end
 
 module S = struct

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -84,10 +84,7 @@ val sha1 : string -> H.t
 val rm_dir : string -> unit
 val index_log_size : int option
 
-module Conf : sig
-  val entries : int
-  val stable_hash : int
-end
+module Conf : Irmin_pack.Conf.S
 
 val random_string : int -> string
 val random_letters : int -> string

--- a/test/irmin-pack/layered.ml
+++ b/test/irmin-pack/layered.ml
@@ -35,6 +35,7 @@ let index_log_size = Some 4
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Hash_bits
   let lower_root = "_lower"
   let upper0_root = "0"
   let with_lower = true

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -27,6 +27,7 @@ let index_log_size = Some 1_000
 module Conf = struct
   let entries = 32
   let stable_hash = 256
+  let inode_child_order = `Hash_bits
 end
 
 module Hash = Irmin.Hash.SHA1

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -166,6 +166,7 @@ module Hash = Irmin.Hash.SHA1
 module V1_maker = Irmin_pack.V1 (struct
   let entries = 2
   let stable_hash = 3
+  let inode_child_order = `Hash_bits
 end)
 
 module V2_maker = Irmin_pack.V2 (Conf)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -25,6 +25,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Conf = struct
   let entries = 2
   let stable_hash = 3
+  let inode_child_order = `Seeded_hash
 end
 
 let log_size = 1000

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -20,6 +20,7 @@ open Common
 module Config = struct
   let entries = 2
   let stable_hash = 3
+  let inode_child_order = `Hash_bits
 end
 
 let test_dir = Filename.concat "_build" "test-db-pack"

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -311,6 +311,7 @@ let test_deeper_proof () =
 module Binary = Make (struct
   let entries = 2
   let stable_hash = 2
+  let inode_child_order = `Hash_bits
 end)
 
 (* test large compressed proofs *)


### PR DESCRIPTION
By default, use the relevant bits in a cryptographic hash of the keys instead
of relying on a seeded short hash.

Fix #1599