### PR TITLE
Remove unix dependency in irmin-test

### DIFF
--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -15,6 +15,7 @@
   repr
   ppx_repr
   bench_common
+  mtime
   rusage))
 
 (library

--- a/bench/irmin-pack/trace_collection.ml
+++ b/bench/irmin-pack/trace_collection.ml
@@ -152,10 +152,7 @@ module Make_stat (Store : Irmin.Generic_key.KV) = struct
         }
 
     let now () =
-      Mtime_clock.now ()
-      |> Mtime.to_uint64_ns
-      |> Int64.to_float
-      |> ( *. ) Mtime.ns_to_s
+      Mtime_clock.now () |> Mtime.to_uint64_ns |> Int64.to_float |> ( *. ) 1e-9
 
     let create store_path prev_merge_durations =
       Def.

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_irmin"    {= version}
   "ocaml"        {>= "4.02.3"}
   "dune"         {>= "2.9.0"}
-  "alcotest"     {>= "1.5.0"}
+  "alcotest-lwt" {>= "1.5.0"}
   "mtime"        {>= "1.0.0"}
   "astring"
   "fmt"
@@ -30,7 +30,6 @@ depends: [
   "metrics" {>= "0.2.0"}
   "hex" {with-test & >= "1.4.0"}
   "vector" {with-test & >= "1.0.0"}
-  "alcotest-lwt" {with-test & >= "1.5.0"}
 ]
 
 synopsis: "Irmin test suite"

