### PR TITLE
irmin: expose `Tree.seq`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- **irmin**
+  - Add `Tree.seq` to `Tree`'s public API (#1923, @metanivek)
+
 ### Changed
 
 - **irmin**

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -1779,7 +1779,7 @@ module Make (P : Backend.S) = struct
     | None -> Lwt.return 0
     | Some n -> Node.length ~cache:true n
 
-  let seq t ?offset ?length ~cache path : (step * t) Seq.t Lwt.t =
+  let seq t ?offset ?length ?(cache = true) path =
     [%log.debug "Tree.seq %a" pp_path path];
     sub ~cache "seq.sub" t path >>= function
     | None -> Lwt.return Seq.empty

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -181,6 +181,15 @@ module type S = sig
       [cache] defaults to [true], see {!Contents.caching} for an explanation of
       the parameter. *)
 
+  val seq :
+    t ->
+    ?offset:int ->
+    ?length:int ->
+    ?cache:bool ->
+    path ->
+    (step * t) Seq.t Lwt.t
+  (** [seq t key] follows the same behavior as {!list} but returns a sequence. *)
+
   val get : t -> path -> contents Lwt.t
   (** Same as {!get_all} but ignore the metadata. *)
 


### PR DESCRIPTION
Closes #1257 

The implementation of `Tree.seq` already exists. This PR adds it to `Tree`'s public API.