### PR TITLE
irmin: better signature for Tree.length (port from 2.10)

### DIFF
--- a/bench/irmin-pack/trace_collection.ml
+++ b/bench/irmin-pack/trace_collection.ml
@@ -222,16 +222,7 @@ module Make_stat (Store : Irmin.Generic_key.KV) = struct
   let create_store_after tree =
     let* watched_nodes_length =
       Lwt_list.map_s
-        (fun (_, steps) ->
-          let* tree = Store.Tree.find_tree tree steps in
-          match tree with
-          | None -> Lwt.return 0
-          | Some tree -> (
-              match Store.Tree.destruct tree with
-              | `Node tree ->
-                  let* length = Store.Tree.length tree in
-                  Lwt.return length
-              | `Contents _ -> Lwt.return 0))
+        (fun (_, steps) -> Store.Tree.length tree steps)
         Def.step_list_per_watched_node
     in
     Lwt.return Def.{ watched_nodes_length }

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1179,6 +1179,18 @@ module Make (S : Generic_key) = struct
       let* d5 = S.Tree.diff v3 v2 in
       check_diffs "diff 4" [ ([ "foo"; "bar"; "1" ], `Removed (foo1, d0)) ] d5;
 
+      (* Testing length *)
+      let check_length msg t =
+        let* n = S.Tree.length t [] in
+        let+ l = S.Tree.list t [] in
+        Alcotest.(check int) msg n (List.length l)
+      in
+      let* () = check_length "bindings1 length" v2 in
+      let* () =
+        let t = contents "foo" in
+        check_length "contents length" t
+      in
+
       (* Testing paginated lists *)
       let tree =
         let c ?(info = S.Metadata.default) blob = `Contents (blob, info) in

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1496,7 +1496,11 @@ module Make (P : Backend.S) = struct
             | Some (`Contents _) -> Lwt.return_some `Contents
             | Some (`Node _) -> Lwt.return_some `Node))
 
-  let length = Node.length ~cache:true
+  let length t ?(cache = true) path =
+    [%log.debug "Tree.length %a" pp_path path];
+    sub ~cache "length" t path >>= function
+    | None -> Lwt.return 0
+    | Some n -> Node.length ~cache:true n
 
   let seq t ?offset ?length ~cache path : (step * t) Seq.t Lwt.t =
     [%log.debug "Tree.seq %a" pp_path path];

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -145,8 +145,15 @@ module type S = sig
   (** [find_all t k] is [Some (b, m)] if [k] is associated to the contents [b]
       and metadata [m] in [t] and [None] if [k] is not present in [t]. *)
 
-  val length : node -> int Lwt.t
-  (** [find n] is the number of entries in [n]. *)
+  val length : t -> ?cache:bool -> path -> int Lwt.t
+  (** [length t key] is the number of files and sub-nodes stored under [key] in
+      [t].
+
+      It is equivalent to [List.length (list t k)] but backends might optimise
+      this call: for instance it's a constant time operation in [irmin-pack].
+
+      [cache] defaults to [true], see {!caching} for an explanation of the
+      parameter.*)
 
   val find : t -> path -> contents option Lwt.t
   (** [find] is similar to {!find_all} but it discards metadata. *)


### PR DESCRIPTION
Forward port of https://github.com/mirage/irmin/pull/1676.