### PR TITLE
Add pretty-printers for use in utop

### DIFF
--- a/src/irmin-git/backend.ml
+++ b/src/irmin-git/backend.ml
@@ -35,6 +35,7 @@ struct
   module Key = Irmin.Key.Of_hash (Hash)
   module Commit_key = Key
   module Node_key = Key
+  module Info = Schema.Info
 
   module Contents = struct
     module S = Contents.Make (G) (Schema.Contents)
@@ -51,8 +52,8 @@ struct
   module Node_portable = Irmin.Node.Portable.Of_node (Node.Val)
 
   module Commit = struct
-    module S = Commit.Store (G)
-    include Irmin.Commit.Store (Schema.Info) (Node) (S) (S.Hash) (S.Val)
+    module S = Commit.Store (G) (Info)
+    include Irmin.Commit.Store (Info) (Node) (S) (S.Hash) (S.Val)
   end
 
   module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.S.Val)

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -108,6 +108,7 @@ module Make (G : Git.S) (I : Irmin.Info.S) = struct
 
   let size_of = Irmin.Type.Size.custom_dynamic ()
   let t = Irmin.Type.map ~bin:(encode_bin, decode_bin, size_of) C.t of_c to_c
+  let pp ppf t = C.pp ppf (to_c t)
 end
 
 module Store (G : Git.S) (I : Irmin.Info.S) = struct
@@ -125,4 +126,3 @@ module Store (G : Git.S) (I : Irmin.Info.S) = struct
 
   include Content_addressable.Check_closed (Content_addressable.Make (G) (V))
 end
-

--- a/src/irmin-git/commit.mli
+++ b/src/irmin-git/commit.mli
@@ -16,20 +16,20 @@
 
 (** Backend module: turn a Git store into an Irmin backend for Git commits. *)
 
-module Make (G : Git.S) :
+module Make (G : Git.S) (I : Irmin.Info.S):
   Irmin.Commit.S
     with type t = G.Value.Commit.t
      and type hash = G.hash
-     and module Info = Irmin.Info.Default
+     and module Info = I
 
-module Store (G : Git.S) : sig
+module Store (G : Git.S) (I : Irmin.Info.S) : sig
   include
     Irmin.Content_addressable.S
       with type _ t = bool ref * G.t
        and type key = G.Hash.t
        and type value = G.Value.Commit.t
 
-  module Info = Irmin.Info.Default
+  module Info : Irmin.Info.S with type t = I.t
   module Hash : Irmin.Hash.S with type t = key
 
   module Val :
@@ -38,3 +38,4 @@ module Store (G : Git.S) : sig
        and type hash = key
        and module Info = Info
 end
+

--- a/src/irmin-git/reference.ml
+++ b/src/irmin-git/reference.ml
@@ -28,6 +28,7 @@ let pp_ref ppf = function
   | `Tag t -> Fmt.pf ppf "refs/tags/%s" t
   | `Other o -> Fmt.pf ppf "refs/%s" o
 
+let pp = pp_ref
 let path l = String.concat ~sep:"/" l
 
 let of_ref str =

--- a/src/irmin-git/schema.ml
+++ b/src/irmin-git/schema.ml
@@ -21,7 +21,6 @@ module type S = sig
     Irmin.Schema.S
       with module Metadata = Metadata
        and module Branch := Branch
-       and type Info.t = Irmin.Info.default
        and type Path.step = string
        and type Path.t = string list
 
@@ -34,11 +33,12 @@ module type S = sig
   module Commit : Irmin.Commit.S with module Info := Info and type hash = Hash.t
 end
 
-module Make (G : Git.S) (V : Irmin.Contents.S) (B : Branch.S) :
+module Make (G : Git.S) (V : Irmin.Contents.S) (B : Branch.S) (I : Irmin.Info.S) :
   S
     with type Hash.t = G.hash
      and module Contents = V
      and module Branch = B
+     and module Info = I
      and type Node.t = G.Value.Tree.t
      and type Commit.t = G.Value.Commit.t = struct
   module Metadata = Metadata
