### PR TITLE
[2.10] Proof api tweaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
     (#1625, @samoht)
   - `Tree.empty` now takes a unit argument. (#1566, @CraigFe)
   - `Tree.length` now takes a tree as argument (#1676, @samoht)
+  - `Tree.Proof.t` now uses a more precise datatype to encode value
+    invariants (#1688, @samoht)
 
 - **irmin-pack**
   - irmin-pack: add an option to configure the index function and pick

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -21,7 +21,6 @@ module Content_addressable = Store.Content_addressable
 module Contents = Contents
 module Merge = Merge
 module Branch = Branch
-module Proof = Proof
 module Info = Info
 module Dot = Dot.Make
 module Hash = Hash

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -130,7 +130,6 @@ module Contents = Contents
     {{!Contents.Json} JSON} contents are provided. *)
 
 module Branch = Branch
-module Proof = Proof
 
 type remote = S.remote = ..
 (** The type for remote stores. *)

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -38,9 +38,15 @@ struct
   type tree =
     | Blinded_node of hash
     | Node of (step * tree) list
-    | Inode of tree inode
+    | Inode of inode_tree inode
     | Blinded_contents of hash * metadata
     | Contents of contents * metadata
+  [@@deriving irmin]
+
+  and inode_tree =
+    | Blinded_inode of hash
+    | Inode_values of (step * tree) list
+    | Inode_tree of inode_tree inode
   [@@deriving irmin]
 
   type elt =

--- a/src/irmin/proof_intf.ml
+++ b/src/irmin/proof_intf.ml
@@ -75,7 +75,8 @@ module type S = sig
 
       [Inode i] is an optimized representation of a node as a tree. Pointers in
       that trees would refer to blinded nodes, nodes or to other inodes. E.g.
-      Blinded content is not expected to appear directly in an inodes.
+      Blinded content nor contents is not expected to appear directly in an
+      inodes.
 
       [Blinded_contents (h, m)] is a shallow pointer to contents having hash [h]
       and metadata [m].
@@ -84,9 +85,15 @@ module type S = sig
   type tree =
     | Blinded_node of hash
     | Node of (step * tree) list
-    | Inode of tree inode
+    | Inode of inode_tree inode
     | Blinded_contents of hash * metadata
     | Contents of contents * metadata
+  [@@deriving irmin]
+
+  and inode_tree =
+    | Blinded_inode of hash
+    | Inode_values of (step * tree) list
+    | Inode_tree of inode_tree inode
   [@@deriving irmin]
 
   type kinded_hash = [ `Contents of hash * metadata | `Node of hash ]

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -400,15 +400,18 @@ module type S = sig
         case of nested proofs, it's unclear what [verify_proof] should do...). *)
 
     type ('proof, 'result) verifier :=
-      'proof -> (tree -> (tree * 'result) Lwt.t) -> (tree * 'result) Lwt.t
+      'proof ->
+      (tree -> (tree * 'result) Lwt.t) ->
+      (tree * 'result, [ `Msg of string ]) result Lwt.t
     (** [verify t f] runs [f] in checking mode, loading data from the proof as
         needed.
 
-        The generated tree is the tree after [f] has completed. More operations
-        can be run on that tree, but it won't be able to access the underlying
-        storage.
+        When the result is [Ok (t, r)], [t] is the generated tree after [f] has
+        completed and [r] is the result of the computation. More operations can
+        be run on [t], but it won't be able to access the underlying storage and
+        will raise [Dangling_hash] when trying to read unloaded parts of [t].
 
-        Raise [Proof.Bad_proof] when the proof is rejected. *)
+        When the result is [Error msg], the proof is rejected. *)
 
     type tree_proof := Proof.tree Proof.t
     (** The type for tree proofs.

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1824,6 +1824,7 @@ module Make (P : Private.S) = struct
     include Tree_proof
 
     type proof_tree = tree
+    type proof_inode = inode_tree
 
     let bad_proof_exn c = Proof.bad_proof_exn ("Irmin.Tree." ^ c)
     let bad_stream_exn c = Proof.bad_stream_exn ("Irmin.Tree." ^ c) ""
@@ -1882,13 +1883,33 @@ module Make (P : Private.S) = struct
       | `Inode (length, proofs) -> proof_of_inode node length proofs k
       | `Values vs -> proof_of_values node vs k
 
+    and proof_inode_of_node_proof :
+        type a. node -> node_proof -> (proof_inode -> a) -> a =
+     fun node p k ->
+      match p with
+      | `Blinded h -> k (Blinded_inode h)
+      | `Inode (length, proofs) -> proof_inode_of_inode node length proofs k
+      | `Values vs -> proof_inode_of_values node vs k
+
     and proof_of_inode :
         type a. node -> int -> (_ * node_proof) list -> (proof_tree -> a) -> a =
      fun node length proofs k ->
       let rec aux acc = function
         | [] -> k (Inode { length; proofs = List.rev acc })
         | (index, proof) :: rest ->
-            proof_of_node_proof node proof (fun proof ->
+            proof_inode_of_node_proof node proof (fun proof ->
+                aux ((index, proof) :: acc) rest)
+      in
+      aux [] proofs
+
+    and proof_inode_of_inode :
+        type a. node -> int -> (_ * node_proof) list -> (proof_inode -> a) -> a
+        =
+     fun node length proofs k ->
+      let rec aux acc = function
+        | [] -> k (Inode_tree { length; proofs = List.rev acc })
+        | (index, proof) :: rest ->
+            proof_inode_of_node_proof node proof (fun proof ->
                 aux ((index, proof) :: acc) rest)
       in
       aux [] proofs
@@ -1900,6 +1921,22 @@ module Make (P : Private.S) = struct
       let findv = findv "Proof.proof_of_values" node in
       let rec aux acc = function
         | [] -> k (Node (List.rev acc))
+        | (step, _) :: rest -> (
+            match findv step with
+            | None -> assert false
+            | Some t ->
+                let k p = aux ((step, p) :: acc) rest in
+                proof_of_tree t k)
+      in
+      aux [] steps
+
+    and proof_inode_of_values :
+        type a.
+        node -> (step * P.Node.Val.value) list -> (proof_inode -> a) -> a =
+     fun node steps k ->
+      let findv = findv "Proof.proof_of_values" node in
+      let rec aux acc = function
+        | [] -> k (Inode_values (List.rev acc))
         | (step, _) :: rest -> (
             match findv step with
             | None -> assert false
@@ -1941,8 +1978,8 @@ module Make (P : Private.S) = struct
 
     (* Recontruct private node from [P.Node.Val.proof] *)
     and load_inode_proof :
-        type a. env:_ -> int -> (_ * proof_tree) list -> (kinded_hash -> a) -> a
-        =
+        type a.
+        env:_ -> int -> (_ * proof_inode) list -> (kinded_hash -> a) -> a =
      fun ~env len proofs k ->
       let rec aux : _ list -> _ list -> a =
        fun acc proofs ->
@@ -1965,20 +2002,16 @@ module Make (P : Private.S) = struct
       aux [] proofs
 
     and node_proof_of_proof :
-        type a. env:_ -> proof_tree -> (node_proof -> a) -> a =
+        type a. env:_ -> proof_inode -> (node_proof -> a) -> a =
      fun ~env t k ->
       match t with
-      | Blinded_contents _ ->
-          bad_proof_exn
-            "Proof.to_node_proof: found Blinded_contents inside an inode"
-      | Contents _ ->
-          bad_proof_exn "Proof.to_node_proof: found Contents inside an inode"
-      | Blinded_node x -> k (`Blinded x)
-      | Inode { length; proofs } -> node_proof_of_inode ~env length proofs k
-      | Node n -> node_proof_of_node ~env n k
+      | Blinded_inode x -> k (`Blinded x)
+      | Inode_tree { length; proofs } ->
+          node_proof_of_inode ~env length proofs k
+      | Inode_values n -> node_proof_of_node ~env n k
 
     and node_proof_of_inode :
-        type a. env:_ -> int -> (_ * proof_tree) list -> (node_proof -> a) -> a
+        type a. env:_ -> int -> (_ * proof_inode) list -> (node_proof -> a) -> a
         =
      fun ~env length proofs k ->
       let rec aux acc = function

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -434,7 +434,9 @@ module type Tree = sig
       ('proof * 'result) Lwt.t
 
     type ('proof, 'result) verifier :=
-      'proof -> (t -> (t * 'result) Lwt.t) -> (t * 'result) Lwt.t
+      'proof ->
+      (t -> (t * 'result) Lwt.t) ->
+      (t * 'result, [ `Msg of string ]) result Lwt.t
 
     type tree_proof := Proof.tree Proof.t
 


### PR DESCRIPTION
Use a result type and define a more precise datatype to encode proof invariants