### PR TITLE
Pack store lru on offsets

### DIFF
--- a/bench/irmin-pack/trace_replay_intf.ml
+++ b/bench/irmin-pack/trace_replay_intf.ml
@@ -30,6 +30,9 @@ module Config = struct
     keep_stat_trace : bool;
     empty_blobs : bool;
     return_type : 'a return_type;
+    gc_every : int;
+    gc_distance_in_the_past : int;
+    gc_wait_after : int;
   }
   (** Replay configuration
 
@@ -61,7 +64,20 @@ module Config = struct
       blobs, instead of their actual value read in the trace.
 
       [inode_config] is a pair of ints that will be stored in the results of the
-      replay. *)
+      replay.
+
+      A GC is triggered every [gc_every] commits. When GC is triggered, we
+      select a previous commit that is [gc_distance_in_the_past] commits away
+      from the current head commit.
+
+      The first GC will be started after [gc_distance_in_the_past + 1] commits
+      were replayed. [gc_distance_in_the_past] only makes sense if [gc_every] is
+      not [0].
+
+      [gc_wait_after] defines how many commits separate the start of a GC and
+      the moment we block to wait for it to finish. [0] means that we will only
+      block when the next gc starts or at the end of the replay. This parameter
+      only makes sense if [gc_every] is not [0]. *)
 end
 
 module type Config = module type of Config
@@ -70,8 +86,14 @@ include Config
 
 module type Store = sig
   type store_config
+  type key
 
-  include Irmin.Generic_key.KV with type Schema.Contents.t = bytes
+  include
+    Irmin.Generic_key.KV
+      with type Schema.Contents.t = bytes
+       and type commit_key = key
+       and type node_key = key
+       and type contents_key = key
 
   type on_commit := int -> Hash.t -> unit Lwt.t
   type on_end := unit -> unit Lwt.t

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -38,10 +38,9 @@ struct
   module Key = Pack_key.Make (Hash)
 
   module Lru = Irmin.Backend.Lru.Make (struct
-    include Hash
+    include Int63
 
-    let hash = Hash.short_hash
-    let equal = Irmin.Type.(unstage (equal Hash.t))
+    let hash = Hashtbl.hash
   end)
 
   type file_manager = Fm.t
@@ -95,6 +94,16 @@ struct
             assert false)
     | None ->
         corrupted_store "Unexpected object %a missing from index" pp_hash hash
