### PR TITLE
Overhaul GraphQL test suite

### DIFF
--- a/test/irmin-graphql/common.ml
+++ b/test/irmin-graphql/common.ml
@@ -82,7 +82,12 @@ let rec retry n f =
         incr retries;
         retry (n + 1) f)
 
-type param = Var of string | String of string | Int of int | Float of float
+type param =
+  | Var of string
+  | Raw of string
+  | String of string
+  | Int of int
+  | Float of float
 
 type query =
   | Mutation of query
@@ -110,6 +115,7 @@ and string_of_args args =
         match v with
         | Var s -> "$" ^ s
         | String s -> "\"" ^ s ^ "\""
+        | Raw s -> s
         | Int i -> string_of_int i
         | Float f -> string_of_float f
       in
@@ -123,6 +129,7 @@ let list l = List l
 let func name ?(params = []) q = Func (name, params, q)
 let field s = Field s
 let string s = String s
+let raw s = Raw s
 let var s = Var s
 let int i = Int i
 let float f = Float f

--- a/test/irmin-graphql/common.mli
+++ b/test/irmin-graphql/common.mli
@@ -25,15 +25,63 @@ module Store :
 type server = {
   event_loop : 'a. 'a Lwt.t;
       (** The server runtime. Cancelling this thread terminates the server. *)
-  set_tree : Store.Tree.concrete -> unit Lwt.t;
-      (** Set the state of the [main] branch in the underlying store. *)
+  store : Store.t;  (** The store used by the server *)
 }
 
 val spawn_graphql_server : unit -> server Lwt.t
 (** Initialise a GraphQL server. At most one server may be running concurrently. *)
