### PR TITLE
irmin-pack: Add `forbid_empty_dir_persistence` conf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,12 @@
+## Unreleased
+
+### Added
+
 ## 3.1.0 (2022-02-25)
+
+- **irmin-pack**
+  - Add `forbid_empty_dir_persistence` in store configuration. (#1789,
+    @ngoguey42)
 
 ### Fixed
 

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -21,6 +21,7 @@ module Config = struct
   let stable_hash = 3
   let contents_length_header = Some `Varint
   let inode_child_order = `Hash_bits
+  let forbid_empty_dir_persistence = false
 end
 
 module KV = struct

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -24,6 +24,7 @@ module type S = sig
   val stable_hash : int
   val contents_length_header : length_header
   val inode_child_order : inode_child_order
+  val forbid_empty_dir_persistence : bool
 end
 
 module Default = struct

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -39,6 +39,14 @@ module type S = sig
         information). *)
 
   val inode_child_order : inode_child_order
+
+  val forbid_empty_dir_persistence : bool
+  (** If [true], irmin-pack raises [Failure] if it is asked to save the empty
+      inode. This default is [false]. It should be set to [true] if the [Schema]
+      of the store allows a hash collision between the empty inode and this
+      string of length 1: ["\000"].
+
+      See https://github.com/mirage/irmin/issues/1304 *)
 end
 
 val spec : Irmin.Backend.Conf.Spec.t

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1944,6 +1944,10 @@ struct
     let hash_exn ?force t = apply t { f = (fun _ v -> I.hash_exn ?force v) }
 
     let save ~add ~index ~mem t =
+      if Conf.forbid_empty_dir_persistence && is_empty t then
+        failwith
+          "Persisting an empty node is forbidden by the configuration of the \
+           irmin-pack store";
       let f layout v =
         I.check_write_op_supported v;
         I.save layout ~add ~index ~mem v

--- a/src/irmin-tezos/irmin_tezos.ml
+++ b/src/irmin-tezos/irmin_tezos.ml
@@ -21,6 +21,7 @@ module Conf = struct
   let stable_hash = 256
   let contents_length_header = Some `Varint
   let inode_child_order = `Seeded_hash
+  let forbid_empty_dir_persistence = true
 end
 
 module Maker = Irmin_pack_unix.Maker (Conf)

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -96,6 +96,7 @@ module Small_conf = struct
   let stable_hash = 3
   let contents_length_header = Some `Varint
   let inode_child_order = `Hash_bits
+  let forbid_empty_dir_persistence = false
 end
 
 module V1_maker = Irmin_pack_unix.Maker (Small_conf)

--- a/test/irmin-pack/test_hashes.ml
+++ b/test/irmin-pack/test_hashes.ml
@@ -72,8 +72,10 @@ struct
 
   let persist_tree tree =
     let* repo = Repo.v conf in
-    let empty = Tree.empty () in
-    let* init_commit = Commit.v ~parents:[] ~info:Info.empty repo empty in
+    let* init_commit =
+      Commit.v ~parents:[] ~info:Info.empty repo
+        (Tree.singleton [ "singleton-step" ] (Bytes.of_string "singleton-val"))
+    in
     let h = Commit.hash init_commit in
     let info = Info.v ~author:"Tezos" 0L in
     let* commit =
@@ -173,14 +175,14 @@ module Test_tezos_conf = struct
     encode_bin_hash h (fun x ->
         check_string ~msg:"commit hash"
           ~expected:
-            "2c85e6014a7e6c8fb655cc0272d3d202c3610738b1e3c6fa378d633f324bb17b"
+            "c20860adda3c3d40d8d03fab22b07e889979cdac880d979711aa852a0896ae30"
           ~got:x);
     let checks =
       [
         ("hash of root node", hash_root_small_tree);
         ("len of parents", "01");
         ( "parent hash",
-          "bf50614cb5f7c3a35e613ed5abd6ea1e2619a0e832e88bbbe436b74a6151ed03" );
+          "634d894802f9032ef48bbe1253563dbeb2aad7dc684da83bdea5692fde2185ae" );
         ("date", "0000000000000000");
         ("len of author", "05");
         ("author", "54657a6f73");
@@ -197,7 +199,7 @@ module Test_tezos_conf = struct
         ("len of parents", "0000000000000001");
         ("len of parent hash", "0000000000000020");
         ( "parent hash",
-          "bf50614cb5f7c3a35e613ed5abd6ea1e2619a0e832e88bbbe436b74a6151ed03" );
+          "634d894802f9032ef48bbe1253563dbeb2aad7dc684da83bdea5692fde2185ae" );
         ("date", "0000000000000000");
         ("len of author", "0000000000000005");
         ("author", "54657a6f73");
