### PR TITLE
Run code coverage on pushes to the `main` branch too

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: coverage
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   schedule:
     # Prime the caches every Monday


### PR DESCRIPTION
This is necessary to get coverage results for the merge commits of PRs that were not fully rebased against `main` when merging (so no fast-forward merge was performed), so that Codecov has baseline coverage information to compare against when computing diffs for PRs.