### PR TITLE
irmin-pack: remove `Double_close error

### DIFF
--- a/src/irmin-pack/unix/errors_base.ml
+++ b/src/irmin-pack/unix/errors_base.ml
@@ -15,8 +15,7 @@
  *)
 
 type base_error =
-  [ `Double_close
-  | `File_exists of string
+  [ `File_exists of string
   | `Invalid_parent_directory
   | `No_such_file_or_directory
   | `Not_a_file

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -496,8 +496,7 @@ struct
       let path = Irmin_pack.Layout.V1_and_v2.pack ~root in
       match read_version_from_legacy_file path with
       | Ok v -> Ok v
-      | Error `Double_close | Error `Invalid_argument | Error `Read_on_closed ->
-          assert false
+      | Error `Invalid_argument | Error `Read_on_closed -> assert false
       | Error `No_such_file_or_directory -> Error `Invalid_layout
       | Error `Not_a_file -> Error `Invalid_layout
       | Error `Corrupted_legacy_file | Error `Read_out_of_bounds ->

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -56,7 +56,6 @@ module type S = sig
 
   type open_rw_error :=
     [ `Corrupted_control_file
-    | `Double_close
     | `File_exists of string
     | `Index_failure of string
     | `Invalid_argument
@@ -111,10 +110,7 @@ module type S = sig
       not be closed. *)
 
   type close_error :=
-    [ `Double_close
-    | `Index_failure of string
-    | `Io_misc of Io.misc_error
-    | `Pending_flush ]
+    [ `Index_failure of string | `Io_misc of Io.misc_error | `Pending_flush ]
 
   val close : t -> (unit, [> close_error ]) result
   (** Close all the files.
@@ -135,7 +131,6 @@ module type S = sig
 
   type reload_error :=
     [ `Corrupted_control_file
-    | `Double_close
     | `Index_failure of string
     | `Invalid_argument
     | `Io_misc of Io.misc_error
@@ -167,8 +162,7 @@ module type S = sig
   (** [version ~root] is the version of the files at [root]. *)
 
   type swap_error :=
-    [ `Double_close
-    | `Io_misc of Control.Io.misc_error
+    [ `Io_misc of Control.Io.misc_error
     | `No_such_file_or_directory
     | `Not_a_file
     | `Pending_flush

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -69,7 +69,7 @@ module Unix = struct
   type write_error =
     [ `Io_misc of misc_error | `Ro_not_allowed | `Write_on_closed ]
 
-  type close_error = [ `Io_misc of misc_error | `Double_close ]
+  type close_error = [ `Io_misc of misc_error ]
 
   type mkdir_error =
     [ `Io_misc of misc_error
@@ -144,11 +144,11 @@ module Unix = struct
 
   let close t =
     match t.closed with
-    | true -> Error `Double_close
+    | true -> Ok () (* no-op for already closed file *)
     | false -> (
-        t.closed <- true;
         try
           Unix.close t.fd;
+          t.closed <- true;
           Ok ()
         with Unix.Unix_error (e, s1, s2) -> Error (`Io_misc (e, s1, s2)))
 

--- a/src/irmin-pack/unix/io_intf.ml
+++ b/src/irmin-pack/unix/io_intf.ml
@@ -46,7 +46,7 @@ module type S = sig
   type write_error =
     [ `Io_misc of misc_error | `Ro_not_allowed | `Write_on_closed ]
 
-  type close_error = [ `Io_misc of misc_error | `Double_close ]
+  type close_error = [ `Io_misc of misc_error ]
 
   type mkdir_error =
     [ `Io_misc of misc_error

--- a/src/irmin-pack/unix/snapshot_intf.ml
+++ b/src/irmin-pack/unix/snapshot_intf.ml
@@ -50,8 +50,7 @@ module type Sigs = sig
       val close :
         t ->
         ( unit,
-          [> `Double_close
-          | `Index_failure of string
+          [> `Index_failure of string
           | `Io_misc of File_manager.Io.misc_error
           | `Pending_flush ] )
         result


### PR DESCRIPTION
A thought that I had while discussing errors earlier is that we should treat this as a no-op. This also fixes a subtle bug where a file could be considered closed even if the underlying call failed.