### PR TITLE
Simpify merkle proof computation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
     takes a callback over tree and instead of a static list of operations
     -- this now means that the full `Tree` API can now be used in proofs,
     including sub-tree operations, folds and paginated lists
-    (#1625, #1663, @samoht)
+    (#1625, #1663, #1683, @samoht, @Ngoguey42)
 
 - **irmin-pack**
   - Verify inode depth invariants (#1665, @samoht)


### PR DESCRIPTION
After a careful analysis of the current algorithm for the computation of merkle proof, I could come up with some simplifications.

On branch 2.10 the computation of proofs relies both on the `with_handler` function and the pointer sharing between inodes. It turned out that `with_handler` is currently not necessary, the pointer sharing being enough.

The `tree_of_proof` function on 2.10 behaved quadratically given the number of inode roots. I've switched to a `load_proof` scheme to solve this.

I've added 2 more tags in `Env`'s `mode` to better keep track of what is supposed to happen.

I have changed `verify_proof` and `produce_proof` so that `f ` and `Proof.of_tree` act on cache-less tree (only `Env`). This has the advantage that these cache can't hide bugs during UT.



