### PR TITLE
Add `bisect_ppx` instrumentation to all libraries

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,63 @@
+name: coverage
+
+on:
+  pull_request:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        packages: [ '.' ]
+        ocaml-compiler:
+          - 4.13.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-local-packages: $${ matrix.opam-local-packages }}
+          opam-depext-flags: --with-test
+
+      - name: Pin local packages
+        run: |
+          # Pin all local opam files to avoid internal conflicts
+          # 
+          # TODO: replace with `opam pin --with-version` when Opam 2.1 is
+          # available via `setup-ocaml`.
+          find . -maxdepth 1 -name '*.opam' -printf '%P\n' |\
+              cut -d. -f1 |\
+              xargs -I{} -n 1 opam pin add {}.dev ./ -n
+
+      - name: Install depexts
+        run: |
+          find . -maxdepth 1 -name '*.opam' -printf '%P\n' |\
+             cut -d. -f1 |\
+             xargs opam depext --update -y
+
+      - name: Install Opam dependencies
+        run: opam install ${{ matrix.packages }} --with-test --deps-only
+
+      - name: Run tests with coverage instrumentation
+        run: opam exec -- dune runtest --instrument-with bisect_ppx
+
+      - name: Send coverage report to Codecov
+        run: opam exec -- bisect-ppx-report send-to Codecov
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
+_coverage
 *~
 *.install
 *.merlin

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <br />
 
 [![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Firmin%2Fmain&logo=ocaml&style=flat-square)](https://ci.ocamllabs.io/github/mirage/irmin)
+[![codecov](https://codecov.io/gh/mirage/irmin/branch/main/graph/badge.svg?token=n4mWfgURqT)](https://codecov.io/gh/mirage/irmin)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/mirage/irmin?style=flat-square&color=09aa89)](https://github.com/mirage/irmin/releases/latest)
 [![docs](https://img.shields.io/badge/doc-online-blue.svg?style=flat-square)](https://mirage.github.io/irmin/)
 

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -13,7 +13,9 @@
  (modules bench_common)
  (libraries irmin-pack irmin-tezos unix progress uuidm)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))
 
 (library
  (name irmin_traces)
@@ -23,7 +25,9 @@
  (preprocess
   (pps ppx_irmin.internal ppx_repr ppx_deriving.enum))
  (libraries irmin irmin-pack unix lwt repr ppx_repr bentov mtime printbox
-   uucp uutf printbox.unicode mtime.clock.os bench_common))
+   uucp uutf printbox.unicode mtime.clock.os bench_common)
+ (instrumentation
+  (backend bisect_ppx)))
 
 (executable
  (name tree)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+comment:
+   layout: diff
+   behaviour: default
+   require_changes: true

--- a/irmin.opam
+++ b/irmin.opam
@@ -35,6 +35,7 @@ depends: [
   "vector" {with-test}
   "mdx" {>= "2.0.0" & with-test}
   "odoc" {(< "2.0.1" | > "2.0.2") & with-doc} # See https://github.com/ocaml/odoc/issues/793
+  "bisect_ppx" {dev & >= "2.5.0"}
 ]
 
 conflicts: [

--- a/ppx_irmin.opam
+++ b/ppx_irmin.opam
@@ -19,6 +19,7 @@ depends: [
   "ppxlib" {>= "0.12.0"}
   "logs" {>= "0.5.0"}
   "fmt" {with-test & >= "0.8.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
 ]
 
 synopsis: "PPX deriver for Irmin type representations"

--- a/src/irmin-chunk/dune
+++ b/src/irmin-chunk/dune
@@ -3,4 +3,6 @@
  (public_name irmin-chunk)
  (libraries irmin fmt logs lwt)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-containers/dune
+++ b/src/irmin-containers/dune
@@ -3,4 +3,6 @@
  (public_name irmin-containers)
  (libraries irmin irmin.mem irmin-unix irmin-git mtime)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-fs/dune
+++ b/src/irmin-fs/dune
@@ -3,4 +3,6 @@
  (public_name irmin-fs)
  (libraries astring irmin logs lwt)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-git/dune
+++ b/src/irmin-git/dune
@@ -3,4 +3,6 @@
  (public_name irmin-git)
  (libraries astring cstruct fmt fpath git irmin logs lwt uri irmin.mem)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-graphql/dune
+++ b/src/irmin-graphql/dune
@@ -2,4 +2,6 @@
  (name irmin_graphql)
  (public_name irmin-graphql)
  (libraries fmt cohttp cohttp-lwt graphql-cohttp graphql graphql-lwt
-   graphql_parser irmin lwt))
+   graphql_parser irmin lwt)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-http/dune
+++ b/src/irmin-http/dune
@@ -3,4 +3,6 @@
  (public_name irmin-http)
  (libraries astring cohttp cohttp-lwt fmt irmin jsonm logs lwt uri webmachine)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-layers/dune
+++ b/src/irmin-layers/dune
@@ -3,4 +3,6 @@
  (name irmin_layers)
  (libraries irmin irmin.mem logs lwt mtime mtime.clock.os)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-mirage/dune
+++ b/src/irmin-mirage/dune
@@ -1,4 +1,6 @@
 (library
  (name irmin_mirage)
  (public_name irmin-mirage)
- (libraries fmt irmin irmin.mem mirage-clock ptime))
+ (libraries fmt irmin irmin.mem mirage-clock ptime)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-mirage/git/dune
+++ b/src/irmin-mirage/git/dune
@@ -2,4 +2,6 @@
  (name irmin_mirage_git)
  (public_name irmin-mirage-git)
  (libraries fmt git irmin irmin-mirage irmin-git lwt mirage-clock mirage-kv
-   uri))
+   uri)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-mirage/graphql/dune
+++ b/src/irmin-mirage/graphql/dune
@@ -2,4 +2,6 @@
  (name irmin_mirage_graphql)
  (public_name irmin-mirage-graphql)
  (libraries git.nss.git cohttp-lwt irmin irmin-mirage irmin-graphql lwt
-   mirage-clock uri))
+   mirage-clock uri)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-pack/dune
+++ b/src/irmin-pack/dune
@@ -4,4 +4,6 @@
  (libraries fmt index index.unix irmin irmin-layers logs lwt lwt.unix mtime
    ppx_irmin cmdliner optint)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-pack/mem/dune
