### PR TITLE
Use decode_int63 for reading old offsets

### DIFF
--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -309,15 +309,16 @@ struct
     in
     finish_constructing_rw config control ~make_dict ~make_suffix ~make_index
 
+  let decode_int63 buf = Int63.decode ~off:0 buf
+
   let read_offset_from_legacy_file path =
     let open Result_syntax in
     (* Bytes 0-7 contains the offset. Bytes 8-15 contain the version. *)
     let* io = Io.open_ ~path ~readonly:true in
     let* s = Io.read_to_string io ~off:Int63.zero ~len:8 in
     let* () = Io.close io in
-    match Int63.of_string_opt s with
-    | None -> Error `Corrupted_legacy_file
-    | Some i -> Ok i
+    let x = decode_int63 s in
+    Ok x
 
   let open_rw_migrate_from_v1_v2 config =
     let open Result_syntax in

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -1,5 +1,6 @@
 open! Import
 module Io_legacy = Io_legacy.Unix
+(* TODO: Use new Io in traverse pack file *)
 
 module Stats : sig
   type t
@@ -87,7 +88,7 @@ end = struct
       let dest =
         match dest with
         | `Output path ->
-            if Io_legacy.exists path then
+            if Sys.file_exists path then
               Fmt.invalid_arg "Can't reconstruct index. File already exits.";
             path
         | `In_place ->

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -17,7 +17,7 @@
 open! Import
 open Common
 
-let src = Logs.Src.create "tests.migration" ~doc:"Test migrations"
+let src = Logs.Src.create "tests.integrity_checks" ~doc:"Test integrity checks"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
@@ -49,11 +49,12 @@ module Config_store = struct
   let root_v1_archive, root_v1, tmp =
     let open Fpath in
     ( v "test" / "irmin-pack" / "data" / "version_1" |> to_string,
-      v "_build" / "test_pack_migrate_1_to_2" |> to_string,
+      v "_build" / "test_pack_version_1" |> to_string,
       v "_build" / "test_index_reconstruct" |> to_string )
 
   let setup_test_env () =
     goto_project_root ();
+    rm_dir root_v1;
     let cmd =
       Filename.quote_command "cp" [ "-R"; "-p"; root_v1_archive; root_v1 ]
     in


### PR DESCRIPTION
Fixing `existing stores 0` and `existing stores 2`.

While this fixes the test, I think we should move to using the new IO in traverse_pack_file instead of the legacy_io, as the legacy_io cannot read files in V3.