@@ -47,6 +47,6 @@ module Make (G : Git.S) (V : Irmin.Contents.S) (B : Branch.S) :
   module Branch = B
   module Hash = Irmin.Hash.Make (G.Hash)
   module Node = Node.Make (G) (Path)
-  module Commit = Commit.Make (G)
-  module Info = Irmin.Info.Default
+  module Info = I
+  module Commit = Commit.Make (G) (Info)
 end

--- a/src/irmin-mirage/git/irmin_mirage_git.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git.ml
@@ -32,13 +32,15 @@ let remote ?(ctx = Mimic.empty) ?headers uri =
 module Maker (G : Irmin_git.G) = struct
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
-  module Maker = Irmin_git.Maker (G) (Git.Mem.Sync (G))
+  module I = Irmin.Info.Default
+  module Maker = Irmin_git.Maker (G) (Git.Mem.Sync (G)) (I)
 
   module Make
       (S : Irmin_git.Schema.S
              with type Hash.t = G.hash
               and type Node.t = G.Value.Tree.t
-              and type Commit.t = G.Value.Commit.t) =
+              and type Commit.t = G.Value.Commit.t
+              and type Info.t = I.t) =
   struct
     include Maker.Make (S)
 
@@ -47,8 +49,9 @@ module Maker (G : Irmin_git.G) = struct
 end
 
 module Ref (G : Irmin_git.G) = struct
-  module Maker = Irmin_git.Ref (G) (Git.Mem.Sync (G))
   module G = G
+  module I = Irmin.Info.Default
+  module Maker = Irmin_git.Ref (G) (Git.Mem.Sync (G)) (I)
 
   type branch = Maker.branch
   type endpoint = Maker.endpoint
@@ -61,8 +64,9 @@ module Ref (G : Irmin_git.G) = struct
 end
 
 module KV (G : Irmin_git.G) = struct
-  module Maker = Irmin_git.KV (G) (Git.Mem.Sync (G))
   module G = G
+  module I = Irmin.Info.Default
+  module Maker = Irmin_git.KV (G) (Git.Mem.Sync (G)) (I)
 
   type endpoint = Maker.endpoint
   type branch = Maker.branch

--- a/src/irmin-mirage/git/irmin_mirage_git_intf.ml
+++ b/src/irmin-mirage/git/irmin_mirage_git_intf.ml
@@ -25,6 +25,7 @@ end
 
 module type Maker = sig
   module G : Irmin_git.G
+  module I : Irmin.Info.S
 
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
@@ -32,7 +33,8 @@ module type Maker = sig
       (Schema : Irmin_git.Schema.S
                   with type Hash.t = G.hash
                   with type Node.t = G.Value.Tree.t
-                   and type Commit.t = G.Value.Commit.t) :
+                   and type Commit.t = G.Value.Commit.t
+                   and type Info.t = I.t) :
     S
       with module Git = G
        and type Backend.Remote.endpoint = endpoint
@@ -41,6 +43,7 @@ end
 
 module type KV_maker = sig
   module G : Irmin_git.G
+  module I : Irmin.Info.S
 
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
   type branch
@@ -50,7 +53,7 @@ module type KV_maker = sig
       with module Git = G
        and type Schema.Contents.t = C.t
        and module Schema.Metadata = Irmin_git.Metadata
-       and type Schema.Info.t = Irmin.Info.default
+       and type Schema.Info.t = I.t
        and type Schema.Path.step = string
        and type Schema.Path.t = string list
        and type Schema.Hash.t = G.hash
@@ -129,6 +132,7 @@ module type Sigs = sig
   (** Embed an Irmin store into an in-memory Git repository. *)
   module Mem : sig
     module G : Irmin_git.G
+    module I : Irmin.Info.S
 
     type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