+
+type query
+(** GraphQL query *)
+
+type param
+(** Parameter to GraphQL function *)
+
+val query : query -> query
+(** Start a query *)
+
+val mutation : query -> query
+(** Start a mutation *)
+
+val list : query list -> query
+(** List of [field] or [func] *)
+
+val func : string -> ?params:(string * param) list -> query -> query
+(** GraphQL method *)
+
+val field : string -> query
+(** Named field *)
+
+val var : string -> param
+(** Variable parameter *)
+
+val string : string -> param
+(** String parameter *)
+
+val int : int -> param
+(** Int parameter *)
+
+val float : float -> param
+(** Float parameter *)
+
+val string_of_query : query -> string
+(** Convert [query] to [string] *)
 
 val send_query :
   ?vars:(string * Yojson.Safe.t) list ->
   string ->
   (string, [ `Msg of string ]) result Lwt.t
 (** Send a GraphQL query string to the currently running test GraphQL instance. *)
+
+val members : string list -> Yojson.Safe.t -> Yojson.Safe.t
+(** Get key from JSON object *)
+
+val parse_result : string list -> (Yojson.Safe.t -> 'a) -> Yojson.Safe.t -> 'a
+(** Get key from JSON object and apply conversion function *)
+
+val exec :
+  ?vars:(string * Yojson.Safe.t) list ->
+  query ->
+  (Yojson.Safe.t -> 'a) ->
+  'a Lwt.t
+(** Send a [query] to the running GraphQL instance and parse the results *)

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -17,12 +17,17 @@
 open! Import
 open Common
 
+module Json = struct
+  include Yojson.Safe
+  include Yojson.Safe.Util
+end
+
 type concrete = Store.Tree.concrete
 
 module Alcotest = struct
   include Alcotest
 
-  let yojson = testable Yojson.Safe.pp Yojson.Safe.equal
+  let yojson = testable Json.pp Json.equal
 end
 
 (** Helpers for constructing data *)
@@ -53,14 +58,35 @@ let test_get_contents_list : test_case =
          (list [ field "path"; field "__typename" ])
   in
   set_tree store data >>= fun () ->
-  let+ (result : (string * Yojson.Safe.t) list) =
-    exec query Yojson.Safe.Util.to_assoc
-  in
+  let+ (result : (string * Json.t) list) = exec query Json.to_assoc in
   Alcotest.(check (list (pair string yojson)))
     "Returned entry data is valid"
     [ ("path", `String "/a/b/c"); ("__typename", `String "Contents") ]
     result;
   ()
+
+let test_list_contents_recursively : test_case =
+ fun store ->
+  let* () =
+    Store.set_exn store [ "a"; "b"; "c" ] "data" ~info:Store.Info.none
+  in
+  let* () =
+    Store.set_exn store [ "a"; "b"; "d" ] "data1" ~info:Store.Info.none
+  in
+  let q =
+    query
+    @@ func "main"
+    @@ func "tree"
+    @@ func "list_contents_recursively" (list [ field "path"; field "value" ])
+  in
+  let+ contents = exec q Json.to_list >|= List.map Json.to_assoc in
+  Alcotest.(check (list (list (pair string yojson))))
+    "Contents list matches"
+    [
+      [ ("path", `String "/a/b/c"); ("value", `String "data") ];
+      [ ("path", `String "/a/b/d"); ("value", `String "data1") ];
+    ]
+    contents
 
 let test_get_tree_list : test_case =
  fun store ->
@@ -76,9 +102,7 @@ let test_get_tree_list : test_case =
     @@ func "list" (list [ field "path"; field "__typename" ])
   in
   set_tree store data >>= fun () ->
-  let+ path_data =
-    exec query Yojson.Safe.Util.(fun x -> to_list x |> List.map to_assoc)
-  in
+  let+ path_data = exec query Json.(fun x -> to_list x |> List.map to_assoc) in
   Alcotest.(check (list (list (pair string yojson))))
     "Returned entry data is valid"
     [
@@ -102,9 +126,7 @@ let test_get_last_modified : test_case =
          (list [ field "value"; field "__typename" ])
   in
   set_tree store data >>= fun () ->
-  let+ result =
-    exec query Yojson.Safe.Util.(fun m -> to_list m |> List.map to_assoc)
-  in
+  let+ result = exec query Json.(fun m -> to_list m |> List.map to_assoc) in
   Alcotest.(check (list (list (pair string yojson))))
     "Returned entry data is valid "
     [ [ ("value", `String "data"); ("__typename", `String "Contents") ] ]
@@ -116,14 +138,14 @@ let test_commit : test_case =
   let query0 =
     query @@ func "main" @@ func "head" (list [ field "hash"; field "key" ])
   in
-  let* result = exec query0 Yojson.Safe.Util.to_assoc in
-  let hash = List.assoc "hash" result |> Yojson.Safe.Util.to_string in
-  let key = List.assoc "key" result |> Yojson.Safe.Util.to_string in
+  let* result = exec query0 Json.to_assoc in
+  let hash = List.assoc "hash" result |> Json.to_string in
+  let key = List.assoc "key" result |> Json.to_string in
   let query1 =
     query @@ func "commit_of_key" ~params:[ ("key", var "key") ] @@ field "hash"
   in
   let vars = [ ("key", `String key) ] in
-  let+ hash' = exec ~vars query1 Yojson.Safe.Util.to_string in
+  let+ hash' = exec ~vars query1 Json.to_string in
   Alcotest.(check string) "Hashes equal" hash hash'
 
 let test_mutation : test_case =
@@ -133,7 +155,7 @@ let test_mutation : test_case =
     @@ func "set" ~params:[ ("path", string "foo"); ("value", string "bar") ]
     @@ field "hash"
   in
-  let* _hash = exec m Yojson.Safe.Util.to_string in
+  let* _hash = exec m Json.to_string in
   let q =
     query
     @@ func "main"
@@ -142,9 +164,103 @@ let test_mutation : test_case =
     @@ field "value"
   in
   let* value = Store.get store [ "foo" ] in
-  let+ result' = exec q Yojson.Safe.Util.to_string in
+  let+ result' = exec q Json.to_string in
   Alcotest.(check string) "Contents equal" "bar" result';
   Alcotest.(check string) "Contents equal stored value" "bar" value
