### PR TITLE
Add libirmin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,10 @@
   - Add a new package to mirror Tezos `tezos-context.encoding` library.
     That'll simplify building benchmarks and custom tools (#1579, @samoht)
 
+- **libirmin**
+  - Create `libirmin` package providing a C interface to the irmin API
+    (#1713, @zshipko)
+
 ### Changed
 
 - **irmin**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@
     side-effect of this update is that the `remote` function now returns an Lwt
     promise. (#1778, @zshipko)
 
+### Added
+
+- **libirmin**
+  - Create `libirmin` package providing a C interface to the irmin API
+    (#1713, @zshipko)
+
 ## 3.0.0 (2022-02-11)
 
 ### Fixed
@@ -87,10 +93,6 @@
 - **irmin-tezos**
   - Add a new package to mirror Tezos `tezos-context.encoding` library.
     That'll simplify building benchmarks and custom tools (#1579, @samoht)
-
-- **libirmin**
-  - Create `libirmin` package providing a C interface to the irmin API
-    (#1713, @zshipko)
 
 ### Changed
 

--- a/README_LIBIRMIN.md
+++ b/README_LIBIRMIN.md
@@ -1,0 +1,173 @@
+# libirmin
+
+`libirmin` provides C bindings to the irmin API.
+
+## Installation
+
+To install from the root of this repo:
+
+```
+$ opam pin add libirmin .
+```
+
+After installing `libirmin.so` can be found in `$OPAM_SWITCH_PREFIX/libirmin/lib`
+and `irmin.h` will be in `$OPAM_SWITCH_PREFIX/libirmin/include`
+
+This means when compiling programs that use `libirmin` you will need to include those
+directories:
+
+```
+$ export IRMIN_CFLAGS=-I$OPAM_SWITCH_PREFIX/libirmin/include
+$ export IRMIN_LDFLAGS=-L$OPAM_SWITCH_PREFIX/libirmin/lib -lirmin
+$ cc $IRMIN_CFLAGS my-program.c -o my-program $IRMIN_LDFLAGS
+```
+
+## Usage examples
+
+### Opening a store
+
+The first thing you will need to do is configure a backend:
+
+Using `irmin-git`:
+
+```c
+IrminConfig *config = irmin_config_git("string");
+if (config == NULL){
+  // Print error message
+  IrminString *err = irmin_error_msg();
+  fputs(irmin_string_data(err), stderr);
+  irmin_string_free(err);
+}
+```
+
+When using `irmin-mem`, `irmin-fs` or `irmin-pack` you can specify the hash type
+in addition to the content type:
+
+```c
+IrminConfig *config = irmin_config_mem("sha256", "string");
+```
+
+Available backends: `irmin_config_mem`, `irmin_config_git`, `irmin_config_git_mem`, `irmin_config_fs`,
+`irmin_config_pack`, `irmin_config_tezos`
+
+If `NULL` is passed for the content parameter then `string` will be used by default and
+when `NULL` is passed for the hash argument `blake2b` is used.
+
+Available content types: `string`, `json` (JSON objects), `json-value` (any JSON value)
+Available hash types: `blake2b`, `blake2s`, `rmd160`, `sha1`, `sha224`, `sha256`, `sha384`,
+`sha512`, `tezos`
+
+The `IrminConfig*` value should eventually be freed using `irmin_config_free`.
+
+When using a backend that stores information on disk, you will probably want to set the `root` parameter:
+
+```c
+assert(irmin_config_set_root(config, "path/to/store"));
+```
+
+Next you can initialize the repo:
+
+```c
+IrminRepo *repo = irmin_repo_new(config);
+if (repo == NULL){
+  // handle error
+}
+```
+
+From there you can create a store using the main branch:
+
+```c
+Irmin *store = irmin_main(repo);
+```
+
+Or from your branch of choice:
+
+```c
+Irmin *store = irmin_of_branch(repo, "my-branch");
+```
+
+### Cleanup
+
+Every `IrminX` type should be released using the matching `irmin_X_free` function:
+
+```c
+irmin_free(store);
+irmin_repo_free(repo);
+irmin_config_free(config);
+```
+
+### Setting values
+
+Setting a value when using string contents:
+
+```c
+IrminString *value = irmin_string_new("Hello, world!", -1);
+IrminPath *path = irmin_path_of_string(repo, "a/b/c");
+IrminInfo *info = irmin_info_new(repo, "author", "commit message");
+assert(irmin_set(store, path, (IrminContents*)value, info));
+irmin_info_free(info);
+irmin_path_free(path);
+irmin_string_free(value);
+```
+
+The `-1` argument to `irmin_string_new` is used to pass the length of
+the string. If it ends with a NULL byte then passing `-1` will auto-
+matically detect the string length. This also shows that `IrminString`
+can be cast to `IrminContents` safely when using `string` contents.
+
+When using `json` contents:
+
+```c
+IrminType *t = irmin_type_json();
+IrminContents *value = irmin_contents_of_string(t, "{\"foo\": \"bar\"}", -1);
+IrminPath *path = irmin_path_of_string(repo, "a/b/c");
+IrminInfo *info = irmin_info_new(repo, "author", "commit message");
+assert(irmin_set(store, path, value, info));
+irmin_info_free(info);
+irmin_path_free(path);
+irmin_contents_free(value);
+irmin_type_free(t);
+```
+
+### Getting values
+
+The following will get the value associated with a path and print its string
+representation to stdout:
+
+```c
+IrminPath *path = irmin_path_of_string(repo, "a/b/c");
+IrminContents *value = irmin_find(store, path);
+if (value != NULL){
+  // value exists, print it to stdout
+  IrminString *s = irmin_contents_to_string(repo, value);
+  puts(irmin_string_data(s));
+  irmin_string_free(s);
+  irmin_contents_free(value);
+}
+irmin_path_free(path);
+```
+
+### Trees
+
+Working with trees is similar to working with stores, only you will be using the
+`irmin_tree_X` functions:
+
+```c
+IrminTree *tree = irmin_tree_new(repo);
+IrminString *value = irmin_string_new("Hello, world!", -1);
+IrminPath *path = irmin_path_of_string(repo, "a/b/c");
+assert(irmin_tree_add(tree, path, value, NULL); // The NULL parameter here is for
+                                                // metadata and will typically be
+                                                // NULL
+
+IrminPath *empty_path = irmin_path_empty();
+IrminInfo *info = irmin_info_new(repo, "author", "commit message");
+irmin_set_tree(store, empty_path, tree, info);
+
+irmin_string_free(value);
+irmin_path_free(path);
+irmin_path_free(empty_path);
+irmin_info_free(info);
+irmin_tree_free(tree);
+```
+

--- a/libirmin.opam
+++ b/libirmin.opam
@@ -27,3 +27,5 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
+
+available: [ arch != "arm64" ] # disabled because of SEGFAULT

--- a/libirmin.opam
+++ b/libirmin.opam
@@ -7,7 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
-  "dune" {> "2.0"}
+  "dune" {> "2.7"}
   "ctypes" {>= "0.19"}
   "ctypes-foreign" {>= "0.18"}
   "irmin-unix" {= version}

--- a/libirmin.opam
+++ b/libirmin.opam
@@ -7,7 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
-  "dune" {> "2.7"}
+  "dune" {>= "2.9"}
   "ctypes" {>= "0.19"}
   "ctypes-foreign" {>= "0.18"}
   "irmin-unix" {= version}

--- a/libirmin.opam
+++ b/libirmin.opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "C bindings for irmin"
+description: "C bindings for irmin using Ctypes inverted stubs"
+maintainer: ["zachshipko@gmail.com"]
+authors: ["Zach Shipko"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {> "2.0"}
+  "ctypes" {>= "0.19"}
+  "ctypes-foreign" {>= "0.18"}
+  "irmin-unix" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"

--- a/src/libirmin/commit.ml
+++ b/src/libirmin/commit.ml
@@ -5,7 +5,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "commit_info"
       (repo @-> commit @-> returning info)
       (fun (type repo) repo commit ->
-        catch' (fun () ->
+        catch' info (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -16,7 +16,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "commit_hash"
       (repo @-> commit @-> returning hash)
       (fun (type repo) repo commit ->
-        catch' (fun () ->
+        catch' hash (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -27,7 +27,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "commit_key"
       (repo @-> commit @-> returning commit_key)
       (fun (type repo) repo commit ->
-        catch' (fun () ->
+        catch' commit_key (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -38,37 +38,37 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "commit_of_hash"
       (repo @-> hash @-> returning commit)
       (fun (type repo) repo hash ->
-        catch' (fun () ->
+        catch' commit (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), repo
                 =
               Root.get_repo repo
             in
             let hash = Root.get_hash (module Store) hash in
-            let commit = run (Store.Commit.of_hash repo hash) in
-            match commit with
+            let c = run (Store.Commit.of_hash repo hash) in
+            match c with
             | Some c -> Root.create_commit (module Store) c
-            | None -> null))
+            | None -> null commit))
 
   let () =
     fn "commit_of_key"
       (repo @-> commit_key @-> returning commit)
       (fun (type repo) repo hash ->
-        catch' (fun () ->
+        catch' commit (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), repo
                 =
               Root.get_repo repo
             in
             let hash = Root.get_commit_key (module Store) hash in
-            let commit = run (Store.Commit.of_key repo hash) in
-            match commit with
+            let c = run (Store.Commit.of_key repo hash) in
+            match c with
             | Some c -> Root.create_commit (module Store) c
-            | None -> null))
+            | None -> null commit))
 
   let () =
     fn "commit_new"
       (repo @-> ptr commit @-> uint64_t @-> tree @-> info @-> returning commit)
       (fun (type repo) repo parents n tree info ->
-        catch' (fun () ->
+        catch' commit (fun () ->
             let n = UInt64.to_int n in
             let (module Store : Irmin.Generic_key.S with type repo = repo), repo
                 =
@@ -91,7 +91,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "commit_parents"
       (repo @-> commit @-> returning commit_list)
       (fun (type repo) repo commit ->
-        catch' (fun () ->
+        catch' commit_list (fun () ->
             let open Lwt.Infix in
             let (module Store : Irmin.Generic_key.S with type repo = repo), repo
                 =

--- a/src/libirmin/commit.ml
+++ b/src/libirmin/commit.ml
@@ -1,0 +1,128 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "commit_info"
+      (repo @-> commit @-> returning info)
+      (fun (type repo) repo commit ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let commit = Root.get_commit (module Store) commit in
+            Root.create_info (module Store) (Store.Commit.info commit)))
+
+  let () =
+    fn "commit_hash"
+      (repo @-> commit @-> returning hash)
+      (fun (type repo) repo commit ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let commit = Root.get_commit (module Store) commit in
+            Root.create_hash (module Store) (Store.Commit.hash commit)))
+
+  let () =
+    fn "commit_key"
+      (repo @-> commit @-> returning commit_key)
+      (fun (type repo) repo commit ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let commit = Root.get_commit (module Store) commit in
+            Root.create_commit_key (module Store) (Store.Commit.key commit)))
+
+  let () =
+    fn "commit_of_hash"
+      (repo @-> hash @-> returning commit)
+      (fun (type repo) repo hash ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let hash = Root.get_hash (module Store) hash in
+            let commit = run (Store.Commit.of_hash repo hash) in
+            match commit with
+            | Some c -> Root.create_commit (module Store) c
+            | None -> null))
+
+  let () =
+    fn "commit_of_key"
+      (repo @-> commit_key @-> returning commit)
+      (fun (type repo) repo hash ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let hash = Root.get_commit_key (module Store) hash in
+            let commit = run (Store.Commit.of_key repo hash) in
+            match commit with
+            | Some c -> Root.create_commit (module Store) c
+            | None -> null))
+
+  let () =
+    fn "commit_new"
+      (repo @-> ptr commit @-> uint64_t @-> tree @-> info @-> returning commit)
+      (fun (type repo) repo parents n tree info ->
+        catch' (fun () ->
+            let n = UInt64.to_int n in
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let parents =
+              if is_null parents || n = 0 then []
+              else
+                CArray.from_ptr parents n
+                |> CArray.to_list
+                |> List.map (Root.get_commit (module Store))
+                |> List.map Store.Commit.key
+            in
+            let tree = Root.get_tree (module Store) tree in
+            let info = Root.get_info (module Store) info in
+            let commit = run (Store.Commit.v repo ~parents ~info tree) in
+            Root.create_commit (module Store) commit))
+
+  let () =
+    fn "commit_parents"
+      (repo @-> commit @-> returning commit_list)
+      (fun (type repo) repo commit ->
+        catch' (fun () ->
+            let open Lwt.Infix in
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let commit = Root.get_commit (module Store) commit in
+            let parents = Store.Commit.parents commit in
+            let parents =
+              run
+                (Lwt_list.filter_map_s
+                   (fun x ->
+                     Store.Commit.of_key repo x >|= function
+                     | None -> None
+                     | Some x -> Some x)
+                   parents)
+            in
+            Root.create_commit_list (module Store) parents))
+
+  let () =
+    fn "commit_equal"
+      (repo @-> commit @-> commit @-> returning bool)
+      (fun (type repo) repo a b ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let a = Root.get_commit (module Store) a in
+            let b = Root.get_commit (module Store) b in
+            Irmin.Type.(unstage (equal (Store.commit_t repo))) a b))
+
+  let () = fn "commit_free" (commit @-> returning void) free
+  let () = fn "commit_key_free" (commit_key @-> returning void) free
+end

--- a/src/libirmin/commit.ml
+++ b/src/libirmin/commit.ml
@@ -133,7 +133,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
           (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let i = UInt64.to_int i in
             let arr = Root.get_commit_array (module Store) p in
-            if i >= Array.length arr then null commit
+            if i >= Array.length arr then failwith "index out of bounds"
             else
               let x = Array.unsafe_get arr i in
               Root.create_commit (module Store) x))

--- a/src/libirmin/config.ml
+++ b/src/libirmin/config.ml
@@ -21,7 +21,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun () ->
         match !Util.error_msg with
         | Some s -> Root.create_string s
-        | None -> null)
+        | None -> null irmin_string)
 
   let () =
     fn "error_msg_is_set"
@@ -32,7 +32,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_pack"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
-        catch' (fun () ->
+        catch' config (fun () ->
             let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
             let c : config =
               Irmin_unix.Resolver.load_config ~store:"pack" ?hash ?contents ()
@@ -43,7 +43,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_tezos"
       (void @-> returning config)
       (fun () ->
-        catch' (fun () ->
+        catch' config (fun () ->
             let c : config =
               Irmin_unix.Resolver.load_config ~store:"tezos" ()
             in
@@ -53,7 +53,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_git"
       (string_opt @-> returning config)
       (fun contents ->
-        catch' (fun () ->
+        catch' config (fun () ->
             let c = Irmin_unix.Resolver.load_config ~store:"git" ?contents () in
             Root.create_config c))
 
@@ -61,7 +61,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_git_mem"
       (string_opt @-> returning config)
       (fun contents ->
-        catch' (fun () ->
+        catch' config (fun () ->
             let c =
               Irmin_unix.Resolver.load_config ~store:"git-mem" ?contents ()
             in
@@ -71,7 +71,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_fs"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
-        catch' (fun () ->
+        catch' config (fun () ->
             let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
             let c =
               Irmin_unix.Resolver.load_config ~store:"irf" ?hash ?contents ()
@@ -82,7 +82,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_mem"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
-        catch' (fun () ->
+        catch' config (fun () ->
             let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
             let c =
               Irmin_unix.Resolver.load_config ~store:"mem" ?hash ?contents ()

--- a/src/libirmin/config.ml
+++ b/src/libirmin/config.ml
@@ -3,91 +3,87 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "log_level"
-      (string_opt @-> returning void)
+      (string_opt @-> returning bool)
       (fun level ->
-        catch () (fun () ->
-            match level with
-            | None -> Logs.set_level None
-            | Some level -> (
-                Fmt_tty.setup_std_outputs ();
-                Logs.set_reporter (Logs_fmt.reporter ());
-                match Logs.level_of_string level with
-                | Error _ -> ()
-                | Ok level -> Logs.set_level level)))
-
-  let () =
-    fn "error_msg"
-      (void @-> returning irmin_string)
-      (fun () ->
-        match !Util.error_msg with
-        | Some s -> Root.create_string s
-        | None -> null irmin_string)
-
-  let () =
-    fn "error_msg_is_set"
-      (void @-> returning bool)
-      (fun () -> match !Util.error_msg with Some _ -> true | None -> false)
+        try
+          match level with
+          | None ->
+              Logs.set_level None;
+              true
+          | Some level -> (
+              Fmt_tty.setup_std_outputs ();
+              Logs.set_reporter (Logs_fmt.reporter ());
+              match Logs.level_of_string level with
+              | Error _ -> false
+              | Ok level ->
+                  Logs.set_level level;
+                  true)
+        with _ -> false)
 
   let () =
     fn "config_pack"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
-        catch' config (fun () ->
-            let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
-            let c : config =
-              Irmin_unix.Resolver.load_config ~store:"pack" ?hash ?contents ()
-            in
-            Root.create_config c))
+        try
+          let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
+          let c : config =
+            Irmin_unix.Resolver.load_config ~store:"pack" ?hash ?contents ()
+          in
+          Root.create_config c
+        with _ -> null config)
 
   let () =
     fn "config_tezos"
       (void @-> returning config)
       (fun () ->
-        catch' config (fun () ->
-            let c : config =
-              Irmin_unix.Resolver.load_config ~store:"tezos" ()
-            in
-            Root.create_config c))
+        try
+          let c : config = Irmin_unix.Resolver.load_config ~store:"tezos" () in
+          Root.create_config c
+        with _ -> null config)
 
   let () =
     fn "config_git"
       (string_opt @-> returning config)
       (fun contents ->
-        catch' config (fun () ->
-            let c = Irmin_unix.Resolver.load_config ~store:"git" ?contents () in
-            Root.create_config c))
+        try
+          let c = Irmin_unix.Resolver.load_config ~store:"git" ?contents () in
+          Root.create_config c
+        with _ -> null config)
 
   let () =
     fn "config_git_mem"
       (string_opt @-> returning config)
       (fun contents ->
-        catch' config (fun () ->
-            let c =
-              Irmin_unix.Resolver.load_config ~store:"git-mem" ?contents ()
-            in
-            Root.create_config c))
+        try
+          let c =
+            Irmin_unix.Resolver.load_config ~store:"git-mem" ?contents ()
+          in
+          Root.create_config c
+        with _ -> null config)
 
   let () =
     fn "config_fs"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
-        catch' config (fun () ->
-            let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
-            let c =
-              Irmin_unix.Resolver.load_config ~store:"irf" ?hash ?contents ()
-            in
-            Root.create_config c))
+        try
+          let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
+          let c =
+            Irmin_unix.Resolver.load_config ~store:"irf" ?hash ?contents ()
+          in
+          Root.create_config c
+        with _ -> null config)
 
   let () =
     fn "config_mem"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
-        catch' config (fun () ->
-            let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
-            let c =
-              Irmin_unix.Resolver.load_config ~store:"mem" ?hash ?contents ()
-            in
-            Root.create_config c))
+        try
+          let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
+          let c =
+            Irmin_unix.Resolver.load_config ~store:"mem" ?hash ?contents ()
+          in
+          Root.create_config c
+        with _ -> null config)
 
   let () = fn "config_free" (config @-> returning void) free
 
@@ -95,42 +91,44 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_set"
       (config @-> string @-> ty @-> value @-> returning bool)
       (fun (type a) c key ty value ->
-        catch false (fun () ->
-            let (s, config) : config = Root.get_config c in
-            let (module S) = Irmin_unix.Resolver.Store.generic_keyed s in
-            let k = find_config_key config key in
-            let ok, config =
-              match k with
-              | None -> (false, config)
-              | Some (Irmin.Backend.Conf.K k) ->
-                  let t : a Irmin.Type.t = Root.get_ty ty in
-                  if type_name t <> type_name (Irmin.Backend.Conf.ty k) then
-                    (false, config)
-                  else
-                    let value = Root.get_value value in
-                    (true, Irmin.Backend.Conf.add config k value)
-            in
-            Root.set_config c (s, config);
-            ok))
+        try
+          let (s, config) : config = Root.get_config c in
+          let (module S) = Irmin_unix.Resolver.Store.generic_keyed s in
+          let k = find_config_key config key in
+          let ok, config =
+            match k with
+            | None -> (false, config)
+            | Some (Irmin.Backend.Conf.K k) ->
+                let t : a Irmin.Type.t = Root.get_ty ty in
+                if type_name t <> type_name (Irmin.Backend.Conf.ty k) then
+                  (false, config)
+                else
+                  let value = Root.get_value value in
+                  (true, Irmin.Backend.Conf.add config k value)
+          in
+          Root.set_config c (s, config);
+          ok
+        with _ -> false)
 
   let () =
     fn "config_set_root"
       (config @-> string @-> returning bool)
       (fun c path ->
-        catch false (fun () ->
-            let (s, config) : config = Root.get_config c in
-            let (module S) = Irmin_unix.Resolver.Store.generic_keyed s in
-            let k = find_config_key config "root" in
-            let ok, config =
-              match k with
-              | None -> (false, config)
-              | Some (Irmin.Backend.Conf.K k) ->
-                  let path =
-                    Irmin.Type.of_string (Irmin.Backend.Conf.ty k) path
-                    |> Result.get_ok
-                  in
-                  (true, Irmin.Backend.Conf.add config k path)
-            in
-            Root.set_config c (s, config);
-            ok))
+        try
+          let (s, config) : config = Root.get_config c in
+          let (module S) = Irmin_unix.Resolver.Store.generic_keyed s in
+          let k = find_config_key config "root" in
+          let ok, config =
+            match k with
+            | None -> (false, config)
+            | Some (Irmin.Backend.Conf.K k) ->
+                let path =
+                  Irmin.Type.of_string (Irmin.Backend.Conf.ty k) path
+                  |> Result.get_ok
+                in
+                (true, Irmin.Backend.Conf.add config k path)
+          in
+          Root.set_config c (s, config);
+          ok
+        with _ -> false)
 end

--- a/src/libirmin/config.ml
+++ b/src/libirmin/config.ml
@@ -112,4 +112,25 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             in
             Root.set_config c (s, config);
             ok))
+
+  let () =
+    fn "config_set_root"
+      (config @-> string @-> returning bool)
+      (fun c path ->
+        catch false (fun () ->
+            let (s, config) : config = Root.get_config c in
+            let (module S) = Irmin_unix.Resolver.Store.generic_keyed s in
+            let k = find_config_key config "root" in
+            let ok, config =
+              match k with
+              | None -> (false, config)
+              | Some (Irmin.Backend.Conf.K k) ->
+                  let path =
+                    Irmin.Type.of_string (Irmin.Backend.Conf.ty k) path
+                    |> Result.get_ok
+                  in
+                  (true, Irmin.Backend.Conf.add config k path)
+            in
+            Root.set_config c (s, config);
+            ok))
 end

--- a/src/libirmin/config.ml
+++ b/src/libirmin/config.ml
@@ -1,0 +1,115 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "log_level"
+      (string_opt @-> returning void)
+      (fun level ->
+        catch () (fun () ->
+            match level with
+            | None -> Logs.set_level None
+            | Some level -> (
+                Fmt_tty.setup_std_outputs ();
+                Logs.set_reporter (Logs_fmt.reporter ());
+                match Logs.level_of_string level with
+                | Error _ -> ()
+                | Ok level -> Logs.set_level level)))
+
+  let () =
+    fn "error_msg"
+      (void @-> returning irmin_string)
+      (fun () ->
+        match !Util.error_msg with
+        | Some s -> Root.create_string s
+        | None -> null)
+
+  let () =
+    fn "error_msg_is_set"
+      (void @-> returning bool)
+      (fun () -> match !Util.error_msg with Some _ -> true | None -> false)
+
+  let () =
+    fn "config_pack"
+      (string_opt @-> string_opt @-> returning config)
+      (fun hash contents ->
+        catch' (fun () ->
+            let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
+            let c : config =
+              Irmin_unix.Resolver.load_config ~store:"pack" ?hash ?contents ()
+            in
+            Root.create_config c))
+
+  let () =
+    fn "config_tezos"
+      (void @-> returning config)
+      (fun () ->
+        catch' (fun () ->
+            let c : config =
+              Irmin_unix.Resolver.load_config ~store:"tezos" ()
+            in
+            Root.create_config c))
+
+  let () =
+    fn "config_git"
+      (string_opt @-> returning config)
+      (fun contents ->
+        catch' (fun () ->
+            let c = Irmin_unix.Resolver.load_config ~store:"git" ?contents () in
+            Root.create_config c))
+
+  let () =
+    fn "config_git_mem"
+      (string_opt @-> returning config)
+      (fun contents ->
+        catch' (fun () ->
+            let c =
+              Irmin_unix.Resolver.load_config ~store:"git-mem" ?contents ()
+            in
+            Root.create_config c))
+
+  let () =
+    fn "config_fs"
+      (string_opt @-> string_opt @-> returning config)
+      (fun hash contents ->
+        catch' (fun () ->
+            let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
+            let c =
+              Irmin_unix.Resolver.load_config ~store:"irf" ?hash ?contents ()
+            in
+            Root.create_config c))
+
+  let () =
+    fn "config_mem"
+      (string_opt @-> string_opt @-> returning config)
+      (fun hash contents ->
+        catch' (fun () ->
+            let hash = Option.map Irmin_unix.Resolver.Hash.find hash in
+            let c =
+              Irmin_unix.Resolver.load_config ~store:"mem" ?hash ?contents ()
+            in
+            Root.create_config c))
+
+  let () = fn "config_free" (config @-> returning void) free
+
+  let () =
+    fn "config_set"
+      (config @-> string @-> ty @-> value @-> returning bool)
+      (fun (type a) c key ty value ->
+        catch false (fun () ->
+            let (s, config) : config = Root.get_config c in
+            let (module S) = Irmin_unix.Resolver.Store.generic_keyed s in
+            let k = find_config_key config key in
+            let ok, config =
+              match k with
+              | None -> (false, config)
+              | Some (Irmin.Backend.Conf.K k) ->
+                  let t : a Irmin.Type.t = Root.get_ty ty in
+                  if type_name t <> type_name (Irmin.Backend.Conf.ty k) then
+                    (false, config)
+                  else
+                    let value = Root.get_value value in
+                    (true, Irmin.Backend.Conf.add config k value)
+            in
+            Root.set_config c (s, config);
+            ok))
+end

--- a/src/libirmin/dune
+++ b/src/libirmin/dune
@@ -1,3 +1,5 @@
 (library
  (name libirmin_bindings)
- (libraries irmin-unix ctypes.foreign))
+ (libraries irmin-unix ctypes.foreign)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/libirmin/dune
+++ b/src/libirmin/dune
@@ -1,0 +1,3 @@
+(library
+ (name libirmin_bindings)
+ (libraries irmin-unix ctypes.foreign))

--- a/src/libirmin/gen/dune
+++ b/src/libirmin/gen/dune
@@ -1,0 +1,4 @@
+(executable
+ (name generate)
+ (modules generate)
+ (libraries libirmin_bindings))