@@ -136,7 +140,8 @@ module type Sigs = sig
         (Schema : Irmin_git.Schema.S
                     with type Hash.t = G.hash
                      and type Node.t = G.Value.Tree.t
-                     and type Commit.t = G.Value.Commit.t) :
+                     and type Commit.t = G.Value.Commit.t
+                     and type Info.t = I.t) :
       S
         with module Git = G
          and type Backend.Remote.endpoint = endpoint

--- a/src/irmin-unix/cli.ml
+++ b/src/irmin-unix/cli.ml
@@ -26,7 +26,7 @@ let () = Hook.init ()
 let info (type a) (module S : Irmin.Generic_key.S with type Schema.Info.t = a)
     ?(author = "irmin") fmt =
   let module Info = Info.Make (S.Info) in
-  Info.v ~author fmt
+  Info.vf ~author fmt
 
 (* Help sections common to all commands *)
 let help_sections =

--- a/src/irmin-unix/graphql.ml
+++ b/src/irmin-unix/graphql.ml
@@ -41,7 +41,7 @@ module Server = struct
 
         type info = S.info
 
-        let info = Info.v
+        let info = Info.vf
 
         let remote =
           match Remote.remote with
@@ -62,7 +62,7 @@ module Server = struct
 
         type info = S.info
 
-        let info = Info.v
+        let info = Info.vf
 
         let remote =
           match Remote.remote with

