### PR TITLE
irmin-unix: Add ability to load contents/hash/store types from Dynlink plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   - Add `Metrics` module to describe metric gathering in irmin.
     (#1817, @maiste)
 
+- **irmin-unix**
+  - Add `--plugin` flag to load Dynlink plugins that can register new
+    contents, hash and store types (#1808, @zshipko)
+
 ## 3.2.1 (2022-04-07)
 
 - Support all version of cmdliner (#1803, @samoht)

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -1,0 +1,34 @@
+# Example plugin
+
+## Building
+
+From the root of the irmin repository:
+
+```shell
+$ dune build ./examples/plugin/plugin.cmxs
+```
+
+## Usage
+
+To load this plugin you can use the `--plugin` flag when using `irmin` (or
+`dune exec ./src/irmin-unix/bin/main.exe` from the root of the irmin repo):
+
+```shell
+$ dune exec ./src/irmin-unix/bin/main.exe -- set --plugin _build/default/examples/plugin/plugin.cmxs a/b/c 123
+```
+
+By default this will use the `mem-int` store defined in [plugin.ml](https://github.com/mirage/irmin/blob/main/examples/plugin/plugin.ml)
+since the `default` parameter is `true` when calling `Irmin_unix.Resolver.Store.add`.
+
+It is still possible to select the store and content type after a plugin has
+been loaded. To use the `int` content type with a git store you can run:
+
+```shell
+$ echo 'plugin: _build/default/examples/plugin/plugin.cmxs' > irmin.yml # Set the plugin path in a
+                                                                          config file
+$ dune exec ./src/irmin-unix/bin/main.exe -- set --root /tmp/irmin-plugin -s git -c int a/b/c 123
+```
+
+Since the `default` parameter is `true` when registering the content type using
+`Irmin_unix.Resolver.Contents.add`, `int` contents will already be the default,
+which means `-c int` could be left out.

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -4,7 +4,7 @@
 
 From the root of the irmin repository:
 
-```shell
+```sh
 $ dune build ./examples/plugin/plugin.cmxs
 ```
 
@@ -13,7 +13,7 @@ $ dune build ./examples/plugin/plugin.cmxs
 To load this plugin you can use the `--plugin` flag when using `irmin` (or
 `dune exec ./src/irmin-unix/bin/main.exe` from the root of the irmin repo):
 
-```shell
+```sh
 $ dune exec ./src/irmin-unix/bin/main.exe -- set --plugin _build/default/examples/plugin/plugin.cmxs a/b/c 123
 ```
 
@@ -23,9 +23,8 @@ since the `default` parameter is `true` when calling `Irmin_unix.Resolver.Store.
 It is still possible to select the store and content type after a plugin has
 been loaded. To use the `int` content type with a git store you can run:
 
-```shell
-$ echo 'plugin: _build/default/examples/plugin/plugin.cmxs' > irmin.yml # Set the plugin path in a
-                                                                          config file
+```sh
+$ echo 'plugin: _build/default/examples/plugin/plugin.cmxs' > irmin.yml # Set the plugin in config file
 $ dune exec ./src/irmin-unix/bin/main.exe -- set --root /tmp/irmin-plugin -s git -c int a/b/c 123
 ```
 

--- a/examples/plugin/dune
+++ b/examples/plugin/dune
@@ -1,0 +1,11 @@
+(executable
+  (name plugin)
+  (modes plugin)
+  (modules plugin)
+  (libraries irmin-unix))
+
+(alias
+ (name runtest)
+ (package irmin-unix)
+ (deps
+  plugin.exe))

--- a/examples/plugin/dune
+++ b/examples/plugin/dune
@@ -1,9 +1,14 @@
 (executable
  (name plugin)
  (modes plugin)
+ (modules plugin)
  (libraries irmin-unix))
 
 (alias
  (name runtest)
  (package irmin-unix)
  (deps plugin.cmxs))
+
+(cram
+ (package irmin-unix)
+ (deps %{bin:irmin} plugin.cmxs))

--- a/examples/plugin/dune
+++ b/examples/plugin/dune
@@ -1,7 +1,7 @@
 (executable
-  (name plugin)
-  (modes plugin)
-  (libraries irmin-unix))
+ (name plugin)
+ (modes plugin)
+ (libraries irmin-unix))
 
 (alias
  (name runtest)

--- a/examples/plugin/dune
+++ b/examples/plugin/dune
@@ -1,11 +1,9 @@
 (executable
   (name plugin)
   (modes plugin)
-  (modules plugin)
   (libraries irmin-unix))
 
 (alias
  (name runtest)
  (package irmin-unix)
- (deps
-  plugin.exe))
+ (deps plugin.cmxs))

--- a/examples/plugin/plugin.ml
+++ b/examples/plugin/plugin.ml
@@ -1,0 +1,28 @@
+open Irmin_unix
+
+(* Adding a new content type *)
+
+module Int = struct
+  type t = int
+
+  let t = Irmin.Type.int
+  let merge = Irmin.Merge.(option (idempotent t))
+end
+
+let () = Resolver.Contents.add "int" (module Int)
+
+module Schema = struct
+  module Contents = Int
+  module Hash = Irmin.Hash.BLAKE2B
+  module Branch = Irmin.Branch.String
+  module Path = Irmin.Path.String_list
+  module Info = Irmin.Info.Default
+  module Metadata = Irmin.Metadata.None
+end
+
+(* Adding a new store type *)
+
+module Store = Irmin_mem.Make (Schema)
+
+let store = Resolver.Store.v Irmin_mem.Conf.spec (module Store)
+let () = Resolver.Store.add "mem-int" (Fixed store)

--- a/examples/plugin/plugin.ml
+++ b/examples/plugin/plugin.ml
@@ -9,7 +9,7 @@ module Int = struct
   let merge = Irmin.Merge.(option (idempotent t))
 end
 
-let () = Resolver.Contents.add "int" (module Int)
+let () = Resolver.Contents.add ~default:true "int" (module Int)
 
 module Schema = struct
   module Contents = Int
@@ -25,4 +25,4 @@ end
 module Store = Irmin_mem.Make (Schema)
 
 let store = Resolver.Store.v Irmin_mem.Conf.spec (module Store)
-let () = Resolver.Store.add "mem-int" (Fixed store)
+let () = Resolver.Store.add ~default:true "mem-int" (Fixed store)

--- a/examples/plugin/plugin.t
+++ b/examples/plugin/plugin.t
@@ -1,0 +1,9 @@
+  $ irmin set --plugin ./plugin.cmxs a/b/c 123
+  $ echo 'plugin: plugin.cmxs' > irmin.yml # Set the plugin in config file
+  $ irmin set --root /tmp/irmin-plugin -s git -c int a/b/c 123
+  $ irmin get --root /tmp/irmin-plugin -s git -c int a/b/c
+  123
+  $ irmin set --root /tmp/irmin-plugin -s git -c int a/b/c "AAA"
+  ERROR: int_of_string
+  [1]
+

--- a/src/irmin-unix/dune
+++ b/src/irmin-unix/dune
@@ -2,6 +2,7 @@
  (name irmin_unix)
  (public_name irmin-unix)
  (libraries
+  dynlink
   astring
   cmdliner
   cohttp

--- a/src/irmin-unix/resolver.ml
+++ b/src/irmin-unix/resolver.ml
@@ -386,7 +386,7 @@ module Store = struct
       let arg_info =
         Arg.info ~doc ~docs:global_option_section [ "s"; "store" ]
       in
-      Arg.(value & opt (some (enum store_types)) None & arg_info)
+      Arg.(value & opt (some string) None & arg_info)
     in
     let create store hash contents = (store, hash, contents) in
     Term.(const create $ store $ Hash.term () $ Contents.term ())
@@ -624,12 +624,17 @@ let commit =
   in
   Arg.(value & opt (some string) None & doc)
 
+let plugin =
+  let doc = "Register new contents, store or hash types" in
+  Arg.(value & opt (some string) None & info ~doc [ "plugin" ])
+
 let store () =
-  let create store (root, config_path, opts) branch commit =
+  let create plugin store (root, config_path, opts) branch commit =
+    let () = match plugin with Some p -> Dynlink.loadfile p | None -> () in
     let y = read_config_file config_path in
     build_irmin_config y root opts store branch commit
   in
-  Term.(const create $ Store.term () $ config_term $ branch $ commit)
+  Term.(const create $ plugin $ Store.term () $ config_term $ branch $ commit)
 
 let header_conv =
   let parse str =

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -104,6 +104,7 @@ end
 (** {1 Stores} *)
 
 val load_config :
+  ?plugin:string ->
   ?root:string ->
   ?config_path:string ->
   ?store:string ->
@@ -112,6 +113,8 @@ val load_config :
   unit ->
   Store.t * Irmin.config
 (** Load config file from disk
+
+    [plugin] is the path to a plugin to be loaded at runtime
 
     [config_path] can be used to specify the location of a configuration file.
 

--- a/src/irmin-unix/resolver.mli
+++ b/src/irmin-unix/resolver.mli
@@ -114,7 +114,8 @@ val load_config :
   Store.t * Irmin.config
 (** Load config file from disk
 
-    [plugin] is the path to a plugin to be loaded at runtime
+    [plugin] is the path to an OCaml plugin in cmxs format to be loaded at
+    runtime
 
     [config_path] can be used to specify the location of a configuration file.
 


### PR DESCRIPTION
Here’s one approach that allows user-defined types.

- New `--plugin` flag allows users to load a cmxs file to register additional contents, hash and store types
- Example plugin in `examples/plugin/plugin.ml`