--- a/src/libirmin/gen/generate.ml
+++ b/src/libirmin/gen/generate.ml
@@ -44,6 +44,7 @@ __attribute__((section(".init_array"))) void (* p_irmin_init)(int,char*[],char*[
       "IrminType";
       "IrminValue";
       "IrminMetadata";
+      "IrminContents";
       "IrminConfig";
       "IrminRepo";
       "Irmin";

--- a/src/libirmin/gen/generate.ml
+++ b/src/libirmin/gen/generate.ml
@@ -68,8 +68,10 @@ __attribute__((section(".init_array"))) void (* p_irmin_init)(int,char*[],char*[
     ~prefix stubs;
   writeln h_fd
     {|
+#ifndef IRMIN_NO_AUTO
 static void _irmin_cleanup(void *p) { if (p) { irmin_free(*(Irmin**)p); p = (void*)0;} };
 #define AUTO __attribute__((cleanup(_irmin_cleanup)))
+#endif
     |};
 
   close_out h_fd;

--- a/src/libirmin/gen/generate.ml
+++ b/src/libirmin/gen/generate.ml
@@ -59,6 +59,7 @@ __attribute__((section(".init_array"))) void (*p_irmin_init)(void) = irmin_init;
       "IrminPathArray";
       "IrminCommitArray";
       "IrminBranchArray";
+      "IrminRemote";
     ];
   writeln h_fd "void caml_startup(char *argv[]);";
   writeln h_fd "void caml_shutdown();";

--- a/src/libirmin/gen/generate.ml
+++ b/src/libirmin/gen/generate.ml
@@ -22,15 +22,18 @@ let generate dirname =
     stubs;
   writeln c_fd
     {|
+#ifndef IRMIN_NO_INIT
+#ifdef __APPLE__
 void irmin_init(int argc, char* argv[], char* envp[]){
   caml_startup(argv);
 }
-
-#ifndef IRMIN_NO_INIT
-#ifdef __APPLE__
 __attribute__((section("__DATA,__mod_init_func"))) typeof(irmin_init) *__init = irmin_init;
 #else
-__attribute__((section(".init_array"))) void (* p_irmin_init)(int,char*[],char*[]) = &irmin_init;
+static char *_libirmin_args[] = {"libirmin", NULL};
+void irmin_init(void){
+  caml_startup(_libirmin_args);
+}
+void (*p_irmin_init)(void) __attribute__((section(".init_array"))) = irmin_init;
 #endif
 #endif
     |};

--- a/src/libirmin/gen/generate.ml
+++ b/src/libirmin/gen/generate.ml
@@ -1,0 +1,78 @@
+let generate dirname =
+  let prefix = "irmin" in
+  let path basename = Filename.concat dirname basename in
+  let ml_fd = open_out (path "irmin_bindings.ml") in
+  let c_fd = open_out (path "irmin.c") in
+  let h_fd = open_out (path "irmin.h") in
+  let stubs = (module Libirmin_bindings.Stubs : Cstubs_inverted.BINDINGS) in
+  let writeln fd s = output_string fd (s ^ "\n") in
+  let types fd names =
+    List.iter
+      (fun n -> writeln fd (Printf.sprintf "typedef struct %s %s;" n n))
+      names
+  in
+  (* Generate the ML module that links in the generated C. *)
+  Cstubs_inverted.write_ml (Format.formatter_of_out_channel ml_fd) ~prefix stubs;
+
+  (* Generate the C source file that exports OCaml functions. *)
+  Format.fprintf
+    (Format.formatter_of_out_channel c_fd)
+    "#include \"irmin.h\"@\n%a"
+    (Cstubs_inverted.write_c ~prefix)
+    stubs;
+  writeln c_fd
+    {|
+void irmin_init(int argc, char* argv[], char* envp[]){
+  caml_startup(argv);
+}
+
+#ifndef IRMIN_NO_INIT
+#ifdef __APPLE__
+__attribute__((section("__DATA,__mod_init_func"))) typeof(irmin_init) *__init = irmin_init;
+#else
+__attribute__((section(".init_array"))) void (* p_irmin_init)(int,char*[],char*[]) = &irmin_init;
+#endif
+#endif
+    |};
+
+  (* Generate the C header file that exports OCaml functions. *)
+  writeln h_fd "#pragma once";
+  writeln h_fd "#include <stdbool.h>";
+  writeln h_fd "#include <stdint.h>";
+  types h_fd
+    [
+      "IrminType";
+      "IrminValue";
+      "IrminMetadata";
+      "IrminConfig";
+      "IrminRepo";
+      "Irmin";
+      "IrminPath";
+      "IrminCommitKey";
+      "IrminKindedKey";
+      "IrminTree";
+      "IrminCommit";
+      "IrminInfo";
+      "IrminHash";
+      "IrminString";
+      "IrminPathList";
+      "IrminCommitList";
+      "IrminBranchList";
+    ];
+  writeln h_fd "void caml_startup(char *argv[]);";
+  writeln h_fd "void caml_shutdown();";
+
+  Cstubs_inverted.write_c_header
+    (Format.formatter_of_out_channel h_fd)
+    ~prefix stubs;
+  writeln h_fd
+    {|
+static void _irmin_cleanup(void *p) { if (p) { irmin_free(*(Irmin**)p); p = (void*)0;} };
+#define AUTO __attribute__((cleanup(_irmin_cleanup)))
+    |};
+
+  close_out h_fd;
+  close_out c_fd;
+  close_out ml_fd
+
+let () = generate Sys.argv.(1)

--- a/src/libirmin/gen/generate.ml
+++ b/src/libirmin/gen/generate.ml
@@ -23,17 +23,14 @@ let generate dirname =
   writeln c_fd
     {|
 #ifndef IRMIN_NO_INIT
-#ifdef __APPLE__
-void irmin_init(int argc, char* argv[], char* envp[]){
-  caml_startup(argv);
-}
-__attribute__((section("__DATA,__mod_init_func"))) typeof(irmin_init) *__init = irmin_init;
-#else
 static char *_libirmin_args[] = {"libirmin", NULL};
 void irmin_init(void){
   caml_startup(_libirmin_args);
 }
-void (*p_irmin_init)(void) __attribute__((section(".init_array"))) = irmin_init;
+#ifdef __APPLE__
+__attribute__((section("__DATA,__mod_init_func"))) typeof(irmin_init) *p_irmin_init = irmin_init;
+#else
+__attribute__((section(".init_array"))) void (*p_irmin_init)(void) = irmin_init;
 #endif
 #endif
     |};
@@ -59,9 +56,9 @@ void (*p_irmin_init)(void) __attribute__((section(".init_array"))) = irmin_init;
       "IrminInfo";
       "IrminHash";
       "IrminString";
-      "IrminPathList";
-      "IrminCommitList";
-      "IrminBranchList";
+      "IrminPathArray";
+      "IrminCommitArray";
+      "IrminBranchArray";
     ];
   writeln h_fd "void caml_startup(char *argv[]);";
   writeln h_fd "void caml_shutdown();";

--- a/src/libirmin/info.ml
+++ b/src/libirmin/info.ml
@@ -5,7 +5,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_new"
       (repo @-> string_opt @-> string @-> returning info)
       (fun (type repo) repo author message ->
-        catch' (fun () ->
+        catch' info (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -28,7 +28,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_message"
       (repo @-> info @-> returning irmin_string)
       (fun (type repo) repo info ->
-        catch' (fun () ->
+        catch' irmin_string (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -40,7 +40,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_author"
       (repo @-> info @-> returning irmin_string)
       (fun (type repo) repo info ->
-        catch' (fun () ->
+        catch' irmin_string (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in

--- a/src/libirmin/info.ml
+++ b/src/libirmin/info.ml
@@ -5,10 +5,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_new"
       (repo @-> string_opt @-> string @-> returning info)
       (fun (type repo) repo author message ->
-        catch' info (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo info
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let module Info = Irmin_unix.Info (Store.Info) in
             let info : Info.t = Info.v ?author "%s" message () in
             Root.create_info (module Store) info))
@@ -17,10 +15,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_update"
       (repo @-> info @-> string_opt @-> string @-> returning void)
       (fun (type repo) repo info author message ->
-        catch () (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo repo ()
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let module Info = Irmin_unix.Info (Store.Info) in
             Root.set_info (module Store) info (Info.v ?author "%s" message ())))
 
@@ -28,10 +24,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_message"
       (repo @-> info @-> returning irmin_string)
       (fun (type repo) repo info ->
-        catch' irmin_string (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo irmin_string
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let info = Root.get_info (module Store) info in
             let s = Store.Info.message info in
             Root.create_string s))
@@ -40,10 +34,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_author"
       (repo @-> info @-> returning irmin_string)
       (fun (type repo) repo info ->
-        catch' irmin_string (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo irmin_string
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let info = Root.get_info (module Store) info in
             let s = Store.Info.author info in
             Root.create_string s))
@@ -52,10 +44,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "info_date"
       (repo @-> info @-> returning int64_t)
       (fun (type repo) repo info ->
-        catch (-1L) (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo repo (-1L)
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let info = Root.get_info (module Store) info in
             Store.Info.date info))
 

--- a/src/libirmin/info.ml
+++ b/src/libirmin/info.ml
@@ -1,0 +1,63 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "info_new"
+      (repo @-> string_opt @-> string @-> returning info)
+      (fun (type repo) repo author message ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let module Info = Irmin_unix.Info (Store.Info) in
+            let info : Info.t = Info.v ?author "%s" message () in
+            Root.create_info (module Store) info))
+
+  let () =
+    fn "info_update"
+      (repo @-> info @-> string_opt @-> string @-> returning void)
+      (fun (type repo) repo info author message ->
+        catch () (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let module Info = Irmin_unix.Info (Store.Info) in
+            Root.set_info (module Store) info (Info.v ?author "%s" message ())))
+
+  let () =
+    fn "info_message"
+      (repo @-> info @-> returning irmin_string)
+      (fun (type repo) repo info ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let info = Root.get_info (module Store) info in
+            let s = Store.Info.message info in
+            Root.create_string s))
+
+  let () =
+    fn "info_author"
+      (repo @-> info @-> returning irmin_string)
+      (fun (type repo) repo info ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let info = Root.get_info (module Store) info in
+            let s = Store.Info.author info in
+            Root.create_string s))
+
+  let () =
+    fn "info_date"
+      (repo @-> info @-> returning int64_t)
+      (fun (type repo) repo info ->
+        catch (-1L) (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let info = Root.get_info (module Store) info in
+            Store.Info.date info))
+
+  let () = fn "info_free" (info @-> returning void) free
+end

--- a/src/libirmin/lib/dune
+++ b/src/libirmin/lib/dune
@@ -11,16 +11,19 @@
  (public_name libirmin)
  (libraries libirmin_bindings)
  (modes
-  (native shared_object) native)
+  (native shared_object)
+  native)
  (modules libirmin irmin_bindings)
  (foreign_stubs
   (language c)
   (names irmin)))
 
 (install
-  (package libirmin)
-  (section lib)
-  (files (irmin.h as include/irmin.h) (libirmin.so as lib/libirmin.so)))
+ (package libirmin)
+ (section lib)
+ (files
+  (irmin.h as include/irmin.h)
+  (libirmin.so as lib/libirmin.so)))
 
 (env
  (dev

--- a/src/libirmin/lib/dune
+++ b/src/libirmin/lib/dune
@@ -1,0 +1,28 @@
+(rule
+ (targets irmin_bindings.ml irmin.c irmin.h)
+ (deps
+  (:gen ../gen/generate.exe))
+ (action
+  (run %{gen} .)))
+
+(executable
+ (name libirmin)
+ (package libirmin)
+ (public_name libirmin)
+ (libraries libirmin_bindings)
+ (modes
+  (native shared_object) native)
+ (modules libirmin irmin_bindings)
+ (foreign_stubs
+  (language c)
+  (names irmin)))
+
+(install
+  (package libirmin)
+  (section lib)
+  (files (irmin.h as include/irmin.h) (libirmin.so as lib/libirmin.so)))
+
+(env
+ (dev
+  (flags
+   (:standard -w -unused-var-strict))))

--- a/src/libirmin/lib/libirmin.ml
+++ b/src/libirmin/lib/libirmin.ml
@@ -1,0 +1,1 @@
+include Libirmin_bindings.Stubs (Irmin_bindings)

--- a/src/libirmin/libirmin_bindings.ml
+++ b/src/libirmin/libirmin_bindings.ml
@@ -1,0 +1,11 @@
+module Stubs (I : Cstubs_inverted.INTERNAL) = struct
+  include Type.Make (I)
+  include Value.Make (I)
+  include Info.Make (I)
+  include Config.Make (I)
+  include Store.Make (I)
+  include Tree.Make (I)
+  include Repo.Make (I)
+  include Commit.Make (I)
+  include Path.Make (I)
+end

--- a/src/libirmin/path.ml
+++ b/src/libirmin/path.ml
@@ -5,7 +5,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "path"
       (repo @-> ptr string_opt @-> returning path)
       (fun (type repo) repo arr ->
-        catch' (fun () ->
+        catch' path (fun () ->
             let rec loop i acc =
               if is_null arr then acc
               else
@@ -28,7 +28,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "path_of_string"
       (repo @-> ptr char @-> int64_t @-> returning path)
       (fun (type repo) repo s length ->
-        catch' (fun () ->
+        catch' path (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -38,13 +38,13 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             | Ok p -> Root.create_path (module Store) p
             | Error (`Msg e) ->
                 Util.error_msg := Some e;
-                null))
+                null path))
 
   let () =
     fn "path_empty"
       (repo @-> returning path)
       (fun (type repo) repo ->
-        catch' (fun () ->
+        catch' path (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -65,38 +65,38 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "path_parent"
       (repo @-> path @-> returning path)
       (fun (type repo) repo p ->
-        catch' (fun () ->
+        catch' path (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
-            let path = Root.get_path (module Store) p in
-            let path = Store.Path.rdecons path |> Option.map fst in
-            match path with
+            let p = Root.get_path (module Store) p in
+            let p = Store.Path.rdecons p |> Option.map fst in
+            match p with
             | Some p -> Root.create_path (module Store) p
-            | None -> null))
+            | None -> null path))
 
   let () =
     fn "path_append"
       (repo @-> path @-> ptr char @-> int64_t @-> returning path)
       (fun (type repo) repo p s length ->
-        catch' (fun () ->
+        catch' path (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
             let length = get_length length s in
-            let path = Root.get_path (module Store) p in
+            let p = Root.get_path (module Store) p in
             let s = string_from_ptr s ~length in
             match Irmin.Type.of_string Store.step_t s with
-            | Ok s -> Root.create_path (module Store) (Store.Path.rcons path s)
+            | Ok s -> Root.create_path (module Store) (Store.Path.rcons p s)
             | Error (`Msg e) ->
                 let () = Util.error_msg := Some e in
-                null))
+                null path))
 
   let () =
     fn "path_append_path"
       (repo @-> path @-> path @-> returning path)
       (fun (type repo) repo p s ->
-        catch' (fun () ->
+        catch' path (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in

--- a/src/libirmin/path.ml
+++ b/src/libirmin/path.ml
@@ -1,0 +1,126 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "path"
+      (repo @-> ptr string_opt @-> returning path)
+      (fun (type repo) repo arr ->
+        catch' (fun () ->
+            let rec loop i acc =
+              if is_null arr then acc
+              else
+                match !@(arr +@ i) with
+                | None -> List.rev acc
+                | Some x -> loop (i + 1) (x :: acc)
+            in
+            let l = loop 0 [] in
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let l =
+              List.map
+                (fun x -> Irmin.Type.of_string Store.step_t x |> Result.get_ok)
+                l
+            in
+            Store.Path.v l |> Root.create_path (module Store)))
+
+  let () =
+    fn "path_of_string"
+      (repo @-> ptr char @-> int64_t @-> returning path)
+      (fun (type repo) repo s length ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let length = get_length length s in
+            let s = string_from_ptr s ~length in
+            match Irmin.Type.of_string Store.Path.t s with
+            | Ok p -> Root.create_path (module Store) p
+            | Error (`Msg e) ->
+                Util.error_msg := Some e;
+                null))
+
+  let () =
+    fn "path_empty"
+      (repo @-> returning path)
+      (fun (type repo) repo ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            Root.create_path (module Store) Store.Path.empty))
+
+  let () =
+    fn "path_to_string"
+      (repo @-> path @-> returning irmin_string)
+      (fun (type repo) repo p ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let path = Root.get_path (module Store) p in
+        let s = Irmin.Type.to_string Store.Path.t path in
+        Root.create_string s)
+
+  let () =
+    fn "path_parent"
+      (repo @-> path @-> returning path)
+      (fun (type repo) repo p ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let path = Root.get_path (module Store) p in
+            let path = Store.Path.rdecons path |> Option.map fst in
+            match path with
+            | Some p -> Root.create_path (module Store) p
+            | None -> null))
+
+  let () =
+    fn "path_append"
+      (repo @-> path @-> ptr char @-> int64_t @-> returning path)
+      (fun (type repo) repo p s length ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let length = get_length length s in
+            let path = Root.get_path (module Store) p in
+            let s = string_from_ptr s ~length in
+            match Irmin.Type.of_string Store.step_t s with
+            | Ok s -> Root.create_path (module Store) (Store.Path.rcons path s)
+            | Error (`Msg e) ->
+                let () = Util.error_msg := Some e in
+                null))
+
+  let () =
+    fn "path_append_path"
+      (repo @-> path @-> path @-> returning path)
+      (fun (type repo) repo p s ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let rec concat_paths a b =
+              match Store.Path.decons b with
+              | Some (step, path) -> concat_paths (Store.Path.rcons a step) path
+              | None -> a
+            in
+            let path = Root.get_path (module Store) p in
+            let path' = Root.get_path (module Store) s in
+            let dest = concat_paths path path' in
+            Root.create_path (module Store) dest))
+
+  let () =
+    fn "path_equal"
+      (repo @-> path @-> path @-> returning bool)
+      (fun (type repo) repo a b ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let a = Root.get_path (module Store) a in
+            let b = Root.get_path (module Store) b in
+            Irmin.Type.(unstage (equal Store.path_t)) a b))
+
+  let () = fn "path_free" (path @-> returning void) free
+end

--- a/src/libirmin/repo.ml
+++ b/src/libirmin/repo.ml
@@ -5,24 +5,25 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "repo_new"
       (config @-> returning repo)
       (fun config ->
-        catch' repo (fun () ->
-            let (s, config) : config = Root.get_config config in
-            let (module Store) = Irmin_unix.Resolver.Store.generic_keyed s in
-            let repo : Store.repo = run (Store.Repo.v config) in
-            Root.create_repo
-              (module Store)
-              ( (module Store : Irmin.Generic_key.S with type repo = Store.repo),
-                repo )))
+        let (s, config) : config = Root.get_config config in
+        let (module Store) = Irmin_unix.Resolver.Store.generic_keyed s in
+        let repo : Store.repo = run (Store.Repo.v config) in
+        Root.create_repo
+          (module Store)
+          {
+            error = None;
+            repo_mod =
+              (module Store : Irmin.Generic_key.S with type repo = Store.repo);
+            repo;
+          })
 
   let () =
     fn "repo_branches"
       (repo @-> returning branch_array)
       (fun (type repo) repo ->
-        catch' branch_array (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
-                =
-              Root.get_repo repo
-            in
+        with_repo' repo branch_array
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
+          ->
             let b = run (Store.Repo.branches repo) in
             Root.create_branch_array (module Store) b))
 
@@ -30,10 +31,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "branch_array_length"
       (repo @-> branch_array @-> returning uint64_t)
       (fun (type repo) repo p ->
-        catch UInt64.zero (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo repo UInt64.zero
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let arr = Root.get_branch_array (module Store) p in
             UInt64.of_int (Array.length arr)))
 
@@ -41,24 +40,21 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "branch_array_get"
       (repo @-> branch_array @-> uint64_t @-> returning irmin_string)
       (fun (type repo) repo p i ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        let i = UInt64.to_int i in
-        let arr = Root.get_branch_array (module Store) p in
-        if i >= Array.length arr then null irmin_string
-        else
-          let x = Array.unsafe_get arr i in
-          Root.create_string (Irmin.Type.to_string Store.Branch.t x))
+        with_repo' repo irmin_string
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            let i = UInt64.to_int i in
+            let arr = Root.get_branch_array (module Store) p in
+            if i >= Array.length arr then null irmin_string
+            else
+              let x = Array.unsafe_get arr i in
+              Root.create_string (Irmin.Type.to_string Store.Branch.t x)))
 
   let () =
     fn "hash_equal"
       (repo @-> hash @-> hash @-> returning bool)
       (fun (type repo) repo a b ->
-        catch false (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo repo false
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let a = Root.get_hash (module Store) a in
             let b = Root.get_hash (module Store) b in
             Irmin.Type.(unstage (equal Store.hash_t)) a b))
@@ -67,10 +63,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "contents_hash"
       (repo @-> contents @-> returning hash)
       (fun (type repo) repo a ->
-        catch' hash (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo hash
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let a = Root.get_contents (module Store) a in
             Root.create_hash (module Store) (Store.Contents.hash a)))
 