--- a/src/irmin-test/dune
+++ b/src/irmin-test/dune
@@ -5,14 +5,13 @@
  (preprocess
   (pps ppx_irmin.internal))
  (libraries
-  alcotest
+  alcotest-lwt
   astring
   fmt
   irmin
   jsonm
   logs.fmt
   lwt
-  lwt.unix
   mtime
   mtime.clock.os)
  (instrumentation

--- a/src/irmin-test/irmin_test.mli
+++ b/src/irmin-test/irmin_test.mli
@@ -65,9 +65,10 @@ module Store : sig
     string ->
     ?slow:bool ->
     ?random_seed:int ->
-    misc:unit Alcotest.test list ->
+    sleep:(float -> unit Lwt.t) ->
+    misc:unit Alcotest_lwt.test list ->
     (Alcotest.speed_level * Suite.t) list ->
-    unit
+    unit Lwt.t
 end
 
 module Node = Node

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2412,7 +2412,7 @@ module Make (S : Generic_key) = struct
       S.Backend.Repo.close repo
     in
     (* Test collisions with the empty node (and its commit), *)
-    run x (test @@ fun () -> S.Tree.empty () |> Lwt.return) >>= fun () ->
+    let* () = run x (test @@ fun () -> S.Tree.empty () |> Lwt.return) in
     (* with a length one node, *)
     run x (test @@ fun () -> add_entries (S.Tree.empty ()) 1) >>= fun () ->
     (* and with a length >256 node (which is the threshold for unstable inodes

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -2412,9 +2412,9 @@ module Make (S : Generic_key) = struct
       S.Backend.Repo.close repo
     in
     (* Test collisions with the empty node (and its commit), *)
-    run x (test @@ fun () -> S.Tree.empty () |> Lwt.return);
+    run x (test @@ fun () -> S.Tree.empty () |> Lwt.return) >>= fun () ->
     (* with a length one node, *)
-    run x (test @@ fun () -> add_entries (S.Tree.empty ()) 1);
+    run x (test @@ fun () -> add_entries (S.Tree.empty ()) 1) >>= fun () ->
     (* and with a length >256 node (which is the threshold for unstable inodes
        in irmin pack). *)
     run x (test @@ fun () -> add_entries (S.Tree.empty ()) 260)
@@ -2427,11 +2427,14 @@ let suite' l ?(prefix = "") (_, x) =
 
 let when_ b x = if b then x else []
 
-let suite (speed, x) =
+let suite sleep (speed, x) =
   let (module S) = Suite.store_generic_key x in
+  let module Zzz = struct
+    let sleep = sleep
+  end in
   let module T = Make (S) in
   let module T_graph = Store_graph.Make (S) in
-  let module T_watch = Store_watch.Make (Log) (S) in
+  let module T_watch = Store_watch.Make (Log) (Zzz) (S) in
   let with_tree_enabled =
     (* Disabled for flakiness. See https://github.com/mirage/irmin/issues/1090. *)
     not
@@ -2494,7 +2497,7 @@ let slow_suite (speed, x) =
     ]
     (speed, x)
 
-let run name ?(slow = false) ?random_seed ~misc tl =
+let run name ?(slow = false) ?random_seed ~sleep ~misc tl =
   let () =
     match random_seed with
     | Some x -> Random.init x
@@ -2503,6 +2506,6 @@ let run name ?(slow = false) ?random_seed ~misc tl =
   Printexc.record_backtrace true;
   (* Ensure that failures occuring in async lwt threads are raised. *)
   (Lwt.async_exception_hook := fun exn -> raise exn);
-  let tl1 = List.map suite tl in
+  let tl1 = List.map (suite sleep) tl in
   let tl1 = if slow then tl1 @ List.map slow_suite tl else tl1 in
-  Alcotest.run name (misc @ tl1)
+  Alcotest_lwt.run name (misc @ tl1)

--- a/src/irmin-test/store.mli
+++ b/src/irmin-test/store.mli
@@ -18,6 +18,7 @@ val run :
   string ->
   ?slow:bool ->
   ?random_seed:int ->
-  misc:unit Alcotest.test list ->
+  sleep:(float -> unit Lwt.t) ->
+  misc:unit Alcotest_lwt.test list ->
   (Alcotest.speed_level * Common.t) list ->
-  unit
+  unit Lwt.t

--- a/src/irmin-test/store_watch.mli
+++ b/src/irmin-test/store_watch.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (_ : Logs.LOG) : Common.Store_tests
+module Make (_ : Logs.LOG) (_ : Common.Sleep) : Common.Store_tests

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -22,8 +22,7 @@ let key_t : Test_chunk.Key.t Alcotest.testable = (module Test_chunk.Key)
 let value_t : Test_chunk.Value.t Alcotest.testable = (module Test_chunk.Value)
 
 let run f () =
-  let open Lwt.Infix in
-  f () >|= fun () ->
+  let+ () = f () in
   flush stderr;
   flush stdout
 

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -22,7 +22,8 @@ let key_t : Test_chunk.Key.t Alcotest.testable = (module Test_chunk.Key)
 let value_t : Test_chunk.Value.t Alcotest.testable = (module Test_chunk.Value)
 
 let run f () =
-  Lwt_main.run (f ());
+  let open Lwt.Infix in
+  f () >|= fun () ->
   flush stderr;
   flush stdout
 
@@ -77,5 +78,7 @@ let stable =
     ] )
 
 let () =
-  Irmin_test.Store.run "irmin-chunk" ~slow:true ~misc:[ simple; stable ]
-    [ (`Quick, Test_chunk.suite) ]
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-chunk" ~slow:true ~misc:[ simple; stable ]
+       ~sleep:Lwt_unix.sleep
+       [ (`Quick, Test_chunk.suite) ]

--- a/test/irmin-fs/dune
+++ b/test/irmin-fs/dune
@@ -11,7 +11,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest irmin irmin-test test_fs))
+ (libraries alcotest lwt.unix irmin irmin-test test_fs))
 
 (executable
  (name test_unix)

--- a/test/irmin-fs/test.ml
+++ b/test/irmin-fs/test.ml
@@ -15,5 +15,6 @@
  *)
 
 let () =
-  Irmin_test.Store.run "irmin-fs" ~slow:true ~misc:[]
-    [ (`Quick, Test_fs.suite) ]
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-fs" ~slow:true ~misc:[] ~sleep:Lwt_unix.sleep
+       [ (`Quick, Test_fs.suite) ]

--- a/test/irmin-fs/test_unix.ml
+++ b/test/irmin-fs/test_unix.ml
@@ -15,5 +15,7 @@
  *)
 
 let () =
