### PR TITLE
Update to cmdliner.1.1.0

### DIFF
--- a/bench/irmin-pack/trace_stats.ml
+++ b/bench/irmin-pack/trace_stats.ml
@@ -165,7 +165,7 @@ let term_cb =
 let () =
   let man = [] in
   let i =
-    Term.info ~man ~doc:"Processing of stat traces and stat trace summaries."
+    Cmd.info ~man ~doc:"Processing of stat traces and stat trace summaries."
       "trace_stats"
   in
 
@@ -176,7 +176,7 @@ let () =
       `P "trace_stats.exe summarise run0.repr > run0.json";
     ]
   in
-  let j = Term.info ~man ~doc:"Stat Trace to Summary" "summarise" in
+  let j = Cmd.info ~man ~doc:"Stat Trace to Summary" "summarise" in
 
   let man =
     [
@@ -200,10 +200,10 @@ let () =
       `P "trace_stats.exe pp -f r0,run0.json -f r1,run1.repr";
     ]
   in
-  let k = Term.info ~man ~doc:"Comparative Pretty Printing" "pp" in
+  let k = Cmd.info ~man ~doc:"Comparative Pretty Printing" "pp" in
   let l =
-    Term.info ~man ~doc:"Summary JSON to Continous Benchmarks JSON" "cb"
+    Cmd.info ~man ~doc:"Summary JSON to Continous Benchmarks JSON" "cb"
   in
-  Term.exit
-  @@ Term.eval_choice (term_summarise, i)
-       [ (term_summarise, j); (term_pp, k); (term_cb, l) ]
+  let commands = List.map (fun (term, info) -> Cmd.v info term)
+                   [ (term_summarise, j); (term_pp, k); (term_cb, l) ] in
+  exit @@ Cmd.eval (Cmd.group ~default:term_summarise i commands)

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -548,5 +548,5 @@ let () =
          http://data.tarides.com/irmin/data_1343496commits.repr";
     ]
   in
-  let info = Term.info ~man ~doc:"Benchmarks for tree operations" "tree" in
-  Term.exit @@ Term.eval (main_term, info)
+  let info = Cmd.info ~man ~doc:"Benchmarks for tree operations" "tree" in
+  exit @@ Cmd.eval (Cmd.v info main_term)

--- a/irmin-bench.opam
+++ b/irmin-bench.opam
@@ -17,7 +17,7 @@ depends: [
   "irmin-pack"   {= version}
   "irmin-test"   {= version}
   "irmin-tezos"  {= version}
-  "cmdliner"     {< "1.1.0"}
+  "cmdliner"     {>= "1.1.0"}
   "logs"
   "lwt"          {>= "5.3.0"}
   "memtrace"     {>= "0.1.1"}

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "lwt"          {>= "5.3.0"}
   "mtime"
-  "cmdliner"     {< "1.1.0"}
+  "cmdliner"     {>= "1.1.0"}
   "optint"       {>= "0.1.0"}
   "irmin-test"   {with-test & = version}
   "alcotest-lwt" {with-test}

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -26,7 +26,7 @@ depends: [
   "lwt"          {>= "5.3.0"}
   "metrics-unix"
   "ocaml-syntax-shims"
-  "cmdliner"     {< "1.1.0"}
+  "cmdliner"     {>= "1.1.0"}
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -39,7 +39,7 @@ depends: [
   "conduit-lwt-unix"
   "logs"
   "uri"
-  "cmdliner"      {< "1.1.0"}
+  "cmdliner"      {>= "1.1.0"}
   "cohttp-lwt-unix"
   "fmt"
   "git"           {>= "3.7.0"}

--- a/src/irmin-pack/unix/checks.ml
+++ b/src/irmin-pack/unix/checks.ml
@@ -130,7 +130,8 @@ module Make (Store : Store) = struct
 
     let term =
       let doc = "Print high-level statistics about the store." in
-      Cmdliner.Term.(term_internal $ setup_log, info ~doc "stat")
+      let info = Cmdliner.Cmd.info ~doc "stat" in
+      Cmdliner.Term.(term_internal $ setup_log), info
   end
 
   module Reconstruct_index = struct
@@ -165,7 +166,8 @@ module Make (Store : Store) = struct
 
     let term =
       let doc = "Reconstruct index from an existing pack file." in
-      Cmdliner.Term.(term_internal $ setup_log, info ~doc "reconstruct-index")
+      let info = Cmdliner.Cmd.info ~doc "reconstruct-index" in
+      Cmdliner.Term.(term_internal $ setup_log), info
   end
 
   module Integrity_check_index = struct
@@ -189,8 +191,8 @@ module Make (Store : Store) = struct
 
     let term =
       let doc = "Check index integrity." in
-      Cmdliner.Term.
-        (term_internal $ setup_log, info ~doc "integrity-check-index")
+      let info = Cmdliner.Cmd.info ~doc "integrity-check-index" in
+      Cmdliner.Term.(term_internal $ setup_log), info
   end
 
   module Integrity_check = struct
@@ -225,7 +227,8 @@ module Make (Store : Store) = struct
 
     let term =
       let doc = "Check integrity of an existing store." in
-      Cmdliner.Term.(term_internal $ setup_log, info ~doc "integrity-check")
+      let info = Cmdliner.Cmd.info ~doc "integrity-check" in
+      Cmdliner.Term.(term_internal $ setup_log), info
   end
 
   module Integrity_check_inodes = struct
@@ -266,8 +269,8 @@ module Make (Store : Store) = struct
 
     let term =
       let doc = "Check integrity of inodes in an existing store." in
-      Cmdliner.Term.
-        (term_internal $ setup_log, info ~doc "integrity-check-inodes")
+      let info = Cmdliner.Cmd.info ~doc "integrity-check-inodes" in
+      Cmdliner.Term.(term_internal $ setup_log), info
   end
 
   module Stats_commit = struct
@@ -327,7 +330,8 @@ module Make (Store : Store) = struct
         "Traverse one commit, specified with the --commit argument, in the \
          store for stats. If no commit is specified the current head is used."
       in
-      Cmdliner.Term.(term_internal $ setup_log, info ~doc "stat-store")
+      let info = Cmdliner.Cmd.info ~doc "stat-store" in
+      Cmdliner.Term.(term_internal $ setup_log), info
   end
 
   module Cli = struct
@@ -343,15 +347,12 @@ module Make (Store : Store) = struct
             Integrity_check_index.term;
             Stats_commit.term;
           ]) () : empty =
-      let default =
-        let default_info =
-          let doc = "Check Irmin data-stores." in
-          Term.info ~doc "irmin-fsck"
-        in
-        Term.(ret (const (`Help (`Auto, None))), default_info)
+      let info =
+        let doc = "Check Irmin data-stores." in
+        Cmd.info ~doc "irmin-fsck"
       in