@@ -78,11 +72,9 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "contents_of_hash"
       (repo @-> hash @-> returning contents)
       (fun (type repo) repo a ->
-        catch' contents (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
-                =
-              Root.get_repo repo
-            in
+        with_repo' repo contents
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
+          ->
             let a = Root.get_hash (module Store) a in
             let c = run @@ Store.Contents.of_hash repo a in
             match c with
@@ -93,11 +85,9 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "contents_of_key"
       (repo @-> kinded_key @-> returning contents)
       (fun (type repo) repo a ->
-        catch' contents (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
-                =
-              Root.get_repo repo
-            in
+        with_repo' repo contents
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
+          ->
             let a = Root.get_kinded_key (module Store) a in
             match a with
             | `Contents (a, _) -> (
@@ -111,10 +101,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "contents_to_string"
       (repo @-> contents @-> returning irmin_string)
       (fun (type repo) repo contents ->
-        catch' irmin_string (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo irmin_string
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let contents = Root.get_contents (module Store) contents in
             let s = Irmin.Type.to_string Store.contents_t contents in
             Root.create_string s))
@@ -123,27 +111,21 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "contents_of_string"
       (repo @-> ptr char @-> int64_t @-> returning contents)
       (fun (type repo) repo s length ->
-        catch' contents (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo contents
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let length = get_length length s in
             let s = string_from_ptr s ~length in
             let hash = Irmin.Type.of_string Store.contents_t s in
             match hash with
-            | Ok p -> Root.create_contents (module Store) p
-            | Error (`Msg e) ->
-                let () = Util.error_msg := Some e in
-                null contents))
+            | Ok hash -> Root.create_contents (module Store) hash
+            | Error (`Msg e) -> failwith e))
 
   let () =
     fn "hash_to_string"
       (repo @-> hash @-> returning irmin_string)
       (fun (type repo) repo hash ->
-        catch' irmin_string (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo irmin_string
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let hash = Root.get_hash (module Store) hash in
             let s = Irmin.Type.to_string Store.hash_t hash in
             Root.create_string s))
@@ -152,28 +134,38 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "hash_of_string"
       (repo @-> ptr char @-> int64_t @-> returning hash)
       (fun (type repo) repo s length ->
-        catch' hash (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo hash
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let length = get_length length s in
             let s = string_from_ptr s ~length in
             let h = Irmin.Type.of_string Store.Hash.t s in
             match h with
-            | Ok p -> Root.create_hash (module Store) p
-            | Error (`Msg e) ->
-                let () = Util.error_msg := Some e in
-                null hash))
+            | Ok h -> Root.create_hash (module Store) h
+            | Error (`Msg e) -> failwith e))
 
   let () =
     fn "metadata_default"
       (repo @-> returning metadata)
       (fun (type repo) repo ->
-        catch' metadata (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
+        with_repo' repo metadata
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             Root.create_metadata (module Store) Store.Metadata.default))
+
+  let () =
+    fn "repo_has_error"
+      (repo @-> returning bool)
+      (fun repo ->
+        let r = Root.get_repo repo in
+        Option.is_some r.error)
+
+  let () =
+    fn "repo_get_error"
+      (repo @-> returning irmin_string)
+      (fun repo ->
+        let r = Root.get_repo repo in
+        match r.error with
+        | Some x -> Root.create_string x
+        | None -> null irmin_string)
 
   let () = fn "hash_free" (hash @-> returning void) free
   let () = fn "branch_array_free" (branch_array @-> returning void) free

--- a/src/libirmin/repo.ml
+++ b/src/libirmin/repo.ml
@@ -16,36 +16,36 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "repo_branches"
-      (repo @-> returning branch_list)
+      (repo @-> returning branch_array)
       (fun (type repo) repo ->
-        catch' branch_list (fun () ->
+        catch' branch_array (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), repo
                 =
               Root.get_repo repo
             in
             let b = run (Store.Repo.branches repo) in
-            Root.create_branch_list (module Store) b))
+            Root.create_branch_array (module Store) b))
 
   let () =
-    fn "branch_list_length"
-      (repo @-> branch_list @-> returning uint64_t)
+    fn "branch_array_length"
+      (repo @-> branch_array @-> returning uint64_t)
       (fun (type repo) repo p ->
         catch UInt64.zero (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
-            let arr = Root.get_branch_list (module Store) p in
+            let arr = Root.get_branch_array (module Store) p in
             UInt64.of_int (Array.length arr)))
 
   let () =
-    fn "branch_list_get"
-      (repo @-> branch_list @-> uint64_t @-> returning irmin_string)
+    fn "branch_array_get"
+      (repo @-> branch_array @-> uint64_t @-> returning irmin_string)
       (fun (type repo) repo p i ->
         let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
           Root.get_repo repo
         in
         let i = UInt64.to_int i in
-        let arr = Root.get_branch_list (module Store) p in
+        let arr = Root.get_branch_array (module Store) p in
         if i >= Array.length arr then null irmin_string
         else
           let x = Array.unsafe_get arr i in
@@ -176,7 +176,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             Root.create_metadata (module Store) Store.Metadata.default))
 
   let () = fn "hash_free" (hash @-> returning void) free
-  let () = fn "branch_list_free" (branch_list @-> returning void) free
+  let () = fn "branch_array_free" (branch_array @-> returning void) free
   let () = fn "repo_free" (repo @-> returning void) free
   let () = fn "metadata_free" (metadata @-> returning void) free
   let () = fn "contents_free" (contents @-> returning void) free

--- a/src/libirmin/repo.ml
+++ b/src/libirmin/repo.ml
@@ -1,0 +1,182 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "repo_new"
+      (config @-> returning repo)
+      (fun config ->
+        catch' (fun () ->
+            let (s, config) : config = Root.get_config config in
+            let (module Store) = Irmin_unix.Resolver.Store.generic_keyed s in
+            let repo : Store.repo = run (Store.Repo.v config) in
+            Root.create_repo
+              (module Store)
+              ( (module Store : Irmin.Generic_key.S with type repo = Store.repo),
+                repo )))
+
+  let () =
+    fn "repo_branches"
+      (repo @-> returning branch_list)
+      (fun (type repo) repo ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let b = run (Store.Repo.branches repo) in
+            Root.create_branch_list (module Store) b))
+
+  let () =
+    fn "branch_list_length"
+      (repo @-> branch_list @-> returning uint64_t)
+      (fun (type repo) repo p ->
+        catch UInt64.zero (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let arr = Root.get_branch_list (module Store) p in
+            UInt64.of_int (Array.length arr)))
+
+  let () =
+    fn "branch_list_get"
+      (repo @-> branch_list @-> uint64_t @-> returning irmin_string)
+      (fun (type repo) repo p i ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let i = UInt64.to_int i in
+        let arr = Root.get_branch_list (module Store) p in
+        if i >= Array.length arr then null
+        else
+          let x = Array.unsafe_get arr i in
+          Root.create_string (Irmin.Type.to_string Store.Branch.t x))
+
+  let () =
+    fn "hash_equal"
+      (repo @-> hash @-> hash @-> returning bool)
+      (fun (type repo) repo a b ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let a = Root.get_hash (module Store) a in
+            let b = Root.get_hash (module Store) b in
+            Irmin.Type.(unstage (equal Store.hash_t)) a b))
+
+  let () =
+    fn "contents_hash"
+      (repo @-> value @-> returning hash)
+      (fun (type repo) repo a ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let a = Root.get_contents (module Store) a in
+            Root.create_hash (module Store) (Store.Contents.hash a)))
+
+  let () =
+    fn "contents_of_hash"
+      (repo @-> hash @-> returning value)
+      (fun (type repo) repo a ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let a = Root.get_hash (module Store) a in
+            let c = run @@ Store.Contents.of_hash repo a in
+            match c with
+            | Some c -> Root.create_contents (module Store) c
+            | None -> null))
+
+  let () =
+    fn "contents_of_key"
+      (repo @-> kinded_key @-> returning value)
+      (fun (type repo) repo a ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            let a = Root.get_kinded_key (module Store) a in
+            match a with
+            | `Contents (a, _) -> (
+                let c = run @@ Store.Contents.of_key repo a in
+                match c with
+                | Some c -> Root.create_contents (module Store) c
+                | None -> null)
+            | `Node _ -> null))
+
+  let () =
+    fn "contents_to_string"
+      (repo @-> value @-> returning irmin_string)
+      (fun (type repo) repo contents ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let contents = Root.get_contents (module Store) contents in
+            let s = Irmin.Type.to_string Store.contents_t contents in
+            Root.create_string s))
+
+  let () =
+    fn "contents_of_string"
+      (repo @-> ptr char @-> int64_t @-> returning value)
+      (fun (type repo) repo s length ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let length = get_length length s in
+            let s = string_from_ptr s ~length in
+            let hash = Irmin.Type.of_string Store.contents_t s in
+            match hash with
+            | Ok p -> Root.create_contents (module Store) p
+            | Error (`Msg e) ->
+                let () = Util.error_msg := Some e in
+                null))
+
+  let () =
+    fn "hash_to_string"
+      (repo @-> hash @-> returning irmin_string)
+      (fun (type repo) repo hash ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let hash = Root.get_hash (module Store) hash in
+            let s = Irmin.Type.to_string Store.hash_t hash in
+            Root.create_string s))
+
+  let () =
+    fn "hash_of_string"
+      (repo @-> ptr char @-> int64_t @-> returning hash)
+      (fun (type repo) repo s length ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let length = get_length length s in
+            let s = string_from_ptr s ~length in
+            let hash = Irmin.Type.of_string Store.Hash.t s in
+            match hash with
+            | Ok p -> Root.create_hash (module Store) p
+            | Error (`Msg e) ->
+                let () = Util.error_msg := Some e in
+                null))
+
+  let () =
+    fn "metadata_default"
+      (repo @-> returning metadata)
+      (fun (type repo) repo ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            Root.create_metadata (module Store) Store.Metadata.default))
+
+  let () = fn "hash_free" (hash @-> returning void) free
+  let () = fn "branch_list_free" (branch_list @-> returning void) free
+  let () = fn "repo_free" (repo @-> returning void) free
+  let () = fn "metadata_free" (metadata @-> returning void) free
+end

--- a/src/libirmin/repo.ml
+++ b/src/libirmin/repo.ml
@@ -7,6 +7,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun config ->
         let (s, config) : config = Root.get_config config in
         let (module Store) = Irmin_unix.Resolver.Store.generic_keyed s in
+        let remote = Irmin_unix.Resolver.Store.remote s in
         let repo : Store.repo = run (Store.Repo.v config) in
         Root.create_repo
           (module Store)
@@ -15,6 +16,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             repo_mod =
               (module Store : Irmin.Generic_key.S with type repo = Store.repo);
             repo;
+            remote;
           })
 
   let () =
@@ -44,7 +46,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
           (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
             let i = UInt64.to_int i in
             let arr = Root.get_branch_array (module Store) p in
-            if i >= Array.length arr then null irmin_string
+            if i >= Array.length arr then failwith "index out of bounds"
             else
               let x = Array.unsafe_get arr i in
               Root.create_string (Irmin.Type.to_string Store.Branch.t x)))

--- a/src/libirmin/store.ml
+++ b/src/libirmin/store.ml
@@ -33,6 +33,20 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
                     run (Store.of_branch repo branch) )))
 
   let () =
+    fn "of_commit"
+      (repo @-> commit @-> returning store)
+      (fun (type repo) repo commit ->
+        catch' store (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let commit = Root.get_commit (module Store) commit in
+            Root.create_store
+              (module Store)
+              ( (module Store : Irmin.Generic_key.S with type t = Store.t),
+                run (Store.of_commit commit) )))
+
+  let () =
     fn "get_head"
       (store @-> returning commit)
       (fun (type t) store ->

--- a/src/libirmin/store.ml
+++ b/src/libirmin/store.ml
@@ -322,68 +322,42 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "list"
-      (store @-> path @-> returning path_list)
+      (store @-> path @-> returning path_array)
       (fun (type t) store path ->
-        catch' path_list (fun () ->
+        catch' path_array (fun () ->
             let (module Store : Irmin.Generic_key.S with type t = t), store =
               Root.get_store store
             in
             let path : Store.path = Root.get_path (module Store) path in
             let items = run (Store.list store path) in
             let items = List.map (fun (k, _v) -> Store.Path.v [ k ]) items in
-            Root.create_path_list (module Store) items))
+            Root.create_path_array (module Store) items))
 
   let () =
-    fn "path_list_length"
-      (repo @-> path_list @-> returning uint64_t)
+    fn "path_array_length"
+      (repo @-> path_array @-> returning uint64_t)
       (fun (type repo) repo p ->
         catch UInt64.zero (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
-            let arr = Root.get_path_list (module Store) p in
+            let arr = Root.get_path_array (module Store) p in
             UInt64.of_int (Array.length arr)))
 
   let () =
-    fn "commit_list_length"
-      (repo @-> commit_list @-> returning uint64_t)
-      (fun (type repo) repo p ->
-        catch UInt64.zero (fun () ->
-            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-              Root.get_repo repo
-            in
-            let arr = Root.get_commit_list (module Store) p in
-            UInt64.of_int (Array.length arr)))
-
-  let () =
-    fn "path_list_get"
-      (repo @-> path_list @-> uint64_t @-> returning path)
+    fn "path_array_get"
+      (repo @-> path_array @-> uint64_t @-> returning path)
       (fun (type repo) repo p i ->
         let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
           Root.get_repo repo
         in
         let i = UInt64.to_int i in
-        let arr = Root.get_path_list (module Store) p in
+        let arr = Root.get_path_array (module Store) p in
         if i >= Array.length arr then null path
         else
           let x = Array.unsafe_get arr i in
           Root.create_path (module Store) x)
 
-  let () =
-    fn "commit_list_get"
-      (repo @-> commit_list @-> uint64_t @-> returning commit)
-      (fun (type repo) repo p i ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        let i = UInt64.to_int i in
-        let arr = Root.get_commit_list (module Store) p in
-        if i >= Array.length arr then null commit
-        else
-          let x = Array.unsafe_get arr i in
-          Root.create_commit (module Store) x)
-
-  let () = fn "path_list_free" (path_list @-> returning void) free
-  let () = fn "commit_list_free" (commit_list @-> returning void) free
+  let () = fn "path_array_free" (path_array @-> returning void) free
   let () = fn "free" (store @-> returning void) free
 end

--- a/src/libirmin/store.ml
+++ b/src/libirmin/store.ml
@@ -1,0 +1,389 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "main"
+      (repo @-> returning store)
+      (fun (type repo) repo ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            Root.create_store
+              (module Store)
+              ( (module Store : Irmin.Generic_key.S with type t = Store.t),
+                run (Store.main repo) )))
+
+  let () =
+    fn "of_branch"
+      (repo @-> string @-> returning store)
+      (fun (type repo) repo name ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), repo
+                =
+              Root.get_repo repo
+            in
+            match Irmin.Type.of_string Store.Branch.t name with
+            | Error _ -> null
+            | Ok branch ->
+                Root.create_store
+                  (module Store)
+                  ( (module Store : Irmin.Generic_key.S with type t = Store.t),
+                    run (Store.of_branch repo branch) )))
+
+  let () =
+    fn "get_head"
+      (store @-> returning commit)
+      (fun (type t) store ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let commit = run (Store.Head.find store) in
+            match commit with
+            | None -> null
+            | Some x -> Root.create_commit (module Store) x))
+
+  let () =
+    fn "set_head"
+      (store @-> commit @-> returning void)
+      (fun (type t) store commit ->
+        catch () (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let commit : Store.commit = Root.get_commit (module Store) commit in
+            run (Store.Head.set store commit)))
+
+  let () =
+    fn "fast_forward"
+      (store @-> commit @-> returning bool)
+      (fun (type t) store commit ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let commit : Store.commit = Root.get_commit (module Store) commit in
+            let res = run (Store.Head.fast_forward store commit) in
+            match res with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Store.ff_error_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "merge_with_branch"
+      (store @-> string @-> info @-> returning bool)
+      (fun (type t) store branch info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let info = Root.get_info (module Store) info in
+            let branch =
+              Irmin.Type.of_string Store.branch_t branch |> Result.get_ok
+            in
+            let res =
+              run (Store.merge_with_branch store branch ~info:(fun () -> info))
+            in
+            match res with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Irmin.Merge.conflict_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "merge_with_commit"
+      (store @-> commit @-> info @-> returning bool)
+      (fun (type t) store commit info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let info = Root.get_info (module Store) info in
+            let commit = Root.get_commit (module Store) commit in
+            let res =
+              run (Store.merge_with_commit store commit ~info:(fun () -> info))
+            in
+            match res with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Irmin.Merge.conflict_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "merge_into"
+      (store @-> store @-> info @-> returning bool)
+      (fun (type t) store store1 info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let (module Store1 : Irmin.Generic_key.S with type t = t), store1 =
+              Root.get_store store1
+            in
+            let info = Root.get_info (module Store) info in
+            let res =
+              run (Store.merge_into ~into:store store1 ~info:(fun () -> info))
+            in
+            match res with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Irmin.Merge.conflict_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "set"
+      (store @-> path @-> value @-> info @-> returning bool)
+      (fun (type t) store path value info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let info = Root.get_info (module Store) info in
+            let path : Store.path = Root.get_path (module Store) path in
+            let value : Store.contents =
+              Root.get_contents (module Store) value
+            in
+            let x = run (Store.set store path value ~info:(fun () -> info)) in
+            match x with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Store.write_error_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "test_and_set"
+      (store @-> path @-> value @-> value @-> info @-> returning bool)
+      (fun (type t) store path test set info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let info = Root.get_info (module Store) info in
+            let path : Store.path = Root.get_path (module Store) path in
+            let test : Store.contents option =
+              if test = null then None
+              else Some (Root.get_contents (module Store) test)
+            in
+            let set : Store.contents option =
+              if set = null then None
+              else Some (Root.get_contents (module Store) set)
+            in
+            let x =
+              run
+                (Store.test_and_set store path ~test ~set ~info:(fun () -> info))
+            in
+            match x with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Store.write_error_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "test_and_set_tree"
+      (store @-> path @-> tree @-> tree @-> info @-> returning bool)
+      (fun (type t) store path test set info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let info = Root.get_info (module Store) info in
+            let path : Store.path = Root.get_path (module Store) path in
+            let test : Store.tree option =
+              if test = null then None
+              else Some (Root.get_tree (module Store) test)
+            in
+            let set : Store.tree option =
+              if set = null then None
+              else Some (Root.get_tree (module Store) set)
+            in
+            let x =
+              run
+                (Store.test_and_set_tree store path ~test ~set ~info:(fun () ->
+                     info))
+            in
+            match x with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Store.write_error_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "set_tree"
+      (store @-> path @-> tree @-> info @-> returning bool)
+      (fun (type t) store path tree info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let info : Store.info = Root.get_info (module Store) info in
+            let path : Store.path = Root.get_path (module Store) path in
+            let tree' : Store.tree = Root.get_tree (module Store) tree in
+            let x =
+              run (Store.set_tree store path tree' ~info:(fun () -> info))
+            in
+            match x with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Store.write_error_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "find"
+      (store @-> path @-> returning value)
+      (fun (type t) store path ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let path : Store.path = Root.get_path (module Store) path in
+            let x = run (Store.find store path) in
+            match x with
+            | Some x -> Root.create_contents (module Store) x
+            | None -> null))
+
+  let () =
+    fn "find_metadata"
+      (store @-> path @-> returning metadata)
+      (fun (type t) store path ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let path : Store.path = Root.get_path (module Store) path in
+            let x = run (Store.find_all store path) in
+            match x with
+            | Some (_, m) -> Root.create_metadata (module Store) m
+            | None -> null))
+
+  let () =
+    fn "find_tree"
+      (store @-> path @-> returning tree)
+      (fun (type t) store path ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let path : Store.path = Root.get_path (module Store) path in
+            let x : Store.tree option = run (Store.find_tree store path) in
+            match x with
+            | Some x -> Root.create_tree (module Store) x
+            | None -> null))
+
+  let () =
+    fn "remove"
+      (store @-> path @-> info @-> returning bool)
+      (fun (type t) store path info ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let module Info = Irmin_unix.Info (Store.Info) in
+            let info = Root.get_info (module Store) info in
+            let path : Store.path = Root.get_path (module Store) path in
+            match run (Store.remove store path ~info:(fun () -> info)) with
+            | Ok () -> true
+            | Error e ->
+                let s = Irmin.Type.to_string Store.write_error_t e in
+                let () = Util.error_msg := Some s in
+                false))
+
+  let () =
+    fn "mem"
+      (store @-> path @-> returning bool)
+      (fun (type t) store path ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let path : Store.path = Root.get_path (module Store) path in
+            run (Store.mem store path)))
+
+  let () =
+    fn "mem_tree"
+      (store @-> path @-> returning bool)
+      (fun (type t) store path ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let path : Store.path = Root.get_path (module Store) path in
+            run (Store.mem_tree store path)))
+
+  let () =
+    fn "list"
+      (store @-> path @-> returning path_list)
+      (fun (type t) store path ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type t = t), store =
+              Root.get_store store
+            in
+            let path : Store.path = Root.get_path (module Store) path in
+            let items = run (Store.list store path) in
+            let items = List.map (fun (k, _v) -> Store.Path.v [ k ]) items in
+            Root.create_path_list (module Store) items))
+
+  let () =
+    fn "path_list_length"
+      (repo @-> path_list @-> returning uint64_t)
+      (fun (type repo) repo p ->
+        catch UInt64.zero (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let arr = Root.get_path_list (module Store) p in
+            UInt64.of_int (Array.length arr)))
+
+  let () =
+    fn "commit_list_length"
+      (repo @-> commit_list @-> returning uint64_t)
+      (fun (type repo) repo p ->
+        catch UInt64.zero (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let arr = Root.get_commit_list (module Store) p in
+            UInt64.of_int (Array.length arr)))
+
+  let () =
+    fn "path_list_get"
+      (repo @-> path_list @-> uint64_t @-> returning path)
+      (fun (type repo) repo p i ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let i = UInt64.to_int i in
+        let arr = Root.get_path_list (module Store) p in
+        if i >= Array.length arr then null
+        else
+          let x = Array.unsafe_get arr i in
+          Root.create_path (module Store) x)
+
+  let () =
+    fn "commit_list_get"
+      (repo @-> commit_list @-> uint64_t @-> returning commit)
+      (fun (type repo) repo p i ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let i = UInt64.to_int i in
+        let arr = Root.get_commit_list (module Store) p in
+        if i >= Array.length arr then null
+        else
+          let x = Array.unsafe_get arr i in
+          Root.create_commit (module Store) x)
+
+  let () = fn "path_list_free" (path_list @-> returning void) free
+  let () = fn "commit_list_free" (commit_list @-> returning void) free
+  let () = fn "free" (store @-> returning void) free
+end

--- a/src/libirmin/tree.ml
+++ b/src/libirmin/tree.ml
@@ -215,9 +215,9 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "tree_list"
-      (repo @-> tree @-> path @-> returning path_list)
+      (repo @-> tree @-> path @-> returning path_array)
       (fun (type repo) repo tree path ->
-        catch' path_list (fun () ->
+        catch' path_array (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -225,7 +225,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             let path : Store.path = Root.get_path (module Store) path in
             let items = run (Store.Tree.list tree path) in
             let items = List.map (fun (k, _v) -> Store.Path.v [ k ]) items in
-            Root.create_path_list (module Store) items))
+            Root.create_path_array (module Store) items))
 
   let () =
     fn "kinded_key_is_contents"

--- a/src/libirmin/tree.ml
+++ b/src/libirmin/tree.ml
@@ -154,9 +154,9 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "tree_add"
-      (repo @-> tree @-> path @-> contents @-> metadata @-> returning void)
+      (repo @-> tree @-> path @-> contents @-> metadata @-> returning bool)
       (fun (type repo) repo tree path value metadata ->
-        catch () (fun () ->
+        catch false (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -170,13 +170,14 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
               else Some (Root.get_metadata (module Store) metadata)
             in
             let t = run (Store.Tree.add tree' path value ?metadata) in
-            Root.set_tree (module Store) tree t))
+            Root.set_tree (module Store) tree t;
+            true))
 
   let () =
     fn "tree_add_tree"
-      (repo @-> tree @-> path @-> tree @-> returning void)
+      (repo @-> tree @-> path @-> tree @-> returning bool)
       (fun (type repo) repo tree path tr ->
-        catch () (fun () ->
+        catch false (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -184,20 +185,22 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             let path : Store.path = Root.get_path (module Store) path in
             let value : Store.tree = Root.get_tree (module Store) tr in
             let t = run (Store.Tree.add_tree tree' path value) in
-            Root.set_tree (module Store) tree t))
+            Root.set_tree (module Store) tree t;
+            true))
 
   let () =
     fn "tree_remove"
-      (repo @-> tree @-> path @-> returning void)
+      (repo @-> tree @-> path @-> returning bool)
       (fun (type repo) repo tree path ->
-        catch () (fun () ->
+        catch false (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
             let tree' : Store.tree = Root.get_tree (module Store) tree in
             let path : Store.path = Root.get_path (module Store) path in
             let t = run (Store.Tree.remove tree' path) in
-            Root.set_tree (module Store) tree t))
+            Root.set_tree (module Store) tree t;
+            true))
 
   let () =
     fn "tree_equal"

--- a/src/libirmin/tree.ml
+++ b/src/libirmin/tree.ml
@@ -12,7 +12,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "tree_of_contents"
-      (repo @-> value @-> metadata @-> returning tree)
+      (repo @-> contents @-> metadata @-> returning tree)
       (fun (type repo) repo value metadata ->
         let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
           Root.get_repo repo
@@ -38,7 +38,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "tree_hash"
       (repo @-> tree @-> returning hash)
       (fun (type repo) repo tree ->
-        catch' (fun () ->
+        catch' hash (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -57,13 +57,13 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         let t = run (Store.Tree.of_hash repo (`Node k)) in
         match t with
         | Some t -> Root.create_tree (module Store) t
-        | None -> null)
+        | None -> null tree)
 
   let () =
     fn "tree_key"
       (repo @-> tree @-> returning kinded_key)
       (fun (type repo) repo tree ->
-        catch' (fun () ->
+        catch' kinded_key (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
@@ -71,7 +71,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             let k = Store.Tree.key tree in
             match k with
             | Some k -> Root.create_kinded_key (module Store) k
-            | _ -> null))
+            | _ -> null kinded_key))
 
   let () =
     fn "tree_of_key"
@@ -84,7 +84,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         let t = run (Store.Tree.of_key repo k) in
         match t with
         | Some t -> Root.create_tree (module Store) t
-        | None -> null)
+        | None -> null tree)
 
   let () =
     fn "tree_mem"
@@ -112,49 +112,49 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let () =
     fn "tree_find"
-      (repo @-> tree @-> path @-> returning value)
+      (repo @-> tree @-> path @-> returning contents)
       (fun (type repo) repo tree path ->
-        catch null (fun () ->
+        catch' contents (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
             let tree : Store.tree = Root.get_tree (module Store) tree in
             let path : Store.path = Root.get_path (module Store) path in
             match run (Store.Tree.find tree path) with
-            | None -> null
+            | None -> null contents
             | Some x -> Root.create_contents (module Store) x))
 
   let () =
     fn "tree_find_metadata"
       (repo @-> tree @-> path @-> returning metadata)
       (fun (type repo) repo tree path ->
-        catch null (fun () ->
+        catch' metadata (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
             let tree : Store.tree = Root.get_tree (module Store) tree in
             let path : Store.path = Root.get_path (module Store) path in
             match run (Store.Tree.find_all tree path) with
-            | None -> null
+            | None -> null metadata
             | Some (_, m) -> Root.create_metadata (module Store) m))
 
   let () =
     fn "tree_find_tree"
       (repo @-> tree @-> path @-> returning tree)
