### PR TITLE
Traverse gced pack stores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,12 @@
 - **irmin-pack**
   - Fix data race in RO instances when reading control file (#2100, @Ngoguey42)
 
+### Fixed
+
+- **irmin-pack**
+  - Fix the traverse pack files commands in the `irmin-tezos` CLI to work with
+    gced stores. (#1919, @icristescu)
+
 ## 3.4.1 (2022-09-07)
 
 ### Added

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -584,6 +584,7 @@ module Maker (Config : Conf.S) = struct
 
     module Traverse_pack_file = Traverse_pack_file.Make (struct
       module File_manager = File_manager
+      module Dispatcher = Dispatcher
       module Hash = H
       module Index = Index
       module Inode = X.Node.CA

--- a/src/irmin-pack/unix/import.ml
+++ b/src/irmin-pack/unix/import.ml
@@ -63,3 +63,11 @@ end
 let iter_k f (x : 'a) =
   let rec k x = f ~k x in
   k x
+
+module Varint = struct
+  type t = int [@@deriving irmin ~decode_bin]
+
+  (** LEB128 stores 7 bits per byte. An OCaml [int] has at most 63 bits.
+      [63 / 7] equals [9]. *)
+  let max_encoded_size = 9
+end

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -17,14 +17,6 @@
 open Import
 include Pack_store_intf
 
-module Varint = struct
-  type t = int [@@deriving irmin ~decode_bin]
-
-  (** LEB128 stores 7 bits per byte. An OCaml [int] has at most 63 bits.
-      [63 / 7] equals [9]. *)
-  let max_encoded_size = 9
-end
-
 exception Invalid_read of string
 exception Corrupted_store of string
 exception Dangling_hash

--- a/test/irmin-pack/test_existing_stores.ml
+++ b/test/irmin-pack/test_existing_stores.ml
@@ -21,8 +21,10 @@ let src = Logs.Src.create "tests.integrity_checks" ~doc:"Test integrity checks"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let config ?(readonly = false) ?(fresh = true) root =
-  Irmin_pack.config ~readonly ~index_log_size:1000 ~fresh root
+let config ?(readonly = false) ?(fresh = true)
+    ?(indexing_strategy = Irmin_pack.Indexing_strategy.always) root =
+  Irmin_pack.config ~readonly ~index_log_size:1000 ~indexing_strategy ~fresh
+    root
 
 let archive =
   [
@@ -59,6 +61,15 @@ struct
        S.Branch.find repo branch >>= function
        | None -> Alcotest.failf "Couldn't find expected branch `%s'" branch
        | Some commit -> check_commit repo commit bindings
+
+  let commit_of_string repo c =
+    match Irmin.Type.of_string S.Hash.t c with
+    | Ok x -> (
+        let* commit = S.Commit.of_hash repo x in
+        match commit with
+        | None -> Alcotest.fail "could not find commit in store"
+        | Some x -> Lwt.return x)
+    | _ -> Alcotest.fail "could not read hash"
 end
 
 module Small_conf = struct
@@ -98,17 +109,7 @@ module Test_reconstruct = struct
 
   let setup_test_env () =
     setup_test_env ~root_archive:root_v1_archive ~root_local_build:root_v1;
-    rm_dir tmp;
-    let cmd =
-      Filename.quote_command "cp" [ "-R"; "-p"; root_v1_archive; tmp ]
-    in
-    exec_cmd cmd |> function
-    | Ok () -> ()
-    | Error n ->
-        Fmt.failwith
-          "Failed to set up the test environment: command `%s' exited with \
-           non-zero exit code %d"
-          cmd n
+    setup_test_env ~root_archive:root_v1_archive ~root_local_build:tmp
 
   let test_reconstruct () =
     let module Kind = Irmin_pack.Pack_value.Kind in
@@ -190,37 +191,72 @@ module Test_corrupted_inode = struct
 
   let setup_test_env () = setup_test_env ~root_archive ~root_local_build:root
 
+  module S = V1 ()
+  include Test (S)
+
   let test () =
     setup_test_env ();
-    let module S = V1 () in
     let* rw = S.Repo.v (config ~fresh:false root) in
-    let get_head c =
-      match Irmin.Type.of_string S.Hash.t c with
-      | Ok x -> (
-          let* commit = S.Commit.of_hash rw x in
-          match commit with
-          | None -> Alcotest.fail "could not find commit in store"
-          | Some x -> Lwt.return [ x ])
-      | _ -> Alcotest.fail "could not read hash"
-    in
     [%log.app "integrity check of inodes on a store with one corrupted inode"];
     let c2 = "8d89b97726d9fb650d088cb7e21b78d84d132c6e" in
-    let* heads = get_head c2 in
-    let* result = S.integrity_check_inodes ~heads rw in
+    let* c2 = commit_of_string rw c2 in
+    let* result = S.integrity_check_inodes ~heads:[ c2 ] rw in
     (match result with
     | Ok _ ->
         Alcotest.failf
           "Store is corrupted for second commit, the check should fail"
     | Error _ -> ());
     let c1 = "1b1e259ca4e7bb8dc32c73ade93d8181c29cebe6" in
-    let* heads = get_head c1 in
-    let* result = S.integrity_check_inodes ~heads rw in
+    let* c1 = commit_of_string rw c1 in
+    let* result = S.integrity_check_inodes ~heads:[ c1 ] rw in
     (match result with
     | Error _ ->
         Alcotest.fail
           "Store is not corrupted for first commit, the check should not fail."
     | Ok _ -> ());
     S.Repo.close rw
+end
+
+module Test_traverse_gced = struct
+  let root_archive, root_local_build =
+    let open Fpath in
+    ( v "test" / "irmin-pack" / "data" / "version_3_minimal" |> to_string,
+      v "_build" / "test_reconstruct" |> to_string )
+
+  let setup_test_env () = setup_test_env ~root_archive ~root_local_build
+
+  module S = V2 ()
+  include Test (S)
+
+  let commit_and_gc conf =
+    let* repo = S.Repo.v conf in
+    let* commit =
+      commit_of_string repo "22e159de13b427226e5901defd17f0c14e744205"
+    in
+    let tree = S.Commit.tree commit in
+    let* tree = S.Tree.add tree [ "abba"; "baba" ] "x" in
+    let* commit = S.Commit.v repo ~info:S.Info.empty ~parents:[] tree in
+    let commit_key = S.Commit.key commit in
+    let* _launched = S.Gc.start_exn ~unlink:false repo commit_key in
+    let* result = S.Gc.finalise_exn ~wait:true repo in
+    let* () =
+      match result with
+      | `Running -> Alcotest.fail "expected finalised gc"
+      (* consider `Idle as success because gc can finalise during commit as well *)
+      | `Idle | `Finalised _ -> Lwt.return_unit
+    in
+    S.Repo.close repo
+
+  let test_traverse_pack () =
+    let module Kind = Irmin_pack.Pack_value.Kind in
+    setup_test_env ();
+    let conf =
+      config ~readonly:false ~fresh:false
+        ~indexing_strategy:Irmin_pack.Indexing_strategy.minimal root_local_build
+    in
+    let* () = commit_and_gc conf in
+    S.test_traverse_pack_file `Check_index conf;
+    Lwt.return_unit
 end
 
 let tests =
@@ -233,4 +269,6 @@ let tests =
         Test_corrupted_stores.test);
     Alcotest_lwt.test_case "Test integrity check for inodes" `Quick
       (fun _switch -> Test_corrupted_inode.test);
+    Alcotest_lwt.test_case "Test traverse pack on gced store" `Quick
+      (fun _switch -> Test_traverse_gced.test_traverse_pack);
   ]


### PR DESCRIPTION
The traverse_pack_files on v2 stores are anyway broken https://github.com/mirage/irmin/pull/1903. But even more so on gced stores: the traversal of the suffix file needs to read gced objects, without knowing their size. 

We will need to come back to this once we have the good gc. 