### PR TITLE
irmin-test: guard `Random.self_init` behind run

### DIFF
--- a/src/irmin-test/common.ml
+++ b/src/irmin-test/common.ml
@@ -16,7 +16,6 @@
 
 open! Import
 
-let () = Random.self_init ()
 let random_char () = char_of_int (Random.int 256)
 
 let random_ascii () =

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -75,6 +75,7 @@ module Store : sig
   val run :
     string ->
     ?slow:bool ->
+    ?random_seed:int ->
     misc:unit Alcotest.test list ->
     (Alcotest.speed_level * Suite.t) list ->
     unit

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2143,7 +2143,12 @@ let layered_suite (speed, x) =
         @ when_ x.import_supported
             [ ("Basic operations on slices", speed, T.test_slice ~hook x) ] )
 
-let run name ?(slow = false) ~misc tl =
+let run name ?(slow = false) ?random_seed ~misc tl =
+  let () =
+    match random_seed with
+    | Some x -> Random.init x
+    | None -> Random.self_init ()
+  in
   Printexc.record_backtrace true;
   (* Ensure that failures occuring in async lwt threads are raised. *)
   (Lwt.async_exception_hook := fun exn -> raise exn);

--- a/src/irmin-test/store.mli
+++ b/src/irmin-test/store.mli
@@ -17,6 +17,7 @@
 val run :
   string ->
   ?slow:bool ->
+  ?random_seed:int ->
   misc:unit Alcotest.test list ->
   (Alcotest.speed_level * Common.t) list ->
   unit


### PR DESCRIPTION
This ensures that libraries that happen to link against `irmin-test` don't have their random state altered during initialisation.

Fix https://github.com/mirage/irmin/issues/1585.