@@ -208,7 +210,7 @@ module Test_tezos_conf = struct
     let pre_hash_val = Irmin.Type.(unstage (pre_hash Commit.Val.t)) in
     check_iter "pre_hash" pre_hash_val commit_val checks;
     Store.check_hardcoded_hash "commit hash"
-      "CoUyv8vkXeELA2aZ1qAKrBffnSKFeEP7R364T5sfAZEvkm4BsmDS" h;
+      "CoW7mALEs2vue5cfTMdJfSAjNmjmALYS1YyqSsYr9siLcNEcrvAm" h;
     let* () = Store.Repo.close repo in
     Lwt.return_unit
 end
@@ -219,6 +221,7 @@ module Test_small_conf = struct
     let stable_hash = 3
     let contents_length_header = Some `Varint
     let inode_child_order = `Seeded_hash
+    let forbid_empty_dir_persistence = true
   end
 
   module Store = Test (Conf) (Irmin_tezos.Schema)
@@ -293,7 +296,7 @@ module Test_V1 = struct
         ("len of parents", "0000000000000001");
         ("len of parent hash", "0000000000000020");
         ( "parent hash",
-          "bf50614cb5f7c3a35e613ed5abd6ea1e2619a0e832e88bbbe436b74a6151ed03" );
+          "634d894802f9032ef48bbe1253563dbeb2aad7dc684da83bdea5692fde2185ae" );
         ("date", "0000000000000000");
         ("len of author", "0000000000000005");
         ("author", "54657a6f73");

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -100,6 +100,7 @@ module Conf = struct
   let stable_hash = 3
   let contents_length_header = Some `Varint
   let inode_child_order = `Seeded_hash
+  let forbid_empty_dir_persistence = false
 end
 
 module String_contents = struct

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -49,8 +49,15 @@ let suite_pack name_suffix indexing_strategy (module Config : Irmin_pack.Conf.S)
     ~clear_supported:false ~import_supported:false ~init ~store ~config ~clean
     ()
 
+module Irmin_tezos_conf = struct
+  include Irmin_tezos.Conf
+
+  (* The generic test suite relies a lot on the empty tree. Let's allow it. *)
+  let forbid_empty_dir_persistence = false
+end
+
 module Irmin_pack_mem_maker : Irmin_test.Generic_key = struct
-  open Irmin_pack_mem.Maker (Irmin_tezos.Conf)
+  open Irmin_pack_mem.Maker (Irmin_tezos_conf)
 
   include Make (struct
     include Irmin_test.Schema
@@ -74,9 +81,10 @@ let suite =
     let stable_hash = 3
     let contents_length_header = None
     let inode_child_order = `Hash_bits
+    let forbid_empty_dir_persistence = false
   end in
   [
-    suite_pack " { Tezos }" Index.minimal (module Irmin_tezos.Conf);
+    suite_pack " { Tezos }" Index.minimal (module Irmin_tezos_conf);
     suite_pack " { Small_nodes }" Index.always (module Conf_small_nodes);
     suite_mem;
   ]

--- a/test/irmin-pack/test_pack_version_bump.ml
+++ b/test/irmin-pack/test_pack_version_bump.ml
@@ -157,7 +157,10 @@ let test_RW_version_bump () : unit Lwt.t =
   (* force version bump by writing to the store *)
   let* main = S.main repo in
   let info () = S.Info.v (Int64.of_int 0) in
-  let* () = S.set_tree_exn ~info main [] (S.Tree.empty ()) in
+  let* () =
+    S.set_tree_exn ~info main []
+      (S.Tree.singleton [ "singleton-key" ] "singleton-val")
+  in
   let* () = S.Repo.close repo in
   alco_check_version ~pos:__POS__ ~expected:`V2
     ~actual:(io_get_version ~fn:(tmp_dir / "store.pack"));

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -339,6 +339,7 @@ module Binary = Make (struct
   let stable_hash = 2
   let inode_child_order = `Hash_bits
   let contents_length_header = Some `Varint
+  let forbid_empty_dir_persistence = false
 end)
 
 (* test large compressed proofs *)
@@ -397,6 +398,7 @@ module Custom = Make (struct
 
   let inode_child_order = `Custom index
   let contents_length_header = Some `Varint
+  let forbid_empty_dir_persistence = false
 end)
 
 module P = Custom.Tree.Proof


### PR DESCRIPTION
Add this conf value to irmin-pack stores:
```ocaml
  val forbid_empty_dir_persistence : bool
  (** If [true], irmin-pack raises [Failure] if it is asked to save the empty
      inode. This default is [false]. It should be set to [true] if the [Schema]
      of the store allows a hash collision between the empty inode and this
      string of length 1: ["\000"].

      See https://github.com/mirage/irmin/issues/1304 *)
```
