### PR TITLE
Fix irmin-pack `dict-files` tests

### DIFF
--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -159,6 +159,7 @@ module Dict = struct
     ignore_int (Dict.index d.dict "toto");
     ignore_int (Dict.index d.dict "titiabc");
     ignore_int (Dict.index d.dict "foo");
+    flush d.fm;
     reload d2.fm;
     check_index "titiabc" 3;
     check_index "bar" 1;


### PR DESCRIPTION
- Adds a call to `flush` in test to ensure dict file has been written to disk