### PR TITLE
Upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.0
+version = 0.21.0
 profile = conventional
 
 ocaml-version = 4.08.0

--- a/bench/irmin-pack/trace_stat_summary_pp.ml
+++ b/bench/irmin-pack/trace_stat_summary_pp.ml
@@ -420,10 +420,8 @@ module Table2 = struct
       pb "tree.node_val_find" (fun s -> s.tree.node_val_find);
       pb "tree.node_val_list" (fun s -> s.tree.node_val_list);
       `Spacer;
-      pb
-        ~f:(`RM, `Ri)
-        "index.cumu_data_bytes"
-        (fun s -> s.index.cumu_data_bytes);
+      pb ~f:(`RM, `Ri) "index.cumu_data_bytes" (fun s ->
+          s.index.cumu_data_bytes);
       `Spacer;
       pb ~f:(`RM, `RM) "gc.minor_words allocated" (fun s -> s.gc.minor_words);
       pb ~f:(`RM, `RM) "gc.major_words allocated" (fun s -> s.gc.major_words);

--- a/src/irmin/indexable_intf.ml
+++ b/src/irmin/indexable_intf.ml
@@ -65,7 +65,6 @@ module type S = sig
       values they reference. *)
 
   include S_without_key_impl (* @inline *)
-
   module Key : Key.S with type t = key and type hash = hash
 end
 

--- a/test/irmin-graphql/common.mli
+++ b/test/irmin-graphql/common.mli
@@ -59,12 +59,16 @@ type query
     For example, the following query returns the latest commit hash for the
     [main] branch:
 
-    {[ query (func "main" (field "hash")) ]}
+    {[
+      query (func "main" (field "hash"))
+    ]}
 
     To avoid nesting parenthesis, you can use the [@@] operator to chain
     expressions:
 
-    {[ query @@ func "main" @@ field "hash" ]} *)
+    {[
+      query @@ func "main" @@ field "hash"
+    ]} *)
 
 val query : query -> query
 (** Start a query

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -197,8 +197,7 @@ let test_empty _ () =
           Store.save_tree repo c n empty_exported >|= ignore)
     in
     Alcotest.(check inspect)
-      "The exported empty tree is now in Key form"
-      (`Node `Key)
+      "The exported empty tree is now in Key form" (`Node `Key)
       (Tree.inspect empty_exported);
     Alcotest.(check inspect)
       "The non-exported empty tree should still be represented as a Map"
@@ -769,14 +768,10 @@ let test_kind_empty_path _ () =
   let tree = `Tree [ ("k", c "c") ] |> Tree.of_concrete in
   let* k = Tree.kind cont [] in
   Alcotest.(check (option (gtestable kind_t)))
-    "Kind of empty path in content"
-    (Some `Contents)
-    k;
+    "Kind of empty path in content" (Some `Contents) k;
   let* k = Tree.kind tree [] in
   Alcotest.(check (option (gtestable kind_t)))
-    "Kind of empty path in tree"
-    (Some `Node)
-    k;
+    "Kind of empty path in tree" (Some `Node) k;
   Lwt.return_unit
 
 let test_generic_equality _ () =


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

The changes on this project are due to:
- the list of arguments of function applications break on "complex" argument, an argument being composed of a variant is not considered being "complex" anymore.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!