+
+  let offset_of_key t k =
+    match Pack_key.inspect k with
+    | Direct { offset; _ } -> offset
+    | Indexed hash ->
+        let entry_span = get_entry_span_from_index_exn t hash in
+        (* Cache the offset and length information in the existing key: *)
+        Pack_key.promote_exn k ~offset:entry_span.offset
+          ~length:entry_span.length;
+        entry_span.offset
 
   module Entry_prefix = struct
     type t = {
@@ -233,7 +242,7 @@ struct
   let unsafe_mem t k =
     [%log.debug "[pack] mem %a" pp_key k];
     Tbl.mem t.staging (Key.to_hash k)
-    || Lru.mem t.lru (Key.to_hash k)
+    || Lru.mem t.lru (offset_of_key t k)
     || pack_file_contains_key t k
 
   let mem t k =
@@ -297,7 +306,7 @@ struct
       in
       Some v
 
-  let find_in_pack_file ~check_integrity t key hash =
+  let find_in_pack_file ~check_integrity t key =
     let loc, { offset; length } =
       match Pack_key.inspect key with
       | Direct { offset; length; _ } ->
@@ -328,7 +337,7 @@ struct
     else
       match io_read_and_decode_if_not_gced ~off:offset ~len:length t with
       | Some v ->
-          Lru.add t.lru hash v;
+          Lru.add t.lru offset v;
           (if check_integrity then
            check_key key v |> function
            | Ok () -> ()
@@ -341,15 +350,16 @@ struct
   let unsafe_find ~check_integrity t k =
     [%log.debug "[pack] find %a" pp_key k];
     let hash = Key.to_hash k in
+    let off = offset_of_key t k in
     let location, value =
       match Tbl.find t.staging hash with
       | v ->
-          Lru.add t.lru hash v;
+          Lru.add t.lru off v;
           (Stats.Pack_store.Staging, Some v)
       | exception Not_found -> (
-          match Lru.find t.lru hash with
+          match Lru.find t.lru off with
           | v -> (Stats.Pack_store.Lru, Some v)
-          | exception Not_found -> find_in_pack_file ~check_integrity t k hash)
+          | exception Not_found -> find_in_pack_file ~check_integrity t k)
     in
     Stats.report_pack_store ~field:location;
     value
@@ -406,6 +416,7 @@ struct
             Stats.incr_appended_offsets ();
             Some offset
         | Indexed hash -> (
+            (* TODO: Why don't we promote the key here? *)
             match Index.find (Fm.index t.fm) hash with
             | None ->
                 Stats.incr_appended_hashes ();
@@ -431,7 +442,7 @@ struct
           Index.add ~overcommit (Fm.index t.fm) hash (off, len, kind)
       in
       Tbl.add t.staging hash v;
-      Lru.add t.lru hash v;
+      Lru.add t.lru off v;
       [%log.debug "[pack] append done %a <- %a" pp_hash hash pp_key key];
       key
     in

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -10,6 +10,8 @@ module Store = struct
   module Store = Irmin_tezos.Store
   include Store
 
+  type key = commit_key
+
   let create_repo ~root () =
     (* make sure the parent dir exists *)
     let () =
@@ -68,7 +70,10 @@ let replay_1_commit () =
       keep_store = false;
       keep_stat_trace = false;
       empty_blobs = false;
-      return_type = Summary (* TODO: Run gc every 1 *);
+      return_type = Summary;
+      gc_every = 0;
+      gc_distance_in_the_past = 0;
+      gc_wait_after = 0;
     }
   in
   let+ summary = Replay.run () replay_config in
@@ -104,6 +109,8 @@ module Store_mem = struct
   module Maker = Irmin_pack_mem.Maker (Conf)
   module Store = Maker.Make (Irmin_tezos.Schema)
   include Store
+
+  type key = commit_key
 
   let create_repo ~root () =
     let conf = Irmin_pack.config ~readonly:false ~fresh:true root in
@@ -143,6 +150,9 @@ let replay_1_commit_mem () =
       keep_stat_trace = false;
       empty_blobs = false;
       return_type = Summary;
+      gc_every = 0;
+      gc_distance_in_the_past = 0;
+      gc_wait_after = 0;
     }
   in
   let+ summary = Replay_mem.run () replay_config in


### PR DESCRIPTION
On top of #1922

Fixes #1844

Fixes #1920

This will have to be released as a 3.3.1 because the former code could create patterns in the store that will cause crash after GC.

@icristescu Is working on a regression test. 

A replay of 10k commits from genesis shows that the number of cache_miss stays roughly equivalent.

```
 |                          |  before  |     after
 | --                       | --       | --
 | -- main metrics --       |          | 
 | CPU time elapsed         |    1m24s |    1m24s 100%
 | Wall time elapsed        |    1m34s |    1m27s  92%
 | TZ-transactions per sec  |  106.083 |  106.486 100%
 | TZ-operations per sec    | 1196.450 | 1200.996 100%
 | Context.set per sec      | 8548.792 | 8581.276 100%
 | tail latency (1)         |  3.216 s |  2.181 s  68%
 |                          |          | 
 | -- resource usage --     |          | 
 | disk IO (total)          |          | 
 |   IOPS (op/sec)          |   27_936 |   28_554 102%
 |   throughput (bytes/sec) |  2.435 M |  2.469 M 101%
 |   total (bytes)          |  0.205 G |  0.207 G 101%
 | disk IO (read)           |          | 
 |   IOPS (op/sec)          |   27_327 |   27_943 102%
 |   throughput (bytes/sec) |  1.250 M |  1.279 M 102%
 |   total (bytes)          |  0.105 G |  0.107 G 102%
 | disk IO (write)          |          | 
 |   IOPS (op/sec)          |      609 |      611 100%
 |   throughput (bytes/sec) |  1.185 M |  1.189 M 100%
 |   total (bytes)          |  0.100 G |  0.100 G 100%
 |                          |          | 
 | max memory usage         |  1.001 G |  1.001 G 100%
 | mean CPU usage           |      89% |      97%     

 - (1) Longest Context.commit.
 - The "per sec" stats are calculated over CPU time.
 - "TZ-transactions" and "TZ-operations" are approximations.
 - "max memory usage" is the max size of OCaml's major heap.
 - "mean CPU usage" is inexact.

-- global --
 |                              |        | min per block | max per block  | avg per block |  avg per sec
 |                              |        |               |                |               | 
 | Add count                    | before |        3      |   123_869      |   71.987      |  7650.628     
 |                              | after  |        3 100% |   123_869 100% |   71.987 100% |  8293.185 108%
 | Remove count                 | before |        0      |    15_385      |    4.684      |   497.826     
 |                              | after  |        0      |    15_385 100% |    4.684 100% |   539.637 108%
 | Find count                   | before |        2      |    76_663      |  225.012      | 23913.687     
 |                              | after  |        2 100% |    76_663 100% |  225.012 100% | 25922.136 108%
 | Mem count                    | before |        0      |    93_342      |   53.579      |  5694.206     
 |                              | after  |        0      |    93_342 100% |   53.579 100% |  6172.448 108%
 | Mem_tree count               | before |        0      |        33      |   32.993      |  3506.460     
 |                              | after  |        0      |        33 100% |   32.993 100% |  3800.959 108%
 | Copy count                   | before |        0      |         7      |    0.005      |     0.489     
 |                              | after  |        0      |         7 100% |    0.005 100% |     0.530 108%
 | Commit count                 | before |        1      |         1      |    1.000      |   106.278     
 |                              | after  |        1 100% |         1 100% |    1.000 100% |   115.204 108%
 |                              |        |               |                |               | 
 | Disk bytes read              | before |        0      |   2.405 M      |  0.011 M      |   1.119 M     
 |                              | after  |        0      |   2.405 M 100% |  0.011 M 102% |   1.237 M 111%
 | Disk bytes written           | before |  0.000 M      |  13.997 M      |  0.010 M      |   1.060 M     
 |                              | after  |  0.000 M 100% |  13.997 M 100% |  0.010 M 100% |   1.149 M 108%
 | Disk bytes both              | before |  0.000 M      |  14.722 M      |  0.021 M      |   2.179 M     
 |                              | after  |  0.000 M 100% |  14.722 M 100% |  0.021 M 101% |   2.386 M 109%
 |                              |        |               |                |               | 
 | Disk reads                   | before |        0      |    53_452      |  230.118      | 24456.340     
 |                              | after  |        0      |    53_452 100% |  234.410 102% | 27004.923 110%
 | Disk writes                  | before |        4      |        54      |    5.126      |   544.779     
 |                              | after  |        4 100% |        54 100% |    5.126 100% |   590.534 108%
 | Disk both                    | before |        4      |    53_460      |  235.244      | 25001.119     
 |                              | after  |        4 100% |    53_460 100% |  239.536 102% | 27595.457 110%
 |                              |        |               |                |               | 
 | pack.finds                   | before |        0      |    16_619      |  518.010      | 55052.880     
 |                              | after  |        0      |    16_619 100% |  518.010 100% | 59676.631 108%
 | pack.finds.from_staging      | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | pack.finds.from_lru          | before |        0      |    15_901      |  499.783      | 53115.790     
 |                              | after  |        0      |    15_901 100% |  498.156 100% | 57389.321 108%
 | pack.finds.from_pack_direct  | before |        0      |     7_025      |   18.227      |  1937.090     
 |                              | after  |        0      |     7_308 104% |   19.855 109% |  2287.310 118%
 | pack.finds.from_pack_indexed | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | pack.finds.missing           | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | pack.finds.cache_miss        | before |        0      |     7_025      |   18.227      |  1937.090     
 |                              | after  |        0      |     7_308 104% |   19.855 109% |  2287.310 118%
 | pack.appended_hashes         | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | pack.appended_offsets        | before |        2      |   251_296      |  424.821      | 45148.922     
 |                              | after  |        2 100% |   251_296 100% |  424.821 100% | 48940.865 108%
 | pack.inode_add               | before |        0      |     7_029      |   81.662      |  8678.822     
 |                              | after  |        0      |     7_029 100% |   81.662 100% |  9407.734 108%
 | pack.inode_remove            | before |        0      |       208      |    0.968      |   102.824     
 |                              | after  |        0      |       208 100% |    0.968 100% |   111.459 108%
 | pack.inode_of_seq            | before |        0      |   166_816      |   26.099      |  2773.697     
 |                              | after  |        0      |   166_816 100% |   26.099 100% |  3006.653 108%
 | pack.inode_of_raw            | before |        0      |     1_760      |  238.518      | 25349.072     
 |                              | after  |        0      |     1_760 100% |  238.518 100% | 27478.076 108%
 | pack.inode_rec_add           | before |        0      |    91_732      |   97.034      | 10312.596     
 |                              | after  |        0      |    91_732 100% |   97.034 100% | 11178.724 108%
 | pack.inode_rec_remove        | before |        0      |       242      |    1.206      |   128.150     
 |                              | after  |        0      |       242 100% |    1.206 100% |   138.913 108%
 | pack.inode_to_binv           | before |        0      |   210_370      |  109.394      | 11626.113     
 |                              | after  |        0      |   210_370 100% |  109.394 100% | 12602.560 108%
 | pack.inode_decode_bin        | before |        0      |     7_025      |   18.197      |  1933.944     
 |                              | after  |        0      |     7_308 104% |   19.299 106% |  2223.291 115%
 | pack.inode_encode_bin        | before |        0      |   188_594      |   99.781      | 10604.477     
 |                              | after  |        0      |   188_594 100% |   99.781 100% | 11495.119 108%
 |                              |        |               |                |               | 
 | tree.contents_hash           | before |        0      |    62_693      |   28.781      |  3058.744     
 |                              | after  |        0      |    62_693 100% |   28.781 100% |  3315.640 108%
 | tree.contents_find           | before |        0      |       749      |   93.497      |  9936.617     
 |                              | after  |        0      |       749 100% |   93.497 100% | 10771.168 108%
 | tree.contents_add            | before |        0      |    62_693      |   28.764      |  3057.012     
 |                              | after  |        0      |    62_693 100% |   28.764 100% |  3313.763 108%
 | tree.node_hash               | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | tree.node_mem                | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | tree.node_add                | before |        0      |   166_818      |   89.480      |  9509.764     
 |                              | after  |        0      |   166_818 100% |   89.480 100% | 10308.465 108%
 | tree.node_find               | before |        0      |     1_760      |  238.518      | 25349.072     
 |                              | after  |        0      |     1_760 100% |  238.518 100% | 27478.076 108%
 | tree.node_val_v              | before |        0      |   166_816      |   26.099      |  2773.718     
 |                              | after  |        0      |   166_816 100% |   26.099 100% |  3006.676 108%
 | tree.node_val_find           | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 | tree.node_val_list           | before |        0      |       326      |    4.428      |   470.587     
 |                              | after  |        0      |       326 100% |    4.428 100% |   510.110 108%
 |                              |        |               |                |               | 
 | index.cumu_data_bytes        | before |        0      |         0      |        0      |         0     
 |                              | after  |        0      |         0      |        0      |         0     
 |                              |        |               |                |               | 
 | gc.minor_words allocated     | before |  0.018 M      | 630.138 M      |  0.882 M      |  93.713 M     
 |                              | after  |  0.018 M 100% | 626.431 M  99% |  0.874 M  99% | 100.641 M 107%
 | gc.major_words allocated     | before |        0      |  45.608 M      |  0.063 M      |   6.695 M     
 |                              | after  |        0      |  45.819 M 100% |  0.063 M 100% |   7.229 M 108%
 | gc.minor_collections         | before |        0      |     2_411      |    3.367      |   357.794     
 |                              | after  |        0      |     2_397  99% |    3.335  99% |   384.239 107%
 | gc.major_collections         | before |        0      |        13      |    0.006      |     0.638     
 |                              | after  |        0      |        13 100% |    0.006  95% |     0.657 103%

 |                               |        |      min      |       max        |      avg
 |                               |        |               |                  | 
 | Block duration (s)            | before | 0.813 ms      |     5.338 s      |  9.409 ms     
 |                               | after  | 0.731 ms  90% |     3.904 s  73% |  8.680 ms  92%
 | Buildup duration (s)          | before | 0.389 ms      |     2.122 s      |  5.133 ms     
 |                               | after  | 0.382 ms  98% |     1.723 s  81% |  4.405 ms  86%
 | Commit duration (s)           | before | 0.117 ms      |     3.216 s      |  4.277 ms     
 |                               | after  | 0.104 ms  89% |     2.181 s  68% |  4.275 ms 100%
 |                               |        |               |                  | 
 | Add duration (s)              | before | 0.478 µs      |  322.171 ms      |  9.508 µs     
 |                               | after  | 0.472 µs  99% |  401.193 ms 125% |  9.656 µs 102%
 | Remove duration (s)           | before | 0.986 µs      |   39.159 ms      | 12.718 µs     
 |                               | after  | 1.002 µs 102% |    9.407 ms  24% |  8.757 µs  69%
 | Find duration (s)             | before | 0.223 µs      |   14.324 ms      | 11.127 µs     
 |                               | after  | 0.222 µs 100% | 1430.964 ms 100x |  9.369 µs  84%
 | Mem duration (s)              | before | 0.409 µs      | 1419.649 ms      | 13.400 µs     
 |                               | after  | 0.411 µs 100% |    6.984 ms 0.5% |  6.989 µs  52%
 | Mem_tree duration (s)         | before | 0.505 µs      |    5.436 ms      |  2.912 µs     
 |                               | after  | 0.511 µs 101% |    4.947 ms  91% |  3.010 µs 103%
 | Copy duration (s)             | before | 2.445 µs      |    1.354 ms      | 41.869 µs     
 |                               | after  | 2.291 µs  94% |    0.184 ms  14% | 15.749 µs  38%
 | Unseen duration (s)           | before | 0.363 ms      |     1.164 s      |  1.064 ms     
 |                               | after  | 0.340 ms  94% |     0.960 s  82% |  1.080 ms 102%
 |                               |        |               |                  | 
 | Major heap bytes after commit | before |  9.138 M      |  1000.641 M      | 523.847 M     
 |                               | after  |  9.138 M 100% |  1000.641 M 100% | 552.942 M 106%
 |                               |        |               |                  | 
 | CPU Usage                     | before |      12%      |        103%      |       94%     
 |                               | after  |      10%      |        100%      |       98%     

-- evolution through blocks --
 | Block played count *C                      |        | 0 (before) |      3350       |      6700       |   10000 (end)
 | Blocks progress *C                         |        |     0%     |       34%       |       67%       |      100%
 |                                            |        |            |                 |                 | 
 | Wall time elapsed *C                       | before |        0us |    32.253s      |     1min3s      |    1min34s     
 |                                            | after  |        0us |    23.586s  73% |    53.419s  84% |    1min26s  92%
 | CPU time elapsed *C                        | before |        0us |    29.394s      |    56.693s      |    1min24s     
 |                                            | after  |        0us |    23.544s  80% |    52.347s  92% |    1min23s 100%
 | CPU Usage *LA                              | before |        n/a |        92%      |        90%      |        98%     
 |                                            | after  |        n/a |       100%      |        98%      |        96%     
 |                                            |        |            |                 |                 | 
 | Approx. TZ-transaction count *C            | before |          0 |      2_080      |      5_532      |      8_933     
 |                                            | after  |          0 |      2_080 100% |      5_532 100% |      8_933 100%
 | Approx. TZ-operations count *C             | before |          0 |     32_224      |     66_745      |    100_750     
 |                                            | after  |          0 |     32_224 100% |     66_745 100% |    100_750 100%
 | Op count *C                                | before |          0 |  1_518_984      |  2_752_540      |  3_902_594     
 |                                            | after  |          0 |  1_518_984 100% |  2_752_540 100% |  3_902_594 100%
 |                                            |        |            |                 |                 | 
 | Commit per sec *LA *N                      | before |        n/a |    113.866      |     91.756      |    110.661     
 |                                            | after  |        n/a |    131.845 116% |    101.028 110% |    100.642  91%
 | Add per sec *LA *N                         | before |        n/a |   7724.495      |   5182.417      |   5639.293     
 |                                            | after  |        n/a |   8944.142 116% |   5706.138 110% |   5128.724  91%
 | Remove per sec *LA *N                      | before |        n/a |    467.165      |    273.327      |    182.001     
 |                                            | after  |        n/a |    540.927 116% |    300.948 110% |    165.523  91%
 | Find per sec *LA *N                        | before |        n/a |  26338.254      |  19585.191      |  22949.051     
 |                                            | after  |        n/a |  30496.892 116% |  21564.414 110% |  20871.295  91%
 | Mem per sec *LA *N                         | before |        n/a |   6333.563      |   3859.956      |   4060.901     
 |                                            | after  |        n/a |   7333.592 116% |   4250.032 110% |   3693.236  91%
 | Mem_tree per sec *LA *N                    | before |        n/a |   3757.594      |   3027.942      |   3651.822     
 |                                            | after  |        n/a |   4350.893 116% |   3333.937 110% |   3321.194  91%
 | Copy per sec *LA *N                        | before |        n/a |      0.739      |      0.527      |      0.743     
 |                                            | after  |        n/a |      0.856 116% |      0.581 110% |      0.675  91%
 |                                            |        |            |                 |                 | 
 | Add count per block *LA                    | before |        n/a |     67.838      |     56.481      |     50.960     
 |                                            | after  |        n/a |     67.838 100% |     56.481 100% |     50.960 100%
 | Remove count per block *LA                 | before |        n/a |      4.103      |      2.979      |      1.645     
 |                                            | after  |        n/a |      4.103 100% |      2.979 100% |      1.645 100%
 | Find count per block *LA                   | before |        n/a |    231.308      |    213.449      |    207.381     
 |                                            | after  |        n/a |    231.308 100% |    213.449 100% |    207.381 100%
 | Mem count per block *LA                    | before |        n/a |     55.623      |     42.068      |     36.697     
 |                                            | after  |        n/a |     55.623 100% |     42.068 100% |     36.697 100%
 | Mem_tree count per block *LA               | before |        n/a |     33.000      |     33.000      |     33.000     
 |                                            | after  |        n/a |     33.000 100% |     33.000 100% |     33.000 100%
 | Copy count per block *LA                   | before |        n/a |      0.006      |      0.006      |      0.007     
 |                                            | after  |        n/a |      0.006 100% |      0.006 100% |      0.007 100%
 |                                            |        |            |                 |                 | 
 | Block duration *LA                         | before |        n/a |   8.782 ms      |  10.898 ms      |   9.037 ms     
 |                                            | after  |        n/a |   7.585 ms  86% |   9.898 ms  91% |   9.936 ms 110%
 | Buildup duration *LA                       | before |        n/a |   4.758 ms      |   5.468 ms      |   5.335 ms     
 |                                            | after  |        n/a |   3.957 ms  83% |   4.249 ms  78% |   4.732 ms  89%
 | Commit duration *LA                        | before |        n/a |   4.024 ms      |   5.430 ms      |   3.702 ms     
 |                                            | after  |        n/a |   3.628 ms  90% |   5.649 ms 104% |   5.204 ms 141%
 |                                            |        |            |                 |                 | 
 | Add duration *LA                           | before |        n/a |   7.942 µs      |   9.465 µs      |  11.835 µs     
 |                                            | after  |        n/a |   9.326 µs 117% |  11.899 µs 126% |  14.182 µs 120%
 | Remove duration *LA                        | before |        n/a |  18.501 µs      |  23.403 µs      |  24.181 µs     
 |                                            | after  |        n/a |  14.855 µs  80% |  19.224 µs  82% |  20.208 µs  84%
 | Find duration *LA                          | before |        n/a |  11.600 µs      |  13.226 µs      |   8.952 µs     
 |                                            | after  |        n/a |   8.197 µs  71% |   9.514 µs  72% |  11.245 µs 126%
 | Mem duration *LA                           | before |        n/a |   7.381 µs      |  10.247 µs      |  35.101 µs     
 |                                            | after  |        n/a |   8.437 µs 114% |   9.786 µs  96% |  10.781 µs  31%
 | Mem_tree duration *LA                      | before |        n/a |   2.964 µs      |   2.287 µs      |   3.599 µs     
 |                                            | after  |        n/a |   2.915 µs  98% |   2.633 µs 115% |   3.558 µs  99%
 | Copy duration *LA                          | before |        n/a |  15.457 µs      | 260.993 µs      |  11.840 µs     
 |                                            | after  |        n/a |  15.310 µs  99% |  18.274 µs 7.0% |  14.163 µs 120%
 | Checkout duration *LA                      | before |        n/a |   6.341 µs      |   5.451 µs      |   4.755 µs     
 |                                            | after  |        n/a |   4.696 µs  74% |   7.984 µs 146% |   9.739 µs 205%
 |                                            |        |            |                 |                 | 
 | Disk bytes    read *C                      | before |    0.000 M |   20.024 M      |   62.779 M      |  105.266 M     
 |                                            | after  |    0.000 M |   20.395 M 102% |   64.246 M 102% |  107.335 M 102%
 | Disk bytes written *C                      | before |    0.000 M |   32.239 M      |   65.797 M      |   99.766 M     
 |                                            | after  |    0.000 M |   32.239 M 100% |   65.797 M 100% |   99.766 M 100%
 | Disk bytes    both *C                      | before |    0.000 M |   52.263 M      |  128.577 M      |  205.032 M     
 |                                            | after  |    0.000 M |   52.634 M 101% |  130.043 M 101% |  207.102 M 101%
 | Disk bytes read    per block *LA           | before |        n/a |      8_815      |     23_028      |     12_419     
 |                                            | after  |        n/a |      9_327 106% |     23_479 102% |     12_493 101%
 | Disk bytes written per block *LA           | before |        n/a |      7_972      |     10_676      |      9_570     
 |                                            | after  |        n/a |      7_972 100% |     10_676 100% |      9_570 100%
 | Disk bytes both    per block *LA           | before |        n/a |     16_788      |     33_704      |     21_990     
 |                                            | after  |        n/a |     17_300 103% |     34_155 101% |     22_063 100%
 | Disk bytes read    per sec *LA *N          | before |        n/a |    1.004 M      |    2.113 M      |    1.374 M     
 |                                            | after  |        n/a |    1.230 M 123% |    2.372 M 112% |    1.257 M  91%
 | Disk bytes written per sec *LA *N          | before |        n/a |    0.908 M      |    0.980 M      |    1.059 M     
 |                                            | after  |        n/a |    1.051 M 116% |    1.079 M 110% |    0.963 M  91%
 | Disk bytes both    per sec *LA *N          | before |        n/a |    1.912 M      |    3.093 M      |    2.433 M     
 |                                            | after  |        n/a |    2.281 M 119% |    3.451 M 112% |    2.220 M  91%
 |                                            |        |            |                 |                 | 
 | Disk read  count *C                        | before |          3 |    441_998      |  1_372_205      |  2_301_178     
 |                                            | after  |          3 |    449_738 102% |  1_402_673 102% |  2_344_107 102%
 | Disk write count *C                        | before |          4 |     17_398      |     34_946      |     51_264     
 |                                            | after  |          4 |     17_398 100% |     34_946 100% |     51_264 100%
 | Disk both  count *C                        | before |          7 |    459_396      |  1_407_151      |  2_352_442     
 |                                            | after  |          7 |    467_136 102% |  1_437_619 102% |  2_395_371 102%
 | Disk read  count per block *LA             | before |        n/a |    193.805      |    487.155      |    266.340     
 |                                            | after  |        n/a |    204.526 106% |    496.356 102% |    267.891 101%
 | Disk write count per block *LA             | before |        n/a |      5.551      |      5.174      |      4.843     
 |                                            | after  |        n/a |      5.551 100% |      5.174 100% |      4.843 100%
 | Disk both  count per block *LA             | before |        n/a |    199.357      |    492.329      |    271.183     
 |                                            | after  |        n/a |    210.077 105% |    501.530 102% |    272.734 101%
 | Disk read  count per sec *LA *N            | before |        n/a |     22_068      |     44_699      |     29_474     
 |                                            | after  |        n/a |     26_966 122% |     50_146 112% |     26_961  91%
 | Disk write count per sec *LA *N            | before |        n/a |        632      |        475      |        536     
 |                                            | after  |        n/a |        732 116% |        523 110% |        487  91%
 | Disk both  count per sec *LA *N            | before |        n/a |     22_700      |     45_174      |     30_009     
 |                                            | after  |        n/a |     27_698 122% |     50_669 112% |     27_449  91%
 |                                            |        |            |                 |                 | 
 | pack.appended_hashes per block *LA         | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | pack.appended_offsets per block *LA        | before |        n/a |    410.140      |    486.861      |    427.835     
 |                                            | after  |        n/a |    410.140 100% |    486.861 100% |    427.835 100%
 | pack.finds per block *LA                   | before |        n/a |    594.095      |    541.154      |    483.818     
 |                                            | after  |        n/a |    594.095 100% |    541.154 100% |    483.818 100%
 | pack.finds.from_staging per block *LA      | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | pack.finds.from_lru per block *LA          | before |        n/a |    580.604      |    481.299      |    455.553     
 |                                            | after  |        n/a |    576.968  99% |    478.496  99% |    454.618 100%
 | pack.finds.from_pack_direct per block *LA  | before |        n/a |     13.491      |     59.855      |     28.265     
 |                                            | after  |        n/a |     17.127 127% |     62.658 105% |     29.200 103%
 | pack.finds.from_pack_indexed per block *LA | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | pack.finds.missing per block *LA           | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | pack.finds.cache_miss per block *LA        | before |        n/a |     13.491      |     59.855      |     28.265     
 |                                            | after  |        n/a |     17.127 127% |     62.658 105% |     29.200 103%
 | pack.inode_add per block *LA               | before |        n/a |     53.798      |    111.741      |    106.730     
 |                                            | after  |        n/a |     53.798 100% |    111.741 100% |    106.730 100%
 | pack.inode_remove per block *LA            | before |        n/a |  1.658_472      |  0.873_446      |  0.614_557     
 |                                            | after  |        n/a |  1.658_472 100% |  0.873_446 100% |  0.614_557 100%
 | pack.inode_of_seq per block *LA            | before |        n/a |     13.181      |      9.439      |      5.746     
 |                                            | after  |        n/a |     13.181 100% |      9.439 100% |      5.746 100%
 | pack.inode_of_raw per block *LA            | before |        n/a |    259.860      |    242.541      |    238.124     
 |                                            | after  |        n/a |    259.860 100% |    242.541 100% |    238.124 100%
 | pack.inode_rec_add per block *LA           | before |        n/a |     62.443      |    119.689      |    110.829     
 |                                            | after  |        n/a |     62.443 100% |    119.689 100% |    110.829 100%
 | pack.inode_rec_remove per block *LA        | before |        n/a |  2.118_358      |  1.184_256      |  0.718_439     
 |                                            | after  |        n/a |  2.118_358 100% |  1.184_256 100% |  0.718_439 100%
 | pack.inode_to_binv per block *LA           | before |        n/a |     76.051      |    112.011      |    101.037     
 |                                            | after  |        n/a |     76.051 100% |    112.011 100% |    101.037 100%
 | pack.inode_decode_bin per block *LA        | before |        n/a |     13.491      |     59.855      |     28.112     
 |                                            | after  |        n/a |     16.975 126% |     61.837 103% |     28.461 101%
 | pack.inode_encode_bin per block *LA        | before |        n/a |     65.523      |    104.708      |     96.039     
 |                                            | after  |        n/a |     65.523 100% |    104.708 100% |     96.039 100%
 |                                            |        |            |                 |                 | 
 | tree.contents_hash per block *LA           | before |        n/a |     19.574      |     28.271      |     25.126     
 |                                            | after  |        n/a |     19.574 100% |     28.271 100% |     25.126 100%
 | tree.contents_find per block *LA           | before |        n/a |    101.084      |     92.372      |     91.348     
 |                                            | after  |        n/a |    101.084 100% |     92.372 100% |     91.348 100%
 | tree.contents_add per block *LA            | before |        n/a |     19.527      |     28.258      |     25.119     
 |                                            | after  |        n/a |     19.527 100% |     28.258 100% |     25.119 100%
 | tree.node_hash per block *LA               | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | tree.node_mem per block *LA                | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | tree.node_add per block *LA                | before |        n/a |     54.075      |     97.152      |     90.601     
 |                                            | after  |        n/a |     54.075 100% |     97.152 100% |     90.601 100%
 | tree.node_find per block *LA               | before |        n/a |    259.860      |    242.541      |    238.124     
 |                                            | after  |        n/a |    259.860 100% |    242.541 100% |    238.124 100%
 | tree.node_val_v per block *LA              | before |        n/a |     13.181      |      9.439      |      5.746     
 |                                            | after  |        n/a |     13.181 100% |      9.439 100% |      5.746 100%
 | tree.node_val_find per block *LA           | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | tree.node_val_list per block *LA           | before |        n/a |  6.702_069      |  4.148_890      |  3.329_073     
 |                                            | after  |        n/a |  6.702_069 100% |  4.148_890 100% |  3.329_073 100%
 |                                            |        |            |                 |                 | 
 | index.nb_merge *C                          | before |          0 |          0      |          0      |          0     
 |                                            | after  |          0 |          0      |          0      |          0     
 | index.cumu_data_bytes *C                   | before |          0 |          0      |          0      |          0     
 |                                            | after  |          0 |          0      |          0      |          0     
 | index.cumu_data_bytes per block *LA        | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 |                                            |        |            |                 |                 | 
 | gc.minor_words allocated *C                | before |    1.575 M | 3012.375 M      | 6003.336 M      | 8819.366 M     
 |                                            | after  |    1.575 M | 2985.369 M  99% | 5948.876 M  99% | 8737.529 M  99%
 | gc.minor_words allocated per block *LA     | before |        n/a |    898_268      |    904_600      |    802_171     
 |                                            | after  |        n/a |    890_562  99% |    896_002  99% |    794_033  99%
 | gc.promoted_words *C                       | before |    0.360 M |  217.561 M      |  423.024 M      |  616.093 M     
 |                                            | after  |    0.360 M |  217.456 M 100% |  422.565 M 100% |  613.694 M 100%
 | gc.major_words allocated *C                | before |    0.845 M |  223.841 M      |  433.462 M      |  630.759 M     
 |                                            | after  |    0.845 M |  223.735 M 100% |  433.003 M 100% |  628.360 M 100%
 | gc.major_words allocated per block *LA     | before |        n/a |     64_035      |     65_533      |     56_141     
 |                                            | after  |        n/a |     64_330 100% |     65_336 100% |     56_377 100%
 | gc.minor_collections *C                    | before |          7 |     11_507      |     22_923      |     33_673     
 |                                            | after  |          7 |     11_404  99% |     22_715  99% |     33_360  99%
 | gc.minor_collections per block *LA         | before |        n/a |  3.425_377      |  3.452_743      |  3.062_002     
 |                                            | after  |        n/a |  3.396_296  99% |  3.416_690  99% |  3.030_512  99%
 | gc.major_collections *C                    | before |          1 |         30      |         43      |         61     
 |                                            | after  |          1 |         30 100% |         42  98% |         58  95%
 | gc.major_collections per block *LA         | before |        n/a |  2.361e-03      |  5.972e-03      |  9.307e-03     
 |                                            | after  |        n/a |  2.933e-03 124% |  2.553e-03  43% |  8.164e-03  88%
 | gc.compactions *C                          | before |          0 |          0      |          0      |          1     
 |                                            | after  |          0 |          0      |          0      |          1 100%
 |                                            |        |            |                 |                 | 
 | gc.major heap bytes top *C                 | before |    9.138 M |  572.113 M      |  870.121 M      | 1000.641 M     
 |                                            | after  |    9.138 M |  572.113 M 100% |  756.625 M  87% | 1000.641 M 100%
 | gc.major heap bytes *LA                    | before |    9.138 M |  568.156 M      |  764.517 M      |  565.214 M     
 |                                            | after  |    9.138 M |  568.156 M 100% |  664.796 M  87% |  371.868 M  66%
 |                                            |        |            |                 |                 | 
 | index_data bytes *S                        | before |          0 |          0      |          0      |          0     
 |                                            | after  |          0 |          0      |          0      |          0     
 | index_data bytes per block *LA             | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | store_pack bytes *S                        | before |          0 |          0      |          0      |          0     
 |                                            | after  |          0 |          0      |          0      |          0     
 | store_pack bytes per block *LA             | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | index_log bytes *S                         | before |         32 |    142_689      |    293_439      |    441_939     
 |                                            | after  |         32 |    142_689 100% |    293_439 100% |    441_939 100%
 | index_log_async *S                         | before |          0 |          0      |          0      |          0     
 |                                            | after  |          0 |          0      |          0      |          0     
 | store_dict bytes *S                        | before |          0 |  1_338_810      |  1_466_952      |  1_548_250     
 |                                            | after  |          0 |  1_338_810 100% |  1_466_952 100% |  1_548_250 100%
 |                                            |        |            |                 |                 | 
 | /data/contracts/index *S                   | before |        n/a |          3      |          3      |          4     
 |                                            | after  |        n/a |          3 100% |          3 100% |          4 100%
 | /data/big_maps/index *S                    | before |        n/a |          0      |          0      |          0     
 |                                            | after  |        n/a |          0      |          0      |          0     
 | /data/rolls/index *S                       | before |        n/a |        256      |        256      |        256     
 |                                            | after  |        n/a |        256 100% |        256 100% |        256 100%
 | /data/rolls/owner/current *S               | before |        n/a |        256      |        256      |        256     
 |                                            | after  |        n/a |        256 100% |        256 100% |        256 100%
 | /data/commitments *S                       | before |        n/a |        256      |        256      |        256     
 |                                            | after  |        n/a |        256 100% |        256 100% |        256 100%
 | /data/contracts/index/ed25519 *S           | before |        n/a |        256      |        256      |        256     
 |                                            | after  |        n/a |        256 100% |        256 100% |        256 100%
 | /data/contracts/index/originated *S        | before |        n/a |        244      |        256      |        256     
 |                                            | after  |        n/a |        244 100% |        256 100% |        256 100%

Types of curves:
 *C: Cumulative. No smoothing.
 *LA: Local Average. Smoothed using a weighted sum of the value in the
      block and the exponentially decayed values of the previous blocks.
      Every 125.01 blocks, half of the past is forgotten.
 *S: Size. E.g. directory entries, file bytes. No smoothing.
 *N: Very noisy.



```


