### PR TITLE
irmin-bench: use the latest version of Printbox

### DIFF
--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -25,7 +25,7 @@
  (preprocess
   (pps ppx_irmin.internal ppx_repr ppx_deriving.enum))
  (libraries irmin irmin-pack unix lwt repr ppx_repr bentov mtime printbox
-   uucp uutf printbox.unicode mtime.clock.os bench_common)
+   printbox-text mtime.clock.os bench_common)
  (instrumentation
   (backend bisect_ppx)))
 

--- a/bench/irmin-pack/trace_stat_summary_pp.ml
+++ b/bench/irmin-pack/trace_stat_summary_pp.ml
@@ -30,8 +30,6 @@ module Summary = Trace_stat_summary
 module Pb = struct
   include PrintBox
 
-  let () = PrintBox_unicode.setup ()
-
   (* Some utilities to work with lists instead of array *)
 
   let transpose_matrix l =

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -36,7 +36,8 @@ depends: [
   "rusage"
   "uutf"
   "uucp"
-  "printbox"
+  "printbox"     {>= "0.6"}
+  "printbox-text"
 ]
 
 synopsis: "Irmin benchmarking suite"


### PR DESCRIPTION
Usage of `PrintBox_text` now uses UTF-8 box-drawing characters by default, and the previous optional `printbox.unicode` library no longer exists.

This should fix the CI, which is currently failing on `main` due to the release of `printbox.0.6`.