### PR TITLE
irmin-pack: add an option to configure the index function (port from 2.10)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@
   - Added a `stat-store` command to `irmin-fsck` to output stats on the tree
     under a specified commit (#1391, @icristescu, @Ngoguey42, @CraigFe).
   - Added new counters in `Stats` (#1570, @Ngoguey42).
+  - Added an option to configure the index function and pick
+    the relevant bits in cryptographic a hash by default (#1677, @samoht)
 
 - **irmin-unix**
   - Update `irmin` CLI to raise an exception when an invalid/non-existent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,8 +47,8 @@
   - Added a `stat-store` command to `irmin-fsck` to output stats on the tree
     under a specified commit (#1391, @icristescu, @Ngoguey42, @CraigFe).
   - Added new counters in `Stats` (#1570, @Ngoguey42).
-  - Added an option to configure the index function and pick
-    the relevant bits in cryptographic a hash by default (#1677, @samoht)
+  - Added an option to configure the index function and pick the relevant bits
+    in a cryptographic hash by default (#1677 #1699, @samoht)
 
 - **irmin-unix**
   - Update `irmin` CLI to raise an exception when an invalid/non-existent

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -20,6 +20,7 @@ module Config = struct
   let entries = 2
   let stable_hash = 3
   let contents_length_header = Some `Varint
+  let inode_child_order = `Hash_bits
 end
 
 module KV = struct

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -193,11 +193,12 @@ module type B = sig
 end
 
 let store_of_config config =
-  let entries, stable_hash = config.inode_config in
+  let entries', stable_hash' = config.inode_config in
   let module Conf = struct
-    let entries = entries
-    let stable_hash = stable_hash
-    let contents_length_header = Some `Varint
+    include Irmin_tezos.Conf
+
+    let entries = entries'
+    let stable_hash = stable_hash'
   end in
   match config.store_type with
   | `Pack -> (module Bench_suite (Make_store_pack (Conf)) : B)

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -16,10 +16,14 @@
 
 type length_header = [ `Varint ] option
 
+type inode_child_order =
+  [ `Seeded_hash | `Hash_bits | `Custom of depth:int -> bytes -> int ]
+
 module type S = sig
   val entries : int
   val stable_hash : int
   val contents_length_header : length_header
+  val inode_child_order : inode_child_order
 end
 
 module Default = struct

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -32,6 +32,13 @@ module type S = sig
         {i must} index all contents values (as recovering contents values from
         the store will require referring to the index for their length
         information). *)
+
+  type inode_child_order :=
+    [ `Seeded_hash  (** use a non-crypto seeded-hash of the step *)
+    | `Hash_bits  (** crypto hash the step and extract the relevant bits. *)
+    | `Custom of depth:int -> bytes -> int  (** use a custom index *) ]
+
+  val inode_child_order : inode_child_order
 end
 
 val spec : Irmin.Backend.Conf.Spec.t

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -16,6 +16,11 @@
 
 type length_header = [ `Varint ] option
 
+type inode_child_order =
+  [ `Seeded_hash  (** use a non-crypto seeded-hash of the step *)
+  | `Hash_bits  (** crypto hash the step and extract the relevant bits. *)
+  | `Custom of depth:int -> bytes -> int  (** use a custom index *) ]
+
 module type S = sig
   val entries : int
   val stable_hash : int
@@ -32,11 +37,6 @@ module type S = sig
         {i must} index all contents values (as recovering contents values from
         the store will require referring to the index for their length
         information). *)
-
-  type inode_child_order :=
-    [ `Seeded_hash  (** use a non-crypto seeded-hash of the step *)
-    | `Hash_bits  (** crypto hash the step and extract the relevant bits. *)
-    | `Custom of depth:int -> bytes -> int  (** use a custom index *) ]
 
   val inode_child_order : inode_child_order
 end

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -45,7 +45,7 @@ struct
   end
 
   module T = struct
-    type hash = H.t [@@deriving irmin ~pp ~equal]
+    type hash = H.t [@@deriving irmin ~pp ~to_bin_string ~equal]
     type key = Key.t [@@deriving irmin ~pp ~equal]
     type node_key = Node.node_key [@@deriving irmin]
     type contents_key = Node.contents_key [@@deriving irmin]
@@ -57,6 +57,79 @@ struct
     type value = Node.value [@@deriving irmin ~equal]
 
     module Metadata = Node.Metadata
+  end
+
+  module Step =
+    Irmin.Hash.Typed
+      (H)
+      (struct
+        type t = T.step
+
+        let t = T.step_t
+      end)
+
+  exception Max_depth of int
+
+  module Index : sig
+    type key
+
+    val key : T.step -> key
+    val index : depth:int -> key -> int
+  end = struct
+    open T
+
+    type key = bytes
+
+    let log_entry = int_of_float (log (float Conf.entries) /. log 2.)
+
+    let () =
+      assert (log_entry <> 0);
+      assert (Conf.entries = int_of_float (2. ** float log_entry))
+
+    let key =
+      match Conf.inode_child_order with
+      | `Hash_bits ->
+          fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s))
+      | `Seeded_hash | `Custom _ ->
+          fun s -> Bytes.unsafe_of_string (step_to_bin_string s)
+
+    (* Assume [k = cryto_hash(step)] (see {!key}) and [Conf.entry] can
+       can represented with [n] bits. Then, [hash_bits ~depth k] is
+       the [n]-bits integer [i] with the following binary representation:
+
+         [k(n*depth) ... k(n*depth+n-1)]
+
+       When [n] is not a power of 2, [hash_bits] needs to handle
+       unaligned reads properly. *)
+    let hash_bits ~depth k =
+      let byte = 8 in
+      let n = depth * log_entry / byte in
+      let r = depth * log_entry mod byte in
+      if n >= Bytes.length k then raise (Max_depth depth);
+      if r + log_entry <= byte then
+        let i = Bytes.get_uint8 k n in
+        let e0 = i lsr (byte - log_entry - r) in
+        let r0 = e0 land (Conf.entries - 1) in
+        r0
+      else
+        let i0 = Bytes.get_uint8 k n in
+        let to_read = byte - r in
+        let rest = log_entry - to_read in
+        let mask = (1 lsl to_read) - 1 in
+        let r0 = (i0 land mask) lsl rest in
+        if n + 1 >= Bytes.length k then raise (Max_depth depth);
+        let i1 = Bytes.get_uint8 k (n + 1) in
+        let r1 = i1 lsr (byte - rest) in
+        r0 + r1
+
+    let short_hash = Irmin.Type.(unstage (short_hash bytes))
+    let seeded_hash ~depth k = abs (short_hash ~seed:depth k) mod Conf.entries
+
+    let index =
+      match Conf.inode_child_order with
+      | `Seeded_hash -> seeded_hash
+      | `Hash_bits -> hash_bits
+      | `Custom f -> f
   end
 
   module StepMap = struct
@@ -1027,8 +1100,7 @@ struct
         in
         { v_ref; v = t.v; root = true }
 
-    let hash_key = short_hash_step
-    let index ~depth k = abs (hash_key ~seed:depth k) mod Conf.entries
+    let index ~depth k = Index.index ~depth k
 
     (** This function shouldn't be called with the [Total] layout. In the
         future, we could add a polymorphic variant to the GADT parameter to
@@ -1077,10 +1149,11 @@ struct
 
     let find_value ~cache layout ~depth t s =
       let target_of_ptr = Ptr.target ~cache layout in
+      let key = Index.key s in
       let rec aux ~depth = function
         | Values vs -> ( try Some (StepMap.find s vs) with Not_found -> None)
         | Tree t -> (
-            let i = index ~depth s in
+            let i = index ~depth key in
             let x = t.entries.(i) in
             match x with
             | None -> None
@@ -1090,7 +1163,7 @@ struct
 
     let find ?(cache = true) layout t s = find_value ~cache ~depth:0 layout t s
 
-    let rec add layout ~depth ~copy ~replace t s v k =
+    let rec add layout ~depth ~copy ~replace t s key v k =
       Stats.incr_inode_rec_add ();
       match t.v with
       | Values vs ->
@@ -1105,8 +1178,9 @@ struct
                 tree layout
                   { length = 0; depth; entries = Array.make Conf.entries None }
               in
-              let aux t (s, v) =
-                (add [@tailcall]) layout ~depth ~copy:false ~replace t s v
+              let aux t (s', v) =
+                let key' = Index.key s' in
+                (add [@tailcall]) layout ~depth ~copy:false ~replace t s' key' v
                   (fun x -> x)
               in
               List.fold_left aux empty vs
@@ -1115,7 +1189,7 @@ struct
       | Tree t -> (
           let length = if replace then t.length else t.length + 1 in
           let entries = if copy then Array.copy t.entries else t.entries in
-          let i = index ~depth s in
+          let i = index ~depth key in
           match entries.(i) with
           | None ->
               let target = values layout (StepMap.singleton s v) in
@@ -1128,24 +1202,25 @@ struct
                    [find_value] for that path.*)
                 Ptr.target ~cache:true layout n
               in
-              (add [@tailcall]) layout ~depth:(depth + 1) ~copy ~replace t s v
-                (fun target ->
+              (add [@tailcall]) layout ~depth:(depth + 1) ~copy ~replace t s key
+                v (fun target ->
                   entries.(i) <- Some (Ptr.of_target layout target);
                   let t = tree layout { depth; length; entries } in
                   k t))
 
     let add layout ~copy t s v =
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
+      let k = Index.key s in
       match find_value ~cache:true ~depth:0 layout t s with
       | Some v' when equal_value v v' -> t
       | Some _ ->
-          add ~depth:0 layout ~copy ~replace:true t s v Fun.id
+          add ~depth:0 layout ~copy ~replace:true t s k v Fun.id
           |> stabilize_root layout
       | None ->
-          add ~depth:0 layout ~copy ~replace:false t s v Fun.id
+          add ~depth:0 layout ~copy ~replace:false t s k v Fun.id
           |> stabilize_root layout
 
-    let rec remove layout ~depth t s k =
+    let rec remove layout ~depth t s key k =
       Stats.incr_inode_rec_remove ();
       match t.v with
       | Values vs ->
@@ -1161,7 +1236,7 @@ struct
             k t
           else
             let entries = Array.copy t.entries in
-            let i = index ~depth s in
+            let i = index ~depth key in
             match entries.(i) with
             | None -> assert false
             | Some t ->
@@ -1175,16 +1250,17 @@ struct
                   let t = tree layout { depth; length = len; entries } in
                   k t)
                 else
-                  remove ~depth:(depth + 1) layout t s @@ fun target ->
+                  remove ~depth:(depth + 1) layout t s key @@ fun target ->
                   entries.(i) <- Some (Ptr.of_target layout target);
                   let t = tree layout { depth; length = len; entries } in
                   k t)
 
     let remove layout t s =
       (* XXX: [find_value ~depth:42] should break the unit tests. It doesn't. *)
+      let k = Index.key s in
       match find_value ~cache:true layout ~depth:0 t s with
       | None -> t
-      | Some _ -> remove layout ~depth:0 t s Fun.id |> stabilize_root layout
+      | Some _ -> remove layout ~depth:0 t s k Fun.id |> stabilize_root layout
 
     let of_seq l =
       let t =
@@ -1611,7 +1687,7 @@ struct
     let length t = apply t { f = (fun _ v -> I.length v) }
     let clear t = apply t { f = (fun layout v -> I.clear layout v) }
     let nb_children t = apply t { f = (fun _ v -> I.nb_children v) }
-    let index = I.index
+    let index ~depth s = I.index ~depth (Index.key s)
 
     let integrity_check t =
       let f layout v =

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -16,6 +16,14 @@
 
 open! Import
 
+module type Child_ordering = sig
+  type step
+  type key
+
+  val key : step -> key
+  val index : depth:int -> key -> int
+end
+
 module type Value = sig
   type key
 
@@ -155,6 +163,8 @@ module type Internal = sig
         The result is [Error e] when a subtree tree of [c] has an integrity
         error. *)
   end
+
+  module Child_ordering : Child_ordering with type step := Val.step
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -171,6 +171,9 @@ module type Sigs = sig
   module type S = S
   module type Persistent = Persistent
   module type Internal = Internal
+  module type Child_ordering = Child_ordering
+
+  exception Max_depth of int
 
   module Make_internal
       (Conf : Conf.S)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -151,14 +151,14 @@ module Make (S : Generic_key) = struct
         (* check B.Node.Val.t "v" u w; *)
         ()
       in
-      let l = B.Node.Val.list u in
-      check_list "list all" [ ("x", k); ("y", k); ("z", k) ] l;
+      let all = B.Node.Val.list u in
+      check_list "list all" [ ("x", k); ("y", k); ("z", k) ] all;
       let l = B.Node.Val.list ~length:1 u in
       check_list "list length=1" [ ("x", k) ] l;
       let l = B.Node.Val.list ~offset:1 u in
       check_list "list offset=1" [ ("y", k); ("z", k) ] l;
       let l = B.Node.Val.list ~offset:1 ~length:1 u in
-      check_list "list offset=1 length=1" [ ("y", k) ] l;
+      check_list "list offset=1 length=1" [ List.nth all 1 ] l;
       let u = B.Node.Val.add u "a" k in
       check_node "node: x+y+z+a" u >>= fun () ->
       let u = B.Node.Val.add u "b" k in

--- a/src/irmin-tezos/irmin_tezos.ml
+++ b/src/irmin-tezos/irmin_tezos.ml
@@ -20,6 +20,7 @@ module Conf = struct
   let entries = 32
   let stable_hash = 256
   let contents_length_header = Some `Varint
+  let inode_child_order = `Seeded_hash
 end
 
 module Maker = Irmin_pack.Maker (Conf)

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -106,6 +106,7 @@ module Small_conf = struct
   let entries = 2
   let stable_hash = 3
   let contents_length_header = Some `Varint
+  let inode_child_order = `Hash_bits
 end
 
 module V1_maker = Irmin_pack.Maker (Small_conf)

--- a/test/irmin-pack/test_hashes.ml
+++ b/test/irmin-pack/test_hashes.ml
@@ -218,6 +218,7 @@ module Test_small_conf = struct
     let entries = 2
     let stable_hash = 3
     let contents_length_header = Some `Varint
+    let inode_child_order = `Seeded_hash
   end
 
   module Store = Test (Conf) (Irmin_tezos.Schema)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -26,6 +26,7 @@ module Conf = struct
   let entries = 2
   let stable_hash = 3
   let contents_length_header = Some `Varint
+  let inode_child_order = `Seeded_hash
 end
 
 let log_size = 1000

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -21,6 +21,7 @@ module Config = struct
   let entries = 2
   let stable_hash = 3
   let contents_length_header = Some `Varint
+  let inode_child_order = `Seeded_hash
 end
 
 let test_dir = Filename.concat "_build" "test-db-pack"

--- a/test/irmin-tezos/generate.ml
+++ b/test/irmin-tezos/generate.ml
@@ -27,9 +27,10 @@ module Simple = struct
   let data_dir = "data/pack"
 
   module Conf = struct
+    include Irmin_tezos.Conf
+
     let entries = 2
     let stable_hash = 3
-    let contents_length_header = Some `Varint
   end
 
   module Schema = Irmin.Schema.KV (Irmin.Contents.String)


### PR DESCRIPTION
Forward port of #1677.

Also adds some tests of the new behaviour, and explicitly forbids using `` `Hash_bits `` with `entries >= 2048`.