### PR TITLE
irmin-pack: use one-indexed versioning for pack value version

### DIFF
--- a/src/irmin-pack/checks.ml
+++ b/src/irmin-pack/checks.ml
@@ -103,10 +103,10 @@ module Make (Store : Store) = struct
       let f _ (_, _, (kind : Pack_value.Kind.t)) =
         match kind with
         | Contents -> progress_contents ()
-        | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
+        | Inode_v1_stable | Inode_v1_unstable | Inode_v2_root | Inode_v2_nonroot
           ->
             progress_nodes ()
-        | Commit_v0 | Commit_v1 -> progress_commits ()
+        | Commit_v1 | Commit_v2 -> progress_commits ()
       in
       Index.iter f index;
       let nb_commits, nb_nodes, nb_contents =
@@ -382,11 +382,11 @@ module Index (Index : Pack_index.S) = struct
       | Contents ->
           progress_contents ();
           check ~kind:`Contents ~offset ~length k
-      | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot
+      | Inode_v1_stable | Inode_v1_unstable | Inode_v2_root | Inode_v2_nonroot
         ->
           progress_nodes ();
           check ~kind:`Node ~offset ~length k
-      | Commit_v0 | Commit_v1 ->
+      | Commit_v1 | Commit_v2 ->
           progress_commits ();
           check ~kind:`Commit ~offset ~length k
     in

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -251,37 +251,37 @@ struct
       | V0_stable _ -> assert false
       | V0_unstable _ -> assert false
       | V1_root { length; v } when is_real_length length ->
-          encode_bin_kind Pack_value.Kind.Inode_v1_root f;
+          encode_bin_kind Pack_value.Kind.Inode_v2_root f;
           encode_bin_int length f;
           encode_bin_v v f
       | V1_nonroot { length; v } when is_real_length length ->
-          encode_bin_kind Pack_value.Kind.Inode_v1_nonroot f;
+          encode_bin_kind Pack_value.Kind.Inode_v2_nonroot f;
           encode_bin_int length f;
           encode_bin_v v f
-      | V1_root tv -> encode_bin_tv_staggered tv Pack_value.Kind.Inode_v1_root f
+      | V1_root tv -> encode_bin_tv_staggered tv Pack_value.Kind.Inode_v2_root f
       | V1_nonroot tv ->
-          encode_bin_tv_staggered tv Pack_value.Kind.Inode_v1_nonroot f
+          encode_bin_tv_staggered tv Pack_value.Kind.Inode_v2_nonroot f
 
     let decode_bin_tv s off =
       let kind = decode_bin_kind s off in
       match kind with
-      | Pack_value.Kind.Inode_v0_unstable ->
+      | Pack_value.Kind.Inode_v1_unstable ->
           let v = decode_bin_v s off in
           V0_unstable v
-      | Inode_v0_stable ->
+      | Inode_v1_stable ->
           let v = decode_bin_v s off in
           V0_stable v
-      | Inode_v1_root ->
+      | Inode_v2_root ->
           let length = decode_bin_int s off in
           assert (is_real_length length);
           let v = decode_bin_v s off in
           V1_root { length; v }
-      | Inode_v1_nonroot ->
+      | Inode_v2_nonroot ->
           let length = decode_bin_int s off in
           assert (is_real_length length);
           let v = decode_bin_v s off in
           V1_nonroot { length; v }
-      | Commit_v0 | Commit_v1 -> assert false
+      | Commit_v1 | Commit_v2 -> assert false
       | Contents -> assert false
 
     let size_of_tv =
@@ -304,12 +304,12 @@ struct
         let offref = ref off in
         let kind = decode_bin_kind s offref in
         match kind with
-        | Pack_value.Kind.Inode_v0_unstable | Inode_v0_stable ->
+        | Pack_value.Kind.Inode_v1_unstable | Inode_v1_stable ->
             1 + dynamic_size_of_v_encoding s !offref
-        | Inode_v1_root | Inode_v1_nonroot ->
+        | Inode_v2_root | Inode_v2_nonroot ->
             let len = decode_bin_int s offref in
             len - H.hash_size
-        | Commit_v0 | Commit_v1 | Contents -> assert false
+        | Commit_v1 | Commit_v2 | Contents -> assert false
       in
       Irmin.Type.Size.custom_dynamic ~of_value ~of_encoding ()
 
@@ -1156,8 +1156,8 @@ struct
 
     let kind (t : t) =
       (* This is the kind of newly appended values, let's use v1 then *)
-      if t.root then Pack_value.Kind.Inode_v1_root
-      else Pack_value.Kind.Inode_v1_nonroot
+      if t.root then Pack_value.Kind.Inode_v2_root
+      else Pack_value.Kind.Inode_v2_nonroot
 
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -41,13 +41,13 @@ end
 module type Sigs = sig
   module Kind : sig
     type t =
-      | Commit_v0
       | Commit_v1
+      | Commit_v2
       | Contents
-      | Inode_v0_unstable
-      | Inode_v0_stable
-      | Inode_v1_root
-      | Inode_v1_nonroot
+      | Inode_v1_unstable
+      | Inode_v1_stable
+      | Inode_v2_root
+      | Inode_v2_nonroot
     [@@deriving irmin]
 
     val all : t list

--- a/src/irmin-pack/traverse_pack_file.ml
+++ b/src/irmin-pack/traverse_pack_file.ml
@@ -164,8 +164,8 @@ end = struct
 
   let decode_entry_length = function
     | Pack_value.Kind.Contents -> Contents.decode_bin_length
-    | Commit_v0 | Commit_v1 -> Commit.decode_bin_length
-    | Inode_v0_stable | Inode_v0_unstable | Inode_v1_root | Inode_v1_nonroot ->
+    | Commit_v1 | Commit_v2 -> Commit.decode_bin_length
+    | Inode_v1_stable | Inode_v1_unstable | Inode_v2_root | Inode_v2_nonroot ->
         Inode.decode_bin_length
 
   let decode_entry_exn ~off ~buffer ~buffer_off =


### PR DESCRIPTION
Renames the original object types as `*_v1`, and the new ones (with added length headers) as `*_v2` to be consistent with the one-indexing used for pack _store_ version headers. Now a V1 pack store is a file containing only V1 objects, and V2 pack stores may also contain V2 objects.