### PR TITLE
[2.10] irmin: add Merkle stream proofs

### DIFF
--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -357,6 +357,9 @@ struct
       exception Dangling_hash of { context : string; hash : hash }
 
       let with_handler _ n = n
+      let to_elt t = `Node (list t)
+      let of_values ~depth:_ l = Some (of_list l)
+      let of_inode ~depth:_ ~length:_ _ = None
     end
 
     include Content_addressable (struct

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -848,6 +848,17 @@ struct
       | Unsorted_pointers t -> Error (`Unsorted_pointers t)
       | Blinded_root -> Error `Blinded_root
 
+    let of_inode la ~depth ~length pointers : _ t =
+      let hash v = Bin.V.hash (to_bin_v la v) in
+      let entries = Array.make Conf.entries None in
+      List.iter
+        (fun (index, hash) ->
+          let ptr = Ptr.of_hash la hash in
+          entries.(index) <- Some ptr)
+        pointers;
+      let v = Tree { depth; length; entries } in
+      { hash = lazy (hash v); stable = false; v }
+
     let hash t = Lazy.force t.hash
 
     let is_root t =
@@ -1048,13 +1059,13 @@ struct
       | None -> stabilize layout t
       | Some _ -> remove layout ~depth:0 t (s, k) Fun.id |> stabilize layout
 
-    let of_seq l =
+    let of_seq la l =
       let t =
         let rec aux_big seq inode =
           match seq () with
           | Seq.Nil -> inode
           | Seq.Cons ((s, v), rest) ->
-              aux_big rest (add Total ~copy:false inode s v)
+              aux_big rest (add la ~copy:false inode s v)
         in
         let len =
           (* [StepMap.cardinal] is (a bit) expensive to compute, let's track the
@@ -1065,7 +1076,7 @@ struct
           match seq () with
           | Seq.Nil ->
               assert (!len <= Conf.entries);
-              values Total map
+              values la map
           | Seq.Cons ((s, v), rest) ->
               let map =
                 StepMap.update s
@@ -1076,12 +1087,16 @@ struct
                     | Some _ -> Some v)
                   map
               in
-              if !len = Conf.entries then aux_big rest (values Total map)
+              if !len = Conf.entries then aux_big rest (values la map)
               else aux_small rest map
         in
         aux_small l StepMap.empty
       in
-      stabilize Total t
+      stabilize la t
+
+    let of_values la ~depth l =
+      if depth = 0 then of_seq la (List.to_seq l)
+      else values la (StepMap.of_list l)
 
     let save layout ~add ~mem t =
       let clear =
@@ -1421,8 +1436,13 @@ struct
           if v == v' then t else Truncated v'
 
     let pred t = apply t { f = (fun layout v -> I.pred layout v) }
-    let of_seq l = Total (I.of_seq l)
+    let of_seq l = Total (I.of_seq Total l)
     let of_list l = of_seq (List.to_seq l)
+
+    let of_values ~depth l =
+      let find ~expected_depth:_ _ = assert false in
+      let la = I.Partial find in
+      Some (Partial (la, I.of_values la ~depth l))
 
     let seq ?offset ?length ?cache t =
       apply t { f = (fun layout v -> I.seq layout ?offset ?length ?cache v) }
@@ -1543,6 +1563,31 @@ struct
           in
           let la = I.Partial find_ptr in
           Partial (la, v)
+
+    let of_inode ~depth ~length entries =
+      let find ~expected_depth:_ = assert false in
+      let la = I.Partial find in
+      let v = I.of_inode la ~depth ~length entries in
+      Some (Partial (la, v))
+
+    let to_elt t =
+      let f la (v : _ I.t) =
+        if v.stable then `Node (List.of_seq (I.seq la v))
+        else
+          match v.v with
+          | I.Values n -> `Node (List.of_seq (StepMap.to_seq n))
+          | I.Tree v ->
+              let entries = ref [] in
+              for i = Array.length v.entries - 1 downto 0 do
+                match v.entries.(i) with
+                | None -> ()
+                | Some ptr ->
+                    let h = I.Ptr.hash la ptr in
+                    entries := (i, h) :: !entries
+              done;
+              `Inode (v.length, !entries)
+      in
+      apply t { f }
   end
 end
 

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1403,7 +1403,8 @@ module Make (S : S) = struct
     in
     run x test
 
-  let pp_proof = Irmin.Type.pp S.Tree.Proof.t
+  let pp_proof = Irmin.Type.pp (S.Tree.Proof.t S.Tree.Proof.tree_t)
+  let pp_stream = Irmin.Type.pp (S.Tree.Proof.t S.Tree.Proof.stream_t)
 
   let test_proofs x () =
     let test repo =
@@ -1568,6 +1569,14 @@ module Make (S : S) = struct
       in
       let* () = Lwt_list.iter_s check_proof [ f0; f1 ] in
 
+      let check_stream f =
+        let* p = S.Tree.produce_stream repo hash f in
+        Log.debug (fun l -> l "Verifying stream %a" pp_stream p);
+        let+ _ = S.Tree.verify_stream p f in
+        ()
+      in
+      let* () = Lwt_list.iter_s check_stream [ f0; f1 ] in
+
       (* check env sharing *)
       let tree () =
         S.Tree.of_concrete
