### PR TITLE
Allow snapshot export to work on indexed root nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@
     `Irmin_pack.Indexing_strategy` and the rest of `Pack_store`
     to `Irmin_pack_unix` (#1833, @Ngoguey42)
 
+### Fixed
+
+- **irmin-pack**
+  - Allow snapshot export to work on indexed root nodes (#1845, @icristescu)
+
 ## 3.2.1 (2022-04-07)
 
 - Support all version of cmdliner (#1803, @samoht)


### PR DESCRIPTION
Snapshot export assumed that all visited keys are direct. This is assured for all children of a node, but not for the root node, just under a commit. If the root node is indexed, then the export crashes with an assert false (this is probably the cause for https://gitlab.com/tezos/tezos/-/issues/2999). 

The fix is to convert the root key to a direct one if its not the case.    