### PR TITLE
Add `Tree.is_val` and `Tree.Contents.is_val` functions

### DIFF
--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -1301,6 +1301,13 @@ module Make (S : Generic_key) = struct
 
       (* Testing other tree operations. *)
       let v0 = S.Tree.empty () in
+      let b0 = S.Tree.is_val v0 [] in
+      Alcotest.(check bool) "empty is_val /" true b0;
+      let b0 = S.Tree.is_val v0 [ "foo" ] in
+      Alcotest.(check bool) "empty is_val /foo" true b0;
+      let b0 = S.Tree.is_val v0 [ "foo"; "bar" ] in
+      Alcotest.(check bool) "empty is_val /foo/bar" true b0;
+
       let* c = S.Tree.to_concrete v0 in
       (match c with
       | `Tree [] -> ()

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -82,6 +82,12 @@ module type S = sig
   (** [is_empty t] is true iff [t] is {!empty} (i.e. a tree node with no
       children). Trees with {!kind} = [`Contents] are never considered empty. *)
 
+  val is_val : t -> path -> bool
+  (** [is_val t k] is [true] iff the path [k] has already been forced in [t]. In
+      that case, that means that all the nodes traversed by [k] are loaded in
+      memory. If the leaf node is a contents [c], then [Contents.is_val c]
+      should also be [true]. *)
+
   (** {1 Diffs} *)
 
   val diff : t -> t -> (path * (contents * metadata) Diff.t) list Lwt.t
@@ -127,6 +133,10 @@ module type S = sig
     val force_exn : t -> contents Lwt.t
     (** Equivalent to {!val-force}, but raises an exception if the lazy content
         value is not present in the underlying repository. *)
+
+    val is_val : t -> bool
+    (** [is_val x] is [true] iff [x] has already been forced (and so is loaded
+        in memory). *)
 
     val clear : t -> unit
     (** [clear t] clears [t]'s cache. *)


### PR DESCRIPTION
These functions check whether the node/contents are available in
memory or not (ie. if calling a function on those could incur IO
costs).