### PR TITLE
Only run code coverage action in mirage/irmin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'mirage'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It seems like we should avoid running the coverage action in forks since it will fail without the upload token - on Monday I got notified of this failure on a actions that was triggered automatically: https://github.com/zshipko/irmin/runs/4756161105
