### PR TITLE
Prefix the prehash for default contents, nodes and commits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
   - Fix the implementation of comparison on `Irmin.Tree` objects to use the
     comparison defined on hashes. The previous implementation was unstable.
     (#1519, @CraigFe)
+  - Default implementation for contents, nodes and commits can no longer trigger
+    pre_hash collisions. This changes their hash. (#1715, @Ngoguey42,
+    @icristescu)
 
  - **irmin-pack**
    - Improved the performance of Index encode and decode operations by
@@ -35,6 +38,9 @@
     (#TODO, @Ngoguey42) Forward ported from #1741.
   - Add a `Store.Tree.kinded_hash` function. (#1767, @Ngoguey) Forward ported
     from #1625.
+  - Add `Contents.String_v2`, `Node.Generic_key.Make_v2` and
+    `Commit.Generic_key.Make_v2` for backward compatibility with older stores.
+    (#1715, @icristescu)
 
 - **irmin-bench**
   - Many improvements to the actions trace replay:

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -39,6 +39,8 @@ module Maker_generic_key (I : Info.S) = struct
     type t = { node : node_key; parents : commit_key list; info : Info.t }
     [@@deriving irmin]
 
+    type t_not_prefixed = t [@@deriving irmin]
+
     let pre_hash = Type.(unstage (pre_hash t))
 
     (* Manually add a prefix to default commits, in order to prevent hash
@@ -87,6 +89,25 @@ module Maker_generic_key (I : Info.S) = struct
         let node = N.to_hash node in
         let parents = List.map C.to_hash parents in
         { node; parents; info }
+    end
+  end
+
+  module Make_v2
+      (H : Type.S)
+      (N : Key.S with type hash = H.t)
+      (C : Key.S with type hash = H.t) =
+  struct
+    include Make (H) (N) (C)
+
+    type t = t_not_prefixed [@@deriving irmin]
+
+    module Portable = struct
+      include (
+        Portable :
+          Portable
+            with type hash = hash
+             and type commit = t
+             and module Info = Info)
     end
   end
 end

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -39,6 +39,20 @@ module Maker_generic_key (I : Info.S) = struct
     type t = { node : node_key; parents : commit_key list; info : Info.t }
     [@@deriving irmin]
 
+    let pre_hash = Type.(unstage (pre_hash t))
+
+    (* Manually add a prefix to default commits, in order to prevent hash
+       collision between contents and commits (see
+       https://github.com/mirage/irmin/issues/1304).
+       If we only prefix the prehash of contents, (suppose the prefix is "B"),
+       then we can have a collision with the prehash of a commit (the prehash of
+       a commit starts with the hash of the root and can start with a "B" - the
+       prefix of the contents is not enough to prevent the collision). *)
+    let pre_hash_prefixed x f =
+      f "C";
+      pre_hash x f
+
+    let t = Type.(like t ~pre_hash:pre_hash_prefixed)
     let parents t = t.parents
     let node t = t.node
     let info t = t.info

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -72,6 +72,16 @@ module Maker_generic_key (I : Info.S) = struct
       type t = { node : hash; parents : hash list; info : Info.t }
       [@@deriving irmin]
 
+      type t_not_prefixed = t [@@deriving irmin]
+
+      let pre_hash = Type.(unstage (pre_hash t))
+
+      let pre_hash_prefixed x f =
+        f "C";
+        pre_hash x f
+
+      let t = Type.(like t ~pre_hash:pre_hash_prefixed)
+
       type commit_key = H.t [@@deriving irmin]
       type node_key = H.t [@@deriving irmin]
       type hash = H.t [@@deriving irmin]
@@ -99,15 +109,12 @@ module Maker_generic_key (I : Info.S) = struct
   struct
     include Make (H) (N) (C)
 
-    type t = t_not_prefixed [@@deriving irmin]
+    let t = t_not_prefixed_t
 
     module Portable = struct
-      include (
-        Portable :
-          Portable
-            with type hash = hash
-             and type commit = t
-             and module Info = Info)
+      include Portable
+
+      let t = t_not_prefixed_t
     end
   end
 end

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -79,6 +79,20 @@ module type Maker_generic_key = sig
     module Portable :
       Portable with type commit := t and type hash := H.t and module Info = Info
   end
+
+  module Make_v2
+      (H : Type.S)
+      (N : Key.S with type hash = H.t)
+      (C : Key.S with type hash = H.t) : sig
+    include
+      S_generic_key
+        with type node_key = N.t
+         and type commit_key = C.t
+         and module Info = Info
+
+    module Portable :
+      Portable with type commit := t and type hash := H.t and module Info = Info
+  end
 end
 
 module type Maker = sig

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -193,6 +193,16 @@ end
 module String = struct
   type t = string [@@deriving irmin]
 
+  let pre_hash = Type.(unstage (pre_hash t))
+
+  (* Manually add a prefix to default contents, in order to prevent hash
+     collision between contents and nodes or commits (see
+     https://github.com/mirage/irmin/issues/1304). *)
+  let pre_hash_prefixed x f =
+    f "B";
+    pre_hash x f
+
+  let t = Type.(like t ~pre_hash:pre_hash_prefixed)
   let merge = Merge.idempotent Type.(option string)
 end
 

--- a/src/irmin/contents.ml
+++ b/src/irmin/contents.ml
@@ -190,6 +190,12 @@ module Json = struct
     Merge.(option (alist Type.string Json_value.t (fun _ -> Json_value.merge)))
 end
 
+module String_v2 = struct
+  type t = string [@@deriving irmin]
+
+  let merge = Merge.idempotent Type.(option string)
+end
+
 module String = struct
   type t = string [@@deriving irmin]
 

--- a/src/irmin/contents_intf.ml
+++ b/src/irmin/contents_intf.ml
@@ -54,6 +54,10 @@ module type Sigs = sig
       merge strategy: assume that update operations are idempotent and conflict
       iff values are modified concurrently. *)
 
+  module String_v2 : S with type t = string
+  (** Similar to [String] above, but the hash computation is compatible with
+      versions older than irmin.3.0 *)
+
   type json =
     [ `Null
     | `Bool of bool

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -228,6 +228,19 @@ struct
     [@@deriving irmin]
 
     type t = entry list [@@deriving irmin ~pre_hash]
+
+    let pre_hash = Type.(unstage (pre_hash t))
+
+    (* Manually add a prefix to default nodes, in order to prevent hash
+       collision between contents and nodes (see
+       https://github.com/mirage/irmin/issues/1304).
+
+       Prefixing the contents is not enough to prevent the collision: the
+       prehash of a node starts with the number of its children, which can
+       coincide with the prefix of the content's prehash. *)
+    let pre_hash x f =
+      f "N";
+      pre_hash x f
   end
 
   let t =

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -228,7 +228,7 @@ struct
     [@@deriving irmin]
 
     type t = entry list [@@deriving irmin ~pre_hash]
-    type t_not_prefixed = t [@@deriving irmin]
+    type t_not_prefixed = t [@@deriving irmin ~pre_hash]
 
     let pre_hash = Type.(unstage (pre_hash t))
 
@@ -269,6 +269,10 @@ struct
 
   let t =
     let pre_hash = pre_hash Hash_preimage.pre_hash in
+    Type.map ~pre_hash Type.(list entry_t) of_entries entries
+
+  let t_not_prefixed =
+    let pre_hash = pre_hash Hash_preimage.pre_hash_t_not_prefixed in
     Type.map ~pre_hash Type.(list entry_t) of_entries entries
 
   let with_handler _ t = t
@@ -408,27 +412,12 @@ module Make_generic_key_v2
 struct
   include Make_generic_key (Hash) (Path) (Metadata) (Contents_key) (Node_key)
 
-  module Hash_preimage = struct
-    include Hash_preimage
-
-    type t = t_not_prefixed [@@deriving irmin ~pre_hash]
-  end
-
-  let t =
-    let pre_hash = pre_hash Hash_preimage.pre_hash in
-    Type.map ~pre_hash Type.(list entry_t) of_entries entries
-
-  module P = Portable
+  let t = t_not_prefixed
 
   module Portable = struct
-    include (
-      Portable :
-        Portable
-          with type t = t
-           and type node := t
-           and type metadata := metadata
-           and type hash := hash
-           and type step := step)
+    include Portable
+
+    let t = t_not_prefixed
   end
 end
 

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -369,6 +369,10 @@ module type Sigs = sig
 
     module Make : Maker
 
+    module Make_v2 : Maker
+    (** [Make_v2] provides a similar implementation as [Make] but the hash
+        computation is compatible with versions older than irmin.3.0 *)
+
     module Store
         (C : Contents.Store)
         (S : Indexable.S)

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -27,6 +27,7 @@ let run f () =
   flush stdout
 
 let hash x = Test_chunk.Key.hash (fun l -> l x)
+let hash_contents x = hash ("B" ^ x)
 let value_to_bin = Irmin.Type.(unstage (to_bin_string Test_chunk.Value.t))
 
 let test_add_read ?(stable = false) (module AO : Test_chunk.S) () =
@@ -37,7 +38,7 @@ let test_add_read ?(stable = false) (module AO : Test_chunk.S) () =
     let* k = AO.batch t (fun t -> AO.add t v) in
     (if stable then
      let str = value_to_bin v in
-     Alcotest.(check key_t) (name ^ " is stable") k (hash str));
+     Alcotest.(check key_t) (name ^ " is stable") k (hash_contents str));
     let+ v' = AO.find t k in
     Alcotest.(check @@ option value_t) name (Some v) v'
   in

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -41,12 +41,12 @@ module Conf = Irmin_tezos.Conf
 module Schema = struct
   open Irmin
   module Metadata = Metadata.None
-  module Contents = Contents.String
+  module Contents = Contents.String_v2
   module Path = Path.String_list
   module Branch = Branch.String
   module Hash = Hash.SHA1
-  module Node = Node.Generic_key.Make (Hash) (Path) (Metadata)
-  module Commit = Commit.Generic_key.Make (Hash)
+  module Node = Node.Generic_key.Make_v2 (Hash) (Path) (Metadata)
+  module Commit = Commit.Generic_key.Make_v2 (Hash)
   module Info = Info.Default
 end
 

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -20,6 +20,7 @@ module Dict = Irmin_pack.Dict
 
 let get = function Some x -> x | None -> Alcotest.fail "None"
 let sha1 x = Irmin.Hash.SHA1.hash (fun f -> f x)
+let sha1_contents x = sha1 ("B" ^ x)
 
 let rm_dir root =
   if Sys.file_exists root then (

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -99,6 +99,7 @@ end
 
 val get : 'a option -> 'a
 val sha1 : string -> Schema.Hash.t
+val sha1_contents : string -> Schema.Hash.t
 val rm_dir : string -> unit
 val index_log_size : int option
 val random_string : int -> string

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -100,8 +100,21 @@ end
 
 module V1_maker = Irmin_pack.Maker (Small_conf)
 module V2_maker = Irmin_pack.Maker (Conf)
-module V1 () = V1_maker.Make (Schema)
-module V2 () = V2_maker.Make (Schema)
+
+module Schema_v2 = struct
+  open Irmin
+  module Metadata = Metadata.None
+  module Contents = Contents.String_v2
+  module Path = Path.String_list
+  module Branch = Branch.String
+  module Hash = Hash.SHA1
+  module Node = Node.Generic_key.Make_v2 (Hash) (Path) (Metadata)
+  module Commit = Commit.Generic_key.Make_v2 (Hash)
+  module Info = Info.Default
+end
+
+module V1 () = V1_maker.Make (Schema_v2)
+module V2 () = V2_maker.Make (Schema_v2)
 
 module Test_store = struct
   module S = V2 ()

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -35,7 +35,7 @@ struct
   module Key = Irmin_pack.Pack_key.Make (Schema.Hash)
 
   module Node =
-    Irmin.Node.Generic_key.Make (Schema.Hash) (Schema.Path) (Schema.Metadata)
+    Irmin.Node.Generic_key.Make_v2 (Schema.Hash) (Schema.Path) (Schema.Metadata)
       (Key)
       (Key)
 
@@ -275,7 +275,7 @@ let test_add_values () =
   let v1 = Inode.Val.add (Inode.Val.empty ()) "x" (normal foo) in
   let v2 = Inode.Val.add v1 "y" (normal bar) in
   check_node "node x+y" v2 t >>= fun () ->
-  check_hardcoded_hash "hash v2" "c7f712f1be10dc0aedf53e63f077f878bf0eb183" v2;
+  check_hardcoded_hash "hash v2" "d4b55db5d2d806283766354f0d7597d332156f74" v2;
   let v3 = Inode.Val.of_list [ ("x", normal foo); ("y", normal bar) ] in
   check_values "add x+y vs v x+y" v2 v3;
   Context.close t
@@ -299,7 +299,7 @@ let test_add_inodes () =
       [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
   in
   check_values "add x+y+z vs v x+z+y" v2 v3;
-  check_hardcoded_hash "hash v3" "bce58c3d82f74526c3efe2860bba20083f7812d5" v3;
+  check_hardcoded_hash "hash v3" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v3;
   integrity_check v1;
   integrity_check v2;
   let v4 = Inode.Val.add v2 "a" (normal foo) in
@@ -313,7 +313,7 @@ let test_add_inodes () =
       ]
   in
   check_values "add x+y+z+a vs v x+z+a+y" v4 v5;
-  check_hardcoded_hash "hash v4" "db91d8b4acf0d77a8ca625d5ef8be2ae2e92e8c7" v4;
+  check_hardcoded_hash "hash v4" "c330c08571d088141dfc82f644bffcfcf6696539" v4;
   integrity_check v4 ~stable:false;
   Context.close t
 
@@ -326,13 +326,13 @@ let test_remove_values () =
   let v2 = Inode.Val.remove v1 "y" in
   let v3 = Inode.Val.of_list [ ("x", normal foo) ] in
   check_values "node x obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "e1168f832d223676aca295dcc047eaae9473dd40" v2;
+  check_hardcoded_hash "hash v2" "a1996f4309ea31cc7ba2d4c81012885aa0e08789" v2;
   let v4 = Inode.Val.remove v2 "x" in
   check_node "remove results in an empty node" (Inode.Val.empty ()) t
   >>= fun () ->
   let v5 = Inode.Val.remove v4 "x" in
   check_values "remove on an already empty node" v4 v5;
-  check_hardcoded_hash "hash v4" "e42e8bb820d4f7550a0f04619f4e15fdc56943b9" v4;
+  check_hardcoded_hash "hash v4" "5ba93c9db0cff93f52b521d7420e43f6eda2784f" v4;
   Alcotest.(check bool) "v5 is empty" (Inode.Val.is_empty v5) true;
   Context.close t
 
@@ -345,11 +345,11 @@ let test_remove_inodes () =
     Inode.Val.of_list
       [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
   in
-  check_hardcoded_hash "hash v1" "bce58c3d82f74526c3efe2860bba20083f7812d5" v1;
+  check_hardcoded_hash "hash v1" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v1;
   let v2 = Inode.Val.remove v1 "x" in
   let v3 = Inode.Val.of_list [ ("y", normal bar); ("z", normal foo) ] in
   check_values "node y+z obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "13667c467db76311bef78d77dee178fb9f3df6ff" v2;
+  check_hardcoded_hash "hash v2" "ea22a2936eed53978bde62f0185cee9d8bbf9489" v2;
   let v4 =
     Inode.Val.of_list
       [

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -275,7 +275,7 @@ let test_add_values () =
   let v1 = Inode.Val.add (Inode.Val.empty ()) "x" (normal foo) in
   let v2 = Inode.Val.add v1 "y" (normal bar) in
   check_node "node x+y" v2 t >>= fun () ->
-  check_hardcoded_hash "hash v2" "d4b55db5d2d806283766354f0d7597d332156f74" v2;
+  check_hardcoded_hash "hash v2" "c7d45d1ce5ebf54de0d2f5b7aae25814e1670bb0" v2;
   let v3 = Inode.Val.of_list [ ("x", normal foo); ("y", normal bar) ] in
   check_values "add x+y vs v x+y" v2 v3;
   Context.close t
@@ -299,7 +299,7 @@ let test_add_inodes () =
       [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
   in
   check_values "add x+y+z vs v x+z+y" v2 v3;
-  check_hardcoded_hash "hash v3" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v3;
+  check_hardcoded_hash "hash v3" "5fb0c63eec0d7662580754367a93d56c4e4e0686" v3;
   integrity_check v1;
   integrity_check v2;
   let v4 = Inode.Val.add v2 "a" (normal foo) in
@@ -313,7 +313,7 @@ let test_add_inodes () =
       ]
   in
   check_values "add x+y+z+a vs v x+z+a+y" v4 v5;
-  check_hardcoded_hash "hash v4" "c330c08571d088141dfc82f644bffcfcf6696539" v4;
+  check_hardcoded_hash "hash v4" "db91d8b4acf0d77a8ca625d5ef8be2ae2e92e8c7" v4;
   integrity_check v4 ~stable:false;
   Context.close t
 
@@ -326,7 +326,7 @@ let test_remove_values () =
   let v2 = Inode.Val.remove v1 "y" in
   let v3 = Inode.Val.of_list [ ("x", normal foo) ] in
   check_values "node x obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "a1996f4309ea31cc7ba2d4c81012885aa0e08789" v2;
+  check_hardcoded_hash "hash v2" "82b6785796efe7c7a2d0c24d570d3da8df36dfce" v2;
   let v4 = Inode.Val.remove v2 "x" in
   check_node "remove results in an empty node" (Inode.Val.empty ()) t
   >>= fun () ->
@@ -345,11 +345,11 @@ let test_remove_inodes () =
     Inode.Val.of_list
       [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
   in
-  check_hardcoded_hash "hash v1" "46fe6c68a11a6ecd14cbe2d15519b6e5f3ba2864" v1;
+  check_hardcoded_hash "hash v1" "5fb0c63eec0d7662580754367a93d56c4e4e0686" v1;
   let v2 = Inode.Val.remove v1 "x" in
   let v3 = Inode.Val.of_list [ ("y", normal bar); ("z", normal foo) ] in
   check_values "node y+z obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "ea22a2936eed53978bde62f0185cee9d8bbf9489" v2;
+  check_hardcoded_hash "hash v2" "85c1087b5a7172583f8e0f344e23366029b3ff8b" v2;
   let v4 =
     Inode.Val.of_list
       [

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -275,7 +275,7 @@ let test_add_values () =
   let v1 = Inode.Val.add (Inode.Val.empty ()) "x" (normal foo) in
   let v2 = Inode.Val.add v1 "y" (normal bar) in
   check_node "node x+y" v2 t >>= fun () ->
-  check_hardcoded_hash "hash v2" "c7d45d1ce5ebf54de0d2f5b7aae25814e1670bb0" v2;
+  check_hardcoded_hash "hash v2" "c7f712f1be10dc0aedf53e63f077f878bf0eb183" v2;
   let v3 = Inode.Val.of_list [ ("x", normal foo); ("y", normal bar) ] in
   check_values "add x+y vs v x+y" v2 v3;
   Context.close t
@@ -299,7 +299,7 @@ let test_add_inodes () =
       [ ("x", normal foo); ("z", normal foo); ("y", normal bar) ]
   in
   check_values "add x+y+z vs v x+z+y" v2 v3;
-  check_hardcoded_hash "hash v3" "5fb0c63eec0d7662580754367a93d56c4e4e0686" v3;
+  check_hardcoded_hash "hash v3" "bce58c3d82f74526c3efe2860bba20083f7812d5" v3;
   integrity_check v1;
   integrity_check v2;
   let v4 = Inode.Val.add v2 "a" (normal foo) in
@@ -326,13 +326,13 @@ let test_remove_values () =
   let v2 = Inode.Val.remove v1 "y" in
   let v3 = Inode.Val.of_list [ ("x", normal foo) ] in
   check_values "node x obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "82b6785796efe7c7a2d0c24d570d3da8df36dfce" v2;
+  check_hardcoded_hash "hash v2" "e1168f832d223676aca295dcc047eaae9473dd40" v2;
   let v4 = Inode.Val.remove v2 "x" in
   check_node "remove results in an empty node" (Inode.Val.empty ()) t
   >>= fun () ->
   let v5 = Inode.Val.remove v4 "x" in
   check_values "remove on an already empty node" v4 v5;
-  check_hardcoded_hash "hash v4" "5ba93c9db0cff93f52b521d7420e43f6eda2784f" v4;
+  check_hardcoded_hash "hash v4" "e42e8bb820d4f7550a0f04619f4e15fdc56943b9" v4;
   Alcotest.(check bool) "v5 is empty" (Inode.Val.is_empty v5) true;
   Context.close t
 
@@ -345,11 +345,11 @@ let test_remove_inodes () =
     Inode.Val.of_list
       [ ("x", normal foo); ("y", normal bar); ("z", normal foo) ]
   in
-  check_hardcoded_hash "hash v1" "5fb0c63eec0d7662580754367a93d56c4e4e0686" v1;
+  check_hardcoded_hash "hash v1" "bce58c3d82f74526c3efe2860bba20083f7812d5" v1;
   let v2 = Inode.Val.remove v1 "x" in
   let v3 = Inode.Val.of_list [ ("y", normal bar); ("z", normal foo) ] in
   check_values "node y+z obtained two ways" v2 v3;
-  check_hardcoded_hash "hash v2" "85c1087b5a7172583f8e0f344e23366029b3ff8b" v2;
+  check_hardcoded_hash "hash v2" "13667c467db76311bef78d77dee178fb9f3df6ff" v2;
   let v4 =
     Inode.Val.of_list
       [

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -172,10 +172,10 @@ module Pack = struct
     let x2 = "bar" in
     let x3 = "otoo" in
     let x4 = "sdadsadas" in
-    let h1 = sha1 x1 in
-    let h2 = sha1 x2 in
-    let h3 = sha1 x3 in
-    let h4 = sha1 x4 in
+    let h1 = sha1_contents x1 in
+    let h2 = sha1_contents x2 in
+    let h3 = sha1_contents x3 in
+    let h4 = sha1_contents x4 in
     let* k1, k2, k3, k4 =
       Pack.batch t.pack (fun w ->
           Lwt_list.map_s
@@ -214,8 +214,8 @@ module Pack = struct
       in
       let x1 = "foo" in
       let x2 = "bar" in
-      let h1 = sha1 x1 in
-      let h2 = sha1 x2 in
+      let h1 = sha1_contents x1 in
+      let h2 = sha1_contents x2 in
       let[@warning "-8"] [ _k1; k2 ] = adds [ (h1, x1); (h2, x2) ] in
       let* y2 = Pack.find r k2 in
       Alcotest.(check (option string)) "before sync" None y2;
@@ -225,8 +225,8 @@ module Pack = struct
       Alcotest.(check (option string)) "after sync" (Some x2) y2;
       let x3 = "otoo" in
       let x4 = "sdadsadas" in
-      let h3 = sha1 x3 in
-      let h4 = sha1 x4 in
+      let h3 = sha1_contents x3 in
+      let h4 = sha1_contents x4 in
       let[@warning "-8"] [ k3; _k4 ] = adds [ (h3, x3); (h4, x4) ] in
       Pack.flush w;
       Pack.sync r;
@@ -247,7 +247,7 @@ module Pack = struct
       Pack.v ~fresh:true ~index ~indexing_strategy (Context.fresh_name "pack")
     in
     let x1 = "foo" in
-    let h1 = sha1 x1 in
+    let h1 = sha1_contents x1 in
     let k1 =
       Pack.unsafe_append ~ensure_unique:true ~overcommit:false w1 h1 x1
     in
@@ -261,7 +261,7 @@ module Pack = struct
     let* t = Context.get_pack () in
     let w = t.pack in
     let x1 = "foo" in
-    let h1 = sha1 x1 in
+    let h1 = sha1_contents x1 in
     let k1 = Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h1 x1 in
     Pack.flush w;
     Index.close t.index;
@@ -287,8 +287,8 @@ module Pack = struct
     let w = t.pack in
     let x1 = "foo" in
     let x2 = "bar" in
-    let h1 = sha1 x1 in
-    let h2 = sha1 x2 in
+    let h1 = sha1_contents x1 in
+    let h2 = sha1_contents x2 in
     let* k1, k2 =
       Pack.batch w (fun w ->
           Lwt_list.map_s
@@ -307,7 +307,7 @@ module Pack = struct
     Alcotest.(check string) "x1.1" x1 y1;
     (*open and close two packs *)
     let x3 = "toto" in
-    let h3 = sha1 x3 in
+    let h3 = sha1_contents x3 in
     let k3 = Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h3 x3 in
     let* w2 = t.clone_pack ~readonly:false in
     Pack.close w >>= fun () ->
@@ -340,7 +340,7 @@ module Pack = struct
     let* i, r = t.clone_index_pack ~readonly:true in
     let test w =
       let x1 = "foo" in
-      let h1 = sha1 x1 in
+      let h1 = sha1_contents x1 in
       let k1 =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h1 x1
       in
@@ -352,7 +352,7 @@ module Pack = struct
       let* y1 = Pack.find r k1 in
       Alcotest.(check (option string)) "sync after filter" (Some x1) y1;
       let x2 = "foo" in
-      let h2 = sha1 x2 in
+      let h2 = sha1_contents x2 in
       let k2 =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h2 x2
       in
@@ -372,7 +372,7 @@ module Pack = struct
     in
     let test w =
       let x1 = "foo" in
-      let h1 = sha1 x1 in
+      let h1 = sha1_contents x1 in
       let k1 =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h1 x1
       in
@@ -382,7 +382,7 @@ module Pack = struct
       Index.filter t.index (fun _ -> true);
       check k1 x1 "find after filter" >>= fun () ->
       let x2 = "bar" in
-      let h2 = sha1 x2 in
+      let h2 = sha1_contents x2 in
       let k2 =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h2 x2
       in
@@ -390,7 +390,7 @@ module Pack = struct
       Pack.sync r;
       check k2 x2 "find before flush" >>= fun () ->
       let x3 = "toto" in
-      let h3 = sha1 x3 in
+      let h3 = sha1_contents x3 in
       let k3 =
         Pack.unsafe_append ~ensure_unique:true ~overcommit:false w h3 x3
       in


### PR DESCRIPTION
This changes the hash for all stores that use the default contents. 

Still wip because I need to regenerate the existing stores to use the new hash.   

closes #1304