### PR TITLE
Failing test "Basic operations on contents"; diagnosis; needs decisio…

### DIFF
--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -140,7 +140,7 @@ module Maker (Config : Conf.S) = struct
             Lwt.return res
           in
           let on_fail exn =
-            [%log.info "[pack] batch failed. calling flush"];
+            [%log.info "[pack] batch failed. calling flush. (exn was %s)" (Printexc.to_string exn)];
             let () =
               match File_manager.flush t.fm with
               | Ok () -> ()

--- a/src/irmin-test/store.ml
+++ b/src/irmin-test/store.ml
@@ -102,7 +102,26 @@ module Make (S : Generic_key) = struct
         (fun () ->
           let+ _ = with_contents repo (fun t -> B.Contents.add t v2) in
           Alcotest.fail "Add after close should not be allowed")
-        (function Irmin.Closed -> Lwt.return_unit | exn -> Lwt.fail exn)
+        (function Irmin.Closed -> Lwt.return_unit 
+                (* | Index.Closed -> Lwt.return_unit 
+
+                   presumably, previously the exception thrown when operating on a closed
+                   repo was "Irmin.Closed"; after the IO refactor, the exception seems to
+                   be "Index.closed"; the library for this file store.ml (in
+                   src/irmin-test) doesn't depend on Index; thus we can't pattern match on
+                   the Index.Closed exception
+
+                   So, presumably we should catch Index.Closed everywhere and convert to
+                   Irmin.closed? 
+
+                   Catching all exceptions and returning unit seems wrong (what if the
+                   exception isn't an Index.Closed exception, but something else?)
+
+                   Another alternative is to depend on index, and catch Index.Closed (but
+                   these tests are supposed to be independent of the backend... so this
+                   can't be right).
+                *)
+                | exn -> Lwt.fail exn)
     in
     run x test
 


### PR DESCRIPTION
…n on what to do

   ```┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
   │ [FAIL]        PACK { Tezos }                1   Basic operations on contents.                                                                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
   +764647us index                               [INFO] [test_59] v fresh=true readonly=false log_size=2500000
   +764666us index                               [DEBUG] [test_59] not found in cache, creating a new instance
   +764673us index_unix                          [DEBUG] Locking test_59/index/lock
   +764723us index                               [DEBUG] [test_59] log file detected. Loading 0 entries
   +764734us index_unix                          [DEBUG] get_generation: 0
   +764743us index                               [DEBUG] [test_59] no index file detected.
   +764844us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +764854us index                               [DEBUG] [test_59] find ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +764864us src/irmin-pack/unix/pack_store.ml:365 [DEBUG] [pack] append ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +764872us src/irmin-pack/unix/pack_store.ml:398 [DEBUG] [pack] append done ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec <- {"Direct":["ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec",0,22]}
   +777936us index                               [DEBUG] [test_59] flush
   +778032us index                               [DEBUG] [test_59] flushing instance
   +778059us index                               [DEBUG] [test_59] flushing log
   +781577us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +781682us index                               [DEBUG] [test_59] find ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +781729us src/irmin-pack/unix/pack_store.ml:365 [DEBUG] [pack] append ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +781769us src/irmin-pack/unix/pack_store.ml:398 [DEBUG] [pack] append done ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec <- {"Direct":["ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec",22,22]}
   +792265us index                               [DEBUG] [test_59] flush
   +792352us index                               [DEBUG] [test_59] flushing instance
   +792380us index                               [DEBUG] [test_59] flushing log
   ASSERT kv2
   +792569us src/irmin-pack/unix/pack_store.ml:308 [DEBUG] [pack] find {"Direct":["ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec",22,22]}
   ASSERT v2
   +792692us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +792723us index                               [DEBUG] [test_59] find ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +792758us src/irmin-pack/unix/pack_store.ml:365 [DEBUG] [pack] append ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +792790us src/irmin-pack/unix/pack_store.ml:398 [DEBUG] [pack] append done ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec <- {"Direct":["ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec",44,22]}
   +803059us index                               [DEBUG] [test_59] flush
   +803156us index                               [DEBUG] [test_59] flushing instance
   +803184us index                               [DEBUG] [test_59] flushing log
   ASSERT kv2
   +803431us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index 7a1f0c381befdb0962318d65ee89b63f64486716
   +803487us index                               [DEBUG] [test_59] find 7a1f0c381befdb0962318d65ee89b63f64486716
   +803528us src/irmin-pack/unix/pack_store.ml:365 [DEBUG] [pack] append 7a1f0c381befdb0962318d65ee89b63f64486716
   +803565us src/irmin-pack/unix/pack_store.ml:398 [DEBUG] [pack] append done 7a1f0c381befdb0962318d65ee89b63f64486716 <- {"Direct":["7a1f0c381befdb0962318d65ee89b63f64486716",66,32]}
   +813856us index                               [DEBUG] [test_59] flush
   +813966us index                               [DEBUG] [test_59] flushing instance
   +813998us index                               [DEBUG] [test_59] flushing log
   +814157us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index 7a1f0c381befdb0962318d65ee89b63f64486716
   +814206us index                               [DEBUG] [test_59] find 7a1f0c381befdb0962318d65ee89b63f64486716
   +814244us src/irmin-pack/unix/pack_store.ml:365 [DEBUG] [pack] append 7a1f0c381befdb0962318d65ee89b63f64486716
   +814280us src/irmin-pack/unix/pack_store.ml:398 [DEBUG] [pack] append done 7a1f0c381befdb0962318d65ee89b63f64486716 <- {"Direct":["7a1f0c381befdb0962318d65ee89b63f64486716",98,32]}
   +824189us index                               [DEBUG] [test_59] flush
   +824257us index                               [DEBUG] [test_59] flushing instance
   +824285us index                               [DEBUG] [test_59] flushing log
   ASSERT kv1
   +824456us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index 7a1f0c381befdb0962318d65ee89b63f64486716
   +824512us index                               [DEBUG] [test_59] find 7a1f0c381befdb0962318d65ee89b63f64486716
   +824548us src/irmin-pack/unix/pack_store.ml:365 [DEBUG] [pack] append 7a1f0c381befdb0962318d65ee89b63f64486716
   +824582us src/irmin-pack/unix/pack_store.ml:398 [DEBUG] [pack] append done 7a1f0c381befdb0962318d65ee89b63f64486716 <- {"Direct":["7a1f0c381befdb0962318d65ee89b63f64486716",130,32]}
   +834667us index                               [DEBUG] [test_59] flush
   +834740us index                               [DEBUG] [test_59] flushing instance
   +834770us index                               [DEBUG] [test_59] flushing log
   ASSERT kv1
   +835010us src/irmin-pack/unix/pack_store.ml:308 [DEBUG] [pack] find {"Direct":["7a1f0c381befdb0962318d65ee89b63f64486716",66,32]}
   ASSERT v1
   +835134us src/irmin-pack/unix/pack_store.ml:308 [DEBUG] [pack] find {"Direct":["ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec",0,22]}
   ASSERT v2
   +835221us index                               [DEBUG] [test_59] close
   +835251us index                               [DEBUG] [test_59] last open instance: closing the file descriptor
   +835274us index                               [DEBUG] [test_59] flushing instance
   +835295us index                               [DEBUG] [test_59] flushing log
   +835428us index_unix                          [DEBUG] Unlocking test_59/index/lock
   +835477us src/irmin-pack/unix/io_legacy.ml:21 [DEBUG] IO flush test_59/store.branches
   +835516us src/irmin-pack/unix/pack_store.ml:62 [DEBUG] index ae4f281df5a5d0ff3cad6371f76d5c29b6d953ec
   +835546us src/irmin-pack/unix/ext.ml:143      [INFO] [pack] batch failed. calling flush
   +835572us src/irmin-pack/unix/ext.ml:148      [ERROR] [pack] batch failed and flush failed. Silencing flush fail
   +835623us test/irmin-pack/common.ml:27        [INFO] exec: rm -rf test_59

   [exception] File "src/irmin-pack/unix/ext.ml", line 151, characters 18-24: Assertion failed
               Raised at Irmin_pack_unix__Ext.Maker.Make.X.Repo.batch.on_fail in file "src/irmin-pack/unix/ext.ml", line 151, characters 18-30
               Called from Irmin_test__Store.Make.test_contents.test.(fun) in file "src/irmin-test/store.ml", line 103, characters 19-68
               Called from Lwt.Sequential_composition.catch in file "src/core/lwt.ml", line 2019, characters 16-20
               Re-raised at Irmin_test__Common.Make_helpers.run.(fun) in file "src/irmin-test/common.ml", line 259, characters 11-47
               Called from Lwt.Sequential_composition.map.(fun) in file "src/core/lwt.ml", line 2004, characters 35-40
               Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3068, characters 20-29
               Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 31, characters 10-20
               Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 118, characters 8-13
               Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 124, characters 4-13
               Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 180, characters 17-23
               Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35```