+
+let test_update_tree : test_case =
+ fun store ->
+  let* commit = Store.Head.get store in
+  let hash = Store.Commit.hash commit |> Irmin.Type.to_string Store.hash_t in
+  let m =
+    mutation
+    @@ func "update_tree" ~params:[ ("path", string "/"); ("tree", raw "[]") ]
+    @@ field "hash"
+  in
+  let* hash' = exec m Json.to_string in
+  Alcotest.(check string) "Hashes equal" hash hash';
+  let m =
+    mutation
+    @@ func "update_tree"
+         ~params:
+           [
+             ("path", string "/");
+             ("tree", raw {| [{path: "foo", value: "bar1"}] |});
+           ]
+    @@ field "hash"
+  in
+  let* hash' = exec m Json.to_string in
+  if String.equal hash hash' then
+    Alcotest.fail "Hashes should not be equal after update";
+  let* contents = Store.get store [ "foo" ] in
+  Alcotest.(check string) "Contents at foo" contents "bar1";
+  let m =
+    mutation
+    @@ func "update_tree"
+         ~params:[ ("path", string "/"); ("tree", raw {| [{path: "foo"}] |}) ]
+    @@ field "hash"
+  in
+  let* () = exec m ignore in
+  let+ contents = Store.find store [ "foo" ] in
+  Alcotest.(check (option string)) "Contents empty after update" contents None
+
+let test_remove : test_case =
+ fun store ->
+  let info () = Store.Info.v 0L in
+  let path_param = string "test/remove" in
+  let* () = Store.set_exn store [ "test"; "remove" ] "XXX" ~info in
+  let m =
+    mutation @@ func "remove" ~params:[ ("path", path_param) ] @@ field "hash"
+  in
+  let* () = exec m ignore in
+  let q =
+    query
+    @@ func "main"
+    @@ func "tree"
+    @@ func "get_contents" ~params:[ ("path", path_param) ]
+    @@ field "value"
+  in
+  let+ c = exec q Json.to_string_option in
+  Alcotest.(check (option string)) "Contents have been removed" c None
+
+let test_branch_list : test_case =
+ fun store ->
+  let repo = Store.repo store in
+  let* head = Store.Head.get store in
+  let* () = Store.Branch.set repo "A" head in
+  let* () = Store.Branch.set repo "B" head in
+  let q = query @@ func "branches" @@ list [ field "name" ] in
+  let+ branches =
+    exec q (fun x ->
+        Json.to_list x |> List.map Json.to_assoc |> List.map List.hd)
+  in
+  let branches =
+    List.sort
+      (fun (_, a) (_, b) ->
+        String.compare (Json.to_string a) (Json.to_string b))
+      branches
+  in
+  Alcotest.(check (list (pair string yojson)))
+    "Check branch list" branches
+    [ ("name", `String "A"); ("name", `String "B"); ("name", `String "main") ]
+
+let test_revert store =
+  let* head = Store.Head.get store in
+  let parents = Store.Commit.parents head in
+  let parent = List.hd parents in
+  let parent_s = Irmin.Type.to_string Store.hash_t parent in
+  let q =
+    mutation
+    @@ func "revert" ~params:[ ("commit", string parent_s) ]
+    @@ field "hash"
+  in
+  let* hash = exec q Json.to_string in
+  Alcotest.(check string) "hash is parent hash" hash parent_s;
+  let+ new_head = Store.Head.get store in
+  let new_hash =
+    Store.Commit.hash new_head |> Irmin.Type.to_string Store.hash_t
+  in
+  Alcotest.(check string) "parent is new head" parent_s new_hash
 
 let suite store =
   let test_case : string -> test_case -> unit Alcotest_lwt.test_case =
@@ -154,10 +270,15 @@ let suite store =
     ( "GRAPHQL",
       [
         test_case "get_contents-list" test_get_contents_list;
+        test_case "list_contents_recursively" test_list_contents_recursively;
         test_case "get_tree-list" test_get_tree_list;
         test_case "get_last_modified" test_get_last_modified;
         test_case "commit" test_commit;
         test_case "mutation" test_mutation;
+        test_case "update_tree" test_update_tree;
+        test_case "remove" test_remove;
+        test_case "branches" test_branch_list;
+        test_case "revert" test_revert;
       ] );
   ]
 


### PR DESCRIPTION
- Adds a `query` type to the graphql tests:
- Makes writing queries in tests easier (see https://github.com/mirage/irmin/pull/1750/files?diff=split&w=0#diff-3131055e1ed5ebb5e09f20fe0b53836c27ac4205cde1805309c678198c2c499dR98)
- Allows for response to be parsed (almost) automatically