@@ -1664,6 +1673,47 @@ module Make (S : S) = struct
           (fun c -> check_bad_proof (proof ~state:c ()))
           some_contents
       in
+
+      (* test negative streams *)
+      let check_bad_stream p =
+        Lwt.catch
+          (fun () ->
+            let+ _ = S.Tree.verify_stream p f0 in
+            Alcotest.failf "verify_stream should have failed %a" pp_stream p)
+          (function
+            | Irmin.Proof.Bad_stream _ -> Lwt.return () | e -> Lwt.fail e)
+      in
+      let* p0 = S.Tree.produce_stream repo hash f0 in
+      let proof ?(before = S.Tree.Proof.before p0)
+          ?(after = S.Tree.Proof.after p0) ?(contents = S.Tree.Proof.state p0)
+          () =
+        S.Tree.Proof.v ~before ~after contents
+      in
+      let wrong_hash = P.Contents.Key.hash "not the right hash!" in
+      let wrong_kinded_hash = `Node wrong_hash in
+      let* () = check_bad_stream (proof ~before:wrong_kinded_hash ()) in
+      let* () = check_bad_stream (proof ~after:wrong_kinded_hash ()) in
+      let* _ = S.Tree.verify_stream (proof ()) f0 in
+      let some_contents : S.Tree.Proof.stream list =
+        let s : S.Tree.Proof.elt list -> S.Tree.Proof.stream = List.to_seq in
+        let ok = List.of_seq (S.Tree.Proof.state p0) in
+        [
+          s [];
+          s [ Node [] ];
+          s [ Inode { length = 0; proofs = [] } ];
+          s [ Contents "yo" ];
+          s (ok @ [ Node [] ]);
+        ]
+      in
+      let* () =
+        let x = ref 1 in
+        Lwt_list.iter_s
+          (fun c ->
+            incr x;
+            check_bad_stream (proof ~contents:c ()))
+          some_contents
+      in
+
       P.Repo.close repo
     in
 

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -143,6 +143,9 @@ struct
         let e = List.map to_entry e in
         Some (of_entries e)
 
+  let to_elt t = `Node (list t)
+  let of_values ~depth:_ l = Some (of_list l)
+  let of_inode ~depth:_ ~length:_ _ = None
   let with_handler _ t = t
 
   exception Dangling_hash of { context : string; hash : hash }
@@ -429,6 +432,11 @@ module V1 (N : S with type step = string) = struct
   let to_proof t = N.to_proof t.n
   let of_proof p = Option.map import (N.of_proof p)
   let with_handler _ t = t
+  let to_elt t = N.to_elt t.n
+  let of_values ~depth t = Option.map import (N.of_values ~depth t)
+
+  let of_inode ~depth ~length p =
+    Option.map import (N.of_inode ~depth ~length p)
 
   let of_seq entries =
     let n = N.of_seq entries in

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -113,6 +113,14 @@ module type S = sig
 
   exception Dangling_hash of { context : string; hash : hash }
 
+  type elt :=
+    [ `Node of (step * value) list | `Inode of int * (int * hash) list ]
+  [@@deriving irmin]
+
+  val to_elt : t -> elt
+  val of_values : depth:int -> (step * value) list -> t option
+  val of_inode : depth:int -> length:int -> (int * hash) list -> t option
+
   (** {1 Recursive Nodes} *)
 
   (** Some [Node] implementations (like [irmin-pack]'s inodes) can represent a

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -468,12 +468,4 @@ struct
            the same blinded/visible coverage (i.e. the same node proof). *)
         Hashes.replace set.nodes h v
     | _ -> assert false
-
-  (* x' = y' <- x union y *)
-  let merge (x : t) (y : t) =
-    match (!x, !y) with
-    | Empty, Empty -> ()
-    | Empty, y -> x := y
-    | x, Empty -> y := x
-    | _ -> failwith "Merging two non-empty [Proof.Env.t] is forbidden"
 end

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -43,7 +43,15 @@ struct
     | Contents of contents * metadata
   [@@deriving irmin]
 
-  type t = { before : kinded_hash; after : kinded_hash; state : tree }
+  type elt =
+    | Node of (step * kinded_hash) list
+    | Inode of hash inode
+    | Contents of contents
+  [@@deriving irmin]
+
+  type stream = elt Seq.t [@@deriving irmin]
+
+  type 'a t = { before : kinded_hash; after : kinded_hash; state : 'a }
   [@@deriving irmin]
 
   let before t = t.before
@@ -53,10 +61,20 @@ struct
 end
 
 exception Bad_proof of { context : string }
+exception Bad_stream of { context : string; reason : string }
 
 let bad_proof_exn context = raise (Bad_proof { context })
+let bad_stream_exn context reason = raise (Bad_stream { context; reason })
 
