### PR TITLE
Fix irmin-tezos cli

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -477,12 +477,17 @@ struct
       let of_encoding s off =
         let offref = ref off in
         let kind = decode_bin_kind s offref in
+        let magic_len = 1 in
         match kind with
         | Pack_value.Kind.Inode_v1_unstable | Inode_v1_stable ->
-            1 + dynamic_size_of_v_encoding s !offref
+            let vlen = dynamic_size_of_v_encoding s !offref in
+            magic_len + vlen
         | Inode_v2_root | Inode_v2_nonroot ->
-            let len = decode_bin_int s offref in
-            len - H.hash_size
+            let before = !offref in
+            let vlen = decode_bin_int s offref in
+            let after = !offref in
+            let lenlen = after - before in
+            magic_len + lenlen + vlen
         | Commit_v1 | Commit_v2 | Contents -> assert false
         | Dangling_parent_commit -> assert false
       in

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -146,14 +146,14 @@ let check_tree_1 tree =
 
 let check_1 t c =
   S.Commit.of_key t.repo (S.Commit.key c) >>= function
-  | None -> Alcotest.fail "no hash found in repo"
+  | None -> Alcotest.fail "no hash found in repo for check_1"
   | Some commit ->
       let tree = S.Commit.tree commit in
       check_tree_1 tree
 
 let check_2 t c =
   S.Commit.of_key t.repo (S.Commit.key c) >>= function
-  | None -> Alcotest.fail "no hash found in repo"
+  | None -> Alcotest.fail "no hash found in repo for check_2"
   | Some commit ->
       let tree = S.Commit.tree commit in
       let* () = check_blob tree [ "a"; "d" ] "Mars" in
@@ -162,21 +162,21 @@ let check_2 t c =
 
 let check_3 t c =
   S.Commit.of_key t.repo (S.Commit.key c) >>= function
-  | None -> Alcotest.fail "no hash found in repo"
+  | None -> Alcotest.fail "no hash found in repo for check_3"
   | Some commit ->
       let tree = S.Commit.tree commit in
       check_blob tree [ "a"; "f" ] "Fevrier"
 
 let check_4 t c =
   S.Commit.of_key t.repo (S.Commit.key c) >>= function
-  | None -> Alcotest.fail "no hash found in repo"
+  | None -> Alcotest.fail "no hash found in repo for check_4"
   | Some commit ->
       let tree = S.Commit.tree commit in
       check_blob tree [ "a"; "e" ] "Mars"
 
 let check_5 t c =
   S.Commit.of_key t.repo (S.Commit.key c) >>= function
-  | None -> Alcotest.fail "no hash found in repo"
+  | None -> Alcotest.fail "no hash found in repo for check_5"
   | Some commit ->
       let tree = S.Commit.tree commit in
       let* () = check_blob tree [ "e"; "a" ] "Avril" in
@@ -186,7 +186,7 @@ let check_5 t c =
 
 let check_del_1 t c =
   S.Commit.of_key t.repo (S.Commit.key c) >>= function
-  | None -> Alcotest.fail "no hash found in repo"
+  | None -> Alcotest.fail "no hash found in repo for check_del_1"
   | Some commit ->
       let tree = S.Commit.tree commit in
       check_none tree [ "a"; "c" ]

--- a/test/irmin-tezos/stat.t/run.t
+++ b/test/irmin-tezos/stat.t/run.t
@@ -1,0 +1,17 @@
+Running stat on a v3 store
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/pack
+  >> Getting statistics for store: `../data/pack'
+  
+  mits": 3,
+      "nb_nodes": 16,
+      "nb_contents": 3
+    }
+  }
+
+Running index-integrity-check on a v3 store minimal
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/pack
+  >> Beginning index checking with parameters: { log_size = 2500000 }
+  in-fsck: internal error, uncaught exception:
+              (Failure "Kind.of_magic: unexpected magic char '\\000'")
+              
+  [125]

--- a/test/irmin-tezos/stat.t/run.t
+++ b/test/irmin-tezos/stat.t/run.t
@@ -1,17 +1,32 @@
 Running stat on a v3 store
-  $ STORE=PACK ../irmin_fsck.exe stat ../data/pack
-  >> Getting statistics for store: `../data/pack'
-  
-  mits": 3,
-      "nb_nodes": 16,
-      "nb_contents": 3
-    }
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/pack 2>&1 | cat -e
+  >> Getting statistics for store: `../data/pack'$
+  $
+  ^[[?25l                                                                               ^M                                                                               ^M$
+  ^[[?25h{$
+    "hash_size": {$
+      "Bytes": 64$
+    },$
+    "log_size": 2500000,$
+    "objects": {$
+      "nb_commits": 3,$
+      "nb_nodes": 16,$
+      "nb_contents": 3$
+    }$
   }
 
 Running index-integrity-check on a v3 store minimal
-  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/pack
-  >> Beginning index checking with parameters: { log_size = 2500000 }
-  in-fsck: internal error, uncaught exception:
-              (Failure "Kind.of_magic: unexpected magic char '\\000'")
-              
-  [125]
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/pack 2>&1 | cat -e
+  >> Beginning index checking with parameters: { log_size = 2500000 }$
+  ^[[?25lChecking index    0.0 B   00:00 [-----------------------------------------]   0%^MChecking index    1.7 KiB 00:00 [#########################################] 100%^M$
+  ^[[?25h>> Success in 452us. Store statistics:$
+    { "Commit_v1" = 0;$
+      "Commit_v2" = 3;$
+      "Contents" = 3;$
+      "Inode_v1_unstable" = 0;$
+      "Inode_v1_stable" = 0;$
+      "Inode_v2_root" = 12;$
+      "Inode_v2_nonroot" = 4;$
+      "Dangling_parent_commit" = 0;$
+      "Duplicated entries" = 0;$
+      "Missing entries" = 0 }$


### PR DESCRIPTION
The irmin-tezos cli (and `./tezos-node storage`) are broken, they cannot read stores containing v2 inodes. 

We used to have tests for the cli but we removed them at some point and forgot to put them back. I add them back, but their output is truncated, not sure why. 

This bug occurs on the gc branch (and its fixed there by this PR as well), but since its unrelated to gc and the bug is already in the released versions, I don't think it should block the progress on the gc.