### PR TITLE
ci: add ocamlformat linter

### DIFF
--- a/.github/workflows/lint-fmt.yml
+++ b/.github/workflows/lint-fmt.yml
@@ -1,0 +1,19 @@
+name: Lint ocamlformat
+
+on: pull_request
+
+jobs:
+  lint-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml 4.13.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.13.x
+          dune-cache: true
+
+      - name: Lint fmt
+        uses: ocaml/setup-ocaml/lint-fmt@v2


### PR DESCRIPTION
I like automatically formatted code, but sometimes my editor doesn't auto-format (separate issue... 😅). This PR adds a GitHub action from [setup-ocaml](https://github.com/ocaml/setup-ocaml#lint-fmt) to ensure consistent formatting. 🎉 

You can see an example failure in [this test PR](https://github.com/metanivek/irmin/pull/1).

My only open question: should we limit the scope of the pull request trigger to only `main`? My reason for leaving it for all PRs is that it could be useful for PRs against feature branches as well.