### PR TITLE
irmin: remove redundant/unused module

### DIFF
--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -42,7 +42,6 @@ module Make (B : Backend.S) = struct
   module Commits = Commit.History (B.Commit)
   module Backend = B
   module Info = B.Commit.Info
-  module H = Commit.History (B.Commit)
   module T = Tree.Make (B)
 
   module Contents = struct


### PR DESCRIPTION
Small cleanup. `Commits` is the module in use, so `H` gets removed.