### PR TITLE
irmin: mark as incompatible with Odoc.2.0.{1,2}

### DIFF
--- a/irmin.opam
+++ b/irmin.opam
@@ -33,6 +33,7 @@ depends: [
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
   "vector" {with-test}
+  "odoc" {(< "2.0.1" | > "2.0.2") & with-doc} # See https://github.com/ocaml/odoc/issues/793
 ]
 
 conflicts: [


### PR DESCRIPTION
These versions fail when attempting to build Irmin's documentation:

```
odoc: internal error, uncaught exception:
      Not_found
      Raised at Stdlib__map.Make.find in file "map.ml", line 137, characters 10-25
      Called from Odoc_xref2__Env.ElementsByName.remove in file "src/xref2/env.ml", line 116, characters 12-33
      Called from Odoc_xref2__Env.remove in file "src/xref2/env.ml", line 241, characters 11-52
      Called from Stdlib__list.fold_left in file "list.ml", line 121, characters 24-34
      Called from Odoc_xref2__Compile.include_.get_expansion in file "src/xref2/compile.ml", line 335, characters 20-63
      Called from Odoc_xref2__Compile.signature_items.(fun) in file "src/xref2/compile.ml", line 236, characters 21-35
      Called from Stdlib__list.fold_left in file "list.ml", line 121, characters 24-34
...
```

See https://github.com/ocaml/odoc/issues/793.