+++ b/src/irmin-pack/mem/dune
@@ -3,4 +3,6 @@
  (name irmin_pack_mem)
  (libraries irmin-pack irmin.mem)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -6,7 +6,9 @@
  (preprocess
   (pps ppx_irmin.internal))
  (libraries alcotest astring fmt irmin irmin-layers jsonm logs.fmt lwt
-   lwt.unix mtime mtime.clock.os))
+   lwt.unix mtime mtime.clock.os)
+ (instrumentation
+  (backend bisect_ppx)))
 
 (library
  (foreign_stubs
@@ -16,4 +18,6 @@
  (public_name irmin-test.bench)
  (modules Irmin_bench Rusage)
  (libraries fmt.tty fmt.cli cmdliner irmin logs.fmt logs.cli lwt lwt.unix
-   metrics metrics-unix irmin-test))
+   metrics metrics-unix irmin-test)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-tezos/dune
+++ b/src/irmin-tezos/dune
@@ -1,4 +1,6 @@
 (library
  (name irmin_tezos)
  (public_name irmin-tezos)
- (libraries tezos-base58 digestif fmt irmin irmin-pack))
+ (libraries tezos-base58 digestif fmt irmin irmin-pack)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -6,4 +6,6 @@
    irmin-graphql irmin-http irmin.mem irmin-pack irmin-tezos irmin-watcher
    logs.cli logs.fmt lwt lwt.unix uri yaml)
  (preprocess
-  (pps ppx_irmin.internal)))
+  (pps ppx_irmin.internal))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/irmin/dune
+++ b/src/irmin/dune
@@ -16,4 +16,6 @@
   uutf
   (re_export repr))
  (preprocess
-  (pps ppx_irmin.internal -- --lib "Type")))
+  (pps ppx_irmin.internal -- --lib "Type"))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/ppx_irmin/dune
+++ b/src/ppx_irmin/dune
@@ -4,4 +4,6 @@
  (public_name ppx_irmin)
  (modules ppx_irmin)
  (kind ppx_deriver)
- (libraries ppx_repr.lib))
+ (libraries ppx_repr.lib)
+ (instrumentation
+  (backend bisect_ppx)))


### PR DESCRIPTION
... and a GitHub actions CI job that runs the tests with instrumentation and then submits the report to [Codecov](https://codecov.io/).

The workflow is as described [here](https://github.com/aantron/bisect_ppx#dune). I picked Codecov as a report viewer fairly randomly; we could also go with Coveralls with a small change. Our first coverage report is [here](https://codecov.io/gh/mirage/irmin/tree/1a8a492ff59ac63402bf4d7630a486813dec5934).

Note on authentication: Codecov provides a secret token that can be used to submit coverage reports securely, but this is not necessary when uploading from a small number of whitelisted CI providers including GitHub Actions (see [docs](https://docs.codecov.com/docs/frequently-asked-questions#where-is-the-repository-upload-token-found)). This is fortunate because there is no secure way to give GitHub _forks_ secure access to the secrets for a repository. If we ever port this workflow to OCaml-CI, we'll need to revisit this.