### PR TITLE
irmin-unix: Update default Mimic.ctx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 - **irmin-unix**
   - Fix conflicting command line arguments for `push`, `pull`, `fetch` and
     `clone` (#1776, @zshipko)
+  - Fix issues with Sync functions by provided a better default `Mimic.ctx`. A
+    side-effect of this update is that the `remote` function now returns an Lwt
+    promise. (#1778, @zshipko)
 
 ## 3.0.0 (2022-02-11)
 

--- a/examples/push.ml
+++ b/examples/push.ml
@@ -31,13 +31,12 @@ let headers =
   let e = Cohttp.Header.of_list [] in
   Cohttp.Header.add_authorization e (`Basic (user, token))
 
-let remote = Store.remote ~headers url
-
 let test () =
   Config.init ();
   let config = Irmin_git.config Config.root in
   let* repo = Store.Repo.v config in
   let* t = Store.main repo in
+  let* remote = Store.remote ~headers url in
   let* _ = Sync.pull_exn t remote `Set in
   let* readme = Store.get t [ "README.md" ] in
   let* tree = Store.get_tree t [] in

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -25,13 +25,12 @@ let path =
 module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 module Sync = Irmin.Sync.Make (Store)
 
-let upstream = Store.remote path
-
 let test () =
   Config.init ();
   let config = Irmin_git.config Config.root in
   let* repo = Store.Repo.v config in
-  let* t = Store.main repo in
+  let* t = Store.of_branch repo "master" in
+  let* upstream = Store.remote path in
   let* _ = Sync.pull_exn t upstream `Set in
   let* readme = Store.get t [ "README.md" ] in
   let* tree = Store.get_tree t [] in

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -27,6 +27,7 @@ depends: [
   "logs"
   "lwt"        {>= "5.3.0"}
   "uri"
+  "mimic"
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.7.0"}
   "mtime"      {with-test & >= "1.0.0"}

--- a/irmin-unix.opam
+++ b/irmin-unix.opam
@@ -43,6 +43,7 @@ depends: [
   "cohttp-lwt-unix"
   "fmt"
   "git"           {>= "3.7.0"}
+  "happy-eyeballs-lwt"
   "lwt"           {>= "5.3.0"}
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}

--- a/src/irmin-git/dune
+++ b/src/irmin-git/dune
@@ -1,7 +1,7 @@
 (library
  (name irmin_git)
  (public_name irmin-git)
- (libraries astring cstruct fmt fpath git irmin logs lwt uri irmin.mem)
+ (libraries astring cstruct fmt fpath git irmin logs lwt uri irmin.mem mimic)
  (preprocess
   (pps ppx_irmin.internal))
  (instrumentation

--- a/src/irmin-graphql/server.mli
+++ b/src/irmin-graphql/server.mli
@@ -42,7 +42,7 @@ end
 module type CONFIG = sig
   type info
 
-  val remote : (?headers:Cohttp.Header.t -> string -> Irmin.remote) option
+  val remote : (?headers:Cohttp.Header.t -> string -> Irmin.remote Lwt.t) option
 
   val info :
     ?author:string -> ('a, Format.formatter, unit, unit -> info) format4 -> 'a

--- a/src/irmin-mirage/graphql/irmin_mirage_graphql.ml
+++ b/src/irmin-mirage/graphql/irmin_mirage_graphql.ml
@@ -56,7 +56,7 @@ module Server = struct
                       ~some:(!Smart_git.Endpoint.with_headers_if_http edn)
                       headers
                   in
-                  Store.E edn
+                  Lwt.return (Store.E edn)
               | Ok _ -> Fmt.invalid_arg "invalid remote: %s" uri
               | Error (`Msg err) -> Fmt.invalid_arg "invalid remote: %s" err)
       end in

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -13,6 +13,7 @@
   fmt.tty
   git
   git-unix
+  happy-eyeballs-lwt
   irmin
   irmin-fs
   irmin-git

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -256,7 +256,7 @@ module Store = struct
   end
 
   type remote_fn =
-    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote Lwt.t
 
   type t =
     | T : {

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -60,7 +60,7 @@ module Store : sig
   end
 
   type remote_fn =
-    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote Lwt.t
 
   type t
   (** The type for store configurations. A configuration value contains: the

--- a/src/irmin-unix/xgit_intf.ml
+++ b/src/irmin-unix/xgit_intf.ml
@@ -26,7 +26,7 @@ module type S = sig
       with type Backend.Remote.endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   val remote :
-    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote
+    ?ctx:Mimic.ctx -> ?headers:Cohttp.Header.t -> string -> Irmin.remote Lwt.t
 end
 
 module type Backend = sig


### PR DESCRIPTION
Fixes #1777 by using `Git_unix.ctx (Happy_eyeballs_lwt.create ())` when no `Mimic.ctx` is provided by the user.

There are some errors logged that I'm not sure what do with, but it works now so I think that should be addressed in another PR:
```
irmin: [ERROR] connection to 127.0.0.53:853 failed: Unix.Unix_error(Unix.ECONNREFUSED, "connect", "")
irmin: [WARNING] Reference refs/heads/master not found.
irmin: [ERROR] Object 1d83f084815d11140f9b77fcb4732851bb6dec18 not found.
```

/cc @dinosaure 