### PR TITLE
Add _metrics to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build
 _coverage
+_metrics
 *~
 *.install
 *.merlin


### PR DESCRIPTION
While working on #1839 I noticed a `_metrics` directory was created after playing with stores in `utop`. This PR adds it to git's ignore list.