### PR TITLE
Fix to_bin_string bug

### DIFF
--- a/src/irmin-pack/unix/control_file.ml
+++ b/src/irmin-pack/unix/control_file.ml
@@ -76,7 +76,12 @@ module Data = struct
 
   let size_of = Irmin.Type.Size.custom_dynamic ~of_value ~of_encoding ()
   let bin = (encode_bin, decode_bin, size_of)
-  let t = Irmin.Type.like t ~bin
+
+  let t =
+    (* [unboxed_bin] is necessary here.
+       See https://github.com/mirage/repr/issues/97 *)
+    Irmin.Type.like t ~bin ~unboxed_bin:bin
+
   let of_bin_string = Irmin.Type.of_bin_string t |> Irmin.Type.unstage
   let to_bin_string = Irmin.Type.to_bin_string t |> Irmin.Type.unstage
 end


### PR DESCRIPTION
I noticed that the hexdump of a control file wasn't right. I investigated with @fabbing and found the issue.