-  Irmin_test.Store.run "irmin-fs.unix" ~slow:false ~misc:[]
-    [ (`Quick, Test_fs_unix.suite) ]
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-fs.unix" ~slow:false ~sleep:Lwt_unix.sleep
+       ~misc:[]
+       [ (`Quick, Test_fs_unix.suite) ]

--- a/test/irmin-git/test.ml
+++ b/test/irmin-git/test.ml
@@ -17,5 +17,6 @@
 let misc = [ ("misc", Test_git.(misc mem)) ]
 
 let () =
-  Irmin_test.Store.run "irmin-git" ~slow:true ~misc
-    [ (`Quick, Test_git.suite); (`Quick, Test_git.suite_generic) ]
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-git" ~slow:true ~misc ~sleep:Lwt_unix.sleep
+       [ (`Quick, Test_git.suite); (`Quick, Test_git.suite_generic) ]

--- a/test/irmin-git/test_git.ml
+++ b/test/irmin-git/test_git.ml
@@ -228,14 +228,13 @@ let misc (module S : G) =
   let s = (module S : S) in
   let g = (module S : G) in
   let generic = (module Generic (Irmin.Contents.String) : S) in
-  let run f x () = Lwt_main.run (f x) in
   [
-    ("Testing sort order", `Quick, run test_sort_order s);
-    ("Testing sort order (generic)", `Quick, run test_sort_order generic);
-    ("Testing listing refs", `Quick, run test_list_refs g);
-    ("git -> mem", `Quick, run test_import_export s);
-    ("git blobs", `Quick, run test_blobs s);
-    ("git blobs of generic", `Quick, run test_blobs s);
+    ("Testing sort order", `Quick, fun () -> test_sort_order s);
+    ("Testing sort order (generic)", `Quick, fun () -> test_sort_order generic);
+    ("Testing listing refs", `Quick, fun () -> test_list_refs g);
+    ("git -> mem", `Quick, fun () -> test_import_export s);
+    ("git blobs", `Quick, fun () -> test_blobs s);
+    ("git blobs of generic", `Quick, fun () -> test_blobs s);
   ]
 
 let mem = (module Mem (Irmin.Contents.String) : G)

--- a/test/irmin-git/test_git.mli
+++ b/test/irmin-git/test_git.mli
@@ -29,5 +29,5 @@ module type G = sig
   module Git : Irmin_git.G
 end
 
-val misc : (module G) -> unit Alcotest.test_case list
+val misc : (module G) -> unit Alcotest_lwt.test_case list
 val mem : (module G)

