### PR TITLE
[2.10] Add tezos store type to resolver.ml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@
 - **irmin-pack**
   - Verify inode depth invariants (#1665, @samoht)
 
+- **irmin-unix**
+  - Add `tezos` store type for `irmin` command-line (#1678, @zshipko)
+
 ### Changed
 
 - **irmin**

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -25,6 +25,7 @@ depends: [
   "irmin-pack"    {= version}
   "irmin-graphql" {= version}
   "irmin-layers"  {= version}
+  "irmin-tezos"   {= version}
   "git-unix"      {>= "3.5.0"}
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -3,5 +3,5 @@
  (public_name irmin-unix)
  (libraries astring cmdliner cohttp cohttp-lwt cohttp-lwt-unix conduit
    conduit-lwt-unix git-cohttp-unix fmt.cli fmt.tty git git-unix irmin
-   irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack irmin-tezos
-   irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml))
+   irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack
+   irmin-tezos irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml))

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -3,5 +3,5 @@
  (public_name irmin-unix)
  (libraries astring cmdliner cohttp cohttp-lwt cohttp-lwt-unix conduit
    conduit-lwt-unix git-cohttp-unix fmt.cli fmt.tty git git-unix irmin
-   irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack
+   irmin-fs irmin-git irmin-graphql irmin-http irmin.mem irmin-pack irmin-tezos
    irmin-watcher logs.cli logs.fmt lwt lwt.unix uri yaml))

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -251,6 +251,7 @@ module Store = struct
   type store_functor =
     | Fixed_hash of (contents -> t)
     | Variable_hash of (hash -> contents -> t)
+    | Fixed of t
 
   module type G = sig
     include Irmin.S
@@ -281,7 +282,6 @@ module Store = struct
   end
 
   let pack = create (module Irmin_pack.V1 (Inode_config))
-
   let tezos = T ((module Irmin_tezos.Store), None)
 
   let all =
@@ -294,7 +294,7 @@ module Store = struct
         ("http", Variable_hash (fun h c -> http (mem h c)));
         ("http.git", Fixed_hash (fun c -> http (git c)));
         ("pack", Variable_hash pack);
-        ("tezos", Fixed_hash (fun _ -> tezos));
+        ("tezos", Fixed tezos);
       ]
 
   let default = "git" |> fun n -> ref (n, List.assoc n !all)
@@ -412,6 +412,12 @@ let from_config_file_with_defaults path (store, hash, contents) config branch :
         (* error if a hash function has been passed *)
         match (hash, assoc "hash" Hash.find) with
         | None, None -> s contents
+        | _ ->
+            Fmt.failwith
+              "Cannot customize the hash function for the given store")
+    | Fixed s -> (
+        match hash with
+        | None -> s
         | _ ->
             Fmt.failwith
               "Cannot customize the hash function for the given store")

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -148,6 +148,7 @@ module Hash = struct
         ("sha256", Fixed (module Irmin.Hash.SHA256 : Irmin.Hash.S));
         ("sha384", Fixed (module Irmin.Hash.SHA384 : Irmin.Hash.S));
         ("sha512", Fixed (module Irmin.Hash.SHA512 : Irmin.Hash.S));
+        ("tezos", Fixed (module Irmin_tezos.Schema.Hash : Irmin.Hash.S));
       ]
 
   let default = ref ("blake2b", (module Irmin.Hash.BLAKE2B : Irmin.Hash.S))
@@ -281,6 +282,8 @@ module Store = struct
 
   let pack = create (module Irmin_pack.V1 (Inode_config))
 
+  let tezos = T ((module Irmin_tezos.Store), None)
+
   let all =
     ref
       [
@@ -291,6 +294,7 @@ module Store = struct
         ("http", Variable_hash (fun h c -> http (mem h c)));
         ("http.git", Fixed_hash (fun c -> http (git c)));
         ("pack", Variable_hash pack);
+        ("tezos", Fixed_hash (fun _ -> tezos));
       ]
 
   let default = "git" |> fun n -> ref (n, List.assoc n !all)

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -53,6 +53,7 @@ module Store : sig
   type store_functor =
     | Fixed_hash of (contents -> t)
     | Variable_hash of (hash -> contents -> t)
+    | Fixed of t
 
   type remote_fn =
     ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote


### PR DESCRIPTION
This allows the tezos store type to be picked from the command-line