### PR TITLE
[2.10] Fix large stable inodes in streamed proofs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- *irmin*
+  - Add `Store.Private.Node.Val.hash_exn` (#1741, @Ngoguey42)
+
 ## 2.10.1 (2021-01-20)
 
 ### Fixed

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -349,6 +349,15 @@ struct
       let t =
         Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) N.t of_n to_n
 
+      module Ht =
+        Irmin.Hash.Typed
+          (H)
+          (struct
+            type nonrec t = t [@@deriving irmin]
+          end)
+
+      let hash_exn ?force:_ = Ht.hash
+
       type proof = N.proof [@@deriving irmin]
 
       let to_proof t = N.to_proof (to_n t)

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -73,7 +73,6 @@ module type Internal = sig
     val of_raw : (expected_depth:int -> hash -> Raw.t option) -> Raw.t -> t
     val to_raw : t -> Raw.t
     val save : add:(hash -> Raw.t -> unit) -> mem:(hash -> bool) -> t -> unit
-    val hash : t -> hash
     val stable : t -> bool
     val length : t -> int
     val index : depth:int -> step -> int

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -113,6 +113,7 @@ module type Internal = sig
         | `Unsorted_entries of t
         | `Unsorted_pointers of t
         | `Blinded_root
+        | `Too_large_values of t
         | `Empty ]
       [@@deriving irmin]
       (** The type for errors. *)

--- a/src/irmin-pack/layered/inode_layers.ml
+++ b/src/irmin-pack/layered/inode_layers.ml
@@ -47,7 +47,7 @@ struct
         let v = Val.of_raw find v in
         Some v
 
-  let hash v = Val.hash v
+  let hash v = Val.hash_exn v
   let equal_hash = Irmin.Type.(unstage (equal H.t))
 
   let check_hash expected got =

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -77,6 +77,17 @@ module type S = sig
   val length : t -> int
   (** [length t] is the number of entries in [t]. *)
 
+  val hash_exn : ?force:bool -> t -> hash
+  (** [hash_exn t] is the hash of [t].
+
+      Another way of computing it is [Hash.Typed(Hash)(Node).hash t] which
+      computes the pre-hash of [t] before hashing it using [Hash]. [hash_exn]
+      might be faster because the it may be optimised (e.g. it may use caching).
+
+      [hash_exn t] is [hash_exn ~force:true t] which is not expected to raise an
+      exception. [hash_exn ~force:false t] will raise [Not_found] if the hash
+      requires IOs to be computed. *)
+
   val clear : t -> unit
   (** Cleanup internal caches. *)
 

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -123,6 +123,7 @@ struct
       set : unit Hashes.t;
       singleton_inodes : (int * H.t) Hashes.t;
       rev_elts : (H.t * P.elt) list ref;
+      rev_elts_size : int ref;
     }
     [@@deriving irmin]
 
@@ -139,7 +140,24 @@ struct
       let set = Hashes.create 13 in
       let singleton_inodes = Hashes.create 13 in
       let rev_elts = ref [] in
-      Produce { set; singleton_inodes; rev_elts }
+      let rev_elts_size = ref 0 in
+      Produce { set; singleton_inodes; rev_elts; rev_elts_size }
+
+    let list_insert l idx v =
+      (* [list_insert l 0 v] is [v :: l] *)
+      assert (idx >= 0);
+      let rec aux l i acc =
+        if i = 0 then List.rev_append acc (v :: l)
+        else
+          match l with
+          | [] -> failwith "list_insert: input list too short"
+          | hd :: tl -> aux tl (i - 1) (hd :: acc)
+      in
+      aux l idx []
+
+    let push { rev_elts; rev_elts_size; _ } h_elt index =
+      incr rev_elts_size;
+      rev_elts := list_insert !rev_elts index h_elt
   end
 
   type v = Empty | Set of Set.t | Stream of Stream.t [@@deriving irmin]
@@ -302,6 +320,11 @@ struct
         pp_hash h
 
   let dehydrate_stream_node v =
+    (* [v] is fresh out of the node store, meaning that if it is represented
+       recursively it is still in a shallow state.
+
+       [N.head v] might trigger IOs. These will be recorded because [v] is
+       already wrapped with [with_handler]. *)
     match N.head v with
     | `Node l -> P.Node l
     | `Inode (length, proofs) -> P.Inode { length; proofs }
@@ -413,12 +436,12 @@ struct
     | Set { mode = Consume; _ } ->
         (* This phase has no repo pointer *)
         assert false
-    | Stream (Produce { set; rev_elts; _ }) ->
+    | Stream (Produce ({ set; _ } as cache)) ->
         (* Registering when seen for the first time *)
         if not @@ Hashes.mem set h then (
           Hashes.add set h ();
-          let elt : hash * P.elt = (h, Contents v) in
-          rev_elts := elt :: !rev_elts)
+          let h_elt : hash * P.elt = (h, Contents v) in
+          Stream.push cache h_elt 0)
     | Stream (Consume _) ->
         (* This phase has no repo pointer *)
         assert false
@@ -471,13 +494,15 @@ struct
         (* This phase only fills the env, it should search for anything *)
         assert false
     | Set { mode = Consume; set } ->
-        (* Use the Env to feed the values during consume *)
+        (* [set] has been filled during deserialise. Using it to provide values
+           during consume. *)
         Hashes.find_opt set.nodes h
     | Stream (Produce _) ->
         (* There is no need for sharing with stream proofs *)
         None
     | Stream (Consume { nodes; stream; _ }) -> (
-        (* Use the Env to feed the values during consume *)
+        (* Use the Env to provide the values during consume. Since all hashes
+           are unique in [stream], [nodes] provides a hash-based sharing. *)
         match Hashes.find_opt nodes h with
         | Some v -> Some v
         | None -> (
@@ -486,18 +511,33 @@ struct
                 bad_stream_exn "find_node"
                   "empty stream when looking for hash %a" pp_hash h
             | Cons (v, rest) ->
-                (* [depth] is 0 because this context deals with root nodes *)
-                let v = rehydrate_stream_node ~depth:0 v h in
-                let v = N.with_handler (find_recnode t) v in
-                check_node_integrity v h;
+                (* Shorten [stream] before calling [head] as it might itself
+                   perform reads. *)
                 stream := rest;
+                let v =
+                  (* [depth] is 0 because this context deals with root nodes *)
+                  rehydrate_stream_node ~depth:0 v h
+                in
+                let v =
+                  (* Call [with_handler] before [head] because the later might
+                     perform reads *)
+                  N.with_handler (find_recnode t) v
+                in
+                let (_ : [ `Node of _ | `Inode of _ ]) =
+                  (* At produce time [dehydrate_stream_node] called [head] which
+                     might have performed IOs. If it did then we must consume
+                     the stream accordingly right now in order to preserve
+                     stream ordering. *)
+                  N.head v
+                in
+                check_node_integrity v h;
                 Hashes.add nodes h v;
                 Some v))
 
   let add_recnode_from_store t find ~expected_depth h =
     assert (expected_depth > 0);
     match !t with
-    | Stream (Produce { set; rev_elts; singleton_inodes }) -> (
+    | Stream (Produce ({ set; singleton_inodes; _ } as cache)) -> (
         (* Registering when seen for the first time, there is no need
            for sharing. *)
         match find ~expected_depth h with
@@ -512,7 +552,7 @@ struct
                     Hashes.add singleton_inodes h bucket
                 | _ -> ()
               in
-              rev_elts := (h, elt) :: !rev_elts);
+              Stream.push cache (h, elt) 0);
             Some v)
     | _ -> assert false
 
@@ -521,7 +561,8 @@ struct
     | Empty -> v
     | Set { mode = Produce; set } ->
         (* Registering in [set] for sharing during [Produce] and traversal
-           during [Serialise]. *)
+           during [Serialise]. This assertion is guarenteed because
+           [add_node_from_store] is guarded by a call to [find_node] in tree. *)
         assert (not (Hashes.mem set.nodes h));
         Hashes.add set.nodes h v;
         v
@@ -534,20 +575,40 @@ struct
     | Set { mode = Consume; _ } ->
         (* This phase has no repo pointer *)
         assert false
-    | Stream (Produce { set; rev_elts; singleton_inodes }) ->
+    | Stream (Produce ({ set; rev_elts_size; singleton_inodes; _ } as cache)) ->
         (* Registering when seen for the first time and wrap its [find]
-           function. *)
-        if not @@ Hashes.mem set h then (
+           function. Since there is no sharing during the production of
+           streamed proofs, the hash may already have been seened. *)
+        let new_hash = not @@ Hashes.mem set h in
+        let v =
+          (* In all case [v] should be wrapped.
+
+             If [not new_hash] then wrap it for future IOs on it.
+
+             If [new_hash] then it additionally should be wrapped before
+             calling [dehydrate_stream_node] as this call may trigger IOs. *)
+          N.with_handler (add_recnode_from_store t) v
+        in
+        if new_hash then (
           Hashes.add set h ();
+          let len0 = !rev_elts_size in
           let elt = dehydrate_stream_node v in
+          let len1 = !rev_elts_size in
+          let delta =
+            (* [delta] is the number of reads that were performed by
+               [dehydrate_stream_node]. *)
+            len1 - len0
+          in
           let () =
             match elt with
             | Inode { proofs = [ bucket ]; _ } ->
                 Hashes.add singleton_inodes h bucket
             | _ -> ()
           in
-          rev_elts := (h, elt) :: !rev_elts);
-        let v = N.with_handler (add_recnode_from_store t) v in
+          (* if [delta = 0] then push the pair at the head of the list.
+
+             if [delta > 0] then insert it before the calls that it triggered. *)
+          Stream.push cache (h, elt) delta);
         v
     | Stream (Consume _) ->
         (* This phase has no repo pointer *)

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -277,7 +277,6 @@ struct
     res
 
   module Contents_hash = Hash.Typed (H) (C)
-  module Node_hash = Hash.Typed (H) (N)
 
   let bad_stream_exn s fmt = Fmt.kstr (bad_stream_exn ("Proof.Env." ^ s)) fmt
 
@@ -288,7 +287,16 @@ struct
         pp_hash h
 
   let check_node_integrity v h =
-    let h' = Node_hash.hash v in
+    let h' =
+      try N.hash_exn ~force:false v
+      with Not_found ->
+        (* [v] is out of [of_proof], it is supposed to have its hash available
+           without IOs.
+
+           If these IOs were to occur, it would corrupt the stream being read.
+        *)
+        assert false
+    in
     if not (equal_hash h' h) then
       bad_stream_exn "check_node_integrity" "got %a expected %a" pp_hash h'
         pp_hash h

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1884,7 +1884,10 @@ module Make (P : Private.S) = struct
       match to_value node with
       | Error (`Dangling_hash h) -> k (Blinded_node h)
       | Error (`Pruned_hash h) -> k (Blinded_node h)
-      | Ok v -> proof_of_node_proof node (P.Node.Val.to_proof v) k
+      | Ok v ->
+          (* [to_proof] may trigger reads. This is fine. *)
+          let node_proof = P.Node.Val.to_proof v in
+          proof_of_node_proof node node_proof k
 
     (** [of_node_proof n np] is [p] (of type [Tree.Proof.t]) which is very
         similar to [np] (of type [P.Node.Val.proof]) except that the values

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -208,14 +208,14 @@ module Inode_permutations_generator = struct
 end
 
 let check_node msg v t =
-  let h = Inter.Val.hash v in
+  let h = Inter.Val.hash_exn v in
   let+ h' = Inode.batch t.Context.store (fun i -> Inode.add i v) in
   check_hash msg h h'
 
 let check_hardcoded_hash msg h v =
   h |> Irmin.Type.of_string Inode.Val.hash_t |> function
   | Error (`Msg str) -> Alcotest.failf "hash of string failed: %s" str
-  | Ok hash -> check_hash msg hash (Inter.Val.hash v)
+  | Ok hash -> check_hash msg hash (Inter.Val.hash_exn v)
 
 (** Test add values from an empty node. *)
 let test_add_values () =


### PR DESCRIPTION
See the commits and the comments in the code for more details on that bug.