### PR TITLE
Add max-count, skip and reverse options to `irmin log` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -192,7 +192,7 @@
   - Update `irmin` CLI to support empty path in `list` subcommand.
     (#1575, @maiste)
   - Add new commands to CLI: `branches` for listing available branches and
-    `log` which is similar to `git log` (#1609, @zshipko)
+    `log` which is similar to `git log` (#1609, #1727, @zshipko)
   - Update `irmin watch` to take parameters to specify a command that should
     be executed when there are new changes (#1608, @zshipko)
 


### PR DESCRIPTION
Adds some flags to make working with large commit histories easier:

- `--max-count`/`-n`: limits the number of commits to print
- `--skip`: sets the number of commits to skip before printing
- `--reverse`: prints history starting from the earliest commit