--- a/test/irmin-git/test_unix.ml
+++ b/test/irmin-git/test_unix.ml
@@ -16,4 +16,8 @@
 
 let misc = [ ("misc", Test_git.misc Test_git_unix.store) ]
 let suites = [ (`Quick, Test_git_unix.suite) ]
-let () = Irmin_test.Store.run "irmin-git.unix" ~misc ~slow:false suites
+
+let () =
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-git.unix" ~misc ~slow:false
+       ~sleep:Lwt_unix.sleep suites

--- a/test/irmin-http/test.ml
+++ b/test/irmin-http/test.ml
@@ -16,4 +16,5 @@
 
 let () =
   Test_http.(with_server servers) (fun () ->
-      Irmin_test.Store.run "irmin-http" ~misc:[] Test_http.(suites servers))
+      Irmin_test.Store.run "irmin-http" ~misc:[] ~sleep:Lwt_unix.sleep
+        Test_http.(suites servers))

--- a/test/irmin-http/test_http.ml
+++ b/test/irmin-http/test_http.ml
@@ -233,6 +233,6 @@ let with_server servers f =
     let id = int_of_string Sys.argv.(3) in
     Logs.set_reporter (Irmin_test.reporter ~prefix:"S" ());
     serve servers n id)
-  else f ()
+  else Lwt_main.run (f ())
 
 type test = Alcotest.speed_level * Irmin_test.Suite.t

--- a/test/irmin-http/test_http.mli
+++ b/test/irmin-http/test_http.mli
@@ -18,4 +18,4 @@ type test = Alcotest.speed_level * Irmin_test.Suite.t
 
 val servers : test list
 val suites : test list -> test list
-val with_server : test list -> (unit -> unit) -> unit
+val with_server : test list -> (unit -> unit Lwt.t) -> unit

--- a/test/irmin-mem/dune
+++ b/test/irmin-mem/dune
@@ -6,7 +6,7 @@
 (executable
  (name test)
  (modules test)
- (libraries alcotest irmin-test test_mem))
+ (libraries alcotest lwt.unix irmin-test test_mem))
 
 (rule
  (alias runtest)

--- a/test/irmin-mem/test.ml
+++ b/test/irmin-mem/test.ml
@@ -15,5 +15,6 @@
  *)
 
 let () =
-  Irmin_test.Store.run "irmin-mem" ~slow:true ~misc:[]
-    [ (`Quick, Test_mem.suite) ]
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-mem" ~slow:true ~misc:[] ~sleep:Lwt_unix.sleep
+       [ (`Quick, Test_mem.suite) ]

--- a/test/irmin-pack/multiple_instances.ml
+++ b/test/irmin-pack/multiple_instances.ml
@@ -106,9 +106,7 @@ let ro_reload_after_close () =
   binding (check_binding ro c1) >>= fun () -> S.Repo.close ro
 
 let tests =
-  let tc name test =
-    Alcotest.test_case name `Quick (fun () -> Lwt_main.run (test ()))
-  in
+  let tc name test = Alcotest_lwt.test_case name `Quick (fun _switch -> test) in
   [
     tc "Test open ro after rw closed" open_ro_after_rw_closed;
     tc "Test ro reload after add" ro_reload_after_add;

--- a/test/irmin-pack/multiple_instances.mli
+++ b/test/irmin-pack/multiple_instances.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test.ml
+++ b/test/irmin-pack/test.ml
@@ -15,5 +15,7 @@
  *)
 
 let () =
-  Irmin_test.Store.run "irmin-pack" ~misc:Test_pack.misc
-    (List.map (fun s -> (`Quick, s)) Test_pack.suite)
+  Lwt_main.run
+  @@ Irmin_test.Store.run "irmin-pack" ~misc:Test_pack.misc
+       ~sleep:Lwt_unix.sleep
+       (List.map (fun s -> (`Quick, s)) Test_pack.suite)

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -216,10 +216,10 @@ end
 
 let tests =
   [
-    Alcotest.test_case "Test index reconstruction" `Quick (fun () ->
-        Lwt_main.run (Test_reconstruct.test_reconstruct ()));
-    Alcotest.test_case "Test integrity check" `Quick (fun () ->
-        Lwt_main.run (Test_corrupted_stores.test ()));
-    Alcotest.test_case "Test integrity check for inodes" `Quick (fun () ->
-        Lwt_main.run (Test_corrupted_inode.test ()));
+    Alcotest_lwt.test_case "Test index reconstruction" `Quick (fun _switch ->
+        Test_reconstruct.test_reconstruct);
+    Alcotest_lwt.test_case "Test integrity check" `Quick (fun _switch ->
+        Test_corrupted_stores.test);
+    Alcotest_lwt.test_case "Test integrity check for inodes" `Quick
+      (fun _switch -> Test_corrupted_inode.test);
   ]

--- a/test/irmin-pack/test_existing_stores.mli
+++ b/test/irmin-pack/test_existing_stores.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_flush_reload.ml
+++ b/test/irmin-pack/test_flush_reload.ml
@@ -247,8 +247,8 @@ let test_reload () =
 
 let tests =
   [
-    Alcotest.test_case "Reload during flush stages" `Quick (fun () ->
-        Lwt_main.run (test_flush ()));
-    Alcotest.test_case "Flush during reload stages" `Quick (fun () ->
-        Lwt_main.run (test_reload ()));
+    Alcotest_lwt.test_case "Reload during flush stages" `Quick
+      (fun _switch () -> test_flush ());
+    Alcotest_lwt.test_case "Flush during reload stages" `Quick
+      (fun _switch () -> test_reload ());
   ]

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -30,7 +30,7 @@ let fresh_name =
     let name = Filename.concat test_dir ("test-gc" ^ string_of_int !c) in
     name
 
-let tc name f = Alcotest.test_case name `Quick (fun () -> Lwt_main.run (f ()))
+let tc name f = Alcotest_lwt.test_case name `Quick (fun _switch () -> f ())
 
 include struct
   module S = struct

--- a/test/irmin-pack/test_gc.mli
+++ b/test/irmin-pack/test_gc.mli
@@ -15,9 +15,9 @@
  *)
 
 module Blocking_gc : sig
-  val tests : unit Alcotest.test_case list
+  val tests : unit Alcotest_lwt.test_case list
 end
 
 module Concurrent_gc : sig
-  val tests : unit Alcotest.test_case list
+  val tests : unit Alcotest_lwt.test_case list
 end

--- a/test/irmin-pack/test_hashes.ml
+++ b/test/irmin-pack/test_hashes.ml
@@ -311,9 +311,7 @@ module Test_V1 = struct
 end
 
 let tests =
-  let tc name f =
-    Alcotest.test_case name `Quick (fun () -> Lwt_main.run (f ()))
-  in
+  let tc name f = Alcotest_lwt.test_case name `Quick (fun _switch -> f) in
   [
     tc "contents hash" Test_tezos_conf.contents_hash;
     tc "inode_values hash" Test_tezos_conf.inode_values_hash;

--- a/test/irmin-pack/test_hashes.mli
+++ b/test/irmin-pack/test_hashes.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : unit Alcotest_lwt.test_case list
 
 val check_iter :
   string ->

--- a/test/irmin-pack/test_inode.mli
+++ b/test/irmin-pack/test_inode.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -177,8 +177,10 @@ module Dict = struct
 
   let tests =
     [
-      Alcotest.test_case "dict" `Quick test_dict;
-      Alcotest.test_case "RO dict" `Quick test_readonly_dict;
+      Alcotest_lwt.test_case "dict" `Quick (fun _ () ->
+          Lwt.return (test_dict ()));
+      Alcotest_lwt.test_case "RO dict" `Quick (fun _ () ->
+          Lwt.return (test_readonly_dict ()));
     ]
 end
 
@@ -399,17 +401,17 @@ module Pack = struct
 
   let tests =
     [
-      Alcotest.test_case "pack" `Quick (fun () -> Lwt_main.run (test_pack ()));
-      Alcotest.test_case "RO pack" `Quick (fun () ->
-          Lwt_main.run (test_readonly_pack ()));
-      Alcotest.test_case "close" `Quick (fun () ->
-          Lwt_main.run (test_close_pack ()));
-      Alcotest.test_case "close readonly" `Quick (fun () ->
-          Lwt_main.run (test_close_pack_more ()));
-      Alcotest.test_case "readonly reload, index flush" `Quick (fun () ->
-          Lwt_main.run (readonly_reload_index_flush ()));
-      Alcotest.test_case "readonly find, index flush" `Quick (fun () ->
-          Lwt_main.run (readonly_find_index_flush ()));
+      Alcotest_lwt.test_case "pack" `Quick (fun _switch () -> test_pack ());
+      Alcotest_lwt.test_case "RO pack" `Quick (fun _switch () ->
+          test_readonly_pack ());
+      Alcotest_lwt.test_case "close" `Quick (fun _switch () ->
+          test_close_pack ());
+      Alcotest_lwt.test_case "close readonly" `Quick (fun _switch () ->
+          test_close_pack_more ());
+      Alcotest_lwt.test_case "readonly reload, index flush" `Quick
+        (fun _switch () -> readonly_reload_index_flush ());
+      Alcotest_lwt.test_case "readonly find, index flush" `Quick
+        (fun _switch () -> readonly_find_index_flush ());
     ]
 end
 
@@ -487,10 +489,9 @@ module Branch = struct
 
   let tests =
     [
-      Alcotest.test_case "branch" `Quick (fun () ->
-          Lwt_main.run (test_branch ()));
-      Alcotest.test_case "branch close" `Quick (fun () ->
-          Lwt_main.run (test_close_branch ()));
+      Alcotest_lwt.test_case "branch" `Quick (fun _switch -> test_branch);
+      Alcotest_lwt.test_case "branch close" `Quick (fun _switch ->
+          test_close_branch);
     ]
 end
 

--- a/test/irmin-pack/test_pack.mli
+++ b/test/irmin-pack/test_pack.mli
@@ -15,4 +15,4 @@
  *)
 
 val suite : Irmin_test.Suite.t list
-val misc : (string * unit Alcotest.test_case list) list
+val misc : (string * unit Alcotest_lwt.test_case list) list

--- a/test/irmin-pack/test_pack_version_bump.ml
+++ b/test/irmin-pack/test_pack_version_bump.ml
@@ -156,8 +156,8 @@ let test_open_RW () : unit Lwt.t =
   Lwt.return ()
 
 let tests =
-  let f g () = Lwt_main.run @@ g () in
-  Alcotest.
+  let f g _switch () = g () in
+  Alcotest_lwt.
     [
       test_case "test_RO_no_migration" `Quick (f test_RO_no_migration);
       test_case "test_open_RW" `Quick (f test_open_RW);

--- a/test/irmin-pack/test_pack_version_bump.mli
+++ b/test/irmin-pack/test_pack_version_bump.mli
@@ -1,1 +1,1 @@
-val tests : unit Alcotest.test_case list
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_snapshot.ml
+++ b/test/irmin-pack/test_snapshot.ml
@@ -251,9 +251,7 @@ let test_gced_store_on_disk () =
   S.Repo.close repo_import
 
 let tests =
-  let tc name f =
-    Alcotest.test_case name `Quick (fun () -> Lwt_main.run (f ()))
-  in
+  let tc name f = Alcotest_lwt.test_case name `Quick (fun _switch () -> f ()) in
   [
     tc "in memory minimal" test_in_memory_minimal;
     tc "in memory always" test_in_memory_always;

--- a/test/irmin-pack/test_tree.ml
+++ b/test/irmin-pack/test_tree.ml
@@ -694,28 +694,28 @@ let test_reexport_node () =
 
 let tests =
   [
-    Alcotest.test_case "fold over keys in sorted order" `Quick (fun () ->
-        Lwt_main.run (test_fold_sorted ()));
-    Alcotest.test_case "fold over keys in random order" `Quick (fun () ->
-        Lwt_main.run (test_fold_random ()));
-    Alcotest.test_case "fold over keys in undefined order" `Quick (fun () ->
-        Lwt_main.run (test_fold_undefined ()));
-    Alcotest.test_case "test Merkle proof for large inodes" `Quick (fun () ->
-        Lwt_main.run (test_large_inode ()));
-    Alcotest.test_case "test Merkle proof for small inodes" `Quick (fun () ->
-        Lwt_main.run (test_small_inode ()));
-    Alcotest.test_case "test deeper Merkle proof" `Quick (fun () ->
-        Lwt_main.run (test_deeper_proof ()));
-    Alcotest.test_case "test large Merkle proof" `Slow (fun () ->
-        Lwt_main.run (test_large_proofs ()));
-    Alcotest.test_case "test extenders in stream proof" `Quick (fun () ->
-        Lwt_main.run (test_extenders ()));
-    Alcotest.test_case "test hardcoded stream proof" `Quick (fun () ->
-        Lwt_main.run (test_hardcoded_stream ()));
-    Alcotest.test_case "test hardcoded proof" `Quick (fun () ->
-        Lwt_main.run (test_hardcoded_proof ()));
-    Alcotest.test_case "test stream proof exn" `Quick (fun () ->
-        Lwt_main.run (test_proof_exn ()));
-    Alcotest.test_case "test reexport node" `Quick (fun () ->
-        Lwt_main.run (test_reexport_node ()));
+    Alcotest_lwt.test_case "fold over keys in sorted order" `Quick
+      (fun _switch -> test_fold_sorted);
+    Alcotest_lwt.test_case "fold over keys in random order" `Quick
+      (fun _switch -> test_fold_random);
+    Alcotest_lwt.test_case "fold over keys in undefined order" `Quick
+      (fun _switch -> test_fold_undefined);
+    Alcotest_lwt.test_case "test Merkle proof for large inodes" `Quick
+      (fun _switch -> test_large_inode);
+    Alcotest_lwt.test_case "test Merkle proof for small inodes" `Quick
+      (fun _switch -> test_small_inode);
+    Alcotest_lwt.test_case "test deeper Merkle proof" `Quick (fun _switch ->
+        test_deeper_proof);
+    Alcotest_lwt.test_case "test large Merkle proof" `Slow (fun _switch ->
+        test_large_proofs);
+    Alcotest_lwt.test_case "test extenders in stream proof" `Quick
+      (fun _switch -> test_extenders);
+    Alcotest_lwt.test_case "test hardcoded stream proof" `Quick (fun _switch ->
+        test_hardcoded_stream);
+    Alcotest_lwt.test_case "test hardcoded proof" `Quick (fun _switch ->
+        test_hardcoded_proof);
+    Alcotest_lwt.test_case "test stream proof exn" `Quick (fun _switch ->
+        test_proof_exn);
+    Alcotest_lwt.test_case "test reexport node" `Quick (fun _switch ->
+        test_reexport_node);
   ]

--- a/test/irmin-pack/test_upgrade.ml
+++ b/test/irmin-pack/test_upgrade.ml
@@ -675,10 +675,10 @@ let test start_mode () =
 (** Product on start_mode *)
 let tests =
   [
-    Alcotest.test_case "upgrade From_v3" `Quick (fun () ->
-        Lwt_main.run (test From_v3 ()));
-    Alcotest.test_case "upgrade From_v2" `Quick (fun () ->
-        Lwt_main.run (test From_v2 ()));
-    Alcotest.test_case "upgrade From_scratch" `Quick (fun () ->
-        Lwt_main.run (test From_scratch ()));
+    Alcotest_lwt.test_case "upgrade From_v3" `Quick (fun _switch () ->
+        test From_v3 ());
+    Alcotest_lwt.test_case "upgrade From_v2" `Quick (fun _switch () ->
+        test From_v2 ());
+    Alcotest_lwt.test_case "upgrade From_scratch" `Quick (fun _switch () ->
+        test From_scratch ());
   ]

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -11,6 +11,7 @@
   alcotest
   alcotest-lwt
   lwt
+  lwt.unix
   hex
   logs
   logs.fmt))

--- a/test/irmin/generic-key/dune
+++ b/test/irmin/generic-key/dune
@@ -4,4 +4,12 @@
  (package irmin-test)
  (preprocess
   (pps ppx_irmin.internal))
- (libraries irmin irmin.mem irmin-test alcotest alcotest-lwt lwt vector))
+ (libraries
+  irmin
+  irmin.mem
+  irmin-test
+  alcotest
+  alcotest-lwt
+  lwt
+  lwt.unix
+  vector))

--- a/test/irmin/generic-key/test.ml
+++ b/test/irmin/generic-key/test.ml
@@ -15,5 +15,8 @@
  *)
 
 let () =
-  Irmin_test.Store.run __FILE__ ~slow:true ~misc:[]
-    [ (`Quick, Test_store_offset.suite); (`Quick, Test_inlined_contents.suite) ]
+  Lwt_main.run
+  @@ Irmin_test.Store.run __FILE__ ~slow:true ~misc:[] ~sleep:Lwt_unix.sleep
+       [
+         (`Quick, Test_store_offset.suite); (`Quick, Test_inlined_contents.suite);
+       ]


### PR DESCRIPTION
This PR removes the `lwt.unix` dependency in `irmin-test` allowing the test-suite package to be compiled into more exotic locations (the browser, unikernels etc.).

This is how we managed to test the [irmin-server](https://github.com/mirage/irmin-server) port to use websockets so the client could be in the browser. I then tested a few different backends (an updated irmin-indexeddb and `irmin.mem`) using the testsuite [in this repository](https://github.com/patricoferris/irmin-browser-tests) with a [live version available](https://patricoferris.github.io/irmin-browser-tests/).

Note this PR, in order to run in the browser, requires https://github.com/mirage/alcotest/pull/348.