### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/src/irmin-http/dune
+++ b/src/irmin-http/dune
@@ -11,6 +11,7 @@
   logs
   lwt
   uri
+  unix
   webmachine)
  (preprocess
   (pps ppx_irmin.internal))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.