### PR TITLE
Refactor `Tree.export`'s `on_node`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
 - **irmin-pack**
   - Allow snapshot export to work on indexed root nodes (#1845, @icristescu)
 
+- **irmin**
+  - Fix Tree.export for nodes exported twice using different repos. (#1795,
+    @Ngoguey42)
+
 ## 3.2.1 (2022-04-07)
 
 - Support all version of cmdliner (#1803, @samoht)

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1881,6 +1881,14 @@ module Make (S : Generic_key) = struct
       let* () = B.Repo.close repo1 in
       (* Re-export the same tree using a different repo. *)
       let* repo2 = S.Repo.v x.config in
+      let* _ =
+        check_raises_lwt "re-export tree from another repo"
+          (Failure "Can't export the node key from another repo") (fun () ->
+            S.Backend.Repo.batch repo2 (fun c n _ -> S.save_tree repo2 c n tree))
+      in
+      let* () = B.Repo.close repo2 in
+      (* Re-export a fresh tree using a different repo. *)
+      let* repo2 = S.Repo.v x.config in
       let* tree = S.Tree.add (S.Tree.empty ()) [ "foo"; "a" ] "a" in
       let _ = S.Tree.hash tree in
       let* c1 = S.Tree.get_tree tree [ "foo" ] in

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1872,6 +1872,32 @@ module Make (S : Generic_key) = struct
     in
     run x test
 
+  let test_reexport_node x () =
+    let test repo1 =
+      let* tree = S.Tree.add (S.Tree.empty ()) [ "foo"; "a" ] "a" in
+      let* _ =
+        S.Backend.Repo.batch repo1 (fun c n _ -> S.save_tree repo1 c n tree)
+      in
+      let* () = B.Repo.close repo1 in
+      (* Re-export the same tree using a different repo. *)
+      let* repo2 = S.Repo.v x.config in
+      let* tree = S.Tree.add (S.Tree.empty ()) [ "foo"; "a" ] "a" in
+      let _ = S.Tree.hash tree in
+      let* c1 = S.Tree.get_tree tree [ "foo" ] in
+      let* _ =
+        S.Backend.Repo.batch repo2 (fun c n _ -> S.save_tree repo2 c n c1)
+      in
+      let* () =
+        match S.Tree.destruct c1 with
+        | `Contents _ -> Alcotest.fail "got `Contents, expected `Node"
+        | `Node node ->
+            let* _v = S.to_backend_node node in
+            Lwt.return_unit
+      in
+      B.Repo.close repo2
+    in
+    run x test
+
   module Sync = Irmin.Sync.Make (S)
 
   let test_sync x () =
@@ -2516,6 +2542,7 @@ let suite (speed, x) =
        ("Shallow objects", speed, T.test_shallow_objects x);
        ("Closure with disconnected commits", speed, T.test_closure x);
        ("Prehash collisions", speed, T.test_pre_hash_collisions x);
+       ("Re-export node", speed, T.test_reexport_node x);
      ]
     @ when_ x.clear_supported [ ("Clear", speed, T.test_clear x) ]
     @ when_ x.import_supported

--- a/test/irmin/test_tree.ml
+++ b/test/irmin/test_tree.ml
@@ -549,7 +549,7 @@ let test_fold_force _ () =
           "Unforced paths"
           [ [ "dangling"; "subtree"; "hash" ]; [ "other"; "lazy"; "path" ] ]
   in
-  let sample_tree =
+  let create_sample_tree () =
     Tree.of_concrete
       (`Tree
         [
@@ -564,6 +564,7 @@ let test_fold_force _ () =
 
   (* Ensure that [fold ~force:`True ~cache:true] forces all lazy trees. *)
   let* () =
+    let sample_tree = create_sample_tree () in
     let* () = clear_and_assert_lazy sample_tree in
     Tree.fold ~force:`True ~cache:true sample_tree () >>= fun () ->
     Tree.stats ~force:false sample_tree
@@ -574,6 +575,7 @@ let test_fold_force _ () =
   (* Ensure that [fold ~force:`True ~cache:false] visits all children and does
      not leave them cached. *)
   let* () =
+    let sample_tree = create_sample_tree () in
     clear_and_assert_lazy sample_tree >>= fun () ->
     let* contents =
       Tree.fold ~force:`True ~cache:false
@@ -594,6 +596,7 @@ let test_fold_force _ () =
   (* Ensure that [fold ~force:`True ~cache:false] visits newly added values and
      updated values only once and does not visit removed values. *)
   let* () =
+    let sample_tree = create_sample_tree () in
     let* () = clear_and_assert_lazy sample_tree in
     Tree.remove sample_tree [ "a"; "ab" ] >>= fun updated_tree ->
     Tree.add updated_tree [ "a"; "ad" ] "v-ad" >>= fun updated_tree ->


### PR DESCRIPTION
On top of #1794

1. Refactors `on_node`

2. Addresses part of https://github.com/mirage/irmin/pull/1794#discussion_r830016058 by making sure that all the tree nodes exported go through `Node.export`.

3. Identifies 3 new edge cases which now result in exceptions. This led to modifications in `test/irmin/test_tree.ml | test_fold_force`.

