### PR TITLE
Remove runtime dep on the ppx stack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Fixed
 
+- **irmin-pack**
+  - Drop unnecessary runtime dependency on `ppx_irmin`. (#1782, @hhugo)
+
 - **irmin-unix**
   - Fix conflicting command line arguments for `push`, `pull`, `fetch` and
     `clone` (#1776, @zshipko)

--- a/examples/dune
+++ b/examples/dune
@@ -9,17 +9,7 @@
   custom_merge
   push
   custom_graphql)
- (libraries
-  astring
-  cohttp
-  fmt
-  git
-  irmin
-  irmin-git
-  irmin-unix
-  ppx_irmin
-  lwt
-  lwt.unix)
+ (libraries astring cohttp fmt git irmin irmin-git irmin-unix lwt lwt.unix)
  (preprocess
   (pps ppx_irmin)))
 

--- a/src/irmin-pack/dune
+++ b/src/irmin-pack/dune
@@ -10,7 +10,6 @@
   lwt
   lwt.unix
   mtime
-  ppx_irmin
   cmdliner
   optint)
  (preprocess


### PR DESCRIPTION
We currently link a large part of the ppx stack inside executables that depend on irmin-pack 