### PR TITLE
docs: remove basics reference

### DIFF
--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -27,7 +27,7 @@
     OCaml and does not depend on external C stubs; it is thus very portable and
     aims to run everywhere, from Linux to browser and MirageOS unikernels.
 
-    Consult the {!basics} and {!examples} of use for a quick start. See also the
+    Consult the {!examples} of use for a quick start. See also the
     {{!Irmin_unix} documentation} for the unix backends.
 
     {e Release %%VERSION%% - %%HOMEPAGE%%} *)


### PR DESCRIPTION
Found a 77b6d33f19c172494be0762d6091686a4c9cd697 dangling pointer 😄 