### PR TITLE
test_RW_no_version_bump: diagnosis of test failure

### DIFF
--- a/test/irmin-pack/test_pack_version_bump.ml
+++ b/test/irmin-pack/test_pack_version_bump.ml
@@ -144,8 +144,15 @@ let test_RW_no_version_bump () : unit Lwt.t =
   let* () = S.Repo.close repo in
   (* maybe the version bump is only visible after closing the
      store... so check again *)
-  alco_check_version ~pos:__POS__ ~expected:`V1
-    ~actual:(io_get_version ~fn:(tmp_dir / "store.pack"));
+  (* After PR#1877, with the new IO refactoring, the file manager will upgrade the store
+     when it is opened (as above); store.pack then disappears to be replaced by
+     store.0.suffix; so the following "alco_check..." will then fail to find the
+     store.pack file. Presumably the version is actually bumped, so we should instead
+     check for that. However, the file manager doesn't expose a "get version" function,
+     and I couldn't immediately see how to get hold of the file manager at this point in
+     the code (we have just a value of type repo). *)
+  (* alco_check_version ~pos:__POS__ ~expected:`V1
+     ~actual:(io_get_version ~fn:(tmp_dir / "store.pack")); *)
   Lwt.return ()
 
 (** Open a V1 store RW mode, change something, version should bump to V2 *)


### PR DESCRIPTION
(See diff for comment)

This test is failing because after the upgrade to v3 format, there is no "store.pack" file (so we can't check the io version using the store.pack file). We should probably instead use the file manager to check the io version but: File_manager doesn't export a "get version" function; and at that point in the code we only have access to a value of type repo, and there is no obvious way to access the file manager at that point. 

Does anyone have a suggestion about what to do here?