--- a/src/irmin-unix/info.ml
+++ b/src/irmin-unix/info.ml
@@ -14,10 +14,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module type S = sig
+  include Irmin.Info.S
+
+  val vf : ?author:string -> ('b, Format.formatter, unit, f) format4 -> 'b
+end
+
 module Make (I : Irmin.Info.S) = struct
   include I
 
-  let v ?author fmt =
+  let vf ?author fmt =
     Fmt.kstr
       (fun message () ->
         let date = Int64.of_float (Unix.gettimeofday ()) in
@@ -32,3 +38,5 @@ module Make (I : Irmin.Info.S) = struct
         v ~author ~message date)
       fmt
 end
+
+module Default = Make (Irmin.Info.Default)

--- a/src/irmin-unix/info.ml
+++ b/src/irmin-unix/info.ml
@@ -23,6 +23,20 @@ end
 module Make (I : Irmin.Info.S) = struct
   include I
 
+  let pp_date ppf t =
+    let time = t |> date |> Int64.to_float |> Unix.gmtime in
+    Fmt.pf ppf "%d-%02d-%02dT%02d:%02d:%02d.00Z" (time.tm_year + 1900)
+      (time.tm_mon + 1) time.tm_mday time.tm_hour time.tm_min time.tm_sec
+
+  let pp =
+    let open Fmt in
+    record
+      [
+        field "Date" id pp_date;
+        field "Author" id pp_author;
+        field "Message" id pp_message;
+      ]
+
   let vf ?author fmt =
     Fmt.kstr
       (fun message () ->

--- a/src/irmin-unix/info.mli
+++ b/src/irmin-unix/info.mli
@@ -14,8 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (I : Irmin.Info.S) : sig
-  include Irmin.Info.S with type t = I.t
+module type S = sig
+  include Irmin.Info.S
 
-  val v : ?author:string -> ('b, Format.formatter, unit, f) format4 -> 'b
+  val vf : ?author:string -> ('b, Format.formatter, unit, f) format4 -> 'b
 end
+
+module Make (I : Irmin.Info.S) : S with type t = I.t
+module Default : S with type t = Irmin.Info.Default.t

--- a/src/irmin-unix/irmin_unix.ml
+++ b/src/irmin-unix/irmin_unix.ml
@@ -16,11 +16,9 @@
 
 let set_listen_dir_hook = Hook.init
 
-module I = Info.Make (Irmin.Info.Default)
+let info = Info.Default.vf
 
-let info = I.v
-
-module Info = Info.Make
+module Info = Info
 module Git = Xgit
 module Http = Http
 module Graphql = Graphql

--- a/src/irmin-unix/irmin_unix.mli
+++ b/src/irmin-unix/irmin_unix.mli
@@ -30,12 +30,10 @@
       servers} provides a high-level REST API, with 1 RTT for the
       {{!Irmin.S.Backend} private} and {{!Irmin.S} public} functions. *)
 
-module Info = Info.Make
+module Info = Info
 
 val info :
-  ?author:string ->
-  ('a, Format.formatter, unit, unit -> Irmin.Info.default) format4 ->
-  'a
+  ?author:string -> ('a, Format.formatter, unit, unit -> Info.Default.t) format4 -> 'a
 (** [info fmt ()] creates a fresh commit info, with the {{!Irmin.Info.S.date}
     date} set to [Unix.gettimeoday ()] and the {{!Irmin.Info.S.author} author}
     built using [Unix.gethostname()] and [Unix.getpid()] if [author] is not
@@ -76,12 +74,12 @@ module Git : sig
   include Xgit_intf.Sigs
   (** @inline *)
 
-  module Maker (G : Irmin_git.G) : Backend with module G = G
+  module Maker (G : Irmin_git.G) : Backend with module G = G and module I = Info.Default
 
-  module FS : Backend with module G = Git_unix.Store
+  module FS : Backend with module G = Git_unix.Store and module I = Info.Default
   (** Embed an Irmin store into a local Git repository. *)
 
-  module Mem : Backend with module G = Irmin_git.Mem
+  module Mem : Backend with module G = Irmin_git.Mem and module I = Info.Default
   (** Embed an Irmin store into an in-memory Git repository. *)
 end
 

--- a/src/irmin-unix/xgit.ml
+++ b/src/irmin-unix/xgit.ml
@@ -41,13 +41,14 @@ let remote ?ctx ?headers uri =
 
 module Maker (G : Irmin_git.G) = struct
   module G = G
+  module I = Info.Default
 
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   module Maker = struct
-    module S = Irmin_git.Maker (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
-    module KV = Irmin_git.KV (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
-    module Ref = Irmin_git.Ref (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
+    module S = Irmin_git.Maker (G) (Git_unix.Sync (G)) (I)
+    module KV = Irmin_git.KV (G) (Git_unix.Sync (G)) (I)
+    module Ref = Irmin_git.Ref (G) (Git_unix.Sync (G)) (I)
   end
 
   module Make
@@ -55,7 +56,7 @@ module Maker (G : Irmin_git.G) = struct
              with type Hash.t = G.hash
               and type Node.t = G.Value.Tree.t
               and type Commit.t = G.Value.Commit.t
-              and type Info.t = Irmin.Info.default) =
+              and type Info.t = I.t) =
   struct
     include Maker.S.Make (S)
 

--- a/src/irmin-unix/xgit.ml
+++ b/src/irmin-unix/xgit.ml
@@ -45,16 +45,17 @@ module Maker (G : Irmin_git.G) = struct
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
   module Maker = struct
-    module S = Irmin_git.Maker (G) (Git_unix.Sync (G))
-    module KV = Irmin_git.KV (G) (Git_unix.Sync (G))
-    module Ref = Irmin_git.Ref (G) (Git_unix.Sync (G))
+    module S = Irmin_git.Maker (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
+    module KV = Irmin_git.KV (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
+    module Ref = Irmin_git.Ref (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
   end
 
   module Make
       (S : Irmin_git.Schema.S
              with type Hash.t = G.hash
               and type Node.t = G.Value.Tree.t
-              and type Commit.t = G.Value.Commit.t) =
+              and type Commit.t = G.Value.Commit.t
+              and type Info.t = Irmin.Info.default) =
   struct
     include Maker.S.Make (S)
 

--- a/src/irmin-unix/xgit.mli
+++ b/src/irmin-unix/xgit.mli
@@ -17,6 +17,6 @@
 include Xgit_intf.Sigs
 (** @inline *)
 
-module Maker (G : G) : Backend with module G = G
-module FS : Backend with module G = Git_unix.Store
-module Mem : Backend with module G = Irmin_git.Mem
+module Maker (G : G) : Backend with module G = G and module I = Info.Default
+module FS : Backend with module G = Git_unix.Store and module I = Info.Default
+module Mem : Backend with module G = Irmin_git.Mem and module I = Info.Default

--- a/src/irmin-unix/xgit_intf.ml
+++ b/src/irmin-unix/xgit_intf.ml
@@ -40,7 +40,8 @@ module type Backend = sig
       (Schema : Irmin_git.Schema.S
                   with type Hash.t = G.hash
                    and type Node.t = G.Value.Tree.t
-                   and type Commit.t = G.Value.Commit.t) :
+                   and type Commit.t = G.Value.Commit.t
+                   and type Info.t = Irmin.Info.default) :
     S
       with module Git = G
        and type Backend.Remote.endpoint = endpoint

--- a/src/irmin-unix/xgit_intf.ml
+++ b/src/irmin-unix/xgit_intf.ml
@@ -33,6 +33,7 @@ module type Backend = sig
   (* FIXME: remove signature duplication *)
 
   module G : Irmin_git.G
+  module I : Info.S
 
   type endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
@@ -41,7 +42,7 @@ module type Backend = sig
                   with type Hash.t = G.hash
                    and type Node.t = G.Value.Tree.t
                    and type Commit.t = G.Value.Commit.t
-                   and type Info.t = Irmin.Info.default) :
+                   and type Info.t = I.t) :
     S
       with module Git = G
        and type Backend.Remote.endpoint = endpoint
@@ -52,7 +53,7 @@ module type Backend = sig
       with module Git = G
        and type Schema.Contents.t = C.t
        and type Schema.Metadata.t = Irmin_git.Metadata.t
-       and type Schema.Info.t = Irmin.Info.default
+       and type Schema.Info.t = I.t
        and type Schema.Path.step = string
        and type Schema.Path.t = string list
        and type Schema.Hash.t = G.hash
@@ -64,7 +65,7 @@ module type Backend = sig
       with module Git = G
        and type Schema.Contents.t = C.t
        and type Schema.Metadata.t = Irmin_git.Metadata.t
-       and type Schema.Info.t = Irmin.Info.default
+       and type Schema.Info.t = I.t
        and type Schema.Path.step = string
        and type Schema.Path.t = string list
        and type Schema.Hash.t = G.hash

--- a/src/irmin/branch.ml
+++ b/src/irmin/branch.ml
@@ -33,4 +33,6 @@ module String = struct
       incr i
     done;
     !ok
+
+  let pp = Type.pp t
 end

--- a/src/irmin/branch_intf.ml
+++ b/src/irmin/branch_intf.ml
@@ -25,6 +25,9 @@ module type S = sig
 
   val is_valid : t -> bool
   (** Check if the branch is valid. *)
+
+  val pp : t Fmt.t [@@ocaml.toplevel_printer]
+  (** Pretty-printer *)
 end
 
 module Irmin_key = Key

--- a/src/irmin/commit.ml
+++ b/src/irmin/commit.ml
@@ -64,6 +64,17 @@ module Maker_generic_key (I : Info.S) = struct
       let parents = List.fast_sort compare_commit_key parents in
       { node; parents; info }
 
+    let pp =
+      let open Fmt in
+      vbox
+        (record
+           [
+             field "Parents" parents (list (Type.pp commit_key_t));
+             field "Node" node (Type.pp node_key_t);
+           ]
+        ++ sps 1
+        ++ using info Info.pp)
+
     module Portable = struct
       module Info = I
 
@@ -93,6 +104,17 @@ module Maker_generic_key (I : Info.S) = struct
       let v ~info ~node ~parents =
         let parents = List.fast_sort compare_hash parents in
         { node; parents; info }
+
+      let pp =
+        let open Fmt in
+        vbox
+          (record
+             [
+               field "Parents" parents (list (Type.pp commit_key_t));
+               field "Node" node (Type.pp node_key_t);
+             ]
+          ++ sps 1
+          ++ using info Info.pp)
 
       let of_commit : commit -> t =
        fun { node; parents; info } ->
@@ -686,6 +708,7 @@ module V1 = struct
     let info t = C.info t.c
     let v ~info ~node ~parents = { parents; c = C.v ~node ~parents ~info }
     let make = v
+    let pp ppf t = C.pp ppf t.c
 
     let t : t Type.t =
       let open Type in

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -42,6 +42,9 @@ module type S_generic_key = sig
 
   val info : t -> Info.t
   (** The commit info. *)
+
+  val pp : t Fmt.t [@@ocaml.toplevel_printer]
+  (** Pretty-printer *)
 end
 
 module type S = sig

--- a/src/irmin/info.ml
+++ b/src/irmin/info.ml
@@ -36,6 +36,18 @@ module Default = struct
   let author t = t.author
   let message t = t.message
   let none () = empty
+  let pp_date = Fmt.using date Fmt.int64
+  let pp_message = Fmt.using message Fmt.string
+  let pp_author = Fmt.using author Fmt.string
+
+  let pp =
+    let open Fmt in
+    record
+      [
+        field "Date" id pp_date;
+        field "Author" id pp_author;
+        field "Message" id pp_message;
+      ]
 end
 
 type default = Default.t

--- a/src/irmin/info_intf.ml
+++ b/src/irmin/info_intf.ml
@@ -56,6 +56,13 @@ module type S = sig
 
   val none : f
   (** The empty info function. [none ()] is [empty] *)
+
+  (** {1 Pretty-printers} *)
+
+  val pp_date : t Fmt.t
+  val pp_message : t Fmt.t
+  val pp_author : t Fmt.t
+  val pp : t Fmt.t [@@ocaml.toplevel_printer]
 end
 
 module type Sigs = sig

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -41,7 +41,7 @@ module Make (B : Backend.S) = struct
   module Path = B.Node.Path
   module Commits = Commit.History (B.Commit)
   module Backend = B
-  module Info = B.Commit.Info
+  module Info = B.Schema.Info
   module T = Tree.Make (B)
 
   module Contents = struct
@@ -109,7 +109,7 @@ module Make (B : Backend.S) = struct
   type tree = Tree.t [@@deriving irmin ~pp]
   type path = Path.t [@@deriving irmin ~pp]
   type step = Path.step [@@deriving irmin]
-  type info = B.Commit.Info.t [@@deriving irmin]
+  type info = Info.t [@@deriving irmin]
   type Remote.t += E of B.Remote.endpoint
   type lca_error = [ `Max_depth_reached | `Too_many_lcas ] [@@deriving irmin]
   type ff_error = [ `Rejected | `No_change | lca_error ]

--- a/src/irmin/store.ml
+++ b/src/irmin/store.ml
@@ -186,6 +186,11 @@ module Make (B : Backend.S) = struct
     let parents t = B.Commit.Val.parents t.v
     let pp_hash ppf t = Type.pp Hash.t ppf (hash t)
     let pp_key ppf t = Type.pp B.Commit.Key.t ppf t.key
+    let pp_value ppf t = B.Commit.Val.pp ppf t.v
+
+    let pp =
+      let open Fmt in
+      vbox (record [ field "Key" id pp_key ] ++ sps 1 ++ pp_value)
 
     let of_key r key =
       B.Commit.find (B.Repo.commit_t r) key >|= function

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -337,7 +337,11 @@ module type S_generic_key = sig
     (** [t] is the value type for {!type-t}. *)
 
     val pp_hash : t Fmt.t
-    (** [pp] is the pretty-printer for commit. Display only the hash. *)
+    (** [pp_hash] is a pretty-printer for a commit. Display only the hash. *)
+
+    val pp : t Fmt.t
+      [@@ocaml.toplevel_printer]
+    (** [pp] is a full pretty-printer for a commit. Displays all information. *)
 
     val v : repo -> info:info -> parents:commit_key list -> tree -> commit Lwt.t
     (** [v r i ~parents:p t] is the commit [c] such that:

--- a/src/libirmin/info.ml
+++ b/src/libirmin/info.ml
@@ -7,8 +7,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun (type repo) repo author message ->
         with_repo' repo info
           (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
-            let module Info = Irmin_unix.Info (Store.Info) in
-            let info : Info.t = Info.v ?author "%s" message () in
+            let module Info = Irmin_unix.Info.Make (Store.Info) in
+            let info : Info.t = Info.vf ?author "%s" message () in
             Root.create_info (module Store) info))
 
   let () =
@@ -17,8 +17,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun (type repo) repo info author message ->
         with_repo repo ()
           (fun (module Store : Irmin.Generic_key.S with type repo = repo) _ ->
-            let module Info = Irmin_unix.Info (Store.Info) in
-            Root.set_info (module Store) info (Info.v ?author "%s" message ())))
+            let module Info = Irmin_unix.Info.Make (Store.Info) in
+            Root.set_info (module Store) info (Info.vf ?author "%s" message ())))
 
   let () =
     fn "info_message"

--- a/src/libirmin/store.ml
+++ b/src/libirmin/store.ml
@@ -273,7 +273,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun (type t) store path info ->
         with_store store false
           (fun (module Store : Irmin.Generic_key.S with type t = t) store ->
-            let module Info = Irmin_unix.Info (Store.Info) in
+            let module Info = Irmin_unix.Info.Make (Store.Info) in
             let info = Root.get_info (module Store) info in
             let path : Store.path = Root.get_path (module Store) path in
             match run (Store.remove store path ~info:(fun () -> info)) with

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -48,7 +48,7 @@ module type X =
 
 module Mem (C : Irmin.Contents.S) = struct
   module G = Irmin_git.Mem
-  module M = Irmin_git.KV (G) (Git_unix.Sync (G))
+  module M = Irmin_git.KV (G) (Git_unix.Sync (G)) (Irmin.Info.Default)
   module S = M.Make (C)
   include S
 
@@ -60,7 +60,10 @@ end
 
 module Generic (C : Irmin.Contents.S) = struct
   module CA = Irmin.Content_addressable.Make (Irmin_mem.Append_only)
-  module M = Irmin_git.Generic_KV (CA) (Irmin_mem.Atomic_write)
+
+  module M =
+    Irmin_git.Generic_KV (CA) (Irmin_mem.Atomic_write) (Irmin.Info.Default)
+
   include M.Make (C)
 
   let init () =
@@ -124,7 +127,7 @@ let test_sort_order (module S : S) =
   Lwt.return_unit
 
 module Ref (S : Irmin_git.G) = struct
-  module M = Irmin_git.Ref (S) (Git_unix.Sync (S))
+  module M = Irmin_git.Ref (S) (Git_unix.Sync (S)) (Irmin.Info.Default)
   include M.Make (Irmin.Contents.String)
 end
 


### PR DESCRIPTION
This PR addresses #408 by adding printers for commit, branch, and info that also work in utop.

Here is an example output for a commit (info is included):

```sh
- : Store.commit =
Key: e7d8548577850da5ce6953135df0a7a782b87108
Parents: 8fc8534f404ca2c49f14067720b7227c38fc929d
Node: e9eaa978709f7f429ce46609c3dd35694d2e8514
Date: 2022-05-05T19:07:14.00Z
Author: me
Message: update
```

The purpose of the first couple of commits is that I needed to make some refactors to allow for the `Info` in `irmin-unix` to participate in pretty-printing and format the date accordingly (versus just printing an integer). It's a lot of code movement for just adding pretty-printers, but the architecture feels better aligned (based on my understanding) now since going through `irmin-unix` (like in the examples) properly uses its own `Info`.

I thought picking up this issue would allow me to get better acquainted with the code in a lightweight way (how hard could a few pps be!), and surprisingly ended up traversing a lot more than expected. 😄  I'm fairly new to both OCaml and this code, so I welcome any and all feedback!