### PR TITLE
[2.10] irmin-pack: use extenders in proofs

### DIFF
--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -129,7 +129,7 @@ struct
   type proof =
     [ `Blinded of hash
     | `Values of (step * value) list
-    | `Inode of int * (int * proof) list ]
+    | `Inode of int * (int list * proof) list ]
   [@@deriving irmin]
 
   let to_proof (t : t) : proof =

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -104,7 +104,7 @@ module type S = sig
   type proof =
     [ `Blinded of hash
     | `Values of (step * value) list
-    | `Inode of int * (int * proof) list ]
+    | `Inode of int * (int list * proof) list ]
   [@@deriving irmin]
   (** The type for proof trees. *)
 

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -28,7 +28,9 @@ struct
   type hash = H.t [@@deriving irmin]
   type step = S.step [@@deriving irmin]
   type metadata = M.t [@@deriving irmin]
-  type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
+
+  type 'a inode = { length : int; proofs : (int list * 'a) list }
+  [@@deriving irmin]
 
   type kinded_hash = [ `Node of hash | `Contents of hash * metadata ]
   [@@deriving irmin]

--- a/src/irmin/proof_intf.ml
+++ b/src/irmin/proof_intf.ml
@@ -38,7 +38,8 @@ module type S = sig
         valid state of Irmin, without having to have access to the full node's
         storage. *)
 
-  type 'a inode = { length : int; proofs : (int * 'a) list } [@@deriving irmin]
+  type 'a inode = { length : int; proofs : (int list * 'a) list }
+  [@@deriving irmin]
   (** The type for (internal) inode proofs.
 
       These proofs encode large directories into a more efficient tree-like
@@ -46,15 +47,20 @@ module type S = sig
 
       Invariant are dependent on the backend.
 
-      [len] is the total number of entries in the chidren of the inode. E.g. the
-      size of the "flattened" version of that inode. This is used by some
+      [length] is the total number of entries in the chidren of the inode. E.g.
+      the size of the "flattened" version of that inode. This is used by some
       backend (like [irmin-pack]) to efficiently implements paginated lists.
 
+      This list can be sparse so every proof is indexed by their position
+      between [0 ... (Conf.entries-1)]. For binary trees, this boolean index is
+      a step of the left-right sequence / decision proof corresponding to the
+      path in that binary tree.
+
+      Paths of singleton inodes are compacted into a single inode addressed by
+      that path (hence the [int list] indexing).
+
       {e For [irmin-pack]}: [proofs] have a length of at most [Conf.entries]
-      entries. This list can be sparse so every proof is indexed by their
-      position between [0 ... (Conf.entries-1)]. For binary trees, this boolean
-      index is a step of the left-right sequence / decision proof corresponding
-      to the path in that binary tree. *)
+      entries. *)
 
   (** The type for compressed and partial Merkle tree proofs.
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1887,8 +1887,7 @@ module Make (P : Private.S) = struct
       | `Values vs -> proof_of_values node vs k
 
     and proof_of_inode :
-        type a. node -> int -> (int * node_proof) list -> (proof_tree -> a) -> a
-        =
+        type a. node -> int -> (_ * node_proof) list -> (proof_tree -> a) -> a =
      fun node length proofs k ->
       let rec aux acc = function
         | [] -> k (Inode { length; proofs = List.rev acc })
@@ -1960,8 +1959,8 @@ module Make (P : Private.S) = struct
 
     (** [tree_of_inode] is solely called on the root of an inode tree *)
     and tree_of_inode :
-        type a.
-        env:_ -> int -> (int * proof_tree) list -> (irmin_tree -> a) -> a =
+        type a. env:_ -> int -> (_ * proof_tree) list -> (irmin_tree -> a) -> a
+        =
      fun ~env len proofs k ->
       let rev_proof_steps =
         (* Recursively blow up the [Inode] level(s) and compute a list of values
@@ -2007,8 +2006,8 @@ module Make (P : Private.S) = struct
       | Node n -> node_proof_of_node ~env n k
 
     and node_proof_of_inode :
-        type a.
-        env:_ -> int -> (int * proof_tree) list -> (node_proof -> a) -> a =
+        type a. env:_ -> int -> (_ * proof_tree) list -> (node_proof -> a) -> a
+        =
      fun ~env length proofs k ->
       let rec aux acc = function
         | [] -> k (`Inode (length, List.rev acc))

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -514,6 +514,61 @@ let test_concrete_inodes () =
   check v;
   Context.close t
 
+(* Note: this is genrating random hashes - don't use this to verify
+   proof consistency *)
+let wrap index tree =
+  let dummy_hash = Inter.Val.hash Inter.Val.empty in
+  Inter.Val.Concrete.Tree
+    {
+      depth = 0;
+      length = 3;
+      pointers = [ { index; tree; pointer = dummy_hash } ];
+    }
+
+let peek_tree (c : Inter.Val.Concrete.t) =
+  match c with
+  | Tree { pointers = [ { index; tree; _ } ]; _ } -> (index, tree)
+  | Tree _ -> Alcotest.fail "pick tree"
+  | Values _ -> Alcotest.fail "pick values"
+  | Blinded -> Alcotest.fail "pick blinded"
+
+let peek_tree_n n c =
+  let rec aux acc n c =
+    if n = 0 then List.rev acc
+    else
+      let i, c = peek_tree c in
+      aux (i :: acc) (n - 1) c
+  in
+  aux [] n c
+
+let test_proof_extenders () =
+  let is = [ 0; 0; 0; 1; 1; 0; 1 ] in
+  let concrete : Inter.Val.Concrete.t =
+    let v =
+      Inode.Val.of_list
+        [ ("x", normal foo); ("z", normal foo); ("y", node bar) ]
+    in
+    let c = Inter.Val.to_concrete v in
+    List.fold_left (fun c i -> wrap i c) c (List.rev is)
+  in
+  let index = peek_tree_n (List.length is + 2) concrete in
+  Alcotest.(check (list int)) "index" (is @ [ 1; 0 ]) index;
+
+  let proof = Inter.Val.Proof.of_concrete concrete in
+  let ext_index =
+    match proof with
+    | `Inode (_, [ (index, _) ]) -> index
+    | `Inode _ -> Alcotest.fail "proof inoode"
+    | `Blinded _ -> Alcotest.fail "proof blinded"
+    | `Values _ -> Alcotest.fail "proof values"
+  in
+  Fmt.epr "XXX ext_index=%a\n" Fmt.(Dump.list int) ext_index;
+  Alcotest.(check (list int)) "ext_index" index ext_index;
+
+  let concrete' = Inter.Val.Proof.to_concrete proof in
+  let index' = peek_tree_n (List.length is + 2) concrete' in
+  Alcotest.(check (list int)) "index'" index index'
+
 let tests =
   [
     Alcotest.test_case "add values" `Quick (fun () ->
@@ -532,4 +587,5 @@ let tests =
         Lwt_main.run (test_truncated_inodes ()));
     Alcotest.test_case "test intermediate inode as root" `Quick (fun () ->
         Lwt_main.run (test_intermediate_inode_as_root ()));
+    Alcotest.test_case "test proof extenders" `Quick test_proof_extenders;
   ]


### PR DESCRIPTION
Similar to Plebeia, compress the proof paths for singleton nodes.