-      (fun (type repo) repo tree path ->
-        catch null (fun () ->
+      (fun (type repo) repo t path ->
+        catch' tree (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in
-            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let t : Store.tree = Root.get_tree (module Store) t in
             let path : Store.path = Root.get_path (module Store) path in
-            match run (Store.Tree.find_tree tree path) with
-            | None -> null
+            match run (Store.Tree.find_tree t path) with
+            | None -> null tree
             | Some x -> Root.create_tree (module Store) x))
 
   let () =
     fn "tree_add"
-      (repo @-> tree @-> path @-> value @-> metadata @-> returning void)
+      (repo @-> tree @-> path @-> contents @-> metadata @-> returning void)
       (fun (type repo) repo tree path value metadata ->
         catch () (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
@@ -214,7 +214,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "tree_list"
       (repo @-> tree @-> path @-> returning path_list)
       (fun (type repo) repo tree path ->
-        catch' (fun () ->
+        catch' path_list (fun () ->
             let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
               Root.get_repo repo
             in

--- a/src/libirmin/tree.ml
+++ b/src/libirmin/tree.ml
@@ -1,0 +1,251 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "tree_new"
+      (repo @-> returning tree)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_tree (module Store) (Store.Tree.empty ()))
+
+  let () =
+    fn "tree_of_contents"
+      (repo @-> value @-> metadata @-> returning tree)
+      (fun (type repo) repo value metadata ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let metadata =
+          if is_null metadata then None
+          else Some (Root.get_metadata (module Store) metadata)
+        in
+        let value = Root.get_contents (module Store) value in
+        Root.create_tree (module Store) (Store.Tree.of_contents ?metadata value))
+
+  let () =
+    fn "tree_clone"
+      (repo @-> tree @-> returning tree)
+      (fun (type repo) repo tree ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let tree : Store.tree = Root.get_tree (module Store) tree in
+        Root.create_tree (module Store) tree)
+
+  let () =
+    fn "tree_hash"
+      (repo @-> tree @-> returning hash)
+      (fun (type repo) repo tree ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let k = Store.Tree.hash tree in
+            Root.create_hash (module Store) k))
+
+  let () =
+    fn "tree_of_hash"
+      (repo @-> hash @-> returning tree)
+      (fun (type repo) repo k ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), repo =
+          Root.get_repo repo
+        in
+        let k = Root.get_hash (module Store) k in
+        let t = run (Store.Tree.of_hash repo (`Node k)) in
+        match t with
+        | Some t -> Root.create_tree (module Store) t
+        | None -> null)
+
+  let () =
+    fn "tree_key"
+      (repo @-> tree @-> returning kinded_key)
+      (fun (type repo) repo tree ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let k = Store.Tree.key tree in
+            match k with
+            | Some k -> Root.create_kinded_key (module Store) k
+            | _ -> null))
+
+  let () =
+    fn "tree_of_key"
+      (repo @-> kinded_key @-> returning tree)
+      (fun (type repo) repo k ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), repo =
+          Root.get_repo repo
+        in
+        let k = Root.get_kinded_key (module Store) k in
+        let t = run (Store.Tree.of_key repo k) in
+        match t with
+        | Some t -> Root.create_tree (module Store) t
+        | None -> null)
+
+  let () =
+    fn "tree_mem"
+      (repo @-> tree @-> path @-> returning bool)
+      (fun (type repo) repo tree path ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            run (Store.Tree.mem tree path)))
+
+  let () =
+    fn "tree_mem_tree"
+      (repo @-> tree @-> path @-> returning bool)
+      (fun (type repo) repo tree path ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            run (Store.Tree.mem_tree tree path)))
+
+  let () =
+    fn "tree_find"
+      (repo @-> tree @-> path @-> returning value)
+      (fun (type repo) repo tree path ->
+        catch null (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            match run (Store.Tree.find tree path) with
+            | None -> null
+            | Some x -> Root.create_contents (module Store) x))
+
+  let () =
+    fn "tree_find_metadata"
+      (repo @-> tree @-> path @-> returning metadata)
+      (fun (type repo) repo tree path ->
+        catch null (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            match run (Store.Tree.find_all tree path) with
+            | None -> null
+            | Some (_, m) -> Root.create_metadata (module Store) m))
+
+  let () =
+    fn "tree_find_tree"
+      (repo @-> tree @-> path @-> returning tree)
+      (fun (type repo) repo tree path ->
+        catch null (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            match run (Store.Tree.find_tree tree path) with
+            | None -> null
+            | Some x -> Root.create_tree (module Store) x))
+
+  let () =
+    fn "tree_add"
+      (repo @-> tree @-> path @-> value @-> metadata @-> returning void)
+      (fun (type repo) repo tree path value metadata ->
+        catch () (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree' : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            let value : Store.contents =
+              Root.get_contents (module Store) value
+            in
+            let metadata =
+              if is_null metadata then None
+              else Some (Root.get_metadata (module Store) metadata)
+            in
+            let t = run (Store.Tree.add tree' path value ?metadata) in
+            Root.set_tree (module Store) tree t))
+
+  let () =
+    fn "tree_add_tree"
+      (repo @-> tree @-> path @-> tree @-> returning void)
+      (fun (type repo) repo tree path tr ->
+        catch () (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree' : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            let value : Store.tree = Root.get_tree (module Store) tr in
+            let t = run (Store.Tree.add_tree tree' path value) in
+            Root.set_tree (module Store) tree t))
+
+  let () =
+    fn "tree_remove"
+      (repo @-> tree @-> path @-> returning void)
+      (fun (type repo) repo tree path ->
+        catch () (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree' : Store.tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            let t = run (Store.Tree.remove tree' path) in
+            Root.set_tree (module Store) tree t))
+
+  let () =
+    fn "tree_equal"
+      (repo @-> tree @-> tree @-> returning bool)
+      (fun (type repo) repo a b ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        let a = Root.get_tree (module Store) a in
+        let b = Root.get_tree (module Store) b in
+        Irmin.Type.(unstage (equal Store.tree_t)) a b)
+
+  let () =
+    fn "tree_list"
+      (repo @-> tree @-> path @-> returning path_list)
+      (fun (type repo) repo tree path ->
+        catch' (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let tree = Root.get_tree (module Store) tree in
+            let path : Store.path = Root.get_path (module Store) path in
+            let items = run (Store.Tree.list tree path) in
+            let items = List.map (fun (k, _v) -> Store.Path.v [ k ]) items in
+            Root.create_path_list (module Store) items))
+
+  let () =
+    fn "kinded_key_is_contents"
+      (repo @-> kinded_key @-> returning bool)
+      (fun (type repo) repo k ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let k = Root.get_kinded_key (module Store) k in
+            match k with `Contents _ -> true | _ -> false))
+
+  let () =
+    fn "kinded_key_is_node"
+      (repo @-> kinded_key @-> returning bool)
+      (fun (type repo) repo k ->
+        catch false (fun () ->
+            let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+              Root.get_repo repo
+            in
+            let k = Root.get_kinded_key (module Store) k in
+            match k with `Node _ -> true | _ -> false))
+
+  let () = fn "tree_free" (tree @-> returning void) free
+  let () = fn "kinded_key_free" (kinded_key @-> returning void) free
+end

--- a/src/libirmin/type.ml
+++ b/src/libirmin/type.ml
@@ -66,91 +66,81 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "type_path"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.path_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.path_t))
 
   let () =
     fn "type_commit"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), repo =
-          Root.get_repo repo
-        in
-        Root.create_ty (Store.commit_t repo))
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
+          -> Root.create_ty (Store.commit_t repo)))
 
   let () =
     fn "type_metadata"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.metadata_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.metadata_t))
 
   let () =
     fn "type_tree"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.tree_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.tree_t))
 
   let () =
     fn "type_hash"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.hash_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.hash_t))
 
   let () =
     fn "type_commit_key"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.commit_key_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.commit_key_t))
 
   let () =
     fn "type_contents_key"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.contents_key_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.contents_key_t))
 
   let () =
     fn "type_node_key"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.node_key_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.node_key_t))
 
   let () =
     fn "type_kinded_key"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.Tree.kinded_key_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.Tree.kinded_key_t))
 
   let () =
     fn "type_contents"
       (repo @-> returning ty)
       (fun (type repo) repo ->
-        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
-          Root.get_repo repo
-        in
-        Root.create_ty Store.contents_t)
+        with_repo' repo ty
+          (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
+            Root.create_ty Store.contents_t))
 
   let () =
     fn "type_pair"

--- a/src/libirmin/type.ml
+++ b/src/libirmin/type.ml
@@ -1,0 +1,188 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "type_unit"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Type.unit)
+
+  let () =
+    fn "type_bool"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Type.bool)
+
+  let () =
+    fn "type_int"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Type.int)
+
+  let () =
+    fn "type_float"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Type.float)
+
+  let () =
+    fn "type_string"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Type.string)
+
+  let () =
+    fn "type_bytes"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Type.bytes)
+
+  let () =
+    fn "type_list"
+      (ty @-> returning ty)
+      (fun elem ->
+        let elem : 'a Irmin.Type.t = Root.get_ty elem in
+        Root.create_ty (Irmin.Type.list elem))
+
+  let () =
+    fn "type_array"
+      (ty @-> returning ty)
+      (fun elem ->
+        let elem : 'a Irmin.Type.t = Root.get_ty elem in
+        Root.create_ty (Irmin.Type.array elem))
+
+  let () =
+    fn "type_option"
+      (ty @-> returning ty)
+      (fun elem ->
+        let elem : 'a Irmin.Type.t = Root.get_ty elem in
+        Root.create_ty (Irmin.Type.option elem))
+
+  let () =
+    fn "type_json"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Contents.Json.t)
+
+  let () =
+    fn "type_json_value"
+      (void @-> returning ty)
+      (fun () -> Root.create_ty Irmin.Contents.Json_value.t)
+
+  let () =
+    fn "type_path"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.path_t)
+
+  let () =
+    fn "type_commit"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), repo =
+          Root.get_repo repo
+        in
+        Root.create_ty (Store.commit_t repo))
+
+  let () =
+    fn "type_metadata"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.metadata_t)
+
+  let () =
+    fn "type_tree"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.tree_t)
+
+  let () =
+    fn "type_hash"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.hash_t)
+
+  let () =
+    fn "type_commit_key"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.commit_key_t)
+
+  let () =
+    fn "type_contents_key"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.contents_key_t)
+
+  let () =
+    fn "type_node_key"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.node_key_t)
+
+  let () =
+    fn "type_kinded_key"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.Tree.kinded_key_t)
+
+  let () =
+    fn "type_contents"
+      (repo @-> returning ty)
+      (fun (type repo) repo ->
+        let (module Store : Irmin.Generic_key.S with type repo = repo), _ =
+          Root.get_repo repo
+        in
+        Root.create_ty Store.contents_t)
+
+  let () =
+    fn "type_pair"
+      (ty @-> ty @-> returning ty)
+      (fun a b ->
+        let a : 'a Irmin.Type.t = Root.get_ty a in
+        let b : 'b Irmin.Type.t = Root.get_ty b in
+        Root.create_ty (Irmin.Type.pair a b))
+
+  let () =
+    fn "type_triple"
+      (ty @-> ty @-> ty @-> returning ty)
+      (fun a b c ->
+        let a : 'a Irmin.Type.t = Root.get_ty a in
+        let b : 'b Irmin.Type.t = Root.get_ty b in
+        let c : 'c Irmin.Type.t = Root.get_ty c in
+        Root.create_ty (Irmin.Type.triple a b c))
+
+  let () =
+    fn "type_name"
+      (ty @-> returning irmin_string)
+      (fun ty ->
+        let ty = Root.get_ty ty in
+        let s = Fmt.to_to_string Irmin.Type.pp_ty ty in
+        Root.create_string s)
+
+  let () =
+    fn "type_diff"
+      (ty @-> returning ty)
+      (fun ty ->
+        let ty = Root.get_ty ty in
+        Root.create_ty (Irmin.Diff.t ty))
+
+  let () = fn "type_free" (ty @-> returning void) free
+end

--- a/src/libirmin/types.ml
+++ b/src/libirmin/types.ml
@@ -15,9 +15,9 @@ module Struct = struct
   type hash = unit
   type info = unit
   type irmin_string = unit
-  type path_list = unit
-  type commit_list = unit
-  type branch_list = unit
+  type path_array = unit
+  type commit_array = unit
+  type branch_array = unit
   type commit_key = unit
   type kinded_key = unit
 end
@@ -38,13 +38,13 @@ let info : Struct.info ptr typ = ptr (typedef void "IrminInfo")
 let irmin_string : Struct.irmin_string ptr typ =
   ptr (typedef void "IrminString")
 
-let path_list : Struct.path_list ptr typ = ptr (typedef void "IrminPathList")
+let path_array : Struct.path_array ptr typ = ptr (typedef void "IrminPathArray")
 
-let commit_list : Struct.commit_list ptr typ =
-  ptr (typedef void "IrminCommitList")
+let commit_array : Struct.commit_array ptr typ =
+  ptr (typedef void "IrminCommitArray")
 
-let branch_list : Struct.branch_list ptr typ =
-  ptr (typedef void "IrminBranchList")
+let branch_array : Struct.branch_array ptr typ =
+  ptr (typedef void "IrminBranchArray")
 
 let commit_key : Struct.commit_key ptr typ = ptr (typedef void "IrminCommitKey")
 let kinded_key : Struct.kinded_key ptr typ = ptr (typedef void "IrminKindedKey")

--- a/src/libirmin/types.ml
+++ b/src/libirmin/types.ml
@@ -1,27 +1,50 @@
 open Ctypes
+include Types_intf
 
-type config = Irmin_unix.Resolver.Store.t * Irmin.config
+module Struct = struct
+  type config = unit
+  type repo = unit
+  type store = unit
+  type ty = unit
+  type value = unit
+  type metadata = unit
+  type contents = unit
+  type path = unit
+  type tree = unit
+  type commit = unit
+  type hash = unit
+  type info = unit
+  type irmin_string = unit
+  type path_list = unit
+  type commit_list = unit
+  type branch_list = unit
+  type commit_key = unit
+  type kinded_key = unit
+end
 
-let config = ptr (typedef void "IrminConfig")
+let config : Struct.config ptr typ = ptr (typedef void "IrminConfig")
+let repo : Struct.repo ptr typ = ptr (typedef void "IrminRepo")
+let store : Struct.store ptr typ = ptr (typedef void "Irmin")
+let ty : Struct.ty ptr typ = ptr (typedef void "IrminType")
+let value : Struct.value ptr typ = ptr (typedef void "IrminValue")
+let metadata : Struct.metadata ptr typ = ptr (typedef void "IrminMetadata")
+let contents : Struct.metadata ptr typ = ptr (typedef void "IrminContents")
+let path : Struct.path ptr typ = ptr (typedef void "IrminPath")
+let tree : Struct.tree ptr typ = ptr (typedef void "IrminTree")
+let commit : Struct.commit ptr typ = ptr (typedef void "IrminCommit")
+let hash : Struct.hash ptr typ = ptr (typedef void "IrminHash")
+let info : Struct.info ptr typ = ptr (typedef void "IrminInfo")
 
-type 'a repo = (module Irmin.Generic_key.S with type repo = 'a) * 'a
+let irmin_string : Struct.irmin_string ptr typ =
+  ptr (typedef void "IrminString")
 
-let repo = ptr (typedef void "IrminRepo")
+let path_list : Struct.path_list ptr typ = ptr (typedef void "IrminPathList")
 
-type 'a store = (module Irmin.Generic_key.S with type t = 'a) * 'a
+let commit_list : Struct.commit_list ptr typ =
+  ptr (typedef void "IrminCommitList")
 
-let store = ptr (typedef void "Irmin")
-let ty = ptr (typedef void "IrminType")
-let value = ptr (typedef void "IrminValue")
-let metadata = ptr (typedef void "IrminMetadata")
-let path = ptr (typedef void "IrminPath")
-let tree = ptr (typedef void "IrminTree")
-let commit = ptr (typedef void "IrminCommit")
-let hash = ptr (typedef void "IrminHash")
-let info = ptr (typedef void "IrminInfo")
-let irmin_string = ptr (typedef void "IrminString")
-let path_list = ptr (typedef void "IrminPathList")
-let commit_list = ptr (typedef void "IrminCommitList")
-let branch_list = ptr (typedef void "IrminBranchList")
-let commit_key = ptr (typedef void "IrminCommitKey")
-let kinded_key = ptr (typedef void "IrminKindedKey")
+let branch_list : Struct.branch_list ptr typ =
+  ptr (typedef void "IrminBranchList")
+
+let commit_key : Struct.commit_key ptr typ = ptr (typedef void "IrminCommitKey")
+let kinded_key : Struct.kinded_key ptr typ = ptr (typedef void "IrminKindedKey")

--- a/src/libirmin/types.ml
+++ b/src/libirmin/types.ml
@@ -20,6 +20,7 @@ module Struct = struct
   type branch_array = unit
   type commit_key = unit
   type kinded_key = unit
+  type remote = unit
 end
 
 let config : Struct.config ptr typ = ptr (typedef void "IrminConfig")
@@ -34,6 +35,7 @@ let tree : Struct.tree ptr typ = ptr (typedef void "IrminTree")
 let commit : Struct.commit ptr typ = ptr (typedef void "IrminCommit")
 let hash : Struct.hash ptr typ = ptr (typedef void "IrminHash")
 let info : Struct.info ptr typ = ptr (typedef void "IrminInfo")
+let remote : Struct.remote ptr typ = ptr (typedef void "IrminRemote")
 
 let irmin_string : Struct.irmin_string ptr typ =
   ptr (typedef void "IrminString")

--- a/src/libirmin/types.ml
+++ b/src/libirmin/types.ml
@@ -1,0 +1,27 @@
+open Ctypes
+
+type config = Irmin_unix.Resolver.Store.t * Irmin.config
+
+let config = ptr (typedef void "IrminConfig")
+
+type 'a repo = (module Irmin.Generic_key.S with type repo = 'a) * 'a
+
+let repo = ptr (typedef void "IrminRepo")
+
+type 'a store = (module Irmin.Generic_key.S with type t = 'a) * 'a
+
+let store = ptr (typedef void "Irmin")
+let ty = ptr (typedef void "IrminType")
+let value = ptr (typedef void "IrminValue")
+let metadata = ptr (typedef void "IrminMetadata")
+let path = ptr (typedef void "IrminPath")
+let tree = ptr (typedef void "IrminTree")
+let commit = ptr (typedef void "IrminCommit")
+let hash = ptr (typedef void "IrminHash")
+let info = ptr (typedef void "IrminInfo")
+let irmin_string = ptr (typedef void "IrminString")
+let path_list = ptr (typedef void "IrminPathList")
+let commit_list = ptr (typedef void "IrminCommitList")
+let branch_list = ptr (typedef void "IrminBranchList")
+let commit_key = ptr (typedef void "IrminCommitKey")
+let kinded_key = ptr (typedef void "IrminKindedKey")

--- a/src/libirmin/types.mli
+++ b/src/libirmin/types.mli
@@ -1,0 +1,1 @@
+include Types_intf.Sigs

--- a/src/libirmin/types_intf.ml
+++ b/src/libirmin/types_intf.ml
@@ -18,9 +18,9 @@ module type P = sig
   type hash
   type info
   type irmin_string
-  type path_list
-  type commit_list
-  type branch_list
+  type path_array
+  type commit_array
+  type branch_array
   type commit_key
   type kinded_key
 end
@@ -45,9 +45,9 @@ module type Sigs = sig
   val hash : Struct.hash ptr typ
   val info : Struct.info ptr typ
   val irmin_string : Struct.irmin_string ptr typ
-  val path_list : Struct.path_list ptr typ
-  val commit_list : Struct.commit_list ptr typ
-  val branch_list : Struct.branch_list ptr typ
+  val path_array : Struct.path_array ptr typ
+  val commit_array : Struct.commit_array ptr typ
+  val branch_array : Struct.branch_array ptr typ
   val commit_key : Struct.commit_key ptr typ
   val kinded_key : Struct.kinded_key ptr typ
 end

--- a/src/libirmin/types_intf.ml
+++ b/src/libirmin/types_intf.ml
@@ -1,0 +1,53 @@
+open Ctypes
+
+type config = Irmin_unix.Resolver.Store.t * Irmin.config
+type 'a repo = (module Irmin.Generic_key.S with type repo = 'a) * 'a
+type 'a store = (module Irmin.Generic_key.S with type t = 'a) * 'a
+
+module type P = sig
+  type config
+  type repo
+  type store
+  type ty
+  type value
+  type metadata
+  type contents
+  type path
+  type tree
+  type commit
+  type hash
+  type info
+  type irmin_string
+  type path_list
+  type commit_list
+  type branch_list
+  type commit_key
+  type kinded_key
+end
+
+module type Sigs = sig
+  module Struct : P
+
+  type nonrec config = config
+  type nonrec 'a repo = 'a repo
+  type nonrec 'a store = 'a store
+
+  val config : Struct.config ptr typ
+  val repo : Struct.repo ptr typ
+  val store : Struct.store ptr typ
+  val ty : Struct.ty ptr typ
+  val value : Struct.value ptr typ
+  val metadata : Struct.metadata ptr typ
+  val contents : Struct.contents ptr typ
+  val path : Struct.path ptr typ
+  val tree : Struct.tree ptr typ
+  val commit : Struct.commit ptr typ
+  val hash : Struct.hash ptr typ
+  val info : Struct.info ptr typ
+  val irmin_string : Struct.irmin_string ptr typ
+  val path_list : Struct.path_list ptr typ
+  val commit_list : Struct.commit_list ptr typ
+  val branch_list : Struct.branch_list ptr typ
+  val commit_key : Struct.commit_key ptr typ
+  val kinded_key : Struct.kinded_key ptr typ
+end

--- a/src/libirmin/types_intf.ml
+++ b/src/libirmin/types_intf.ml
@@ -1,8 +1,18 @@
 open Ctypes
 
 type config = Irmin_unix.Resolver.Store.t * Irmin.config
-type 'a repo = (module Irmin.Generic_key.S with type repo = 'a) * 'a
-type 'a store = (module Irmin.Generic_key.S with type t = 'a) * 'a
+
+type 'a repo = {
+  mutable error : string option;
+  repo_mod : (module Irmin.Generic_key.S with type repo = 'a);
+  repo : 'a;
+}
+
+type 'a store = {
+  repo : unit ptr;
+  store_mod : (module Irmin.Generic_key.S with type t = 'a);
+  store : 'a;
+}
 
 module type P = sig
   type config

--- a/src/libirmin/types_intf.ml
+++ b/src/libirmin/types_intf.ml
@@ -6,6 +6,7 @@ type 'a repo = {
   mutable error : string option;
   repo_mod : (module Irmin.Generic_key.S with type repo = 'a);
   repo : 'a;
+  remote : Irmin_unix.Resolver.Store.remote_fn option;
 }
 
 type 'a store = {
@@ -33,6 +34,7 @@ module type P = sig
   type branch_array
   type commit_key
   type kinded_key
+  type remote
 end
 
 module type Sigs = sig
@@ -60,4 +62,5 @@ module type Sigs = sig
   val branch_array : Struct.branch_array ptr typ
   val commit_key : Struct.commit_key ptr typ
   val kinded_key : Struct.kinded_key ptr typ
+  val remote : Struct.remote ptr typ
 end

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -21,9 +21,13 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     try
       let () = update_error_msg None in
       f ()
-    with exn ->
-      let () = update_error_msg @@ Some (Printexc.to_string exn) in
-      return
+    with
+    | Failure msg ->
+        let () = update_error_msg (Some msg) in
+        return
+    | exn ->
+        let () = update_error_msg @@ Some (Printexc.to_string exn) in
+        return
     [@@inline]
 
   let null t = Ctypes.coerce (ptr void) t null
@@ -62,7 +66,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   module Root = struct
     let to_voidp x = Obj.magic x
-    let of_voidp x = Obj.magic x
+    let of_voidp x = if is_null x then failwith "null pointer" else Obj.magic x
 
     let get_repo (type a) (x : Struct.repo ptr) : a repo = Root.get (to_voidp x)
       [@@inline]

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -210,34 +210,34 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     let create_string (s : string) : Struct.irmin_string ptr =
       Root.create s |> of_voidp
 
-    let get_branch_list (type a)
+    let get_branch_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
-        (x : Struct.branch_list ptr) : a array =
+        (x : Struct.branch_array ptr) : a array =
       Root.get (to_voidp x)
 
-    let create_branch_list (type a)
+    let create_branch_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
-        (x : S.Branch.t list) : Struct.branch_list ptr =
+        (x : S.Branch.t list) : Struct.branch_array ptr =
       Root.create (Array.of_list x) |> of_voidp
 
-    let get_path_list (type a)
+    let get_path_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
-        (x : Struct.path_list ptr) : a array =
+        (x : Struct.path_array ptr) : a array =
       Root.get (to_voidp x)
 
-    let create_path_list (type a)
+    let create_path_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
-        (x : S.Path.t list) : Struct.path_list ptr =
+        (x : S.Path.t list) : Struct.path_array ptr =
       Root.create (Array.of_list x) |> of_voidp
 
-    let get_commit_list (type a)
+    let get_commit_array (type a)
         (module S : Irmin.Generic_key.S with type commit = a)
-        (x : Struct.commit_list ptr) : a array =
+        (x : Struct.commit_array ptr) : a array =
       Root.get (to_voidp x)
 
-    let create_commit_list (type a)
+    let create_commit_array (type a)
         (module S : Irmin.Generic_key.S with type commit = a) (x : a list) :
-        Struct.commit_list ptr =
+        Struct.commit_array ptr =
       Root.create (Array.of_list x) |> of_voidp
   end
 end

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -19,11 +19,13 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       return
     [@@inline]
 
-  let catch' f = catch null f
+  let null t = Ctypes.coerce (ptr void) t null
+  let catch' t f = catch (null t) f
 
-  let free store =
-    if not (is_null store) then
-      (fun x -> catch () (fun () -> Ctypes.Root.release x)) store
+  let free x =
+    let ptr = Ctypes.to_voidp x in
+    if not (is_null ptr) then
+      (fun x -> catch () (fun () -> Ctypes.Root.release x)) ptr
 
   let strlen ptr =
     if is_null ptr then 0
@@ -48,158 +50,183 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         run x
 
   module Root = struct
-    let get_repo (type a) x : a repo = Root.get x [@@inline]
+    let to_voidp x = Obj.magic x
+    let of_voidp x = Obj.magic x
+
+    let get_repo (type a) (x : Struct.repo ptr) : a repo = Root.get (to_voidp x)
+      [@@inline]
 
     let create_repo (type a) (module S : Irmin.Generic_key.S with type repo = a)
-        (r : a repo) =
-      Root.create r
+        (r : a repo) : Struct.repo ptr =
+      Root.create r |> of_voidp
       [@@inline]
 
-    let get_store (type a) x : a store = Root.get x [@@inline]
+    let get_store (type a) (x : Struct.store ptr) : a store =
+      Root.get (to_voidp x)
+      [@@inline]
 
     let create_store (type a) (module S : Irmin.Generic_key.S with type t = a)
-        (r : a store) =
-      Root.create r
+        (r : a store) : Struct.store ptr =
+      Root.create r |> of_voidp
       [@@inline]
 
-    let get_config x : config = Root.get x
-    let create_config (r : config) = Root.create r
-    let set_config ptr (x : config) = Root.set ptr x
-    let get_ty x : 'a Irmin.Type.t = Root.get x
-    let create_ty (x : 'a Irmin.Type.t) = Root.create x
-    let get_value x : 'a = Root.get x
-    let set_value ptr x = Root.set ptr x
-    let create_value (x : 'a) = Root.create x
+    let get_config (x : Struct.config ptr) : config = Root.get (to_voidp x)
+
+    let create_config (r : config) : Struct.config ptr =
+      Root.create r |> of_voidp
+
+    let set_config (ptr : Struct.config ptr) (x : config) =
+      Root.set (to_voidp ptr) x
+
+    let get_ty (x : Struct.ty ptr) : 'a Irmin.Type.t = Root.get (to_voidp x)
+
+    let create_ty (x : 'a Irmin.Type.t) : Struct.ty ptr =
+      Root.create x |> of_voidp
+
+    let get_value (x : Struct.value ptr) : 'a = Root.get (to_voidp x)
+    let set_value (ptr : Struct.value ptr) x = Root.set (to_voidp ptr) x
+    let create_value (x : 'a) : Struct.value ptr = Root.create x |> of_voidp
 
     let get_path (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Path.t = a) x : S.path
-        =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
+        (x : Struct.path ptr) : S.path =
+      Root.get (to_voidp x)
 
     let create_path (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
-        (r : S.path) =
-      Root.create r
+        (r : S.path) : Struct.path ptr =
+      Root.create r |> of_voidp
 
     let get_metadata (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a) x :
-        S.metadata =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a)
+        (x : Struct.metadata ptr) : S.metadata =
+      Root.get (of_voidp x)
 
     let create_metadata (type a)
         (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a)
-        (r : S.metadata) =
-      Root.create r
+        (r : S.metadata) : Struct.metadata ptr =
+      Root.create r |> of_voidp
 
     let get_hash (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Hash.t = a) x : S.hash
-        =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Hash.t = a)
+        (x : Struct.hash ptr) : S.hash =
+      Root.get (to_voidp x)
 
     let create_hash (type a)
         (module S : Irmin.Generic_key.S with type Schema.Hash.t = a)
-        (r : S.hash) =
-      Root.create r
+        (r : S.hash) : Struct.hash ptr =
+      Root.create r |> of_voidp
 
     let get_commit_key (type a)
-        (module S : Irmin.Generic_key.S with type commit_key = a) x :
-        S.commit_key =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type commit_key = a)
+        (x : Struct.commit_key ptr) : S.commit_key =
+      Root.get (to_voidp x)
 
     let create_commit_key (type a)
         (module S : Irmin.Generic_key.S with type commit_key = a)
-        (r : S.commit_key) =
-      Root.create r
+        (r : S.commit_key) : Struct.commit_key ptr =
+      Root.create r |> of_voidp
 
     let get_kinded_key (type a b c)
         (module S : Irmin.Generic_key.S
           with type node_key = a
            and type contents_key = b
-           and type Schema.Metadata.t = c) x : S.Tree.kinded_key =
-      Root.get x
+           and type Schema.Metadata.t = c) (x : Struct.kinded_key ptr) :
+        S.Tree.kinded_key =
+      Root.get (to_voidp x)
 
     let create_kinded_key (type a b c)
         (module S : Irmin.Generic_key.S
           with type node_key = a
            and type contents_key = b
-           and type Schema.Metadata.t = c) (r : S.Tree.kinded_key) =
-      Root.create r
+           and type Schema.Metadata.t = c) (r : S.Tree.kinded_key) :
+        Struct.kinded_key ptr =
+      Root.create r |> of_voidp
 
-    let get_tree (type a) (module S : Irmin.Generic_key.S with type tree = a) x
-        : S.tree =
-      Root.get x
+    let get_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
+        (x : Struct.tree ptr) : S.tree =
+      Root.get (to_voidp x)
 
     let create_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
-        (r : S.tree) =
-      Root.create r
+        (r : S.tree) : Struct.tree ptr =
+      Root.create r |> of_voidp
 
     let set_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
-        ptr (r : S.tree) =
-      Root.set ptr r
+        (ptr : Struct.tree ptr) (r : S.tree) =
+      Root.set (to_voidp ptr) r
 
     let get_commit (type a)
-        (module S : Irmin.Generic_key.S with type commit = a) x : S.commit =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type commit = a)
+        (x : Struct.commit ptr) : S.commit =
+      Root.get (of_voidp x)
 
     let create_commit (type a)
-        (module S : Irmin.Generic_key.S with type commit = a) (r : S.commit) =
-      Root.create r
+        (module S : Irmin.Generic_key.S with type commit = a) (r : S.commit) :
+        Struct.commit ptr =
+      Root.create r |> to_voidp
 
     let get_contents (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Contents.t = a) x :
-        S.contents =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Contents.t = a)
+        (x : Struct.contents ptr) : S.contents =
+      Root.get (to_voidp x)
 
     let create_contents (type a)
         (module S : Irmin.Generic_key.S with type Schema.Contents.t = a)
-        (r : S.contents) =
-      Root.create r
+        (r : S.contents) : Struct.contents ptr =
+      Root.create r |> of_voidp
 
     let get_info (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Info.t = a) x : S.info
-        =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
+        (x : Struct.info ptr) : S.info =
+      Root.get (to_voidp x)
 
     let set_info (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Info.t = a) ptr
-        (x : S.info) : unit =
-      Root.set ptr x
+        (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
+        (ptr : Struct.info ptr) (x : S.info) : unit =
+      Root.set (to_voidp ptr) x
 
     let create_info (type a)
         (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
-        (r : S.info) =
-      Root.create r
+        (r : S.info) : Struct.info ptr =
+      Root.create r |> of_voidp
 
-    let get_string x : string = Root.get x
-    let set_string ptr (x : string) : unit = Root.set ptr x
-    let create_string (s : string) = Root.create s
+    let get_string (x : Struct.irmin_string ptr) : string =
+      Root.get (of_voidp x)
+
+    let set_string (ptr : Struct.irmin_string ptr) (x : string) : unit =
+      Root.set (to_voidp ptr) x
+
+    let create_string (s : string) : Struct.irmin_string ptr =
+      Root.create s |> of_voidp
 
     let get_branch_list (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Branch.t = a) x :
-        a array =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
+        (x : Struct.branch_list ptr) : a array =
+      Root.get (to_voidp x)
 
     let create_branch_list (type a)
         (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
-        (x : S.Branch.t list) =
-      Root.create (Array.of_list x)
+        (x : S.Branch.t list) : Struct.branch_list ptr =
+      Root.create (Array.of_list x) |> of_voidp
 
     let get_path_list (type a)
-        (module S : Irmin.Generic_key.S with type Schema.Path.t = a) x : a array
-        =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
+        (x : Struct.path_list ptr) : a array =
+      Root.get (to_voidp x)
 
     let create_path_list (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
-        (x : S.Path.t list) =
-      Root.create (Array.of_list x)
+        (x : S.Path.t list) : Struct.path_list ptr =
+      Root.create (Array.of_list x) |> of_voidp
 
     let get_commit_list (type a)
-        (module S : Irmin.Generic_key.S with type commit = a) x : a array =
-      Root.get x
+        (module S : Irmin.Generic_key.S with type commit = a)
+        (x : Struct.commit_list ptr) : a array =
+      Root.get (to_voidp x)
 
     let create_commit_list (type a)
-        (module S : Irmin.Generic_key.S with type commit = a) (x : a list) =
-      Root.create (Array.of_list x)
+        (module S : Irmin.Generic_key.S with type commit = a) (x : a list) :
+        Struct.commit_list ptr =
+      Root.create (Array.of_list x) |> of_voidp
   end
 end

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -10,6 +10,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let type_name x = Fmt.to_to_string Irmin.Type.pp_ty x
 
+  (* Handle errors and set error function, returns [return] if an exception is raised *)
   let catch return f =
     try
       let () = error_msg := None in
@@ -20,8 +21,11 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     [@@inline]
 
   let null t = Ctypes.coerce (ptr void) t null
+
+  (* Similar to catch but returns a null pointer *)
   let catch' t f = catch (null t) f
 
+  (* Generic free function for all rooted values *)
   let free x =
     let ptr = Ctypes.to_voidp x in
     if not (is_null ptr) then
@@ -41,6 +45,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let fn name t f = I.internal ~runtime_lock:false ("irmin_" ^ name) t f
 
+  (* Minimal executor for lwt promises *)
   let rec run x =
     Lwt.wakeup_paused ();
     match Lwt.poll x with

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -65,82 +65,89 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         run x
 
   module Root = struct
-    let to_voidp x = Obj.magic x
-    let of_voidp x = if is_null x then failwith "null pointer" else Obj.magic x
+    let to_voidp t x = Ctypes.coerce t (ptr void) x
 
-    let get_repo (type a) (x : Struct.repo ptr) : a repo = Root.get (to_voidp x)
+    let of_voidp t x =
+      if is_null x then failwith "null pointer"
+      else Ctypes.coerce (ptr void) t x
+
+    let get_repo (type a) (x : Struct.repo ptr) : a repo =
+      Root.get (to_voidp repo x)
       [@@inline]
 
     let create_repo (type a) (module S : Irmin.Generic_key.S with type repo = a)
         (r : a repo) : Struct.repo ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp repo
       [@@inline]
 
     let get_store (type a) (x : Struct.store ptr) : a store =
-      Root.get (to_voidp x)
+      Root.get (to_voidp store x)
       [@@inline]
 
     let create_store (type a) (module S : Irmin.Generic_key.S with type t = a)
         (r : a store) : Struct.store ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp store
       [@@inline]
 
-    let get_config (x : Struct.config ptr) : config = Root.get (to_voidp x)
+    let get_config (x : Struct.config ptr) : config =
+      Root.get (to_voidp config x)
 
     let create_config (r : config) : Struct.config ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp config
 
     let set_config (ptr : Struct.config ptr) (x : config) =
-      Root.set (to_voidp ptr) x
+      Root.set (to_voidp config ptr) x
 
-    let get_ty (x : Struct.ty ptr) : 'a Irmin.Type.t = Root.get (to_voidp x)
+    let get_ty (x : Struct.ty ptr) : 'a Irmin.Type.t = Root.get (to_voidp ty x)
 
     let create_ty (x : 'a Irmin.Type.t) : Struct.ty ptr =
-      Root.create x |> of_voidp
+      Root.create x |> of_voidp ty
 
-    let get_value (x : Struct.value ptr) : 'a = Root.get (to_voidp x)
-    let set_value (ptr : Struct.value ptr) x = Root.set (to_voidp ptr) x
-    let create_value (x : 'a) : Struct.value ptr = Root.create x |> of_voidp
+    let get_value (x : Struct.value ptr) : 'a = Root.get (to_voidp value x)
+    let set_value (ptr : Struct.value ptr) x = Root.set (to_voidp value ptr) x
+
+    let create_value (x : 'a) : Struct.value ptr =
+      Root.create x |> of_voidp value
 
     let get_path (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
         (x : Struct.path ptr) : S.path =
-      Root.get (to_voidp x)
+      Root.get (to_voidp path x)
 
     let create_path (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
         (r : S.path) : Struct.path ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp path
 
     let get_metadata (type a)
         (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a)
         (x : Struct.metadata ptr) : S.metadata =
-      Root.get (of_voidp x)
+      Root.get (to_voidp metadata x)
 
     let create_metadata (type a)
         (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a)
         (r : S.metadata) : Struct.metadata ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp metadata
 
     let get_hash (type a)
         (module S : Irmin.Generic_key.S with type Schema.Hash.t = a)
         (x : Struct.hash ptr) : S.hash =
-      Root.get (to_voidp x)
+      Root.get (to_voidp hash x)
 
     let create_hash (type a)
         (module S : Irmin.Generic_key.S with type Schema.Hash.t = a)
         (r : S.hash) : Struct.hash ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp hash
 
     let get_commit_key (type a)
         (module S : Irmin.Generic_key.S with type commit_key = a)
         (x : Struct.commit_key ptr) : S.commit_key =
-      Root.get (to_voidp x)
+      Root.get (to_voidp commit_key x)
 
     let create_commit_key (type a)
         (module S : Irmin.Generic_key.S with type commit_key = a)
         (r : S.commit_key) : Struct.commit_key ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp commit_key
 
     let get_kinded_key (type a b c)
         (module S : Irmin.Generic_key.S
@@ -148,7 +155,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
            and type contents_key = b
            and type Schema.Metadata.t = c) (x : Struct.kinded_key ptr) :
         S.Tree.kinded_key =
-      Root.get (to_voidp x)
+      Root.get (to_voidp kinded_key x)
 
     let create_kinded_key (type a b c)
         (module S : Irmin.Generic_key.S
@@ -156,92 +163,92 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
            and type contents_key = b
            and type Schema.Metadata.t = c) (r : S.Tree.kinded_key) :
         Struct.kinded_key ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp kinded_key
 
     let get_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
         (x : Struct.tree ptr) : S.tree =
-      Root.get (to_voidp x)
+      Root.get (to_voidp tree x)
 
     let create_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
         (r : S.tree) : Struct.tree ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp tree
 
     let set_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
         (ptr : Struct.tree ptr) (r : S.tree) =
-      Root.set (to_voidp ptr) r
+      Root.set (to_voidp tree ptr) r
 
     let get_commit (type a)
         (module S : Irmin.Generic_key.S with type commit = a)
         (x : Struct.commit ptr) : S.commit =
-      Root.get (of_voidp x)
+      Root.get (to_voidp commit x)
 
     let create_commit (type a)
         (module S : Irmin.Generic_key.S with type commit = a) (r : S.commit) :
         Struct.commit ptr =
-      Root.create r |> to_voidp
+      Root.create r |> of_voidp commit
 
     let get_contents (type a)
         (module S : Irmin.Generic_key.S with type Schema.Contents.t = a)
         (x : Struct.contents ptr) : S.contents =
-      Root.get (to_voidp x)
+      Root.get (to_voidp contents x)
 
     let create_contents (type a)
         (module S : Irmin.Generic_key.S with type Schema.Contents.t = a)
         (r : S.contents) : Struct.contents ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp contents
 
     let get_info (type a)
         (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
         (x : Struct.info ptr) : S.info =
-      Root.get (to_voidp x)
+      Root.get (to_voidp info x)
 
     let set_info (type a)
         (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
         (ptr : Struct.info ptr) (x : S.info) : unit =
-      Root.set (to_voidp ptr) x
+      Root.set (to_voidp info ptr) x
 
     let create_info (type a)
         (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
         (r : S.info) : Struct.info ptr =
-      Root.create r |> of_voidp
+      Root.create r |> of_voidp info
 
     let get_string (x : Struct.irmin_string ptr) : string =
-      Root.get (of_voidp x)
+      Root.get (to_voidp irmin_string x)
 
     let set_string (ptr : Struct.irmin_string ptr) (x : string) : unit =
-      Root.set (to_voidp ptr) x
+      Root.set (to_voidp irmin_string ptr) x
 
     let create_string (s : string) : Struct.irmin_string ptr =
-      Root.create s |> of_voidp
+      Root.create s |> of_voidp irmin_string
 
     let get_branch_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
         (x : Struct.branch_array ptr) : a array =
-      Root.get (to_voidp x)
+      Root.get (to_voidp branch_array x)
 
     let create_branch_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
         (x : S.Branch.t list) : Struct.branch_array ptr =
-      Root.create (Array.of_list x) |> of_voidp
+      Root.create (Array.of_list x) |> of_voidp branch_array
 
     let get_path_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
         (x : Struct.path_array ptr) : a array =
-      Root.get (to_voidp x)
+      Root.get (to_voidp path_array x)
 
     let create_path_array (type a)
         (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
         (x : S.Path.t list) : Struct.path_array ptr =
-      Root.create (Array.of_list x) |> of_voidp
+      Root.create (Array.of_list x) |> of_voidp path_array
 
     let get_commit_array (type a)
         (module S : Irmin.Generic_key.S with type commit = a)
         (x : Struct.commit_array ptr) : a array =
-      Root.get (to_voidp x)
+      Root.get (to_voidp commit_array x)
 
     let create_commit_array (type a)
         (module S : Irmin.Generic_key.S with type commit = a) (x : a list) :
         Struct.commit_array ptr =
-      Root.create (Array.of_list x) |> of_voidp
+      Root.create (Array.of_list x) |> of_voidp commit_array
   end
 end

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -222,6 +222,12 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         (module S : Irmin.Generic_key.S with type commit = a) (x : a list) :
         Struct.commit_array ptr =
       Root.create (Array.of_list x) |> of_voidp commit_array
+
+    let get_remote (x : Struct.remote ptr) : Irmin.remote =
+      Root.get (to_voidp remote x)
+
+    let create_remote (x : Irmin.remote) : Struct.remote ptr =
+      Root.create x |> of_voidp remote
   end
 
   (* Handle errors and set error function, returns [return] if an exception is raised *)
@@ -231,7 +237,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       repo.error <- None;
       f repo.repo_mod repo.repo
     with
-    | Failure msg ->
+    | Failure msg | Invalid_argument msg ->
         repo.error <- Some msg;
         return
     | exn ->
@@ -251,7 +257,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       ctx.error <- None;
       f store.store_mod store.store
     with
-    | Failure msg ->
+    | Failure msg | Invalid_argument msg ->
         ctx.error <- Some msg;
         return
     | exn ->

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -1,0 +1,205 @@
+let error_msg : string option ref = ref None
+
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  include Ctypes
+  include Types
+  include Unsigned
+
+  let find_config_key config name =
+    Irmin.Backend.Conf.Spec.find_key (Irmin.Backend.Conf.spec config) name
+
+  let type_name x = Fmt.to_to_string Irmin.Type.pp_ty x
+
+  let catch return f =
+    try
+      let () = error_msg := None in
+      f ()
+    with exn ->
+      let () = error_msg := Some (Printexc.to_string exn) in
+      return
+    [@@inline]
+
+  let catch' f = catch null f
+
+  let free store =
+    if not (is_null store) then
+      (fun x -> catch () (fun () -> Ctypes.Root.release x)) store
+
+  let strlen ptr =
+    if is_null ptr then 0
+    else
+      let rec loop i =
+        if !@(ptr +@ i) = char_of_int 0 then i else loop (i + 1)
+      in
+      loop 0
+
+  let get_length length s =
+    let length = Int64.to_int length in
+    if length < 0 then strlen s else length
+
+  let fn name t f = I.internal ~runtime_lock:false ("irmin_" ^ name) t f
+
+  let rec run x =
+    Lwt.wakeup_paused ();
+    match Lwt.poll x with
+    | Some x -> x
+    | None ->
+        let () = Lwt_engine.iter true in
+        run x
+
+  module Root = struct
+    let get_repo (type a) x : a repo = Root.get x [@@inline]
+
+    let create_repo (type a) (module S : Irmin.Generic_key.S with type repo = a)
+        (r : a repo) =
+      Root.create r
+      [@@inline]
+
+    let get_store (type a) x : a store = Root.get x [@@inline]
+
+    let create_store (type a) (module S : Irmin.Generic_key.S with type t = a)
+        (r : a store) =
+      Root.create r
+      [@@inline]
+
+    let get_config x : config = Root.get x
+    let create_config (r : config) = Root.create r
+    let set_config ptr (x : config) = Root.set ptr x
+    let get_ty x : 'a Irmin.Type.t = Root.get x
+    let create_ty (x : 'a Irmin.Type.t) = Root.create x
+    let get_value x : 'a = Root.get x
+    let set_value ptr x = Root.set ptr x
+    let create_value (x : 'a) = Root.create x
+
+    let get_path (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Path.t = a) x : S.path
+        =
+      Root.get x
+
+    let create_path (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
+        (r : S.path) =
+      Root.create r
+
+    let get_metadata (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a) x :
+        S.metadata =
+      Root.get x
+
+    let create_metadata (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Metadata.t = a)
+        (r : S.metadata) =
+      Root.create r
+
+    let get_hash (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Hash.t = a) x : S.hash
+        =
+      Root.get x
+
+    let create_hash (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Hash.t = a)
+        (r : S.hash) =
+      Root.create r
+
+    let get_commit_key (type a)
+        (module S : Irmin.Generic_key.S with type commit_key = a) x :
+        S.commit_key =
+      Root.get x
+
+    let create_commit_key (type a)
+        (module S : Irmin.Generic_key.S with type commit_key = a)
+        (r : S.commit_key) =
+      Root.create r
+
+    let get_kinded_key (type a b c)
+        (module S : Irmin.Generic_key.S
+          with type node_key = a
+           and type contents_key = b
+           and type Schema.Metadata.t = c) x : S.Tree.kinded_key =
+      Root.get x
+
+    let create_kinded_key (type a b c)
+        (module S : Irmin.Generic_key.S
+          with type node_key = a
+           and type contents_key = b
+           and type Schema.Metadata.t = c) (r : S.Tree.kinded_key) =
+      Root.create r
+
+    let get_tree (type a) (module S : Irmin.Generic_key.S with type tree = a) x
+        : S.tree =
+      Root.get x
+
+    let create_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
+        (r : S.tree) =
+      Root.create r
+
+    let set_tree (type a) (module S : Irmin.Generic_key.S with type tree = a)
+        ptr (r : S.tree) =
+      Root.set ptr r
+
+    let get_commit (type a)
+        (module S : Irmin.Generic_key.S with type commit = a) x : S.commit =
+      Root.get x
+
+    let create_commit (type a)
+        (module S : Irmin.Generic_key.S with type commit = a) (r : S.commit) =
+      Root.create r
+
+    let get_contents (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Contents.t = a) x :
+        S.contents =
+      Root.get x
+
+    let create_contents (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Contents.t = a)
+        (r : S.contents) =
+      Root.create r
+
+    let get_info (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Info.t = a) x : S.info
+        =
+      Root.get x
+
+    let set_info (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Info.t = a) ptr
+        (x : S.info) : unit =
+      Root.set ptr x
+
+    let create_info (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
+        (r : S.info) =
+      Root.create r
+
+    let get_string x : string = Root.get x
+    let set_string ptr (x : string) : unit = Root.set ptr x
+    let create_string (s : string) = Root.create s
+
+    let get_branch_list (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Branch.t = a) x :
+        a array =
+      Root.get x
+
+    let create_branch_list (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Branch.t = a)
+        (x : S.Branch.t list) =
+      Root.create (Array.of_list x)
+
+    let get_path_list (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Path.t = a) x : a array
+        =
+      Root.get x
+
+    let create_path_list (type a)
+        (module S : Irmin.Generic_key.S with type Schema.Path.t = a)
+        (x : S.Path.t list) =
+      Root.create (Array.of_list x)
+
+    let get_commit_list (type a)
+        (module S : Irmin.Generic_key.S with type commit = a) x : a array =
+      Root.get x
+
+    let create_commit_list (type a)
+        (module S : Irmin.Generic_key.S with type commit = a) (x : a list) =
+      Root.create (Array.of_list x)
+  end
+end

--- a/src/libirmin/value.ml
+++ b/src/libirmin/value.ml
@@ -62,79 +62,35 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         Root.create_value (string_from_ptr s ~length))
 
   let () =
-    fn "value_list_new"
-      (void @-> returning value)
-      (fun () -> Root.create_value [])
+    fn "value_array"
+      (ptr value @-> uint64_t @-> returning value)
+      (fun arr n ->
+        catch' value (fun () ->
+            let n = UInt64.to_int n in
+            let a =
+              if is_null arr || n = 0 then [||]
+              else
+                CArray.from_ptr arr n
+                |> CArray.to_list
+                |> List.map Root.get_value
+                |> Array.of_list
+            in
+            Root.create_value a))
 
   let () =
-    fn "value_list_add"
-      (value @-> value @-> returning void)
-      (fun (type a) list x ->
-        let a : a list = Root.get_value list in
-        let b : a = Root.get_value x in
-        Root.set_value list (a @ [ b ]))
-
-  let () =
-    fn "value_list_hd"
-      (value @-> returning value)
-      (fun list ->
-        let list = Root.get_value list in
-        match list with
-        | [] -> null value
-        | list -> Root.create_value (List.hd list))
-
-  let () =
-    fn "value_list_tl"
-      (value @-> returning value)
-      (fun list ->
-        let list = Root.get_value list in
-        Root.create_value (List.tl list))
-
-  let () =
-    fn "value_list_get"
-      (value @-> uint64_t @-> returning value)
-      (fun (type a) arr i ->
-        let i = UInt64.to_int i in
-        let x : a list = Root.get_value arr in
-        Root.create_value (List.nth x i))
-
-  let () =
-    fn "value_list_length"
-      (value @-> returning uint64_t)
-      (fun (type a) x ->
-        let x : a list = Root.get_value x in
-        List.length x |> UInt64.of_int)
-
-  let () =
-    fn "value_array_new"
-      (uint64_t @-> value @-> returning value)
-      (fun i x ->
-        let x = Root.get_value x in
-        Root.create_value (Array.make (UInt64.to_int i) x))
-
-  let () =
-    fn "value_array_set"
-      (value @-> uint64_t @-> value @-> returning void)
-      (fun (type a) arr i x ->
-        let i = UInt64.to_int i in
-        let arr : a array = Root.get_value arr in
-        let x : a = Root.get_value x in
-        arr.(i) <- x)
-
-  let () =
-    fn "value_array_get"
-      (value @-> uint64_t @-> returning value)
-      (fun (type a) arr i ->
-        let i = UInt64.to_int i in
-        let arr : a array = Root.get_value arr in
-        Root.create_value arr.(i))
-
-  let () =
-    fn "value_array_length"
-      (value @-> returning uint64_t)
-      (fun (type a) arr ->
-        let arr : a array = Root.get_value arr in
-        Array.length arr |> UInt64.of_int)
+    fn "value_list"
+      (ptr value @-> uint64_t @-> returning value)
+      (fun arr n ->
+        catch' value (fun () ->
+            let n = UInt64.to_int n in
+            let l =
+              if is_null arr || n = 0 then []
+              else
+                CArray.from_ptr arr n
+                |> CArray.to_list
+                |> List.map Root.get_value
+            in
+            Root.create_value l))
 
   let () =
     fn "value_option"

--- a/src/libirmin/value.ml
+++ b/src/libirmin/value.ml
@@ -1,0 +1,283 @@
+module Make (I : Cstubs_inverted.INTERNAL) = struct
+  open Util.Make (I)
+
+  let () =
+    fn "value_unit" (void @-> returning value) (fun () -> Root.create_value ())
+
+  let () =
+    fn "value_int"
+      (int64_t @-> returning value)
+      (fun i -> Root.create_value (Int64.to_int i))
+
+  let () =
+    fn "value_float" (double @-> returning value) (fun i -> Root.create_value i)
+
+  let () =
+    fn "value_bool" (bool @-> returning value) (fun b -> Root.create_value b)
+
+  let () =
+    fn "value_clone" (value @-> returning value) (fun x -> Root.create_value x)
+
+  let () =
+    fn "value_get_string"
+      (value @-> returning irmin_string)
+      (fun value ->
+        let obj = Ctypes.Root.get value |> Obj.repr in
+        if Obj.tag obj = Obj.string_tag then Root.create_string (Obj.obj obj)
+        else null)
+
+  let () =
+    fn "value_get_int"
+      (value @-> returning int64_t)
+      (fun x ->
+        let obj = Ctypes.Root.get x |> Obj.repr in
+        if Obj.is_int obj then Int64.of_int (Obj.obj obj) else Int64.zero)
+
+  let () =
+    fn "value_get_bool"
+      (value @-> returning bool)
+      (fun x ->
+        let obj = Ctypes.Root.get x |> Obj.repr in
+        if Obj.is_int obj then Obj.obj obj else false)
+
+  let () =
+    fn "value_get_float"
+      (value @-> returning double)
+      (fun x ->
+        let obj = Ctypes.Root.get x |> Obj.repr in
+        if Obj.is_int obj then Obj.obj obj else 0.)
+
+  let () =
+    fn "value_bytes"
+      (ptr char @-> int64_t @-> returning value)
+      (fun s length ->
+        let length = get_length length s in
+        Root.create_value (Bytes.of_string (string_from_ptr s ~length)))
+
+  let () =
+    fn "value_string"
+      (ptr char @-> int64_t @-> returning value)
+      (fun s length ->
+        let length = get_length length s in
+        Root.create_value (string_from_ptr s ~length))
+
+  let () =
+    fn "value_list_new"
+      (void @-> returning value)
+      (fun () -> Root.create_value [])
+
+  let () =
+    fn "value_list_add"
+      (value @-> value @-> returning void)
+      (fun (type a) list x ->
+        let a : a list = Root.get_value list in
+        let b : a = Root.get_value x in
+        Root.set_value list (a @ [ b ]))
+
+  let () =
+    fn "value_list_hd"
+      (value @-> returning value)
+      (fun list ->
+        let list = Root.get_value list in
+        match list with [] -> null | list -> Root.create_value (List.hd list))
+
+  let () =
+    fn "value_list_tl"
+      (value @-> returning value)
+      (fun list ->
+        let list = Root.get_value list in
+        Root.create_value (List.tl list))
+
+  let () =
+    fn "value_list_get"
+      (value @-> uint64_t @-> returning value)
+      (fun (type a) arr i ->
+        let i = UInt64.to_int i in
+        let x : a list = Root.get_value arr in
+        Root.create_value (List.nth x i))
+
+  let () =
+    fn "value_list_length"
+      (value @-> returning uint64_t)
+      (fun (type a) x ->
+        let x : a list = Root.get_value x in
+        List.length x |> UInt64.of_int)
+
+  let () =
+    fn "value_array_new"
+      (uint64_t @-> value @-> returning value)
+      (fun i x ->
+        let x = Root.get_value x in
+        Root.create_value (Array.make (UInt64.to_int i) x))
+
+  let () =
+    fn "value_array_set"
+      (value @-> uint64_t @-> value @-> returning void)
+      (fun (type a) arr i x ->
+        let i = UInt64.to_int i in
+        let arr : a array = Root.get_value arr in
+        let x : a = Root.get_value x in
+        arr.(i) <- x)
+
+  let () =
+    fn "value_array_get"
+      (value @-> uint64_t @-> returning value)
+      (fun (type a) arr i ->
+        let i = UInt64.to_int i in
+        let arr : a array = Root.get_value arr in
+        Root.create_value arr.(i))
+
+  let () =
+    fn "value_array_length"
+      (value @-> returning uint64_t)
+      (fun (type a) arr ->
+        let arr : a array = Root.get_value arr in
+        Array.length arr |> UInt64.of_int)
+
+  let () =
+    fn "value_option"
+      (value @-> returning value)
+      (fun value ->
+        if is_null value then Root.create_value None
+        else
+          let x = Root.get_value value in
+          Root.create_value (Some x))
+
+  let () =
+    fn "value_pair"
+      (value @-> value @-> returning value)
+      (fun a b ->
+        let a = Root.get_value a in
+        let b = Root.get_value b in
+        Root.create_value (a, b))
+
+  let () =
+    fn "value_triple"
+      (value @-> value @-> value @-> returning value)
+      (fun a b c ->
+        let a = Root.get_value a in
+        let b = Root.get_value b in
+        let c = Root.get_value c in
+        Root.create_value (a, b, c))
+
+  let () =
+    fn "value_to_string"
+      (ty @-> value @-> returning irmin_string)
+      (fun ty value ->
+        let t = Root.get_ty ty in
+        let v = Root.get_value value in
+        let s = Irmin.Type.to_string t v in
+        Root.create_string s)
+
+  let () =
+    fn "value_of_string"
+      (ty @-> ptr char @-> int64_t @-> returning value)
+      (fun ty s length ->
+        catch' (fun () ->
+            let length = get_length length s in
+            let ty = Root.get_ty ty in
+            let s = string_from_ptr s ~length in
+            match Irmin.Type.(of_string ty) s with
+            | Ok x -> Root.create_value x
+            | Error (`Msg e) ->
+                let () = Util.error_msg := Some e in
+                null))
+
+  let () =
+    fn "value_to_bin"
+      (ty @-> value @-> returning irmin_string)
+      (fun ty value ->
+        catch' (fun () ->
+            let t = Root.get_ty ty in
+            let v = Root.get_value value in
+            let s = Irmin.Type.(unstage (to_bin_string t)) v in
+            Root.create_string s))
+
+  let () =
+    fn "value_of_bin"
+      (ty @-> ptr char @-> int64_t @-> returning value)
+      (fun ty s length ->
+        catch' (fun () ->
+            let length = get_length length s in
+            let ty = Root.get_ty ty in
+            let s = string_from_ptr s ~length in
+            match Irmin.Type.(unstage (of_bin_string ty)) s with
+            | Ok x -> Root.create_value x
+            | Error (`Msg e) ->
+                let () = Util.error_msg := Some e in
+                null))
+
+  let () =
+    fn "value_to_json"
+      (ty @-> value @-> returning irmin_string)
+      (fun ty value ->
+        catch' (fun () ->
+            let t = Root.get_ty ty in
+            let v = Root.get_value value in
+            let s = Irmin.Type.(to_json_string t) v in
+            Root.create_string s))
+
+  let () =
+    fn "value_of_json"
+      (ty @-> ptr char @-> int64_t @-> returning value)
+      (fun ty s length ->
+        let length = get_length length s in
+        let ty = Root.get_ty ty in
+        let s = string_from_ptr s ~length in
+        match Irmin.Type.(of_json_string ty) s with
+        | Ok x -> Root.create_value x
+        | Error (`Msg e) ->
+            let () = Util.error_msg := Some e in
+            null)
+
+  let () =
+    fn "value_equal"
+      (ty @-> value @-> value @-> returning bool)
+      (fun ty a b ->
+        catch false (fun () ->
+            let ty = Root.get_ty ty in
+            let a = Root.get_value a in
+            let b = Root.get_value b in
+            Irmin.Type.(unstage (equal ty)) a b))
+
+  let () =
+    fn "value_compare"
+      (ty @-> value @-> value @-> returning int)
+      (fun ty a b ->
+        let ty = Root.get_ty ty in
+        let a = Root.get_value a in
+        let b = Root.get_value b in
+        Irmin.Type.(unstage (compare ty)) a b)
+
+  let () = fn "value_free" (value @-> returning void) free
+
+  let () =
+    fn "string_new"
+      (ptr char @-> int64_t @-> returning irmin_string)
+      (fun ptr i ->
+        catch' (fun () ->
+            let i = Int64.to_int i in
+            let length = if i < 0 then strlen ptr else i in
+            let s = string_from_ptr ptr ~length in
+            Root.create_string s))
+
+  let () =
+    fn "string_data"
+      (irmin_string @-> returning (ptr char))
+      (fun s ->
+        if is_null s then coerce (ptr void) (ptr char) null
+        else
+          let s : string = Root.get_string s in
+          coerce string (ptr char) s)
+
+  let () =
+    fn "string_length"
+      (irmin_string @-> returning uint64_t)
+      (fun s ->
+        if is_null s then UInt64.zero
+        else
+          let s : string = Root.get_string s in
+          String.length s |> UInt64.of_int)
+
+  let () = fn "string_free" (irmin_string @-> returning void) free
+end

