### PR TITLE
Use graphql schema fixpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,10 @@
   - Removed the `irmin-unix` package. Unix backends are now subpackages of their
     relevant backend (see `irmin-fs.unix` and `irmin-git.unix`). The CLI tool is
     in `irmin-cli`. For common unix utilities, see `irmin.unix`. (#1953, @metanivek)
-    
+
+- **irmin-graphql**
+  - Updated to `graphql.0.14.0` (#1843, @patricoferris, @zshipko)
+
 ### Fixed
 
 ## 3.3.1 (2022-06-22)

--- a/examples/custom_graphql.ml
+++ b/examples/custom_graphql.ml
@@ -57,7 +57,8 @@ module Custom_types = struct
 
     let schema_typ =
       Schema.(
-        obj "Car" ~fields:(fun _ ->
+        obj "Car"
+          ~fields:
             [
               field "license" ~typ:(non_null string) ~args:[]
                 ~resolve:(fun _ car -> car.Car.license);
@@ -71,7 +72,7 @@ module Custom_types = struct
                 ~resolve:(fun _ car -> car.Car.license);
               field "owner" ~typ:(non_null string) ~args:[]
                 ~resolve:(fun _ car -> car.Car.owner);
-            ]))
+            ])
 
     let color = Schema.Arg.enum "Color" ~values:color_values
 

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -33,5 +33,13 @@ depends: [
   "logs"            {with-test}
 ]
 
+# Remove when upgrading to a new graphql release
+pin-depends: [
+  [ "graphql.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
+  [ "graphql-lwt.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
+  [ "graphql-cohttp.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
+  [ "graphql_parser.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
+]
+
 
 synopsis: "GraphQL server for Irmin"

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -14,13 +14,13 @@ build: [
 ]
 
 depends: [
-  "ocaml"           {>= "4.03.0"}
-  "dune"            {>= "2.9.0"}
-  "irmin"           {= version}
-  "graphql"         {>= "0.13.0"}
-  "graphql-lwt"     {>= "0.13.0"}
-  "graphql-cohttp"  {>= "0.13.0"}
-  "graphql_parser"  {>= "0.13.0"}
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.9.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.14.0"}
+  "graphql-lwt"    {>= "0.14.0"}
+  "graphql-cohttp" {>= "0.14.0"}
+  "graphql_parser" {>= "0.14.0"}
   "cohttp"
   "cohttp-lwt"
   "cohttp-lwt-unix"
@@ -32,14 +32,5 @@ depends: [
   "alcotest"        {with-test & >= "1.2.3"}
   "logs"            {with-test}
 ]
-
-# Remove when upgrading to a new graphql release
-pin-depends: [
-  [ "graphql.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
-  [ "graphql-lwt.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
-  [ "graphql-cohttp.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
-  [ "graphql_parser.dev" "git+https://github.com/andreas/ocaml-graphql-server#520ccd4013943ee0b2557aa66367b83aaa67084c" ]
-]
-
 
 synopsis: "GraphQL server for Irmin"


### PR DESCRIPTION
This PR upgrades `irmin-graphql` to use the (at time of writing) unreleased graphql schema fixpoint for constructing mutually recursive schemas. It cannot be merged until there is a release, so I've left this PR as a draft for now.

The context for this PR is that in order for `irmin-server` to use websockets, it will need the changes made in https://github.com/andreas/ocaml-graphql-server/pull/206 which means bumping to the latest version of `graphql`.

cc: @dinakajoy, @zshipko 