### PR TITLE
irmin-bench: Improve public API for replay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@
   - Create `libirmin` package providing a C interface to the irmin API
     (#1713, @zshipko)
 
+### Changed
+
+- **irmin-bench**
+  - Make trace replay API public and simpler (#1781, @Ngoguey42)
+
 ## 3.0.0 (2022-02-11)
 
 ### Fixed

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -19,6 +19,7 @@
 
 (library
  (name bench_common)
+ (public_name irmin-bench.common)
  (modules bench_common)
  (libraries irmin-pack irmin-tezos unix progress uuidm)
  (preprocess
@@ -28,6 +29,7 @@
 
 (library
  (name irmin_traces)
+ (public_name irmin-bench.traces)
  (modules
   trace_common
   trace_definitions


### PR DESCRIPTION
This minimal program and its dune file can launch a trace replay

fixes #1779

```ml
open Lwt.Syntax
module Maker = Irmin_pack.Maker (Irmin_tezos.Conf)

module Store = struct
  include Maker.Make (Irmin_tezos.Schema)

  type store_config = unit

  let create_repo ~root () =
    let conf = Irmin_pack.config ~readonly:false ~fresh:true root in
    let* repo = Repo.v conf in
    let on_commit _ _ = Lwt.return_unit in
    let on_end () = Lwt.return_unit in
    Lwt.return (repo, on_commit, on_end)
end

module Replay = Irmin_traces.Trace_replay.Make (Store)

let main () =
  let conf =
    Irmin_traces.Trace_replay.
      {
        number_of_commits_to_replay = 42;
        path_conversion = `None;
        inode_config = (32, 256);
        store_type = `Pack;
        replay_trace_path = "/Users/nico/tz/data5.repr";
        artefacts_path = "/tmp/irmin_trace_replay_arefacts";
        keep_store = false;
        keep_stat_trace = false;
        empty_blobs = false;
        return_type = Summary;
      }
  in
  let+ summary = Replay.run () conf in
  Fmt.epr "Elapsed seconds %.3f\n%!" summary.elapsed_wall

let () = Lwt_main.run (main ())
```

```
(executable (name main)
(libraries fmt irmin-tezos irmin-pack irmin-bench.traces))
```