### PR TITLE
irmin-pack: remove hard-coded random tests

### DIFF
--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -145,13 +145,21 @@ let steps =
    "r0"; "r1"; "r2"; "r3"; "r4"; "r5"; "r6"; "r7"; "r8"; "r9"; "ra";]
 [@@ocamlformat "disable"]
 
+let version =
+  let version = Sys.ocaml_version in
+  Char.code version.[0] - 48
+
 let some_steps = [ "0g"; "1g"; "0h"; "2g"; "1h"; "2h" ]
 
 let some_random_steps =
-  [ [ "2g" ]; [ "1h" ]; [ "0h" ]; [ "2h" ]; [ "0g" ]; [ "1g" ] ]
+  if version >= 5 then
+    [ [ "1g" ]; [ "0h" ]; [ "2h" ]; [ "1h" ]; [ "2g" ]; [ "0g" ] ]
+  else [ [ "2g" ]; [ "1h" ]; [ "0h" ]; [ "2h" ]; [ "0g" ]; [ "1g" ] ]
 
 let another_random_steps =
-  [ [ "1g" ]; [ "2h" ]; [ "1h" ]; [ "0g" ]; [ "0h" ]; [ "2g" ] ]
+  if version >= 5 then
+    [ [ "0g" ]; [ "0h" ]; [ "1h" ]; [ "2h" ]; [ "2g" ]; [ "1g" ] ]
+  else [ [ "1g" ]; [ "2h" ]; [ "1h" ]; [ "0g" ]; [ "0h" ]; [ "2g" ] ]
 
 let zero = String.make 10 '0'
 let bindings steps = List.map (fun x -> ([ x ], zero)) steps

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -191,24 +191,6 @@ let test_fold_sorted () =
   let expected = List.map fst bindings in
   test_fold ~order:`Sorted bindings expected
 
-let test_fold_random () =
-  let bindings = bindings some_steps in
-  let state = Random.State.make [| 0 |] in
-  let* () = test_fold ~order:(`Random state) bindings some_random_steps in
-  let state = Random.State.make [| 1 |] in
-  let* () = test_fold ~order:(`Random state) bindings another_random_steps in
-
-  (* Random fold order should still be respected if [~force:`False]. This is a
-     regression test for a bug in which the fold order of in-memory nodes during
-     a non-forcing traversal was always sorted. *)
-  let state = Random.State.make [| 1 |] in
-  let* () =
-    test_fold ~order:(`Random state) ~export_tree_to_store:false bindings
-      another_random_steps
-  in
-
-  Lwt.return_unit
-
 let test_fold_undefined () =
   let bindings = bindings steps in
   let expected = List.map fst bindings in
@@ -618,8 +600,6 @@ let tests =
   [
     Alcotest.test_case "fold over keys in sorted order" `Quick (fun () ->
         Lwt_main.run (test_fold_sorted ()));
-    Alcotest.test_case "fold over keys in random order" `Quick (fun () ->
-        Lwt_main.run (test_fold_random ()));
     Alcotest.test_case "fold over keys in undefined order" `Quick (fun () ->
         Lwt_main.run (test_fold_undefined ()));
     Alcotest.test_case "test Merkle proof for large inodes" `Quick (fun () ->

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -191,6 +191,24 @@ let test_fold_sorted () =
   let expected = List.map fst bindings in
   test_fold ~order:`Sorted bindings expected
 
+let test_fold_random () =
+  let bindings = bindings some_steps in
+  let state = Random.State.make [| 0 |] in
+  let* () = test_fold ~order:(`Random state) bindings some_random_steps in
+  let state = Random.State.make [| 1 |] in
+  let* () = test_fold ~order:(`Random state) bindings another_random_steps in
+
+  (* Random fold order should still be respected if [~force:`False]. This is a
+     regression test for a bug in which the fold order of in-memory nodes during
+     a non-forcing traversal was always sorted. *)
+  let state = Random.State.make [| 1 |] in
+  let* () =
+    test_fold ~order:(`Random state) ~export_tree_to_store:false bindings
+      another_random_steps
+  in
+
+  Lwt.return_unit
+
 let test_fold_undefined () =
   let bindings = bindings steps in
   let expected = List.map fst bindings in
@@ -600,6 +618,8 @@ let tests =
   [
     Alcotest.test_case "fold over keys in sorted order" `Quick (fun () ->
         Lwt_main.run (test_fold_sorted ()));
+    Alcotest.test_case "fold over keys in random order" `Quick (fun () ->
+        Lwt_main.run (test_fold_random ()));
     Alcotest.test_case "fold over keys in undefined order" `Quick (fun () ->
         Lwt_main.run (test_fold_undefined ()));
     Alcotest.test_case "test Merkle proof for large inodes" `Quick (fun () ->


### PR DESCRIPTION
The random function changed in OCaml 5 so we can't rely on
seeded random to return the same results across OCaml versions.