--- a/src/libirmin/value.ml
+++ b/src/libirmin/value.ml
@@ -21,6 +21,13 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun x -> Root.create_value (Root.get_value x))
 
   let () =
+    fn "realloc"
+      (ptr void @-> ptr void @-> returning (ptr void))
+      (fun src dest ->
+        Ctypes.Root.set src (Ctypes.Root.get dest);
+        src)
+
+  let () =
     fn "value_get_string"
       (value @-> returning irmin_string)
       (fun value ->

--- a/test/libirmin/dune
+++ b/test/libirmin/dune
@@ -1,0 +1,15 @@
+(rule
+ (alias  runtest)
+ (package libirmin)
+ (action
+  (setenv DYLD_FALLBACK_LIBRARY_PATH ../../src/libirmin/lib
+  (setenv LD_LIBRARY_PATH ../../src/libirmin/lib
+   (run ./test.exe)))))
+
+(rule
+ (targets test.exe)
+ (deps
+  (file test.c)
+  (package libirmin))
+ (action
+  (run %{cc} -I../../src/libirmin/lib -o test.exe test.c -L../../src/libirmin/lib -lirmin)))

--- a/test/libirmin/dune
+++ b/test/libirmin/dune
@@ -1,10 +1,14 @@
 (rule
- (alias  runtest)
+ (alias runtest)
  (package libirmin)
  (action
-  (setenv DYLD_FALLBACK_LIBRARY_PATH ../../src/libirmin/lib
-  (setenv LD_LIBRARY_PATH ../../src/libirmin/lib
-   (run ./test.exe)))))
+  (setenv
+   DYLD_FALLBACK_LIBRARY_PATH
+   ../../src/libirmin/lib
+   (setenv
+    LD_LIBRARY_PATH
+    ../../src/libirmin/lib
+    (run ./test.exe)))))
 
 (rule
  (targets test.exe)
@@ -13,4 +17,5 @@
   (file greatest.h)
   (package libirmin))
  (action
-  (run %{cc} -I../../src/libirmin/lib -o test.exe test.c -L../../src/libirmin/lib -lirmin)))
+  (run %{cc} -I../../src/libirmin/lib -o test.exe test.c
+    -L../../src/libirmin/lib -lirmin)))

