### PR TITLE
Adding weights in the pack's lru

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1373,6 +1373,15 @@ struct
       (off, t)
 
     let decode_bin_length = decode_compress_length
+
+    module Weighted = struct
+      type data = t
+      type t = data
+
+      let weight _ = 1
+      let data d = d
+      let weighted_value d _ = d
+    end
   end
 
   type hash = T.hash

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1376,11 +1376,11 @@ struct
 
     module Weighted = struct
       type data = t
-      type t = data
+      type t = data * int
 
-      let weight _ = 1
-      let data d = d
-      let weighted_value d _ = d
+      let weight (_, w) = w
+      let data (d, _) = d
+      let weighted_value d w = (d, w)
     end
   end
 

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -94,7 +94,7 @@ module Of_commit =
     (struct
       type 'a t = 'a
 
-      let weight _ = 1
+      let weight _ = 1000
       let data d = d
       let weighted_value d _ = d
     end)

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -1,5 +1,14 @@
 open! Import
 
+module type Weighted = sig
+  type data
+  type t
+
+  val weight : t -> int
+  val data : t -> data
+  val weighted_value : data -> int -> t
+end
+
 module type S = sig
   include Irmin.Type.S
 
@@ -25,6 +34,8 @@ module type S = sig
     int * t
 
   val decode_bin_length : string -> int -> int
+
+  module Weighted : Weighted with type data = t
 end
 
 module type Sigs = sig
@@ -40,6 +51,12 @@ module type Sigs = sig
 
   module Make (_ : sig
     val selected_kind : Kind.t
+  end) (Weighted : sig
+    type 'a t
+
+    val weight : 'a t -> int
+    val data : 'a t -> 'a
+    val weighted_value : 'a -> int -> 'a t
   end)
   (Hash : Irmin.Hash.S)
   (Data : Irmin.Type.S) : S with type hash = Hash.t

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -76,7 +76,7 @@ module Make (H : Hashtbl.HashedType) (V : Weighted) = struct
   }
 
   let weight t = t.w
-  let create cap = { cap; w = 0; ht = HT.create cap; q = Q.create () }
+  let create cap = { cap; w = 0; ht = HT.create 1000; q = Q.create () }
 
   let drop_lru t =
     match t.q.first with

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -13,12 +13,18 @@
 (* Extracted from https://github.com/pqwy/lru
    Copyright (c) 2016 David Kaloper Meršinjak *)
 
-module Make (H : Hashtbl.HashedType) : sig
+module type Weighted = sig
+  type t
+
+  val weight : t -> int
+end
+
+module Make (H : Hashtbl.HashedType) (V : Weighted) : sig
   type 'a t
 
-  val create : int -> 'a t
-  val add : 'a t -> H.t -> 'a -> unit
-  val find : 'a t -> H.t -> 'a
-  val mem : 'a t -> H.t -> bool
-  val clear : 'a t -> unit
+  val create : int -> V.t t
+  val add : V.t t -> H.t -> V.t -> unit
+  val find : V.t t -> H.t -> V.t
+  val mem : V.t t -> H.t -> bool
+  val clear : V.t t -> unit
 end

--- a/src/irmin/object_graph.ml
+++ b/src/irmin/object_graph.ml
@@ -65,7 +65,15 @@ module Make (Hash : HASH) (Branch : Type.S) = struct
     val add : t -> X.t -> int -> unit
     val mem : t -> X.t -> bool
   end = struct
-    module Lru = Lru.Make (X)
+    module Lru =
+      Lru.Make
+        (X)
+        (struct
+          type t = int
+
+          let weight _ = 1
+        end)
+
     module Tbl = Hashtbl.Make (X)
 
     type t = L of int Lru.t | T of int Tbl.t

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -61,6 +61,15 @@ module S = struct
     match Irmin.Type.(Size.of_encoding (pair H.t t)) with
     | Dynamic f -> f
     | _ -> assert false
+
+  module Weighted = struct
+    type data = t
+    type t = data * int
+
+    let weight (_, w) = w
+    let data (d, _) = d
+    let weighted_value d w = (d, w)
+  end
 end
 
 module H = Irmin.Hash.SHA1


### PR DESCRIPTION
I'm running the benchmarks, so still wip, but this what the lru looks like on ithaca:
- the reachable words for the different lrus 
![lru_stats](https://user-images.githubusercontent.com/16655454/151412981-92e0b4ff-1d61-4297-b31c-dcdaa6b05d5f.png)
- the number of adds in the lru per commit 
![lru_adds](https://user-images.githubusercontent.com/16655454/151412992-58e96c01-4d84-43c7-bfeb-922e8b48335e.png)
 