-      Term.(eval_choice default terms |> (exit : unit result -> _));
-      assert false
+      let terms = List.map (fun (term, info) -> Cmdliner.Cmd.v info term) terms in
+      exit @@ Cmd.eval (Cmd.group info terms)
   end
 
   let cli = Cli.main

--- a/src/irmin-pack/unix/checks_intf.ml
+++ b/src/irmin-pack/unix/checks_intf.ml
@@ -26,7 +26,7 @@ module type Subcommand = sig
   val term_internal : (unit -> unit) Cmdliner.Term.t
   (** A pre-packaged [Cmdliner] term for executing {!run}. *)
 
-  val term : unit Cmdliner.Term.t * Cmdliner.Term.info
+  val term : unit Cmdliner.Term.t * Cmdliner.Cmd.info
   (** [term] is {!term_internal} plus documentation and logs initialisation *)
 end
 
@@ -103,7 +103,7 @@ module type S = sig
   end
 
   val cli :
-    ?terms:(unit Cmdliner.Term.t * Cmdliner.Term.info) list -> unit -> empty
+    ?terms:(unit Cmdliner.Term.t * Cmdliner.Cmd.info) list -> unit -> empty
   (** Run a [Cmdliner] binary containing tools for running offline checks.
       [terms] defaults to the set of checks in this module. *)
 end

--- a/src/irmin-test/irmin_bench.ml
+++ b/src/irmin-test/irmin_bench.ml
@@ -170,15 +170,15 @@ struct
     let t = { t with root } in
     Lwt_main.run (init t config >>= fun () -> run t config size)
 
-  let main_term config size = Term.(const main $ t $ pure config $ pure size)
+  let main_term config size = Term.(const main $ t $ const config $ const size)
 
   let () =
     at_exit (fun () ->
         Fmt.epr "tree counters:\n%a\n%!" Store.Tree.dump_counters ())
 
   let run ~config ~size =
-    let info = Term.info "Simple benchmark for trees" in
-    Term.exit @@ Term.eval (main_term config size, info)
+    let info = Cmd.info "Simple benchmark for trees" in
+    exit @@ Cmd.eval (Cmd.v info (main_term config size))
 end
 
 let () =

--- a/src/irmin-unix/cli.mli
+++ b/src/irmin-unix/cli.mli
@@ -16,7 +16,7 @@
 
 (** CLI commands. *)
 
-type command = unit Cmdliner.Term.t * Cmdliner.Term.info
+type command = unit Cmdliner.Term.t * Cmdliner.Cmd.info
 (** [Cmdliner] commands. *)
 
 val default : command


### PR DESCRIPTION
The only breaking API change introduced by this PR is the switch from `Cmdliner.Term.info` to `Cmdliner.Cmd.info`.

- https://github.com/dinosaure/hxd/pull/12
- https://github.com/mirage/ocaml-git/pull/558