--- a/test/libirmin/dune
+++ b/test/libirmin/dune
@@ -17,5 +17,11 @@
   (file greatest.h)
   (package libirmin))
  (action
-  (run %{cc} -I../../src/libirmin/lib -o test.exe test.c
-    -L../../src/libirmin/lib -lirmin)))
+  (run
+   %{cc}
+   -I../../src/libirmin/lib
+   -o
+   test.exe
+   test.c
+   -L../../src/libirmin/lib
+   -lirmin)))

--- a/test/libirmin/dune
+++ b/test/libirmin/dune
@@ -10,6 +10,7 @@
  (targets test.exe)
  (deps
   (file test.c)
+  (file greatest.h)
   (package libirmin))
  (action
   (run %{cc} -I../../src/libirmin/lib -o test.exe test.c -L../../src/libirmin/lib -lirmin)))

--- a/test/libirmin/greatest.h
+++ b/test/libirmin/greatest.h
@@ -1,0 +1,1290 @@
+/*
+ * Copyright (c) 2011-2021 Scott Vokes <vokes.s@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef GREATEST_H
+#define GREATEST_H
+
+#if defined(__cplusplus) && !defined(GREATEST_NO_EXTERN_CPLUSPLUS)
+extern "C" {
+#endif
+
+/* 1.5.0 */
+#define GREATEST_VERSION_MAJOR 1
+#define GREATEST_VERSION_MINOR 5
+#define GREATEST_VERSION_PATCH 0
+
+/* A unit testing system for C, contained in 1 file.
+ * It doesn't use dynamic allocation or depend on anything
+ * beyond ANSI C89.
+ *
+ * An up-to-date version can be found at:
+ *     https://github.com/silentbicycle/greatest/
+ */
+
+/*********************************************************************
+ * Minimal test runner template
+ *********************************************************************/
+#if 0
+
+#include "greatest.h"
+
+TEST foo_should_foo(void) {
+    PASS();
+}
+
+static void setup_cb(void *data) {
+    printf("setup callback for each test case\n");
+}
+
+static void teardown_cb(void *data) {
+    printf("teardown callback for each test case\n");
+}
+
+SUITE(suite) {
+    /* Optional setup/teardown callbacks which will be run before/after
+     * every test case. If using a test suite, they will be cleared when
+     * the suite finishes. */
+    SET_SETUP(setup_cb, voidp_to_callback_data);
+    SET_TEARDOWN(teardown_cb, voidp_to_callback_data);
+
+    RUN_TEST(foo_should_foo);
+}
+
+/* Add definitions that need to be in the test runner's main file. */
+GREATEST_MAIN_DEFS();
+
+/* Set up, run suite(s) of tests, report pass/fail/skip stats. */
+int run_tests(void) {
+    GREATEST_INIT();            /* init. greatest internals */
+    /* List of suites to run (if any). */
+    RUN_SUITE(suite);
+
+    /* Tests can also be run directly, without using test suites. */
+    RUN_TEST(foo_should_foo);
+
+    GREATEST_PRINT_REPORT();          /* display results */
+    return greatest_all_passed();
+}
+
+/* main(), for a standalone command-line test runner.
+ * This replaces run_tests above, and adds command line option
+ * handling and exiting with a pass/fail status. */
+int main(int argc, char **argv) {
+    GREATEST_MAIN_BEGIN();      /* init & parse command-line args */
+    RUN_SUITE(suite);
+    GREATEST_MAIN_END();        /* display results */
+}
+
+#endif
+/*********************************************************************/
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/***********
+ * Options *
+ ***********/
+
+/* Default column width for non-verbose output. */
+#ifndef GREATEST_DEFAULT_WIDTH
+#define GREATEST_DEFAULT_WIDTH 72
+#endif
+
+/* FILE *, for test logging. */
+#ifndef GREATEST_STDOUT
+#define GREATEST_STDOUT stdout
+#endif
+
+/* Remove GREATEST_ prefix from most commonly used symbols? */
+#ifndef GREATEST_USE_ABBREVS
+#define GREATEST_USE_ABBREVS 1
+#endif
+
+/* Set to 0 to disable all use of setjmp/longjmp. */
+#ifndef GREATEST_USE_LONGJMP
+#define GREATEST_USE_LONGJMP 0
+#endif
+
+/* Make it possible to replace fprintf with another
+ * function with the same interface. */
+#ifndef GREATEST_FPRINTF
+#define GREATEST_FPRINTF fprintf
+#endif
+
+#if GREATEST_USE_LONGJMP
+#include <setjmp.h>
+#endif
+
+/* Set to 0 to disable all use of time.h / clock(). */
+#ifndef GREATEST_USE_TIME
+#define GREATEST_USE_TIME 1
+#endif
+
+#if GREATEST_USE_TIME
+#include <time.h>
+#endif
+
+/* Floating point type, for ASSERT_IN_RANGE. */
+#ifndef GREATEST_FLOAT
+#define GREATEST_FLOAT double
+#define GREATEST_FLOAT_FMT "%g"
+#endif
+
+/* Size of buffer for test name + optional '_' separator and suffix */
+#ifndef GREATEST_TESTNAME_BUF_SIZE
+#define GREATEST_TESTNAME_BUF_SIZE 128
+#endif
+
+/*********
+ * Types *
+ *********/
+
+/* Info for the current running suite. */
+typedef struct greatest_suite_info {
+  unsigned int tests_run;
+  unsigned int passed;
+  unsigned int failed;
+  unsigned int skipped;
+
+#if GREATEST_USE_TIME
+  /* timers, pre/post running suite and individual tests */
+  clock_t pre_suite;
+  clock_t post_suite;
+  clock_t pre_test;
+  clock_t post_test;
+#endif
+} greatest_suite_info;
+
+/* Type for a suite function. */
+typedef void greatest_suite_cb(void);
+
+/* Types for setup/teardown callbacks. If non-NULL, these will be run
+ * and passed the pointer to their additional data. */
+typedef void greatest_setup_cb(void *udata);
+typedef void greatest_teardown_cb(void *udata);
+
+/* Type for an equality comparison between two pointers of the same type.
+ * Should return non-0 if equal, otherwise 0.
+ * UDATA is a closure value, passed through from ASSERT_EQUAL_T[m]. */
+typedef int greatest_equal_cb(const void *expd, const void *got, void *udata);
+
+/* Type for a callback that prints a value pointed to by T.
+ * Return value has the same meaning as printf's.
+ * UDATA is a closure value, passed through from ASSERT_EQUAL_T[m]. */
+typedef int greatest_printf_cb(const void *t, void *udata);
+
+/* Callbacks for an arbitrary type; needed for type-specific
+ * comparisons via GREATEST_ASSERT_EQUAL_T[m].*/
+typedef struct greatest_type_info {
+  greatest_equal_cb *equal;
+  greatest_printf_cb *print;
+} greatest_type_info;
+
+typedef struct greatest_memory_cmp_env {
+  const unsigned char *exp;
+  const unsigned char *got;
+  size_t size;
+} greatest_memory_cmp_env;
+
+/* Callbacks for string and raw memory types. */
+extern greatest_type_info greatest_type_info_string;
+extern greatest_type_info greatest_type_info_memory;
+
+typedef enum {
+  GREATEST_FLAG_FIRST_FAIL = 0x01,
+  GREATEST_FLAG_LIST_ONLY = 0x02,
+  GREATEST_FLAG_ABORT_ON_FAIL = 0x04
+} greatest_flag_t;
+
+/* Internal state for a PRNG, used to shuffle test order. */
+struct greatest_prng {
+  unsigned char random_order; /* use random ordering? */
+  unsigned char initialized;  /* is random ordering initialized? */
+  unsigned char pad_0[6];
+  unsigned long state;      /* PRNG state */
+  unsigned long count;      /* how many tests, this pass */
+  unsigned long count_ceil; /* total number of tests */
+  unsigned long count_run;  /* total tests run */
+  unsigned long a;          /* LCG multiplier */
+  unsigned long c;          /* LCG increment */
+  unsigned long m;          /* LCG modulus, based on count_ceil */
+};
+
+/* Struct containing all test runner state. */
+typedef struct greatest_run_info {
+  unsigned char flags;
+  unsigned char verbosity;
+  unsigned char running_test; /* guard for nested RUN_TEST calls */
+  unsigned char exact_name_match;
+
+  unsigned int tests_run; /* total test count */
+
+  /* currently running test suite */
+  greatest_suite_info suite;
+
+  /* overall pass/fail/skip counts */
+  unsigned int passed;
+  unsigned int failed;
+  unsigned int skipped;
+  unsigned int assertions;
+
+  /* info to print about the most recent failure */
+  unsigned int fail_line;
+  unsigned int pad_1;
+  const char *fail_file;
+  const char *msg;
+
+  /* current setup/teardown hooks and userdata */
+  greatest_setup_cb *setup;
+  void *setup_udata;
+  greatest_teardown_cb *teardown;
+  void *teardown_udata;
+
+  /* formatting info for ".....s...F"-style output */
+  unsigned int col;
+  unsigned int width;
+
+  /* only run a specific suite or test */
+  const char *suite_filter;
+  const char *test_filter;
+  const char *test_exclude;
+  const char *name_suffix; /* print suffix with test name */
+  char name_buf[GREATEST_TESTNAME_BUF_SIZE];
+
+  struct greatest_prng prng[2]; /* 0: suites, 1: tests */
+
+#if GREATEST_USE_TIME
+  /* overall timers */
+  clock_t begin;
+  clock_t end;
+#endif
+
+#if GREATEST_USE_LONGJMP
+  int pad_jmp_buf;
+  unsigned char pad_2[4];
+  jmp_buf jump_dest;
+#endif
+} greatest_run_info;
+
+struct greatest_report_t {
+  /* overall pass/fail/skip counts */
+  unsigned int passed;
+  unsigned int failed;
+  unsigned int skipped;
+  unsigned int assertions;
+};
+
+/* Global var for the current testing context.
+ * Initialized by GREATEST_MAIN_DEFS(). */
+extern greatest_run_info greatest_info;
+
+/* Type for ASSERT_ENUM_EQ's ENUM_STR argument. */
+typedef const char *greatest_enum_str_fun(int value);
+
+/**********************
+ * Exported functions *
+ **********************/
+
+/* These are used internally by greatest macros. */
+int greatest_test_pre(const char *name);
+void greatest_test_post(int res);
+int greatest_do_assert_equal_t(const void *expd, const void *got,
+                               greatest_type_info *type_info, void *udata);
+void greatest_prng_init_first_pass(int id);
+int greatest_prng_init_second_pass(int id, unsigned long seed);
+void greatest_prng_step(int id);
+
+/* These are part of the public greatest API. */
+void GREATEST_SET_SETUP_CB(greatest_setup_cb *cb, void *udata);
+void GREATEST_SET_TEARDOWN_CB(greatest_teardown_cb *cb, void *udata);
+void GREATEST_INIT(void);
+void GREATEST_PRINT_REPORT(void);
+int greatest_all_passed(void);
+void greatest_set_suite_filter(const char *filter);
+void greatest_set_test_filter(const char *filter);
+void greatest_set_test_exclude(const char *filter);
+void greatest_set_exact_name_match(void);
+void greatest_stop_at_first_fail(void);
+void greatest_abort_on_fail(void);
+void greatest_list_only(void);
+void greatest_get_report(struct greatest_report_t *report);
+unsigned int greatest_get_verbosity(void);
+void greatest_set_verbosity(unsigned int verbosity);
+void greatest_set_flag(greatest_flag_t flag);
+void greatest_set_test_suffix(const char *suffix);
+
+/********************
+ * Language Support *
+ ********************/
+
+/* If __VA_ARGS__ (C99) is supported, allow parametric testing
+ * without needing to manually manage the argument struct. */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 19901L) ||               \
+    (defined(_MSC_VER) && _MSC_VER >= 1800)
+#define GREATEST_VA_ARGS
+#endif
+
+/**********
+ * Macros *
+ **********/
+
+/* Define a suite. (The duplication is intentional -- it eliminates
+ * a warning from -Wmissing-declarations.) */
+#define GREATEST_SUITE(NAME)                                                   \
+  void NAME(void);                                                             \
+  void NAME(void)
+
+/* Declare a suite, provided by another compilation unit. */
+#define GREATEST_SUITE_EXTERN(NAME) void NAME(void)
+
+/* Start defining a test function.
+ * The arguments are not included, to allow parametric testing. */
+#define GREATEST_TEST static enum greatest_test_res
+
+/* PASS/FAIL/SKIP result from a test. Used internally. */
+typedef enum greatest_test_res {
+  GREATEST_TEST_RES_PASS = 0,
+  GREATEST_TEST_RES_FAIL = -1,
+  GREATEST_TEST_RES_SKIP = 1
+} greatest_test_res;
+
+/* Run a suite. */
+#define GREATEST_RUN_SUITE(S_NAME) greatest_run_suite(S_NAME, #S_NAME)
+
+/* Run a test in the current suite. */
+#define GREATEST_RUN_TEST(TEST)                                                \
+  do {                                                                         \
+    if (greatest_test_pre(#TEST) == 1) {                                       \
+      enum greatest_test_res res = GREATEST_SAVE_CONTEXT();                    \
+      if (res == GREATEST_TEST_RES_PASS) {                                     \
+        res = TEST();                                                          \
+      }                                                                        \
+      greatest_test_post(res);                                                 \
+    }                                                                          \
+  } while (0)
+
+/* Ignore a test, don't warn about it being unused. */
+#define GREATEST_IGNORE_TEST(TEST) (void)TEST
+
+/* Run a test in the current suite with one void * argument,
+ * which can be a pointer to a struct with multiple arguments. */
+#define GREATEST_RUN_TEST1(TEST, ENV)                                          \
+  do {                                                                         \
+    if (greatest_test_pre(#TEST) == 1) {                                       \
+      enum greatest_test_res res = GREATEST_SAVE_CONTEXT();                    \
+      if (res == GREATEST_TEST_RES_PASS) {                                     \
+        res = TEST(ENV);                                                       \
+      }                                                                        \
+      greatest_test_post(res);                                                 \
+    }                                                                          \
+  } while (0)
+
+#ifdef GREATEST_VA_ARGS
+#define GREATEST_RUN_TESTp(TEST, ...)                                          \
+  do {                                                                         \
+    if (greatest_test_pre(#TEST) == 1) {                                       \
+      enum greatest_test_res res = GREATEST_SAVE_CONTEXT();                    \
+      if (res == GREATEST_TEST_RES_PASS) {                                     \
+        res = TEST(__VA_ARGS__);                                               \
+      }                                                                        \
+      greatest_test_post(res);                                                 \
+    }                                                                          \
+  } while (0)
+#endif
+
+/* Check if the test runner is in verbose mode. */
+#define GREATEST_IS_VERBOSE() ((greatest_info.verbosity) > 0)
+#define GREATEST_LIST_ONLY() (greatest_info.flags & GREATEST_FLAG_LIST_ONLY)
+#define GREATEST_FIRST_FAIL() (greatest_info.flags & GREATEST_FLAG_FIRST_FAIL)
+#define GREATEST_ABORT_ON_FAIL()                                               \
+  (greatest_info.flags & GREATEST_FLAG_ABORT_ON_FAIL)
+#define GREATEST_FAILURE_ABORT()                                               \
+  (GREATEST_FIRST_FAIL() &&                                                    \
+   (greatest_info.suite.failed > 0 || greatest_info.failed > 0))
+
+/* Message-less forms of tests defined below. */
+#define GREATEST_PASS() GREATEST_PASSm(NULL)
+#define GREATEST_FAIL() GREATEST_FAILm(NULL)
+#define GREATEST_SKIP() GREATEST_SKIPm(NULL)
+#define GREATEST_ASSERT(COND) GREATEST_ASSERTm(#COND, COND)
+#define GREATEST_ASSERT_OR_LONGJMP(COND)                                       \
+  GREATEST_ASSERT_OR_LONGJMPm(#COND, COND)
+#define GREATEST_ASSERT_FALSE(COND) GREATEST_ASSERT_FALSEm(#COND, COND)
+#define GREATEST_ASSERT_EQ(EXP, GOT)                                           \
+  GREATEST_ASSERT_EQm(#EXP " != " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_NEQ(EXP, GOT)                                          \
+  GREATEST_ASSERT_NEQm(#EXP " == " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_GT(EXP, GOT)                                           \
+  GREATEST_ASSERT_GTm(#EXP " <= " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_GTE(EXP, GOT)                                          \
+  GREATEST_ASSERT_GTEm(#EXP " < " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_LT(EXP, GOT)                                           \
+  GREATEST_ASSERT_LTm(#EXP " >= " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_LTE(EXP, GOT)                                          \
+  GREATEST_ASSERT_LTEm(#EXP " > " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_EQ_FMT(EXP, GOT, FMT)                                  \
+  GREATEST_ASSERT_EQ_FMTm(#EXP " != " #GOT, EXP, GOT, FMT)
+#define GREATEST_ASSERT_IN_RANGE(EXP, GOT, TOL)                                \
+  GREATEST_ASSERT_IN_RANGEm(#EXP " != " #GOT " +/- " #TOL, EXP, GOT, TOL)
+#define GREATEST_ASSERT_EQUAL_T(EXP, GOT, TYPE_INFO, UDATA)                    \
+  GREATEST_ASSERT_EQUAL_Tm(#EXP " != " #GOT, EXP, GOT, TYPE_INFO, UDATA)
+#define GREATEST_ASSERT_STR_EQ(EXP, GOT)                                       \
+  GREATEST_ASSERT_STR_EQm(#EXP " != " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_STRN_EQ(EXP, GOT, SIZE)                                \
+  GREATEST_ASSERT_STRN_EQm(#EXP " != " #GOT, EXP, GOT, SIZE)
+#define GREATEST_ASSERT_MEM_EQ(EXP, GOT, SIZE)                                 \
+  GREATEST_ASSERT_MEM_EQm(#EXP " != " #GOT, EXP, GOT, SIZE)
+#define GREATEST_ASSERT_ENUM_EQ(EXP, GOT, ENUM_STR)                            \
+  GREATEST_ASSERT_ENUM_EQm(#EXP " != " #GOT, EXP, GOT, ENUM_STR)
+
+/* The following forms take an additional message argument first,
+ * to be displayed by the test runner. */
+
+/* Fail if a condition is not true, with message. */
+#define GREATEST_ASSERTm(MSG, COND)                                            \
+  do {                                                                         \
+    greatest_info.assertions++;                                                \
+    if (!(COND)) {                                                             \
+      GREATEST_FAILm(MSG);                                                     \
+    }                                                                          \
+  } while (0)
+
+/* Fail if a condition is not true, longjmping out of test. */
+#define GREATEST_ASSERT_OR_LONGJMPm(MSG, COND)                                 \
+  do {                                                                         \
+    greatest_info.assertions++;                                                \
+    if (!(COND)) {                                                             \
+      GREATEST_FAIL_WITH_LONGJMPm(MSG);                                        \
+    }                                                                          \
+  } while (0)
+
+/* Fail if a condition is not false, with message. */
+#define GREATEST_ASSERT_FALSEm(MSG, COND)                                      \
+  do {                                                                         \
+    greatest_info.assertions++;                                                \
+    if ((COND)) {                                                              \
+      GREATEST_FAILm(MSG);                                                     \
+    }                                                                          \
+  } while (0)
+
+/* Internal macro for relational assertions */
+#define GREATEST__REL(REL, MSG, EXP, GOT)                                      \
+  do {                                                                         \
+    greatest_info.assertions++;                                                \
+    if (!((EXP)REL(GOT))) {                                                    \
+      GREATEST_FAILm(MSG);                                                     \
+    }                                                                          \
+  } while (0)
+
+/* Fail if EXP is not ==, !=, >, <, >=, or <= to GOT. */
+#define GREATEST_ASSERT_EQm(MSG, E, G) GREATEST__REL(==, MSG, E, G)
+#define GREATEST_ASSERT_NEQm(MSG, E, G) GREATEST__REL(!=, MSG, E, G)
+#define GREATEST_ASSERT_GTm(MSG, E, G) GREATEST__REL(>, MSG, E, G)
+#define GREATEST_ASSERT_GTEm(MSG, E, G) GREATEST__REL(>=, MSG, E, G)
+#define GREATEST_ASSERT_LTm(MSG, E, G) GREATEST__REL(<, MSG, E, G)
+#define GREATEST_ASSERT_LTEm(MSG, E, G) GREATEST__REL(<=, MSG, E, G)
+
+/* Fail if EXP != GOT (equality comparison by ==).
+ * Warning: FMT, EXP, and GOT will be evaluated more
+ * than once on failure. */
+#define GREATEST_ASSERT_EQ_FMTm(MSG, EXP, GOT, FMT)                            \
+  do {                                                                         \
+    greatest_info.assertions++;                                                \
+    if ((EXP) != (GOT)) {                                                      \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: ");                       \
+      GREATEST_FPRINTF(GREATEST_STDOUT, FMT, EXP);                             \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\n     Got: ");                       \
+      GREATEST_FPRINTF(GREATEST_STDOUT, FMT, GOT);                             \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                                 \
+      GREATEST_FAILm(MSG);                                                     \
+    }                                                                          \
+  } while (0)
+
+/* Fail if EXP is not equal to GOT, printing enum IDs. */
+#define GREATEST_ASSERT_ENUM_EQm(MSG, EXP, GOT, ENUM_STR)                      \
+  do {                                                                         \
+    int greatest_EXP = (int)(EXP);                                             \
+    int greatest_GOT = (int)(GOT);                                             \
+    greatest_enum_str_fun *greatest_ENUM_STR = ENUM_STR;                       \
+    if (greatest_EXP != greatest_GOT) {                                        \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: %s",                      \
+                       greatest_ENUM_STR(greatest_EXP));                       \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\n     Got: %s\n",                    \
+                       greatest_ENUM_STR(greatest_GOT));                       \
+      GREATEST_FAILm(MSG);                                                     \
+    }                                                                          \
+  } while (0)
+
+/* Fail if GOT not in range of EXP +|- TOL. */
+#define GREATEST_ASSERT_IN_RANGEm(MSG, EXP, GOT, TOL)                          \
+  do {                                                                         \
+    GREATEST_FLOAT greatest_EXP = (EXP);                                       \
+    GREATEST_FLOAT greatest_GOT = (GOT);                                       \
+    GREATEST_FLOAT greatest_TOL = (TOL);                                       \
+    greatest_info.assertions++;                                                \
+    if ((greatest_EXP > greatest_GOT &&                                        \
+         greatest_EXP - greatest_GOT > greatest_TOL) ||                        \
+        (greatest_EXP < greatest_GOT &&                                        \
+         greatest_GOT - greatest_EXP > greatest_TOL)) {                        \
+      GREATEST_FPRINTF(GREATEST_STDOUT,                                        \
+                       "\nExpected: " GREATEST_FLOAT_FMT                       \
+                       " +/- " GREATEST_FLOAT_FMT                              \
+                       "\n     Got: " GREATEST_FLOAT_FMT "\n",                 \
+                       greatest_EXP, greatest_TOL, greatest_GOT);              \
+      GREATEST_FAILm(MSG);                                                     \
+    }                                                                          \
+  } while (0)
+
+/* Fail if EXP is not equal to GOT, according to strcmp. */
+#define GREATEST_ASSERT_STR_EQm(MSG, EXP, GOT)                                 \
+  do {                                                                         \
+    GREATEST_ASSERT_EQUAL_Tm(MSG, EXP, GOT, &greatest_type_info_string, NULL); \
+  } while (0)
+
+/* Fail if EXP is not equal to GOT, according to strncmp. */
+#define GREATEST_ASSERT_STRN_EQm(MSG, EXP, GOT, SIZE)                          \
+  do {                                                                         \
+    size_t size = SIZE;                                                        \
+    GREATEST_ASSERT_EQUAL_Tm(MSG, EXP, GOT, &greatest_type_info_string,        \
+                             &size);                                           \
+  } while (0)
+
+/* Fail if EXP is not equal to GOT, according to memcmp. */
+#define GREATEST_ASSERT_MEM_EQm(MSG, EXP, GOT, SIZE)                           \
+  do {                                                                         \
+    greatest_memory_cmp_env env;                                               \
+    env.exp = (const unsigned char *)EXP;                                      \
+    env.got = (const unsigned char *)GOT;                                      \
+    env.size = SIZE;                                                           \
+    GREATEST_ASSERT_EQUAL_Tm(MSG, env.exp, env.got,                            \
+                             &greatest_type_info_memory, &env);                \
+  } while (0)
+
+/* Fail if EXP is not equal to GOT, according to a comparison
+ * callback in TYPE_INFO. If they are not equal, optionally use a
+ * print callback in TYPE_INFO to print them. */
+#define GREATEST_ASSERT_EQUAL_Tm(MSG, EXP, GOT, TYPE_INFO, UDATA)              \
+  do {                                                                         \
+    greatest_type_info *type_info = (TYPE_INFO);                               \
+    greatest_info.assertions++;                                                \
+    if (!greatest_do_assert_equal_t(EXP, GOT, type_info, UDATA)) {             \
+      if (type_info == NULL || type_info->equal == NULL) {                     \
+        GREATEST_FAILm("type_info->equal callback missing!");                  \
+      } else {                                                                 \
+        GREATEST_FAILm(MSG);                                                   \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
+
+/* Pass. */
+#define GREATEST_PASSm(MSG)                                                    \
+  do {                                                                         \
+    greatest_info.msg = MSG;                                                   \
+    return GREATEST_TEST_RES_PASS;                                             \
+  } while (0)
+
+/* Fail. */
+#define GREATEST_FAILm(MSG)                                                    \
+  do {                                                                         \
+    greatest_info.fail_file = __FILE__;                                        \
+    greatest_info.fail_line = __LINE__;                                        \
+    greatest_info.msg = MSG;                                                   \
+    if (GREATEST_ABORT_ON_FAIL()) {                                            \
+      abort();                                                                 \
+    }                                                                          \
+    return GREATEST_TEST_RES_FAIL;                                             \
+  } while (0)
+
+/* Optional GREATEST_FAILm variant that longjmps. */
+#if GREATEST_USE_LONGJMP
+#define GREATEST_FAIL_WITH_LONGJMP() GREATEST_FAIL_WITH_LONGJMPm(NULL)
+#define GREATEST_FAIL_WITH_LONGJMPm(MSG)                                       \
+  do {                                                                         \
+    greatest_info.fail_file = __FILE__;                                        \
+    greatest_info.fail_line = __LINE__;                                        \
+    greatest_info.msg = MSG;                                                   \
+    longjmp(greatest_info.jump_dest, GREATEST_TEST_RES_FAIL);                  \
+  } while (0)
+#endif
+
+/* Skip the current test. */
+#define GREATEST_SKIPm(MSG)                                                    \
+  do {                                                                         \
+    greatest_info.msg = MSG;                                                   \
+    return GREATEST_TEST_RES_SKIP;                                             \
+  } while (0)
+
+/* Check the result of a subfunction using ASSERT, etc. */
+#define GREATEST_CHECK_CALL(RES)                                               \
+  do {                                                                         \
+    enum greatest_test_res greatest_RES = RES;                                 \
+    if (greatest_RES != GREATEST_TEST_RES_PASS) {                              \
+      return greatest_RES;                                                     \
+    }                                                                          \
+  } while (0)
+
+#if GREATEST_USE_TIME
+#define GREATEST_SET_TIME(NAME)                                                \
+  NAME = clock();                                                              \
+  if (NAME == (clock_t)-1) {                                                   \
+    GREATEST_FPRINTF(GREATEST_STDOUT, "clock error: %s\n", #NAME);             \
+    exit(EXIT_FAILURE);                                                        \
+  }
+
+#define GREATEST_CLOCK_DIFF(C1, C2)                                            \
+  GREATEST_FPRINTF(GREATEST_STDOUT, " (%lu ticks, %.3f sec)",                  \
+                   (long unsigned int)(C2) - (long unsigned int)(C1),          \
+                   (double)((C2) - (C1)) / (1.0 * (double)CLOCKS_PER_SEC))
+#else
+#define GREATEST_SET_TIME(UNUSED)
+#define GREATEST_CLOCK_DIFF(UNUSED1, UNUSED2)
+#endif
+
+#if GREATEST_USE_LONGJMP
+#define GREATEST_SAVE_CONTEXT()                                                \
+  /* setjmp returns 0 (GREATEST_TEST_RES_PASS) on first call *                 \
+   * so the test runs, then RES_FAIL from FAIL_WITH_LONGJMP. */                \
+  ((enum greatest_test_res)(setjmp(greatest_info.jump_dest)))
+#else
+#define GREATEST_SAVE_CONTEXT()                                                \
+  /*a no-op, since setjmp/longjmp aren't being used */                         \
+  GREATEST_TEST_RES_PASS
+#endif
+
+/* Run every suite / test function run within BODY in pseudo-random
+ * order, seeded by SEED. (The top 3 bits of the seed are ignored.)
+ *
+ * This should be called like:
+ *     GREATEST_SHUFFLE_TESTS(seed, {
+ *         GREATEST_RUN_TEST(some_test);
+ *         GREATEST_RUN_TEST(some_other_test);
+ *         GREATEST_RUN_TEST(yet_another_test);
+ *     });
+ *
+ * Note that the body of the second argument will be evaluated
+ * multiple times. */
+#define GREATEST_SHUFFLE_SUITES(SD, BODY) GREATEST_SHUFFLE(0, SD, BODY)
+#define GREATEST_SHUFFLE_TESTS(SD, BODY) GREATEST_SHUFFLE(1, SD, BODY)
+#define GREATEST_SHUFFLE(ID, SD, BODY)                                         \
+  do {                                                                         \
+    struct greatest_prng *prng = &greatest_info.prng[ID];                      \
+    greatest_prng_init_first_pass(ID);                                         \
+    do {                                                                       \
+      prng->count = 0;                                                         \
+      if (prng->initialized) {                                                 \
+        greatest_prng_step(ID);                                                \
+      }                                                                        \
+      BODY;                                                                    \
+      if (!prng->initialized) {                                                \
+        if (!greatest_prng_init_second_pass(ID, SD)) {                         \
+          break;                                                               \
+        }                                                                      \
+      } else if (prng->count_run == prng->count_ceil) {                        \
+        break;                                                                 \
+      }                                                                        \
+    } while (!GREATEST_FAILURE_ABORT());                                       \
+    prng->count_run = prng->random_order = prng->initialized = 0;              \
+  } while (0)
+
+/* Include several function definitions in the main test file. */
+#define GREATEST_MAIN_DEFS()                                                   \
+                                                                               \
+  /* Is FILTER a subset of NAME? */                                            \
+  static int greatest_name_match(const char *name, const char *filter,         \
+                                 int res_if_none) {                            \
+    size_t offset = 0;                                                         \
+    size_t filter_len = filter ? strlen(filter) : 0;                           \
+    if (filter_len == 0) {                                                     \
+      return res_if_none;                                                      \
+    } /* no filter */                                                          \
+    if (greatest_info.exact_name_match && strlen(name) != filter_len) {        \
+      return 0; /* ignore substring matches */                                 \
+    }                                                                          \
+    while (name[offset] != '\0') {                                             \
+      if (name[offset] == filter[0]) {                                         \
+        if (0 == strncmp(&name[offset], filter, filter_len)) {                 \
+          return 1;                                                            \
+        }                                                                      \
+      }                                                                        \
+      offset++;                                                                \
+    }                                                                          \
+                                                                               \
+    return 0;                                                                  \
+  }                                                                            \
+                                                                               \
+  static void greatest_buffer_test_name(const char *name) {                    \
+    struct greatest_run_info *g = &greatest_info;                              \
+    size_t len = strlen(name), size = sizeof(g->name_buf);                     \
+    memset(g->name_buf, 0x00, size);                                           \
+    (void)strncat(g->name_buf, name, size - 1);                                \
+    if (g->name_suffix && (len + 1 < size)) {                                  \
+      g->name_buf[len] = '_';                                                  \
+      strncat(&g->name_buf[len + 1], g->name_suffix, size - (len + 2));        \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  /* Before running a test, check the name filtering and                       \
+   * test shuffling state, if applicable, and then call setup hooks. */        \
+  int greatest_test_pre(const char *name) {                                    \
+    struct greatest_run_info *g = &greatest_info;                              \
+    int match;                                                                 \
+    greatest_buffer_test_name(name);                                           \
+    match = greatest_name_match(g->name_buf, g->test_filter, 1) &&             \
+            !greatest_name_match(g->name_buf, g->test_exclude, 0);             \
+    if (GREATEST_LIST_ONLY()) { /* just listing test names */                  \
+      if (match) {                                                             \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "  %s\n", g->name_buf);              \
+      }                                                                        \
+      goto clear;                                                              \
+    }                                                                          \
+    if (match && (!GREATEST_FIRST_FAIL() || g->suite.failed == 0)) {           \
+      struct greatest_prng *p = &g->prng[1];                                   \
+      if (p->random_order) {                                                   \
+        p->count++;                                                            \
+        if (!p->initialized || ((p->count - 1) != p->state)) {                 \
+          goto clear; /* don't run this test yet */                            \
+        }                                                                      \
+      }                                                                        \
+      if (g->running_test) {                                                   \
+        fprintf(stderr, "Error: Test run inside another test.\n");             \
+        return 0;                                                              \
+      }                                                                        \
+      GREATEST_SET_TIME(g->suite.pre_test);                                    \
+      if (g->setup) {                                                          \
+        g->setup(g->setup_udata);                                              \
+      }                                                                        \
+      p->count_run++;                                                          \
+      g->running_test = 1;                                                     \
+      return 1; /* test should be run */                                       \
+    } else {                                                                   \
+      goto clear; /* skipped */                                                \
+    }                                                                          \
+  clear:                                                                       \
+    g->name_suffix = NULL;                                                     \
+    return 0;                                                                  \
+  }                                                                            \
+                                                                               \
+  static void greatest_do_pass(void) {                                         \
+    struct greatest_run_info *g = &greatest_info;                              \
+    if (GREATEST_IS_VERBOSE()) {                                               \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "PASS %s: %s", g->name_buf,            \
+                       g->msg ? g->msg : "");                                  \
+    } else {                                                                   \
+      GREATEST_FPRINTF(GREATEST_STDOUT, ".");                                  \
+    }                                                                          \
+    g->suite.passed++;                                                         \
+  }                                                                            \
+                                                                               \
+  static void greatest_do_fail(void) {                                         \
+    struct greatest_run_info *g = &greatest_info;                              \
+    if (GREATEST_IS_VERBOSE()) {                                               \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "FAIL %s: %s (%s:%u)", g->name_buf,    \
+                       g->msg ? g->msg : "", g->fail_file, g->fail_line);      \
+    } else {                                                                   \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "F");                                  \
+      g->col++; /* add linebreak if in line of '.'s */                         \
+      if (g->col != 0) {                                                       \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                               \
+        g->col = 0;                                                            \
+      }                                                                        \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "FAIL %s: %s (%s:%u)\n", g->name_buf,  \
+                       g->msg ? g->msg : "", g->fail_file, g->fail_line);      \
+    }                                                                          \
+    g->suite.failed++;                                                         \
+  }                                                                            \
+                                                                               \
+  static void greatest_do_skip(void) {                                         \
+    struct greatest_run_info *g = &greatest_info;                              \
+    if (GREATEST_IS_VERBOSE()) {                                               \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "SKIP %s: %s", g->name_buf,            \
+                       g->msg ? g->msg : "");                                  \
+    } else {                                                                   \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "s");                                  \
+    }                                                                          \
+    g->suite.skipped++;                                                        \
+  }                                                                            \
+                                                                               \
+  void greatest_test_post(int res) {                                           \
+    GREATEST_SET_TIME(greatest_info.suite.post_test);                          \
+    if (greatest_info.teardown) {                                              \
+      void *udata = greatest_info.teardown_udata;                              \
+      greatest_info.teardown(udata);                                           \
+    }                                                                          \
+                                                                               \
+    greatest_info.running_test = 0;                                            \
+    if (res <= GREATEST_TEST_RES_FAIL) {                                       \
+      greatest_do_fail();                                                      \
+    } else if (res >= GREATEST_TEST_RES_SKIP) {                                \
+      greatest_do_skip();                                                      \
+    } else if (res == GREATEST_TEST_RES_PASS) {                                \
+      greatest_do_pass();                                                      \
+    }                                                                          \
+    greatest_info.name_suffix = NULL;                                          \
+    greatest_info.suite.tests_run++;                                           \
+    greatest_info.col++;                                                       \
+    if (GREATEST_IS_VERBOSE()) {                                               \
+      GREATEST_CLOCK_DIFF(greatest_info.suite.pre_test,                        \
+                          greatest_info.suite.post_test);                      \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                                 \
+    } else if (greatest_info.col % greatest_info.width == 0) {                 \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                                 \
+      greatest_info.col = 0;                                                   \
+    }                                                                          \
+    fflush(GREATEST_STDOUT);                                                   \
+  }                                                                            \
+                                                                               \
+  static void report_suite(void) {                                             \
+    if (greatest_info.suite.tests_run > 0) {                                   \
+      GREATEST_FPRINTF(GREATEST_STDOUT,                                        \
+                       "\n%u test%s - %u passed, %u failed, %u skipped",       \
+                       greatest_info.suite.tests_run,                          \
+                       greatest_info.suite.tests_run == 1 ? "" : "s",          \
+                       greatest_info.suite.passed, greatest_info.suite.failed, \
+                       greatest_info.suite.skipped);                           \
+      GREATEST_CLOCK_DIFF(greatest_info.suite.pre_suite,                       \
+                          greatest_info.suite.post_suite);                     \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                                 \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  static void update_counts_and_reset_suite(void) {                            \
+    greatest_info.setup = NULL;                                                \
+    greatest_info.setup_udata = NULL;                                          \
+    greatest_info.teardown = NULL;                                             \
+    greatest_info.teardown_udata = NULL;                                       \
+    greatest_info.passed += greatest_info.suite.passed;                        \
+    greatest_info.failed += greatest_info.suite.failed;                        \
+    greatest_info.skipped += greatest_info.suite.skipped;                      \
+    greatest_info.tests_run += greatest_info.suite.tests_run;                  \
+    memset(&greatest_info.suite, 0, sizeof(greatest_info.suite));              \
+    greatest_info.col = 0;                                                     \
+  }                                                                            \
+                                                                               \
+  static int greatest_suite_pre(const char *suite_name) {                      \
+    struct greatest_prng *p = &greatest_info.prng[0];                          \
+    if (!greatest_name_match(suite_name, greatest_info.suite_filter, 1) ||     \
+        (GREATEST_FAILURE_ABORT())) {                                          \
+      return 0;                                                                \
+    }                                                                          \
+    if (p->random_order) {                                                     \
+      p->count++;                                                              \
+      if (!p->initialized || ((p->count - 1) != p->state)) {                   \
+        return 0; /* don't run this suite yet */                               \
+      }                                                                        \
+    }                                                                          \
+    p->count_run++;                                                            \
+    update_counts_and_reset_suite();                                           \
+    GREATEST_FPRINTF(GREATEST_STDOUT, "\n* Suite %s:\n", suite_name);          \
+    GREATEST_SET_TIME(greatest_info.suite.pre_suite);                          \
+    return 1;                                                                  \
+  }                                                                            \
+                                                                               \
+  static void greatest_suite_post(void) {                                      \
+    GREATEST_SET_TIME(greatest_info.suite.post_suite);                         \
+    report_suite();                                                            \
+  }                                                                            \
+                                                                               \
+  static void greatest_run_suite(greatest_suite_cb *suite_cb,                  \
+                                 const char *suite_name) {                     \
+    if (greatest_suite_pre(suite_name)) {                                      \
+      suite_cb();                                                              \
+      greatest_suite_post();                                                   \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  int greatest_do_assert_equal_t(const void *expd, const void *got,            \
+                                 greatest_type_info *type_info, void *udata) { \
+    int eq = 0;                                                                \
+    if (type_info == NULL || type_info->equal == NULL) {                       \
+      return 0;                                                                \
+    }                                                                          \
+    eq = type_info->equal(expd, got, udata);                                   \
+    if (!eq) {                                                                 \
+      if (type_info->print != NULL) {                                          \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: ");                     \
+        (void)type_info->print(expd, udata);                                   \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\n     Got: ");                     \
+        (void)type_info->print(got, udata);                                    \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                               \
+      }                                                                        \
+    }                                                                          \
+    return eq;                                                                 \
+  }                                                                            \
+                                                                               \
+  static void greatest_usage(const char *name) {                               \
+    GREATEST_FPRINTF(                                                          \
+        GREATEST_STDOUT,                                                       \
+        "Usage: %s [-hlfavex] [-s SUITE] [-t TEST] [-x EXCLUDE]\n"             \
+        "  -h, --help  print this Help\n"                                      \
+        "  -l          List suites and tests, then exit (dry run)\n"           \
+        "  -f          Stop runner after first failure\n"                      \
+        "  -a          Abort on first failure (implies -f)\n"                  \
+        "  -v          Verbose output\n"                                       \
+        "  -s SUITE    only run suites containing substring SUITE\n"           \
+        "  -t TEST     only run tests containing substring TEST\n"             \
+        "  -e          only run exact name match for -s or -t\n"               \
+        "  -x EXCLUDE  exclude tests containing substring EXCLUDE\n",          \
+        name);                                                                 \
+  }                                                                            \
+                                                                               \
+  static void greatest_parse_options(int argc, char **argv) {                  \
+    int i = 0;                                                                 \
+    for (i = 1; i < argc; i++) {                                               \
+      if (argv[i][0] == '-') {                                                 \
+        char f = argv[i][1];                                                   \
+        if ((f == 's' || f == 't' || f == 'x') && argc <= i + 1) {             \
+          greatest_usage(argv[0]);                                             \
+          exit(EXIT_FAILURE);                                                  \
+        }                                                                      \
+        switch (f) {                                                           \
+        case 's': /* suite name filter */                                      \
+          greatest_set_suite_filter(argv[i + 1]);                              \
+          i++;                                                                 \
+          break;                                                               \
+        case 't': /* test name filter */                                       \
+          greatest_set_test_filter(argv[i + 1]);                               \
+          i++;                                                                 \
+          break;                                                               \
+        case 'x': /* test name exclusion */                                    \
+          greatest_set_test_exclude(argv[i + 1]);                              \
+          i++;                                                                 \
+          break;                                                               \
+        case 'e': /* exact name match */                                       \
+          greatest_set_exact_name_match();                                     \
+          break;                                                               \
+        case 'f': /* first fail flag */                                        \
+          greatest_stop_at_first_fail();                                       \
+          break;                                                               \
+        case 'a': /* abort() on fail flag */                                   \
+          greatest_abort_on_fail();                                            \
+          break;                                                               \
+        case 'l': /* list only (dry run) */                                    \
+          greatest_list_only();                                                \
+          break;                                                               \
+        case 'v': /* first fail flag */                                        \
+          greatest_info.verbosity++;                                           \
+          break;                                                               \
+        case 'h': /* help */                                                   \
+          greatest_usage(argv[0]);                                             \
+          exit(EXIT_SUCCESS);                                                  \
+        default:                                                               \
+        case '-':                                                              \
+          if (0 == strncmp("--help", argv[i], 6)) {                            \
+            greatest_usage(argv[0]);                                           \
+            exit(EXIT_SUCCESS);                                                \
+          } else if (0 == strcmp("--", argv[i])) {                             \
+            return; /* ignore following arguments */                           \
+          }                                                                    \
+          GREATEST_FPRINTF(GREATEST_STDOUT, "Unknown argument '%s'\n",         \
+                           argv[i]);                                           \
+          greatest_usage(argv[0]);                                             \
+          exit(EXIT_FAILURE);                                                  \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  int greatest_all_passed(void) { return (greatest_info.failed == 0); }        \
+                                                                               \
+  void greatest_set_test_filter(const char *filter) {                          \
+    greatest_info.test_filter = filter;                                        \
+  }                                                                            \
+                                                                               \
+  void greatest_set_test_exclude(const char *filter) {                         \
+    greatest_info.test_exclude = filter;                                       \
+  }                                                                            \
+                                                                               \
+  void greatest_set_suite_filter(const char *filter) {                         \
+    greatest_info.suite_filter = filter;                                       \
+  }                                                                            \
+                                                                               \
+  void greatest_set_exact_name_match(void) {                                   \
+    greatest_info.exact_name_match = 1;                                        \
+  }                                                                            \
+                                                                               \
+  void greatest_stop_at_first_fail(void) {                                     \
+    greatest_set_flag(GREATEST_FLAG_FIRST_FAIL);                               \
+  }                                                                            \
+                                                                               \
+  void greatest_abort_on_fail(void) {                                          \
+    greatest_set_flag(GREATEST_FLAG_ABORT_ON_FAIL);                            \
+  }                                                                            \
+                                                                               \
+  void greatest_list_only(void) {                                              \
+    greatest_set_flag(GREATEST_FLAG_LIST_ONLY);                                \
+  }                                                                            \
+                                                                               \
+  void greatest_get_report(struct greatest_report_t *report) {                 \
+    if (report) {                                                              \
+      report->passed = greatest_info.passed;                                   \
+      report->failed = greatest_info.failed;                                   \
+      report->skipped = greatest_info.skipped;                                 \
+      report->assertions = greatest_info.assertions;                           \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  unsigned int greatest_get_verbosity(void) {                                  \
+    return greatest_info.verbosity;                                            \
+  }                                                                            \
+                                                                               \
+  void greatest_set_verbosity(unsigned int verbosity) {                        \
+    greatest_info.verbosity = (unsigned char)verbosity;                        \
+  }                                                                            \
+                                                                               \
+  void greatest_set_flag(greatest_flag_t flag) {                               \
+    greatest_info.flags = (unsigned char)(greatest_info.flags | flag);         \
+  }                                                                            \
+                                                                               \
+  void greatest_set_test_suffix(const char *suffix) {                          \
+    greatest_info.name_suffix = suffix;                                        \
+  }                                                                            \
+                                                                               \
+  void GREATEST_SET_SETUP_CB(greatest_setup_cb *cb, void *udata) {             \
+    greatest_info.setup = cb;                                                  \
+    greatest_info.setup_udata = udata;                                         \
+  }                                                                            \
+                                                                               \
+  void GREATEST_SET_TEARDOWN_CB(greatest_teardown_cb *cb, void *udata) {       \
+    greatest_info.teardown = cb;                                               \
+    greatest_info.teardown_udata = udata;                                      \
+  }                                                                            \
+                                                                               \
+  static int greatest_string_equal_cb(const void *expd, const void *got,       \
+                                      void *udata) {                           \
+    size_t *size = (size_t *)udata;                                            \
+    return (size != NULL                                                       \
+                ? (0 == strncmp((const char *)expd, (const char *)got, *size)) \
+                : (0 == strcmp((const char *)expd, (const char *)got)));       \
+  }                                                                            \
+                                                                               \
+  static int greatest_string_printf_cb(const void *t, void *udata) {           \
+    (void)udata; /* note: does not check \0 termination. */                    \
+    return GREATEST_FPRINTF(GREATEST_STDOUT, "%s", (const char *)t);           \
+  }                                                                            \
+                                                                               \
+  greatest_type_info greatest_type_info_string = {                             \
+      greatest_string_equal_cb,                                                \
+      greatest_string_printf_cb,                                               \
+  };                                                                           \
+                                                                               \
+  static int greatest_memory_equal_cb(const void *expd, const void *got,       \
+                                      void *udata) {                           \
+    greatest_memory_cmp_env *env = (greatest_memory_cmp_env *)udata;           \
+    return (0 == memcmp(expd, got, env->size));                                \
+  }                                                                            \
+                                                                               \
+  /* Hexdump raw memory, with differences highlighted */                       \
+  static int greatest_memory_printf_cb(const void *t, void *udata) {           \
+    greatest_memory_cmp_env *env = (greatest_memory_cmp_env *)udata;           \
+    const unsigned char *buf = (const unsigned char *)t;                       \
+    unsigned char diff_mark = ' ';                                             \
+    FILE *out = GREATEST_STDOUT;                                               \
+    size_t i, line_i, line_len = 0;                                            \
+    int len = 0; /* format hexdump with differences highlighted */             \
+    for (i = 0; i < env->size; i += line_len) {                                \
+      diff_mark = ' ';                                                         \
+      line_len = env->size - i;                                                \
+      if (line_len > 16) {                                                     \
+        line_len = 16;                                                         \
+      }                                                                        \
+      for (line_i = i; line_i < i + line_len; line_i++) {                      \
+        if (env->exp[line_i] != env->got[line_i])                              \
+          diff_mark = 'X';                                                     \
+      }                                                                        \
+      len += GREATEST_FPRINTF(out, "\n%04x %c ", (unsigned int)i, diff_mark);  \
+      for (line_i = i; line_i < i + line_len; line_i++) {                      \
+        int m = env->exp[line_i] == env->got[line_i]; /* match? */             \
+        len += GREATEST_FPRINTF(out, "%02x%c", buf[line_i], m ? ' ' : '<');    \
+      }                                                                        \
+      for (line_i = 0; line_i < 16 - line_len; line_i++) {                     \
+        len += GREATEST_FPRINTF(out, "   ");                                   \
+      }                                                                        \
+      GREATEST_FPRINTF(out, " ");                                              \
+      for (line_i = i; line_i < i + line_len; line_i++) {                      \
+        unsigned char c = buf[line_i];                                         \
+        len += GREATEST_FPRINTF(out, "%c", isprint(c) ? c : '.');              \
+      }                                                                        \
+    }                                                                          \
+    len += GREATEST_FPRINTF(out, "\n");                                        \
+    return len;                                                                \
+  }                                                                            \
+                                                                               \
+  void greatest_prng_init_first_pass(int id) {                                 \
+    greatest_info.prng[id].random_order = 1;                                   \
+    greatest_info.prng[id].count_run = 0;                                      \
+  }                                                                            \
+                                                                               \
+  int greatest_prng_init_second_pass(int id, unsigned long seed) {             \
+    struct greatest_prng *p = &greatest_info.prng[id];                         \
+    if (p->count == 0) {                                                       \
+      return 0;                                                                \
+    }                                                                          \
+    p->count_ceil = p->count;                                                  \
+    for (p->m = 1; p->m < p->count; p->m <<= 1) {                              \
+    }                                                                          \
+    p->state = seed & 0x1fffffff; /* only use lower 29 bits */                 \
+    p->a = 4LU * p->state;        /* to avoid overflow when */                 \
+    p->a = (p->a ? p->a : 4) | 1; /* multiplied by 4 */                        \
+    p->c = 2147483647;            /* and so p->c ((2 ** 31) - 1) is */         \
+    p->initialized = 1;           /* always relatively prime to p->a. */       \
+    fprintf(stderr, "init_second_pass: a %lu, c %lu, state %lu\n", p->a, p->c, \
+            p->state);                                                         \
+    return 1;                                                                  \
+  }                                                                            \
+                                                                               \
+  /* Step the pseudorandom number generator until its state reaches            \
+   * another test ID between 0 and the test count.                             \
+   * This use a linear congruential pseudorandom number generator,             \
+   * with the power-of-two ceiling of the test count as the modulus, the       \
+   * masked seed as the multiplier, and a prime as the increment. For          \
+   * each generated value < the test count, run the corresponding test.        \
+   * This will visit all IDs 0 <= X < mod once before repeating,               \
+   * with a starting position chosen based on the initial seed.                \
+   * For details, see: Knuth, The Art of Computer Programming                  \
+   * Volume. 2, section 3.2.1. */                                              \
+  void greatest_prng_step(int id) {                                            \
+    struct greatest_prng *p = &greatest_info.prng[id];                         \
+    do {                                                                       \
+      p->state = ((p->a * p->state) + p->c) & (p->m - 1);                      \
+    } while (p->state >= p->count_ceil);                                       \
+  }                                                                            \
+                                                                               \
+  void GREATEST_INIT(void) {                                                   \
+    /* Suppress unused function warning if features aren't used */             \
+    (void)greatest_run_suite;                                                  \
+    (void)greatest_parse_options;                                              \
+    (void)greatest_prng_step;                                                  \
+    (void)greatest_prng_init_first_pass;                                       \
+    (void)greatest_prng_init_second_pass;                                      \
+    (void)greatest_set_test_suffix;                                            \
+                                                                               \
+    memset(&greatest_info, 0, sizeof(greatest_info));                          \
+    greatest_info.width = GREATEST_DEFAULT_WIDTH;                              \
+    GREATEST_SET_TIME(greatest_info.begin);                                    \
+  }                                                                            \
+                                                                               \
+  /* Report passes, failures, skipped tests, the number of                     \
+   * assertions, and the overall run time. */                                  \
+  void GREATEST_PRINT_REPORT(void) {                                           \
+    if (!GREATEST_LIST_ONLY()) {                                               \
+      update_counts_and_reset_suite();                                         \
+      GREATEST_SET_TIME(greatest_info.end);                                    \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "\nTotal: %u test%s",                  \
+                       greatest_info.tests_run,                                \
+                       greatest_info.tests_run == 1 ? "" : "s");               \
+      GREATEST_CLOCK_DIFF(greatest_info.begin, greatest_info.end);             \
+      GREATEST_FPRINTF(GREATEST_STDOUT, ", %u assertion%s\n",                  \
+                       greatest_info.assertions,                               \
+                       greatest_info.assertions == 1 ? "" : "s");              \
+      GREATEST_FPRINTF(GREATEST_STDOUT, "Pass: %u, fail: %u, skip: %u.\n",     \
+                       greatest_info.passed, greatest_info.failed,             \
+                       greatest_info.skipped);                                 \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  greatest_type_info greatest_type_info_memory = {                             \
+      greatest_memory_equal_cb,                                                \
+      greatest_memory_printf_cb,                                               \
+  };                                                                           \
+                                                                               \
+  greatest_run_info greatest_info
+
+/* Handle command-line arguments, etc. */
+#define GREATEST_MAIN_BEGIN()                                                  \
+  do {                                                                         \
+    GREATEST_INIT();                                                           \
+    greatest_parse_options(argc, argv);                                        \
+  } while (0)
+
+/* Report results, exit with exit status based on results. */
+#define GREATEST_MAIN_END()                                                    \
+  do {                                                                         \
+    GREATEST_PRINT_REPORT();                                                   \
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);              \
+  } while (0)
+
+/* Make abbreviations without the GREATEST_ prefix for the
+ * most commonly used symbols. */
+#if GREATEST_USE_ABBREVS
+#define TEST GREATEST_TEST
+#define SUITE GREATEST_SUITE
+#define SUITE_EXTERN GREATEST_SUITE_EXTERN
+#define RUN_TEST GREATEST_RUN_TEST
+#define RUN_TEST1 GREATEST_RUN_TEST1
+#define RUN_SUITE GREATEST_RUN_SUITE
+#define IGNORE_TEST GREATEST_IGNORE_TEST
+#define ASSERT GREATEST_ASSERT
+#define ASSERTm GREATEST_ASSERTm
+#define ASSERT_FALSE GREATEST_ASSERT_FALSE
+#define ASSERT_EQ GREATEST_ASSERT_EQ
+#define ASSERT_NEQ GREATEST_ASSERT_NEQ
+#define ASSERT_GT GREATEST_ASSERT_GT
+#define ASSERT_GTE GREATEST_ASSERT_GTE
+#define ASSERT_LT GREATEST_ASSERT_LT
+#define ASSERT_LTE GREATEST_ASSERT_LTE
+#define ASSERT_EQ_FMT GREATEST_ASSERT_EQ_FMT
+#define ASSERT_IN_RANGE GREATEST_ASSERT_IN_RANGE
+#define ASSERT_EQUAL_T GREATEST_ASSERT_EQUAL_T
+#define ASSERT_STR_EQ GREATEST_ASSERT_STR_EQ
+#define ASSERT_STRN_EQ GREATEST_ASSERT_STRN_EQ
+#define ASSERT_MEM_EQ GREATEST_ASSERT_MEM_EQ
+#define ASSERT_ENUM_EQ GREATEST_ASSERT_ENUM_EQ
+#define ASSERT_FALSEm GREATEST_ASSERT_FALSEm
+#define ASSERT_EQm GREATEST_ASSERT_EQm
+#define ASSERT_NEQm GREATEST_ASSERT_NEQm
+#define ASSERT_GTm GREATEST_ASSERT_GTm
+#define ASSERT_GTEm GREATEST_ASSERT_GTEm
+#define ASSERT_LTm GREATEST_ASSERT_LTm
+#define ASSERT_LTEm GREATEST_ASSERT_LTEm
+#define ASSERT_EQ_FMTm GREATEST_ASSERT_EQ_FMTm
+#define ASSERT_IN_RANGEm GREATEST_ASSERT_IN_RANGEm
+#define ASSERT_EQUAL_Tm GREATEST_ASSERT_EQUAL_Tm
+#define ASSERT_STR_EQm GREATEST_ASSERT_STR_EQm
+#define ASSERT_STRN_EQm GREATEST_ASSERT_STRN_EQm
+#define ASSERT_MEM_EQm GREATEST_ASSERT_MEM_EQm
+#define ASSERT_ENUM_EQm GREATEST_ASSERT_ENUM_EQm
+#define PASS GREATEST_PASS
+#define FAIL GREATEST_FAIL
+#define SKIP GREATEST_SKIP
+#define PASSm GREATEST_PASSm
+#define FAILm GREATEST_FAILm
+#define SKIPm GREATEST_SKIPm
+#define SET_SETUP GREATEST_SET_SETUP_CB
+#define SET_TEARDOWN GREATEST_SET_TEARDOWN_CB
+#define CHECK_CALL GREATEST_CHECK_CALL
+#define SHUFFLE_TESTS GREATEST_SHUFFLE_TESTS
+#define SHUFFLE_SUITES GREATEST_SHUFFLE_SUITES
+
+#ifdef GREATEST_VA_ARGS
+#define RUN_TESTp GREATEST_RUN_TESTp
+#endif
+
+#if GREATEST_USE_LONGJMP
+#define ASSERT_OR_LONGJMP GREATEST_ASSERT_OR_LONGJMP
+#define ASSERT_OR_LONGJMPm GREATEST_ASSERT_OR_LONGJMPm
+#define FAIL_WITH_LONGJMP GREATEST_FAIL_WITH_LONGJMP
+#define FAIL_WITH_LONGJMPm GREATEST_FAIL_WITH_LONGJMPm
+#endif
+
+#endif /* USE_ABBREVS */
+
+#if defined(__cplusplus) && !defined(GREATEST_NO_EXTERN_CPLUSPLUS)
+}
+#endif
+
+#endif

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -8,16 +8,11 @@
 TEST test_irmin_value_json(void) {
   AUTO IrminType *json = irmin_type_json();
   IrminValue *j1 = irmin_value_of_string(json, "{\"a\": 1}", -1);
-
-  IrminString *err0 = irmin_error_msg();
-  ASSERT_EQ(err0, NULL);
   ASSERT_NEQ(j1, NULL);
   irmin_value_free(j1);
 
   IrminValue *j2 = irmin_value_of_string(json, "{\"a\": 1", -1);
   ASSERT_EQ(j2, NULL);
-  AUTO IrminString *err = irmin_error_msg();
-  ASSERT_NEQ(err, NULL);
 
   PASS();
 }
@@ -135,6 +130,8 @@ TEST test_irmin_tree(void) {
 
   AUTO IrminType *ty1 = irmin_type_tree(repo);
   ASSERT(irmin_value_equal(ty1, (IrminValue *)tree1, (IrminValue *)tree2));
+
+  ASSERT_FALSE(irmin_repo_has_error(repo));
 
   PASS();
 }

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -23,7 +23,7 @@ TEST test_irmin_value_json(void) {
 }
 
 TEST test_irmin_store(void) {
-  // Setup config for git store
+  // Setup config
   AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
 
   // Initialize repo and store
@@ -94,7 +94,7 @@ TEST test_irmin_store(void) {
 }
 
 TEST test_irmin_tree(void) {
-  // Setup config for git store
+  // Setup config
   AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
 
   // Initialize repo and store

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -87,8 +87,8 @@ TEST test_irmin_store(void) {
   free(src);
 
   // List
-  IrminPathList *paths = irmin_list(store, path1);
-  ASSERT_EQ(irmin_path_list_length(repo, paths), 2);
+  IrminPathArray *paths = irmin_list(store, path1);
+  ASSERT_EQ(irmin_path_array_length(repo, paths), 2);
 
   PASS();
 }

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -23,7 +23,7 @@ void test_irmin_value_json(void) {
 void test_irmin_store(void) {
   puts("Running libirmin store tests");
   // Setup config for git store
-  AUTO IrminConfig *config = irmin_config_git_mem(NULL);
+  AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
 
   // Initialize repo and store
   AUTO IrminRepo *repo = irmin_repo_new(config);
@@ -40,7 +40,7 @@ void test_irmin_store(void) {
   AUTO IrminInfo *info = irmin_info_new(repo, "test", "set");
 
   // Set a/b/c to "123"
-  assert(irmin_set(store, path, (IrminValue *)a, info));
+  assert(irmin_set(store, path, (IrminContents *)a, info));
   assert(irmin_mem(store, path));
 
   // Get a/b/c from store
@@ -61,7 +61,7 @@ void test_irmin_store(void) {
   // Set d to "456"
   AUTO IrminPath *path2 = irmin_path_of_string(repo, "d", 1);
   AUTO IrminString *b = irmin_string_new("456", -1);
-  irmin_tree_add(repo, t, path2, (IrminValue *)b, NULL);
+  irmin_tree_add(repo, t, path2, (IrminContents *)b, NULL);
   assert(irmin_tree_mem(repo, t, path2));
 
   // Commit updated tree
@@ -76,7 +76,8 @@ void test_irmin_store(void) {
   size_t size = 1024 * 1024 * 64;
   char *src = malloc(size);
   memset(src, 'a', size);
-  AUTO IrminValue *big_string = irmin_value_string(src, size);
+  AUTO IrminContents *big_string =
+      (IrminContents *)irmin_value_string(src, size);
   AUTO IrminInfo *info2 = irmin_info_new(repo, "test", "big_string");
   assert(irmin_set(store, path3, big_string, info2));
   AUTO IrminString *big_string_ = (IrminString *)irmin_find(store, path3);
@@ -92,7 +93,7 @@ void test_irmin_store(void) {
 void test_irmin_tree(void) {
   puts("Running libirmin store tests");
   // Setup config for git store
-  AUTO IrminConfig *config = irmin_config_git_mem(NULL);
+  AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
 
   // Initialize repo and store
   AUTO IrminRepo *repo = irmin_repo_new(config);
@@ -101,16 +102,16 @@ void test_irmin_tree(void) {
   AUTO IrminTree *tree = irmin_tree_new(repo);
 
   AUTO IrminPath *p1 = irmin_path_of_string(repo, "a/b/c", -1);
-  AUTO IrminValue *v1 = irmin_contents_of_string(repo, "1", -1);
+  AUTO IrminContents *v1 = irmin_contents_of_string(repo, "1", -1);
   irmin_tree_add(repo, tree, p1, v1, NULL);
 
   AUTO IrminPath *ab = irmin_path_parent(repo, p1);
   assert(irmin_tree_mem_tree(repo, tree, ab));
-  AUTO IrminValue *v2 = irmin_tree_find(repo, tree, p1);
+  AUTO IrminContents *v2 = irmin_tree_find(repo, tree, p1);
   assert(v1);
 
   AUTO IrminType *ty = irmin_type_contents(repo);
-  assert(irmin_value_equal(ty, v1, v2));
+  assert(irmin_value_equal(ty, (IrminValue *)v1, (IrminValue *)v2));
 
   AUTO IrminPath *empty = irmin_path_empty(repo);
   AUTO IrminInfo *info = irmin_info_new(repo, "test", "tree a/b/c");

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -1,27 +1,28 @@
 #include "irmin.h"
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-void test_irmin_value_json(void) {
-  puts("Running libirmin JSON value tests");
+#include "greatest.h"
+
+TEST test_irmin_value_json(void) {
   AUTO IrminType *json = irmin_type_json();
   IrminValue *j1 = irmin_value_of_string(json, "{\"a\": 1}", -1);
 
   IrminString *err0 = irmin_error_msg();
-  assert(err0 == NULL);
-  assert(j1 != NULL);
+  ASSERT_EQ(err0, NULL);
+  ASSERT_NEQ(j1, NULL);
   irmin_value_free(j1);
 
   IrminValue *j2 = irmin_value_of_string(json, "{\"a\": 1", -1);
-  assert(j2 == NULL);
+  ASSERT_EQ(j2, NULL);
   AUTO IrminString *err = irmin_error_msg();
-  assert(err != NULL);
+  ASSERT_NEQ(err, NULL);
+
+  PASS();
 }
 
-void test_irmin_store(void) {
-  puts("Running libirmin store tests");
+TEST test_irmin_store(void) {
   // Setup config for git store
   AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
 
@@ -40,20 +41,20 @@ void test_irmin_store(void) {
   AUTO IrminInfo *info = irmin_info_new(repo, "test", "set");
 
   // Set a/b/c to "123"
-  assert(irmin_set(store, path, (IrminContents *)a, info));
-  assert(irmin_mem(store, path));
+  ASSERT(irmin_set(store, path, (IrminContents *)a, info));
+  ASSERT(irmin_mem(store, path));
 
   // Get a/b/c from store
   AUTO IrminString *v = (IrminString *)irmin_find(store, path);
-  assert(v);
+  ASSERT_NEQ(v, NULL);
 
   // Get string representation
   uint64_t length = irmin_string_length(v);
-  assert(strncmp(irmin_string_data(v), irmin_string_data(a), length) == 0);
+  ASSERT_EQ(strncmp(irmin_string_data(v), irmin_string_data(a), length), 0);
 
   // Check that tree exists at a/b
   AUTO IrminPath *path1 = irmin_path_of_string(repo, "a/b", -1);
-  assert(irmin_mem_tree(store, path1));
+  ASSERT(irmin_mem_tree(store, path1));
 
   // Get tree at a/b
   AUTO IrminTree *t = irmin_find_tree(store, path1);
@@ -62,7 +63,7 @@ void test_irmin_store(void) {
   AUTO IrminPath *path2 = irmin_path_of_string(repo, "d", 1);
   AUTO IrminString *b = irmin_string_new("456", -1);
   irmin_tree_add(repo, t, path2, (IrminContents *)b, NULL);
-  assert(irmin_tree_mem(repo, t, path2));
+  ASSERT(irmin_tree_mem(repo, t, path2));
 
   // Commit updated tree
   AUTO IrminInfo *info1 = irmin_info_new(repo, "test", "tree");
@@ -70,7 +71,7 @@ void test_irmin_store(void) {
 
   // Ensure the store contains a/b/d
   AUTO IrminPath *path3 = irmin_path_of_string(repo, "a/b/d", -1);
-  assert(irmin_mem(store, path3));
+  ASSERT(irmin_mem(store, path3));
 
   // Big string
   size_t size = 1024 * 1024 * 64;
@@ -79,19 +80,20 @@ void test_irmin_store(void) {
   AUTO IrminContents *big_string =
       (IrminContents *)irmin_value_string(src, size);
   AUTO IrminInfo *info2 = irmin_info_new(repo, "test", "big_string");
-  assert(irmin_set(store, path3, big_string, info2));
+  ASSERT(irmin_set(store, path3, big_string, info2));
   AUTO IrminString *big_string_ = (IrminString *)irmin_find(store, path3);
-  assert(irmin_string_length(big_string_) == size);
-  assert(strncmp(irmin_string_data(big_string_), src, size) == 0);
+  ASSERT_EQ(irmin_string_length(big_string_), size);
+  ASSERT_EQ(strncmp(irmin_string_data(big_string_), src, size), 0);
   free(src);
 
   // List
   IrminPathList *paths = irmin_list(store, path1);
-  assert(irmin_path_list_length(repo, paths) == 2);
+  ASSERT_EQ(irmin_path_list_length(repo, paths), 2);
+
+  PASS();
 }
 
-void test_irmin_tree(void) {
-  puts("Running libirmin store tests");
+TEST test_irmin_tree(void) {
   // Setup config for git store
   AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
 
@@ -103,43 +105,47 @@ void test_irmin_tree(void) {
 
   AUTO IrminPath *p1 = irmin_path_of_string(repo, "a/b/c", -1);
   AUTO IrminContents *v1 = irmin_contents_of_string(repo, "1", -1);
-  irmin_tree_add(repo, tree, p1, v1, NULL);
+  ASSERT(irmin_tree_add(repo, tree, p1, v1, NULL));
 
   AUTO IrminPath *ab = irmin_path_parent(repo, p1);
-  assert(irmin_tree_mem_tree(repo, tree, ab));
+  ASSERT(irmin_tree_mem_tree(repo, tree, ab));
   AUTO IrminContents *v2 = irmin_tree_find(repo, tree, p1);
-  assert(v1);
+  ASSERT_NEQ(v2, NULL);
 
   AUTO IrminType *ty = irmin_type_contents(repo);
-  assert(irmin_value_equal(ty, (IrminValue *)v1, (IrminValue *)v2));
+  ASSERT(irmin_value_equal(ty, (IrminValue *)v1, (IrminValue *)v2));
 
   AUTO IrminPath *empty = irmin_path_empty(repo);
   AUTO IrminInfo *info = irmin_info_new(repo, "test", "tree a/b/c");
-  assert(irmin_set_tree(store, empty, tree, info));
-  assert(irmin_tree_mem(repo, tree, p1));
+  ASSERT(irmin_set_tree(store, empty, tree, info));
+  ASSERT(irmin_tree_mem(repo, tree, p1));
 
   AUTO IrminKindedKey *key = irmin_tree_key(repo, tree);
-  assert(key != NULL);
-  assert(irmin_kinded_key_is_node(repo, key));
+  ASSERT_NEQ(key, NULL);
+  ASSERT(irmin_kinded_key_is_node(repo, key));
 
   AUTO IrminHash *hash = irmin_tree_hash(repo, tree);
-  assert(hash != NULL);
+  ASSERT_NEQ(hash, NULL);
 
   AUTO IrminTree *tree1 = irmin_tree_of_key(repo, key);
-  assert(tree1 != NULL);
+  ASSERT_NEQ(tree1, NULL);
 
   AUTO IrminTree *tree2 = irmin_tree_of_key(repo, key);
-  assert(tree2 != NULL);
+  ASSERT_NEQ(tree2, NULL);
 
   AUTO IrminType *ty1 = irmin_type_tree(repo);
-  assert(irmin_value_equal(ty1, (IrminValue *)tree1, (IrminValue *)tree2));
+  ASSERT(irmin_value_equal(ty1, (IrminValue *)tree1, (IrminValue *)tree2));
+
+  PASS();
 }
 
+GREATEST_MAIN_DEFS();
+
 int main(int argc, char *argv[]) {
+  GREATEST_MAIN_BEGIN();
   irmin_log_level("error");
-  test_irmin_value_json();
-  test_irmin_store();
-  test_irmin_tree();
-  puts("Finished libirmin test");
-  return 0;
+  RUN_TEST(test_irmin_value_json);
+  RUN_TEST(test_irmin_store);
+  RUN_TEST(test_irmin_tree);
+  GREATEST_MAIN_END();
 }

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -1,0 +1,144 @@
+#include "irmin.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void test_irmin_value_json(void) {
+  puts("Running libirmin JSON value tests");
+  AUTO IrminType *json = irmin_type_json();
+  IrminValue *j1 = irmin_value_of_string(json, "{\"a\": 1}", -1);
+
+  IrminString *err0 = irmin_error_msg();
+  assert(err0 == NULL);
+  assert(j1 != NULL);
+  irmin_value_free(j1);
+
+  IrminValue *j2 = irmin_value_of_string(json, "{\"a\": 1", -1);
+  assert(j2 == NULL);
+  AUTO IrminString *err = irmin_error_msg();
+  assert(err != NULL);
+}
+
+void test_irmin_store(void) {
+  puts("Running libirmin store tests");
+  // Setup config for git store
+  AUTO IrminConfig *config = irmin_config_git_mem(NULL);
+
+  // Initialize repo and store
+  AUTO IrminRepo *repo = irmin_repo_new(config);
+  AUTO Irmin *store = irmin_main(repo);
+
+  // Create new string value
+  AUTO IrminString *a = irmin_string_new("123", 3);
+
+  // Create path: a/b/c
+  char *k[] = {"a", "b", "c", NULL};
+  AUTO IrminPath *path = irmin_path(repo, k);
+
+  // Create commit info
+  AUTO IrminInfo *info = irmin_info_new(repo, "test", "set");
+
+  // Set a/b/c to "123"
+  assert(irmin_set(store, path, (IrminValue *)a, info));
+  assert(irmin_mem(store, path));
+
+  // Get a/b/c from store
+  AUTO IrminString *v = (IrminString *)irmin_find(store, path);
+  assert(v);
+
+  // Get string representation
+  uint64_t length = irmin_string_length(v);
+  assert(strncmp(irmin_string_data(v), irmin_string_data(a), length) == 0);
+
+  // Check that tree exists at a/b
+  AUTO IrminPath *path1 = irmin_path_of_string(repo, "a/b", -1);
+  assert(irmin_mem_tree(store, path1));
+
+  // Get tree at a/b
+  AUTO IrminTree *t = irmin_find_tree(store, path1);
+
+  // Set d to "456"
+  AUTO IrminPath *path2 = irmin_path_of_string(repo, "d", 1);
+  AUTO IrminString *b = irmin_string_new("456", -1);
+  irmin_tree_add(repo, t, path2, (IrminValue *)b, NULL);
+  assert(irmin_tree_mem(repo, t, path2));
+
+  // Commit updated tree
+  AUTO IrminInfo *info1 = irmin_info_new(repo, "test", "tree");
+  irmin_set_tree(store, path1, t, info1);
+
+  // Ensure the store contains a/b/d
+  AUTO IrminPath *path3 = irmin_path_of_string(repo, "a/b/d", -1);
+  assert(irmin_mem(store, path3));
+
+  // Big string
+  size_t size = 1024 * 1024 * 64;
+  char *src = malloc(size);
+  memset(src, 'a', size);
+  AUTO IrminValue *big_string = irmin_value_string(src, size);
+  AUTO IrminInfo *info2 = irmin_info_new(repo, "test", "big_string");
+  assert(irmin_set(store, path3, big_string, info2));
+  AUTO IrminString *big_string_ = (IrminString *)irmin_find(store, path3);
+  assert(irmin_string_length(big_string_) == size);
+  assert(strncmp(irmin_string_data(big_string_), src, size) == 0);
+  free(src);
+
+  // List
+  IrminPathList *paths = irmin_list(store, path1);
+  assert(irmin_path_list_length(repo, paths) == 2);
+}
+
+void test_irmin_tree(void) {
+  puts("Running libirmin store tests");
+  // Setup config for git store
+  AUTO IrminConfig *config = irmin_config_git_mem(NULL);
+
+  // Initialize repo and store
+  AUTO IrminRepo *repo = irmin_repo_new(config);
+  AUTO Irmin *store = irmin_main(repo);
+
+  AUTO IrminTree *tree = irmin_tree_new(repo);
+
+  AUTO IrminPath *p1 = irmin_path_of_string(repo, "a/b/c", -1);
+  AUTO IrminValue *v1 = irmin_contents_of_string(repo, "1", -1);
+  irmin_tree_add(repo, tree, p1, v1, NULL);
+
+  AUTO IrminPath *ab = irmin_path_parent(repo, p1);
+  assert(irmin_tree_mem_tree(repo, tree, ab));
+  AUTO IrminValue *v2 = irmin_tree_find(repo, tree, p1);
+  assert(v1);
+
+  AUTO IrminType *ty = irmin_type_contents(repo);
+  assert(irmin_value_equal(ty, v1, v2));
+
+  AUTO IrminPath *empty = irmin_path_empty(repo);
+  AUTO IrminInfo *info = irmin_info_new(repo, "test", "tree a/b/c");
+  assert(irmin_set_tree(store, empty, tree, info));
+  assert(irmin_tree_mem(repo, tree, p1));
+
+  AUTO IrminKindedKey *key = irmin_tree_key(repo, tree);
+  assert(key != NULL);
+  assert(irmin_kinded_key_is_node(repo, key));
+
+  AUTO IrminHash *hash = irmin_tree_hash(repo, tree);
+  assert(hash != NULL);
+
+  AUTO IrminTree *tree1 = irmin_tree_of_key(repo, key);
+  assert(tree1 != NULL);
+
+  AUTO IrminTree *tree2 = irmin_tree_of_key(repo, key);
+  assert(tree2 != NULL);
+
+  AUTO IrminType *ty1 = irmin_type_tree(repo);
+  assert(irmin_value_equal(ty1, (IrminValue *)tree1, (IrminValue *)tree2));
+}
+
+int main(int argc, char *argv[]) {
+  irmin_log_level("error");
+  test_irmin_value_json();
+  test_irmin_store();
+  test_irmin_tree();
+  puts("Finished libirmin test");
+  return 0;
+}


### PR DESCRIPTION
Adds a new libirmin package that provides a C interface to the irmin API (from https://github.com/zshipko/libirmin)

Here is an example using the Python interface: https://github.com/zshipko/libirmin/blob/main/examples/json-merge.py

The Python and Rust bindings are not included - I will move them to their own repositories after this is merged.

I plan on adding some proper documentation to the tutorial since there isn't really a good place to document the C interface in this repo.

### Layout

- Implementation is in `src/libirmin/*.ml` - these files use OCaml code to define the C API
- C code and header generator is in `src/libirmin/gen`
- Installable `libirmin` C library is in `src/libirmin/lib`
- Tests are in `test/libirmin/test.c`
- After running `dune build`, `irmin.h` and `libirmin.so` can be found in `_build/default/src/libirmin/lib`

### Implementation

- Values returned from OCaml are rooted using type-safe wrapper functions in `src/libirmin/util.ml`
- Every `IrminX` type has a corresponding `irmin_X_free` function that will unroot the value
- `IrminRepo` and `Irmin` values carry type information about the store's schema
- Functions returning `IrminConfig` (`irmin_config_pack`, `irmin_config_git`, ...) are used to select the backend, content type and hash type (when configurable)

### Installation

- When opam installs the `libirmin` package `libirmin.so` and `irmin.h` are copied to `$OPAM_SWITCH_PREFIX/lib/libirmin/lib/libirmin.so` and `$OPAM_SWITCH_PREFIX/lib/libirmin/include/irmin.h` - this is where the Python/Rust bindings will check

### Issues
- Currently not working on arm64 debian (see https://github.com/mirage/irmin/pull/1713#issuecomment-1012529055), I would like to test on macOS arm64 too but don't have access to an M1 Mac.