### PR TITLE
irmin: fix default `Node.Portable.{find,to_list}` implementations

### DIFF
--- a/src/irmin-test/node.ml
+++ b/src/irmin-test/node.ml
@@ -4,48 +4,108 @@ let check pos typ ~expected actual =
   in
   Alcotest.(check ~pos typ) "" expected actual
 
-module Make (Make_node : Irmin.Node.Generic_key.Maker) : sig
-  val suite : unit Alcotest.test_case list
-end = struct
-  module Schema = Irmin.Schema.KV (Irmin.Contents.String)
-  module Hash = Schema.Hash
-  module Key = Irmin.Key.Of_hash (Hash)
-  module X = Make_node (Hash) (Schema.Path) (Schema.Metadata) (Key) (Key)
+module type Map = sig
+  type t [@@deriving irmin]
+  type data [@@deriving irmin]
+  type key := string
 
-  type key = Key.t [@@deriving irmin]
+  val empty : unit -> t
+  val is_empty : t -> bool
+  val length : t -> int
+  val list : ?offset:int -> ?length:int -> ?cache:bool -> t -> (key * data) list
+  val find : ?cache:bool -> t -> key -> data option
+  val add : t -> key -> data -> t
+  val remove : t -> key -> t
 
-  let random_key =
-    let hash_of_string = Irmin.Type.(unstage (of_bin_string Hash.t)) in
-    let random_string =
-      Irmin.Type.(unstage (random (string_of (`Fixed Hash.hash_size))))
-    in
-    fun () ->
-      match hash_of_string (random_string ()) with
-      | Ok x -> x
-      | Error _ -> assert false
+  (* Generators for use by the tests: *)
+  val random_data : unit -> data
+end
+
+module Suite (Map : Map) = struct
+  type key = string [@@deriving irmin]
 
   let test_empty () =
-    check __POS__ [%typ: bool] ~expected:true X.(is_empty (empty ()));
-    check __POS__ [%typ: int] ~expected:0 X.(length (empty ()));
-    check __POS__ [%typ: (X.step * X.value) list] ~expected:[]
-      X.(list (empty ()))
+    check __POS__ [%typ: bool] ~expected:true Map.(is_empty (empty ()));
+    check __POS__ [%typ: int] ~expected:0 Map.(length (empty ()));
+    check __POS__ [%typ: (key * Map.data) list] ~expected:[]
+      Map.(list (empty ()))
 
   let test_add () =
-    let with_binding k v t = X.add t k v in
-    let k1 = random_key () and k2 = random_key () in
-    let a =
-      X.empty () |> with_binding "a" (`Node k1) |> with_binding "b" (`Node k2)
-    in
-    check __POS__ [%typ: int] ~expected:2 (X.length a)
+    let with_binding k v t = Map.add t k v in
+    let d1 = Map.random_data () and d2 = Map.random_data () in
+    let a = Map.empty () |> with_binding "1" d1 |> with_binding "2" d2 in
+    check __POS__ [%typ: int] ~expected:2 (Map.length a)
 
   let test_remove () =
     (* Remove is a no-op on an empty node *)
-    check __POS__ [%typ: X.t] ~expected:(X.empty ()) X.(remove (empty ()) "foo")
+    check __POS__ [%typ: Map.t] ~expected:(Map.empty ())
+      Map.(remove (empty ()) "foo")
+
+  let test_find () =
+    let bindings =
+      List.init 256 (fun i -> (string_of_int i, Map.random_data ()))
+    in
+    let node =
+      List.fold_left (fun t (k, v) -> Map.add t k v) (Map.empty ()) bindings
+    in
+    bindings
+    |> List.iter (fun (k, v) ->
+           check __POS__ [%typ: Map.data option] ~expected:(Some v)
+             (Map.find node k))
 
   let suite =
     [
-      Alcotest.test_case "empty" `Quick test_empty;
-      Alcotest.test_case "add" `Quick test_add;
-      Alcotest.test_case "remove" `Quick test_remove;
+      ("empty", test_empty);
+      ("add", test_add);
+      ("remove", test_remove);
+      ("find", test_find);
     ]
+end
+
+module Make (Make_node : Irmin.Node.Generic_key.Maker) : sig
+  val suite : unit Alcotest.test_case list
+end = struct
+  (* For each [Node] maker, we can instantiate the test suite above twice: once
+     for regular nodes, and once for portable nodes. *)
+
+  module Schema = Irmin.Schema.KV (Irmin.Contents.String)
+  module Hash = Schema.Hash
+  module Key = Irmin.Key.Of_hash (Hash)
+  module Node = Make_node (Hash) (Schema.Path) (Schema.Metadata) (Key) (Key)
+
+  type key = Key.t [@@deriving irmin]
+
+  module Extras = struct
+    type data = [ `Node of Key.t | `Contents of Key.t * unit ]
+    [@@deriving irmin]
+
+    let random_data =
+      let hash_of_string = Irmin.Type.(unstage (of_bin_string Hash.t)) in
+      let random_string =
+        Irmin.Type.(unstage (random (string_of (`Fixed Hash.hash_size))))
+      in
+      fun () ->
+        match hash_of_string (random_string ()) with
+        | Error _ -> assert false
+        | Ok x -> (
+            match Random.int 2 with
+            | 0 -> `Node x
+            | 1 -> `Contents (x, ())
+            | _ -> assert false)
+  end
+
+  let suite =
+    let tc (name, f) = Alcotest.test_case name `Quick f in
+    let module Suite_node = Suite (struct
+      include Node
+      include Extras
+    end) in
+    let module Suite_node_portable = Suite (struct
+      include Node.Portable
+      include Extras
+    end) in
+    List.map tc Suite_node.suite
+    @ List.map
+        (fun (name, f) -> tc ("Portable." ^ name, f))
+        Suite_node_portable.suite
 end

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -146,7 +146,7 @@ struct
           Contents { name = k; contents = h }
         else Contents_m { metadata = m; name = k; contents = h }
 
-  let of_entry : entry -> step * value = function
+  let inspect_nonportable_entry_exn : entry -> step * value = function
     | Node n -> (n.name, `Node n.node)
     | Contents c -> (c.name, `Contents (c.contents, Metadata.default))
     | Contents_m c -> (c.name, `Contents (c.contents, c.metadata))
@@ -185,13 +185,16 @@ struct
     StepMap.to_seq t |> Seq.drop offset |> take
 
   let seq ?(offset = 0) ?length ?cache:_ (t : t) =
-    seq_entries ~offset ?length t |> Seq.map (fun (_, e) -> of_entry e)
+    seq_entries ~offset ?length t
+    |> Seq.map (fun (_, e) -> inspect_nonportable_entry_exn e)
 
   let list ?offset ?length ?cache:_ t = List.of_seq (seq ?offset ?length t)
   let find_entry ?cache:_ (t : t) s = StepMap.find_opt s t
 
-  let find ?cache t s =
-    Option.map (fun e -> snd (of_entry e)) (find_entry ?cache t s)
+  let find ?cache (t : t) s =
+    Option.map
+      (fun e -> snd (inspect_nonportable_entry_exn e))
+      (find_entry ?cache t s)
 
   let empty = Fun.const StepMap.empty
   let is_empty e = StepMap.is_empty e

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -154,6 +154,15 @@ struct
         (* Not reachable after [Portable.of_node]. See invariant on {!entry}. *)
         assert false
 
+  let step_of_entry : entry -> step = function
+    | Node { name; _ }
+    | Node_hash { name; _ }
+    | Contents { name; _ }
+    | Contents_m { name; _ }
+    | Contents_hash { name; _ }
+    | Contents_m_hash { name; _ } ->
+        name
+
   let weak_of_entry : entry -> step * weak_value = function
     | Node n -> (n.name, `Node (Node_key.to_hash n.node))
     | Node_hash n -> (n.name, `Node n.node)
@@ -200,7 +209,10 @@ struct
     add_entry t k e
 
   let remove t k = StepMap.remove k t
-  let of_entries e = of_list (List.rev_map of_entry e)
+
+  let of_entries es =
+    List.to_seq es |> Seq.map (fun e -> (step_of_entry e, e)) |> StepMap.of_seq
+
   let entries e = List.rev_map (fun (_, e) -> e) (StepMap.bindings e)
 
   module Hash_preimage = struct

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -121,6 +121,9 @@ struct
   type t = entry StepMap.t
   type value = [ `Contents of contents_key * metadata | `Node of node_key ]
 
+  type weak_value = [ `Contents of hash * metadata | `Node of hash ]
+  [@@deriving irmin]
+
   (* FIXME:  special-case the default metadata in the default signature? *)
   let value_t =
     let open Type in
@@ -151,6 +154,16 @@ struct
         (* Not reachable after [Portable.of_node]. See invariant on {!entry}. *)
         assert false
 
+  let weak_of_entry : entry -> step * weak_value = function
+    | Node n -> (n.name, `Node (Node_key.to_hash n.node))
+    | Node_hash n -> (n.name, `Node n.node)
+    | Contents c ->
+        (c.name, `Contents (Contents_key.to_hash c.contents, Metadata.default))
+    | Contents_m c ->
+        (c.name, `Contents (Contents_key.to_hash c.contents, c.metadata))
+    | Contents_hash c -> (c.name, `Contents (c.contents, Metadata.default))
+    | Contents_m_hash c -> (c.name, `Contents (c.contents, c.metadata))
+
   let of_seq l =
     Seq.fold_left
       (fun acc x -> StepMap.add (fst x) (to_entry x) acc)
@@ -158,20 +171,18 @@ struct
 
   let of_list l = of_seq (List.to_seq l)
 
-  let seq ?(offset = 0) ?length ?cache:_ (t : t) =
+  let seq_entries ~offset ?length (t : t) =
     let take seq = match length with None -> seq | Some n -> Seq.take n seq in
-    StepMap.to_seq t
-    |> Seq.drop offset
-    |> take
-    |> Seq.map (fun (_, e) -> of_entry e)
+    StepMap.to_seq t |> Seq.drop offset |> take
+
+  let seq ?(offset = 0) ?length ?cache:_ (t : t) =
+    seq_entries ~offset ?length t |> Seq.map (fun (_, e) -> of_entry e)
 
   let list ?offset ?length ?cache:_ t = List.of_seq (seq ?offset ?length t)
+  let find_entry ?cache:_ (t : t) s = StepMap.find_opt s t
 
-  let find ?cache:_ t s =
-    try
-      let _, v = of_entry (StepMap.find s t) in
-      Some v
-    with Not_found -> None
+  let find ?cache t s =
+    Option.map (fun e -> snd (of_entry e)) (find_entry ?cache t s)
 
   let empty = Fun.const StepMap.empty
   let is_empty e = StepMap.is_empty e
@@ -289,9 +300,7 @@ struct
 
       type contents_key = hash [@@deriving irmin]
       type node_key = hash [@@deriving irmin]
-
-      type value = [ `Contents of hash * metadata | `Node of hash ]
-      [@@deriving irmin]
+      type value = weak_value [@@deriving irmin]
 
       let to_entry name = function
         | `Node node -> Node_hash { name; node }
@@ -299,10 +308,6 @@ struct
             if equal_metadata metadata Metadata.default then
               Contents_hash { name; contents }
             else Contents_m_hash { name; contents; metadata }
-
-      let weaken_value = function
-        | `Node key -> `Node (Node_key.to_hash key)
-        | `Contents (key, m) -> `Contents (Contents_key.to_hash key, m)
 
       let of_seq s =
         Seq.fold_left
@@ -315,18 +320,14 @@ struct
         let entry = to_entry name v in
         add_entry t name entry
 
-      let find ?cache t k =
-        match find ?cache t k with
-        | None -> None
-        | Some value -> Some (weaken_value value)
+      let find ?cache t s =
+        Option.map (fun e -> snd (weak_of_entry e)) (find_entry ?cache t s)
+
+      let seq ?(offset = 0) ?length ?cache:_ (t : t) =
+        seq_entries ~offset ?length t |> Seq.map (fun (_, e) -> weak_of_entry e)
 
       let list ?offset ?length ?cache t =
-        list ?offset ?length ?cache t
-        |> List.map (fun (k, v) -> (k, weaken_value v))
-
-      let seq ?offset ?length ?cache t =
-        seq ?offset ?length ?cache t
-        |> Seq.map (fun (k, v) -> (k, weaken_value v))
+        List.of_seq (seq ?offset ?length ?cache t)
     end
 
     include Of_core (Core)

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -31,4 +31,5 @@ let suite =
 let () =
   Logs.set_level (Some Debug);
   Logs.set_reporter (Irmin_test.reporter ());
+  Random.self_init ();
   Lwt_main.run (Alcotest_lwt.run "irmin" suite)


### PR DESCRIPTION
These functions previously asserted that the returned child pointers were keys, then weakened those keys to hashes. This is not necessary, as we only need to return child hashes.