### PR TITLE
irmin: Add `with_handler` and `head` to `Node_portable`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,8 +25,9 @@
     (#1345, @samoht)
   - Add a function `Store.Tree.singleton` for building trees with a single
     contents binding. (#1567, @CraigFe)
-  - Add `with_handler` and `head` to `Store.Backend.Node` to working with
-    recursive node structure from irmin core. (#1712 @Ngoguey42). Forward
+  - Add `with_handler` and `head` to `Store.Backend.Node` and
+    `Store.Backend.Node_portable`to work with recursive node structures from
+    irmin core. (#1712, #1746 @Ngoguey42). Forward
     port of #1692 and #1670.
   - Add `proof`, `to_proof` and `of_proof` to `Store.Backend.Node_portable`
     (#1716, @Ngoguey42). Forward port from #1583.

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -174,6 +174,7 @@ module type Internal = sig
         error. *)
 
     module Portable : sig
+      (* Extend to the portable signature *)
       include module type of Portable
 
       module Proof : sig

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -258,6 +258,17 @@ struct
       Hash_preimage.pre_hash entries f
     in
     Type.map ~pre_hash Type.(list entry_t) of_entries entries
+
+  let with_handler _ t = t
+
+  let head_entries t =
+    let l = seq_entries ~offset:0 t |> List.of_seq in
+    `Node l
+
+  let head t =
+    let (`Node l) = head_entries t in
+    let l = List.map (fun (_, e) -> inspect_nonportable_entry_exn e) l in
+    `Node l
 end
 
 module Portable = struct
@@ -343,14 +354,16 @@ struct
 
       let list ?offset ?length ?cache t =
         List.of_seq (seq ?offset ?length ?cache t)
+
+      let head t =
+        let (`Node l) = head_entries t in
+        let l = List.map (fun (_, e) -> weak_of_entry e) l in
+        `Node l
     end
 
     include Of_core (Core)
     include Portable.Of_core (Core)
   end
-
-  let with_handler _ t = t
-  let head t = `Node (list t)
 
   exception Dangling_hash of { context : string; hash : hash }
 

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -103,19 +103,6 @@ module type Core = sig
 
       [cache = false] doesn't replace a call to [clear], it only prevents the
       storing of new data, it doesn't discard the existing one. *)
-end
-
-module type S_generic_key = sig
-  include Core
-  (** @inline *)
-
-  (** {2 merging} *)
-
-  val merge :
-    contents:contents_key option Merge.t ->
-    node:node_key option Merge.t ->
-    t Merge.t
-  (** [merge] is the merge function for nodes. *)
 
   (** {1 Recursive Nodes} *)
 
@@ -134,8 +121,6 @@ module type S_generic_key = sig
       will be called for all the recursive read effects that are required by
       recursive operations on nodes. .*)
 
-  exception Dangling_hash of { context : string; hash : hash }
-
   type head :=
     [ `Node of (step * value) list | `Inode of int * (int * hash) list ]
   [@@deriving irmin]
@@ -145,6 +130,21 @@ module type S_generic_key = sig
 
       Only hashes and not keys are revealed in the [`Inode] case, this is
       because these inodes might not be keyed yet. *)
+end
+
+module type S_generic_key = sig
+  include Core
+  (** @inline *)
+
+  (** {2 merging} *)
+
+  val merge :
+    contents:contents_key option Merge.t ->
+    node:node_key option Merge.t ->
+    t Merge.t
+  (** [merge] is the merge function for nodes. *)
+
+  exception Dangling_hash of { context : string; hash : hash }
 end
 
 module type S = sig


### PR DESCRIPTION
based on #1745

Since `portable` nodes are used during the production of streamed proofs, `with_handler` is needed in `portable` nodes.

After #1741, `head` is also used during streamed proof production, which make use of `portable` nodes