-module Env (H : Hash.S) (C : Contents.S) (N : Node.S with type hash = H.t) =
+module Env
+    (H : Hash.S)
+    (C : Contents.S)
+    (N : Node.S with type hash = H.t)
+    (P : S
+           with type contents := C.t
+            and type hash := H.t
+            and type step := N.step
+            and type metadata := N.metadata) =
 struct
   module Hashes = struct
     include Hashtbl.Make (struct
@@ -71,39 +89,194 @@ struct
     let t elt_t = Type.map [%typ: (H.t * elt) list] of_list to_list
   end
 
-  (* Keep track of read effects happening during a computation using
-     sets. This does not keep track of the ordering of the reads. *)
-  type read_set = { nodes : N.t Hashes.t; contents : C.t Hashes.t }
-  [@@deriving irmin]
-
   type mode = Produce | Serialise | Deserialise | Consume [@@deriving irmin]
-  type set_effects = { mode : mode; set : read_set } [@@deriving irmin]
-  type v = Empty | Set of set_effects [@@deriving irmin]
+  type kind = Set | Stream
+
+  module Set = struct
+    (* Keep track of read effects happening during a computation using
+       sets. This does not keep track of the ordering of the reads. *)
+    type read_set = { nodes : N.t Hashes.t; contents : C.t Hashes.t }
+    [@@deriving irmin]
+
+    type t = { mode : mode; set : read_set } [@@deriving irmin]
+
+    let empty () = { contents = Hashes.create 13; nodes = Hashes.create 13 }
+  end
+
+  module Stream = struct
+    let ref_t v = Type.map v ref ( ! )
+
+    type produce = { set : unit Hashes.t; rev_elts : P.elt list ref }
+    [@@deriving irmin]
+
+    type consume = {
+      nodes : N.t Hashes.t;
+      contents : C.t Hashes.t;
+      stream : P.elt Seq.t ref;
+    }
+    [@@deriving irmin]
+
+    type t = Produce of produce | Consume of consume [@@deriving irmin]
+  end
+
+  type v = Empty | Set of Set.t | Stream of Stream.t [@@deriving irmin]
   type t = v ref
 
   let t = Type.map v_t ref ( ! )
   let empty () : t = ref Empty
   let is_empty t = !t = Empty
-  let empty_set () = { contents = Hashes.create 13; nodes = Hashes.create 13 }
-  let copy ~into t = into := !t
-  let mode t = match !t with Empty -> None | Set { mode; _ } -> Some mode
 
-  let to_mode t mode =
-    match (!t, mode) with
-    | Empty, Produce | Empty, Deserialise ->
-        let set = empty_set () in
-        t := Set { mode; set }
-    | Set { mode = Produce; set }, Serialise
-    | Set { mode = Deserialise; set }, Consume ->
-        t := Set { mode; set }
+  let to_stream t =
+    match !t with
+    | Stream (Produce { rev_elts; _ }) -> List.rev !rev_elts |> List.to_seq
     | _ -> assert false
 
-  let with_mode t mode f =
-    let before = !t in
-    to_mode t mode;
-    let+ res = f () in
-    t := before;
+  let is_empty_stream t =
+    match !t with
+    | Stream (Consume { stream; _ }) -> (
+        (* Peek the sequence but do not advance the ref *)
+        match !stream () with Seq.Nil -> true | _ -> false)
+    | _ -> false
+
+  let copy ~into t = into := !t
+
+  let mode t =
+    match !t with
+    | Empty -> None
+    | Set { mode; _ } -> Some mode
+    | Stream (Produce _) -> Some Produce
+    | Stream (Consume _) -> Some Consume
+
+  let set_mode t (kind : kind) mode =
+    match kind with
+    | Set -> (
+        match (!t, mode) with
+        | Empty, Produce | Empty, Deserialise ->
+            let set = Set.empty () in
+            t := Set { mode; set }
+        | Set { mode = Produce; set }, Serialise
+        | Set { mode = Deserialise; set }, Consume ->
+            t := Set { mode; set }
+        | _ -> assert false)
+    | Stream -> (
+        match (!t, mode) with
+        | Empty, Produce ->
+            t := Stream (Produce { set = Hashes.create 13; rev_elts = ref [] })
+        | _ -> assert false)
+
+  let with_set_consume f =
+    let t = ref Empty in
+    set_mode t Set Deserialise;
+    let stop_deserialise () = set_mode t Set Consume in
+    let+ res = f t ~stop_deserialise in
+    t := Empty;
     res
+
+  let with_set_produce f =
+    let t = ref Empty in
+    set_mode t Set Produce;
+    let start_serialise () = set_mode t Set Serialise in
+    let+ res = f t ~start_serialise in
+    t := Empty;
+    res
+
+  let with_stream_produce f =
+    let t = ref Empty in
+    set_mode t Stream Produce;
+    let to_stream () = to_stream t in
+    let+ res = f t ~to_stream in
+    t := Empty;
+    res
+
+  let with_stream_consume stream f =
+    let nodes = Hashes.create 13 in
+    let contents = Hashes.create 13 in
+    let stream = ref stream in
+    let t = Stream (Consume { nodes; contents; stream }) |> ref in
+    let is_empty () = is_empty_stream t in
+    let+ res = f t ~is_empty in
+    t := Empty;
+    res
+
+  type hash = H.t [@@deriving irmin ~equal ~pp]
+
+  module Contents_hash = Hash.Typed (H) (C)
+  module Node_hash = Hash.Typed (H) (N)
+
+  let bad_stream_exn s = bad_stream_exn ("Proof.Env." ^ s)
+
+  let check_contents_integrity v h =
+    let h' = Contents_hash.hash v in
+    if not (equal_hash h' h) then
+      bad_stream_exn "check_contents_integrity"
+        (Fmt.str "got %a expected %a" pp_hash h' pp_hash h)
+
+  let check_node_integrity v h =
+    let h' = Node_hash.hash v in
+    if not (equal_hash h' h) then
+      bad_stream_exn "check_node_integrity"
+        (Fmt.str "got %a expected %a" pp_hash h' pp_hash h)
+
+  let dehydrate_stream_node v =
+    match N.to_elt v with
+    | `Node l -> P.Node l
+    | `Inode (length, proofs) ->
+        let proofs = List.map (fun (index, k) -> ([ index ], k)) proofs in
+        P.Inode { length; proofs }
+
+  let rehydrate_stream_node ~depth (elt : P.elt) h =
+    match elt with
+    | Contents _ ->
+        bad_stream_exn "rehydrate_stream_node"
+          (Fmt.str
+             "found contents at depth %d when looking for node with hash %a"
+             depth pp_hash h)
+    | Node l -> (
+        match N.of_values ~depth l with
+        | None ->
+            bad_stream_exn "rehydrate_stream_node"
+              (Fmt.str
+                 "could not deserialise Node at depth %d when looking for hash \
+                  %a"
+                 depth pp_hash h)
+        | Some v -> v)
+    | Inode { length; proofs } ->
+        let proofs =
+          List.map
+            (fun (index, k) ->
+              let index =
+                match index with
+                | [ i ] -> i
+                | _ ->
+                    bad_stream_exn "rehydrate_stream_node"
+                      (Fmt.str
+                         "extender problem at depth %d when looking for hash %a"
+                         depth pp_hash h)
+              in
+              (index, k))
+            proofs
+        in
+        let v =
+          match N.of_inode ~depth ~length proofs with
+          | None ->
+              bad_stream_exn "rehydrate_stream_node"
+                (Fmt.str
+                   "could not deserialise Inode at depth %d when looking for \
+                    hash %a"
+                   depth pp_hash h)
+          | Some v -> v
+        in
+        v
+
+  let rehydrate_stream_contents (elt : P.elt) h =
+    match elt with
+    | Node _ ->
+        bad_stream_exn "find_contents"
+          (Fmt.str "found Node when looking Contents with hash %a" pp_hash h)
+    | Inode _ ->
+        bad_stream_exn "find_contents"
+          (Fmt.str "found Inode when looking Contents with hash %a" pp_hash h)
+    | Contents v -> v
 
   let find_contents t h =
     match !t with
@@ -120,8 +293,26 @@ struct
         (* This phase only fills the env, it should search for anything *)
         assert false
     | Set { mode = Consume; set } ->
-        (* This is needed in order to read non-blinded contents. *)
+        (* Use the Env to feed the values during consume *)
         Hashes.find_opt set.contents h
+    | Stream (Produce _) ->
+        (* There is no need for sharing with stream proofs *)
+        None
+    | Stream (Consume { contents; stream; _ }) -> (
+        (* Use the Env to feed the values during consume *)
+        match Hashes.find_opt contents h with
+        | Some v -> Some v
+        | None -> (
+            match !stream () with
+            | Seq.Nil ->
+                bad_stream_exn "find_contents"
+                  (Fmt.str "empty stream when looking for hash %a" pp_hash h)
+            | Cons (elt, rest) ->
+                let v = rehydrate_stream_contents elt h in
+                check_contents_integrity v h;
+                stream := rest;
+                Hashes.add contents h v;
+                Some v))
 
   let add_contents_from_store t h v =
     match !t with
@@ -139,6 +330,46 @@ struct
     | Set { mode = Consume; _ } ->
         (* This phase has no repo pointer *)
         assert false
+    | Stream (Produce { set; rev_elts }) ->
+        (* Registering when seen for the first time *)
+        if not @@ Hashes.mem set h then (
+          Hashes.add set h ();
+          let elt : P.elt = Contents v in
+          rev_elts := elt :: !rev_elts)
+    | Stream (Consume _) ->
+        (* This phase has no repo pointer *)
+        assert false
+
+  let add_contents_from_proof t h v =
+    match !t with
+    | Set { mode = Deserialise; set } ->
+        (* Using [replace] because there could be several instances of this
+           contents in the proof, we will not share as this is not strictly
+           needed. *)
+        Hashes.replace set.contents h v
+    | _ -> assert false
+
+  let find_recnode t _find ~expected_depth h =
+    assert (expected_depth > 0);
+    match !t with
+    | Stream (Consume { nodes; stream; _ }) -> (
+        (* Use the Env to feed the values during consume *)
+        match Hashes.find_opt nodes h with
+        | Some v -> Some v
+        | None -> (
+            match !stream () with
+            | Seq.Nil ->
+                bad_stream_exn "find_recnode"
+                  (Fmt.str "empty stream when looking for hash %a" pp_hash h)
+            | Cons (v, rest) ->
+                let v = rehydrate_stream_node ~depth:expected_depth v h in
+                (* There is no need to apply [with_handler] here because there
+                   is no repo pointer in this inode. *)
+                check_node_integrity v h;
+                stream := rest;
+                Hashes.add nodes h v;
+                Some v))
+    | _ -> assert false
 
   let find_node t h =
     match !t with
@@ -157,26 +388,54 @@ struct
         (* This phase only fills the env, it should search for anything *)
         assert false
     | Set { mode = Consume; set } ->
-        (* This is needed in order to read non-blinded nodes. *)
+        (* Use the Env to feed the values during consume *)
         Hashes.find_opt set.nodes h
+    | Stream (Produce _) ->
+        (* There is no need for sharing with stream proofs *)
+        None
+    | Stream (Consume { nodes; stream; _ }) -> (
+        (* Use the Env to feed the values during consume *)
+        match Hashes.find_opt nodes h with
+        | Some v -> Some v
+        | None -> (
+            match !stream () with
+            | Seq.Nil ->
+                bad_stream_exn "find_node"
+                  (Fmt.str "empty stream when looking for hash %a" pp_hash h)
+            | Cons (v, rest) ->
+                (* [depth] is 0 because this context deals with root nodes *)
+                let v = rehydrate_stream_node ~depth:0 v h in
+                let v = N.with_handler (find_recnode t) v in
+                check_node_integrity v h;
+                stream := rest;
+                Hashes.add nodes h v;
+                Some v))
 
-  let add_contents_from_proof t h v =
+  let add_recnode_from_store t find ~expected_depth h =
+    assert (expected_depth > 0);
     match !t with
-    | Set { mode = Deserialise; set } ->
-        (* Using [replace] because there could be several instances of this
-           contents in the proof, we will not share as this is not strictly
-           needed. *)
-        Hashes.replace set.contents h v
+    | Stream (Produce { set; rev_elts }) -> (
+        (* Registering when seen for the first time, there is no need
+           for sharing. *)
+        match find ~expected_depth h with
+        | None -> None
+        | Some v ->
+            if not @@ Hashes.mem set h then (
+              Hashes.add set h ();
+              let elt = dehydrate_stream_node v in
+              rev_elts := elt :: !rev_elts);
+            Some v)
     | _ -> assert false
 
   let add_node_from_store t h v =
     match !t with
-    | Empty -> ()
+    | Empty -> v
     | Set { mode = Produce; set } ->
         (* Registering in [set] for sharing during [Produce] and traversal
            during [Serialise]. *)
         assert (not (Hashes.mem set.nodes h));
-        Hashes.add set.nodes h v
+        Hashes.add set.nodes h v;
+        v
     | Set { mode = Serialise; _ } ->
         (* There shouldn't be new nodes during this phase *)
         assert false
@@ -184,6 +443,18 @@ struct
         (* This phase has no repo pointer *)
         assert false
     | Set { mode = Consume; _ } ->
+        (* This phase has no repo pointer *)
+        assert false
+    | Stream (Produce { set; rev_elts }) ->
+        (* Registering when seen for the first time and wrap its [find]
+           function. *)
+        if not @@ Hashes.mem set h then (
+          Hashes.add set h ();
+          let elt = dehydrate_stream_node v in
+          rev_elts := elt :: !rev_elts);
+        let v = N.with_handler (add_recnode_from_store t) v in
+        v
+    | Stream (Consume _) ->
         (* This phase has no repo pointer *)
         assert false
 
@@ -204,6 +475,5 @@ struct
     | Empty, Empty -> ()
     | Empty, y -> x := y
     | x, Empty -> y := x
-    | Set _, Set _ ->
-        failwith "Merging two non-empty [Proof.Env.t] is forbidden"
+    | _ -> failwith "Merging two non-empty [Proof.Env.t] is forbidden"
 end

--- a/src/irmin/proof_intf.ml
+++ b/src/irmin/proof_intf.ml
@@ -183,7 +183,6 @@ module type Env = sig
 
   val t : t Type.ty
   val is_empty : t -> bool
-  val merge : t -> t -> unit
 
   (** {2 Construction of envs} *)
 

--- a/src/irmin/proof_intf.ml
+++ b/src/irmin/proof_intf.ml
@@ -89,25 +89,36 @@ module type S = sig
     | Contents of contents * metadata
   [@@deriving irmin]
 
-  type t [@@deriving irmin]
-  (** The type for proofs. *)
-
   type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]
   [@@deriving irmin]
   (** The type for kinded hashes. *)
 
-  val v : before:kinded_hash -> after:kinded_hash -> tree -> t
+  type elt =
+    | Node of (step * kinded_hash) list
+    | Inode of hash inode
+    | Contents of contents
+  [@@deriving irmin]
+
+  type stream = elt Seq.t [@@deriving irmin]
+  (** The type for stream proofs. Stream poofs provides stronger ordering
+      guarantees as the read effects have to happen in the exact same order and
+      they are easier to verify. *)
+
+  type 'a t [@@deriving irmin]
+  (** The type for proofs. *)
+
+  val v : before:kinded_hash -> after:kinded_hash -> 'a -> 'a t
   (** [v ~before ~after p] proves that the state advanced from [before] to
       [after]. [p]'s hash is [before], and [p] contains the minimal information
       for the computation to reach [after]. *)
 
-  val before : t -> kinded_hash
+  val before : 'a t -> kinded_hash
   (** [before t] it the state's hash at the beginning of the computation. *)
 
-  val after : t -> kinded_hash
+  val after : 'a t -> kinded_hash
   (** [after t] is the state's hash at the end of the computation. *)
 
-  val state : t -> tree
+  val state : 'a t -> 'a
   (** [proof t] is a subset of the initial state needed to prove that the proven
       computation could run without performing any I/O. *)
 end
@@ -161,12 +172,14 @@ end
     [Node.cached_value] and [Contents.cached_value], making it possible for the
     user to reference by [hash] everything that was contained in the proof. *)
 module type Env = sig
+  type kind = Set | Stream
   type mode = Produce | Serialise | Deserialise | Consume
   type v
   type t
   type hash
   type node
   type contents
+  type stream
 
   val t : t Type.ty
   val is_empty : t -> bool
@@ -180,13 +193,28 @@ module type Env = sig
   (** {2 Modes} *)
 
   val mode : t -> mode option
-  val to_mode : t -> mode -> unit
-  val with_mode : t -> mode -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  val set_mode : t -> kind -> mode -> unit
+
+  val with_set_produce :
+    (t -> start_serialise:(unit -> unit) -> 'a Lwt.t) -> 'a Lwt.t
+
+  val with_set_consume :
+    (t -> stop_deserialise:(unit -> unit) -> 'a Lwt.t) -> 'a Lwt.t
+
+  val with_stream_produce :
+    (t -> to_stream:(unit -> stream) -> 'a Lwt.t) -> 'a Lwt.t
+
+  val with_stream_consume :
+    stream -> (t -> is_empty:(unit -> bool) -> 'a Lwt.t) -> 'a Lwt.t
 
   (** {2 In/out backend objects with [Tree]} *)
 
   val add_contents_from_store : t -> hash -> contents -> unit
-  val add_node_from_store : t -> hash -> node -> unit
+
+  val add_node_from_store : t -> hash -> node -> node
+  (** [add_node_from_store] returns a [node] and not [unit] because [Env] may
+      take the opportunity to wrap the input node in [Node.Val.with_handler]. *)
+
   val add_contents_from_proof : t -> hash -> contents -> unit
   val add_node_from_proof : t -> hash -> node -> unit
   val find_contents : t -> hash -> contents option
@@ -198,8 +226,10 @@ module type Proof = sig
   module type Env = Env
 
   exception Bad_proof of { context : string }
+  exception Bad_stream of { context : string; reason : string }
 
   val bad_proof_exn : string -> 'a
+  val bad_stream_exn : string -> string -> 'a
 
   module Make
       (C : Type.S)
@@ -215,6 +245,18 @@ module type Proof = sig
          and type metadata := M.t
   end
 
-  module Env (H : Hash.S) (C : Contents.S) (N : Node.S with type hash = H.t) :
-    Env with type hash := H.t and type contents := C.t and type node := N.t
+  module Env
+      (H : Hash.S)
+      (C : Contents.S)
+      (N : Node.S with type hash = H.t)
+      (P : S
+             with type contents := C.t
+              and type hash := H.t
+              and type step := N.step
+              and type metadata := N.metadata) :
+    Env
+      with type hash := H.t
+       and type contents := C.t
+       and type node := N.t
+       and type stream := P.stream
 end

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -381,8 +381,10 @@ module type S = sig
 
     (** {1 Proofs} *)
 
+    type tree_proof := Proof.tree Proof.t
+
     val produce_proof :
-      repo -> kinded_hash -> (tree -> tree Lwt.t) -> Proof.t Lwt.t
+      repo -> kinded_hash -> (tree -> tree Lwt.t) -> tree_proof Lwt.t
     (** [produce r h f] runs [f] on top of a real store [r], producing a proof
         using the initial root hash [h].
 
@@ -396,7 +398,7 @@ module type S = sig
         proof should then interact as if they were all unshallowed (note: in the
         case of nested proofs, it's unclear what [verify_proof] should do...). *)
 
-    val verify_proof : Proof.t -> (tree -> tree Lwt.t) -> tree Lwt.t
+    val verify_proof : tree_proof -> (tree -> tree Lwt.t) -> tree Lwt.t
     (** [verify t f] runs [f] in checking mode, loading data from the proof as
         needed.
 
@@ -407,6 +409,15 @@ module type S = sig
         Reject the proof by raising [Proof.Bad_proof] unless the given
         computation performs exactly the same state operations as the generating
         computation, *in some order*. *)
+
+    type stream_proof := Proof.stream Proof.t
+
+    val produce_stream :
+      repo -> kinded_hash -> (tree -> tree Lwt.t) -> stream_proof Lwt.t
+    (** Same as {!produce_proof} but for stream proofs. *)
+
+    val verify_stream : stream_proof -> (tree -> tree Lwt.t) -> tree Lwt.t
+    (** Same as {!verify_proof} but for stream proofs. *)
   end
 
   (** {1 Reads} *)

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -133,6 +133,7 @@ module Make (P : Private.S) = struct
   end
 
   module Metadata = P.Node.Metadata
+  module Tree_proof = Proof.Make (P.Contents.Val) (P.Hash) (Path) (Metadata)
 
   type key = Path.t
   type hash = P.Hash.t
@@ -198,7 +199,7 @@ module Make (P : Private.S) = struct
     | Error (`Pruned_hash hash) -> raise_pruned context hash
     | Error (`Dangling_hash hash) -> raise (Dangling_hash { context; hash })
 
-  module Env = Proof.Env (P.Hash) (P.Contents.Val) (P.Node.Val)
+  module Env = Proof.Env (P.Hash) (P.Contents.Val) (P.Node.Val) (Tree_proof)
 
   module Contents = struct
     type v = Hash of repo option * hash | Value of contents
@@ -596,6 +597,9 @@ module Make (P : Private.S) = struct
             if cache then t.info.value <- Some acc;
             k acc
         | (k, Add e) :: rest ->
+            (* Detail about proofs: There is no need to register that new backend
+               node to Env because it is expected to reused the wrapped read
+               function from [acc] *)
             value_of_elt ~cache e (fun e -> aux (P.Node.Val.add acc k e) rest)
         | (k, Remove) :: rest -> aux (P.Node.Val.remove acc k) rest
       in
@@ -609,7 +613,9 @@ module Make (P : Private.S) = struct
       | None -> (
           cnt.node_find <- cnt.node_find + 1;
           let+ some_v = P.Node.find (P.Repo.node_t repo) k in
-          Option.iter (Env.add_node_from_store t.info.env k) some_v;
+          let some_v =
+            Option.map (Env.add_node_from_store t.info.env k) some_v
+          in
           if cache then t.info.value <- some_v;
           match some_v with None -> Error (`Dangling_hash k) | Some v -> Ok v)
 
@@ -1458,11 +1464,11 @@ module Make (P : Private.S) = struct
         | true -> Some (`Node (Node.of_hash ~env (Some repo) k))
         | false -> None)
 
-  let import_with_env ~env repo = function
-    | `Node k -> `Node (Node.of_hash ~env (Some repo) k)
-    | `Contents (k, m) -> `Contents (Contents.of_hash ~env (Some repo) k, m)
+  let import_with_env ~env repo_opt = function
+    | `Node k -> `Node (Node.of_hash ~env repo_opt k)
+    | `Contents (k, m) -> `Contents (Contents.of_hash ~env repo_opt k, m)
 
-  let import_no_check repo f = import_with_env ~env:(Env.empty ()) repo f
+  let import_no_check repo f = import_with_env ~env:(Env.empty ()) (Some repo) f
 
   let export ?clear repo contents_t node_t n =
     let cache =
@@ -1811,11 +1817,12 @@ module Make (P : Private.S) = struct
   module Proof = struct
     type irmin_tree = t
 
-    include Proof.Make (P.Contents.Val) (P.Hash) (Path) (Metadata)
+    include Tree_proof
 
     type proof_tree = tree
 
     let bad_proof_exn c = Proof.bad_proof_exn ("Irmin.Tree." ^ c)
+    let bad_stream_exn c = Proof.bad_stream_exn ("Irmin.Tree." ^ c) ""
 
     type node_proof = P.Node.Val.proof
     (** The type of tree proofs. *)
@@ -1989,39 +1996,45 @@ module Make (P : Private.S) = struct
 
     let to_tree p =
       let env = Env.empty () in
-      Env.to_mode env Deserialise;
+      Env.set_mode env Env.Set Env.Deserialise;
       let h = load_proof ~env (state p) Fun.id in
       let tree =
         match h with
         | `Contents (h, meta) -> `Contents (Contents.of_hash ~env None h, meta)
         | `Node h -> `Node (Node.of_hash ~env None h)
       in
-      Env.to_mode env Consume;
-      Fmt.epr "to_tree to Consume\n%!";
+      Env.set_mode env Env.Set Env.Consume;
       tree
   end
 
   let produce_proof repo kinded_hash f =
-    let env = Env.empty () in
-    let tree = import_with_env ~env repo kinded_hash in
-    Env.with_mode env Produce @@ fun () ->
+    Env.with_set_produce @@ fun env ~start_serialise ->
+    let tree = import_with_env ~env (Some repo) kinded_hash in
     let* tree_after = f tree in
     let after = hash tree_after in
     (* Here, we build a proof from [tree] (not from [tree_after]!), on purpose:
        we look at the effect on [f] on [tree]'s caches and we rely on the fact
        that the caches are env across copy-on-write copies of [tree]. *)
     clear tree;
-    Env.with_mode env Serialise @@ fun () ->
+    start_serialise ();
     let proof = Proof.of_tree tree in
     (* [env] will be purged when leaving the scope, that should avoid any memory
        leaks *)
     Proof.v ~before:kinded_hash ~after proof |> Lwt.return
 
+  let produce_stream repo kinded_hash f =
+    Env.with_stream_produce @@ fun env ~to_stream ->
+    let tree = import_with_env ~env (Some repo) kinded_hash in
+    let+ tree_after = f tree in
+    let after = hash tree_after in
+    clear tree;
+    let proof = to_stream () in
+    Proof.v ~before:kinded_hash ~after proof
+
   let verify_proof p f =
-    let env = Env.empty () in
+    Env.with_set_consume @@ fun env ~stop_deserialise ->
     let before = Proof.before p in
     let after = Proof.after p in
-    Env.with_mode env Deserialise @@ fun () ->
     (* First convert to proof to [Env] *)
     let h = Proof.(load_proof ~env (state p) Fun.id) in
     (* Then check that the consistency of the proof *)
@@ -2034,19 +2047,41 @@ module Make (P : Private.S) = struct
     in
     Lwt.catch
       (fun () ->
-        Env.with_mode env Consume @@ fun () ->
+        stop_deserialise ();
         (* Then apply [f] on a cleaned tree, an exception will be raised if [f]
            reads out of the proof. *)
         let+ tree_after = f tree in
         (* then check that [after] corresponds to [tree_after]'s hash. *)
         if not (equal_kinded_hash after (hash tree_after)) then
-          Proof.bad_proof_exn "verify_proof: invalid before hash";
+          Proof.bad_proof_exn "verify_proof: invalid after hash";
         tree_after)
       (function
         | Pruned_hash h ->
             (* finaly check that [f] only access valid parts of the proof. *)
             Fmt.kstr Proof.bad_proof_exn
               "verify_proof: %s is trying to read through a blinded node or \
+               object (%a)"
+              h.context pp_hash h.hash
+        | e -> raise e)
+
+  let verify_stream p f =
+    let before = Proof.before p in
+    let after = Proof.after p in
+    let stream = Proof.state p in
+    Env.with_stream_consume stream @@ fun env ~is_empty ->
+    let tree = import_with_env ~env None before in
+    Lwt.catch
+      (fun () ->
+        let+ tree_after = f tree in
+        if not (is_empty ()) then
+          Proof.bad_stream_exn "verify_stream: did not consume the full stream";
+        if not (equal_kinded_hash after (hash tree_after)) then
+          Proof.bad_stream_exn "verify_stream: invalid after hash";
+        tree_after)
+      (function
+        | Pruned_hash h ->
+            Fmt.kstr Proof.bad_stream_exn
+              "verify_stream: %s is trying to read through a blinded node or \
                object (%a)"
               h.context pp_hash h.hash
         | e -> raise e)

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -342,7 +342,7 @@ module type S = sig
 
     type irmin_tree
 
-    val to_tree : t -> irmin_tree
+    val to_tree : tree t -> irmin_tree
     (** [to_tree p] is the tree [t] representing the tree proof [p]. Blinded
         parts of the proof will raise [Dangling_hash] when traversed. *)
   end
@@ -427,9 +427,18 @@ module type Tree = sig
     val of_private_node : P.Repo.t -> P.Node.value -> node
     val to_private_node : node -> P.Node.value or_error Lwt.t
 
-    val produce_proof :
-      P.Repo.t -> kinded_hash -> (t -> t Lwt.t) -> Proof.t Lwt.t
+    type tree_proof := Proof.tree Proof.t
 
-    val verify_proof : Proof.t -> (t -> t Lwt.t) -> t Lwt.t
+    val produce_proof :
+      P.Repo.t -> kinded_hash -> (t -> t Lwt.t) -> tree_proof Lwt.t
+
+    val verify_proof : tree_proof -> (t -> t Lwt.t) -> t Lwt.t
+
+    type stream_proof := Proof.stream Proof.t
+
+    val produce_stream :
+      P.Repo.t -> kinded_hash -> (t -> t Lwt.t) -> stream_proof Lwt.t
+
+    val verify_stream : stream_proof -> (t -> t Lwt.t) -> t Lwt.t
   end
 end

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -95,10 +95,12 @@ module Make (Conf : Irmin_pack.Conf.S) = struct
 
   let run ops tree = Lwt_list.fold_left_s run_one tree ops
 
-  let proof_of_ops repo hash ops : Store.Tree.Proof.t Lwt.t =
+  let proof_of_ops repo hash ops : _ Lwt.t =
     Store.Tree.produce_proof repo hash (run ops)
 
-  let bin_of_proof = Irmin.Type.(unstage (to_bin_string Tree.Proof.t))
+  let tree_proof_t = Tree.Proof.t Tree.Proof.tree_t
+  let bin_of_proof = Irmin.Type.(unstage (to_bin_string tree_proof_t))
+  let proof_of_bin = Irmin.Type.(unstage (of_bin_string tree_proof_t))
 end
 
 module Default = Make (Conf)
@@ -190,9 +192,7 @@ let test_fold_undefined () =
   test_fold ~order:`Undefined bindings expected
 
 let proof_of_bin s =
-  match Irmin.Type.(unstage (of_bin_string Tree.Proof.t)) s with
-  | Ok s -> s
-  | Error (`Msg e) -> Alcotest.fail e
+  match proof_of_bin s with Ok s -> s | Error (`Msg e) -> Alcotest.fail e
 
 let check_equivalence tree proof op =
   match op with
@@ -235,7 +235,7 @@ let test_proofs ctxt ops =
   (* test encoding *)
   let enc = bin_of_proof proof in
   let dec = proof_of_bin enc in
-  Alcotest.(check_repr Tree.Proof.t) "same proof" proof dec;
+  Alcotest.(check_repr tree_proof_t) "same proof" proof dec;
 
   (* test equivalence *)
   let tree_proof = Tree.Proof.to_tree proof in


### PR DESCRIPTION
This WIP PR is a rebase on 2.10 of #1673. See the full diff  https://github.com/samoht/irmin/compare/samoht:merkle-traces-5..Ngoguey42:streamed-proof-as-hash-array

It contains most of the diffs from #1673. 

I've removed the `Empty` tag from the streamed proofs as this didn't seem mandatory.

I've removed the `stream` type from `Node.S`

It misses the extenders for the streamed proofs. @icristescu is working on it.

It misses some documentation.

