### PR TITLE
Add a utility ui for irmin packs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@
   - Add a `weight` parameter in the LRU implementation to bound
     memory usage (#2050, @samoht)
 
+- **irmin-tezos-utils**
+  - Add package `irmin-tezos-utils` containing a graphical tool for manual pack
+    files analysis. (#1939, @clecat)
+
 ### Changed
 
 - **irmin**

--- a/irmin-tezos-utils.opam
+++ b/irmin-tezos-utils.opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Gwenaelle@tarides.com"
+authors:      ["Gwenaëlle Lecat" "Nicolas Goguey"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+available: arch != "arm32" & arch != "x86_32"
+
+depends: [
+  "ocaml"       {>= "4.01.0"}
+  "dune"        {>= "2.9.0"}
+  "irmin-tezos" {= version}
+  "irmin-pack"  {= version}
+  "cmdliner"
+  "notty"       {>= "0.2.3"}
+  "hex"
+  "irmin-test"  {with-test & = version}
+  "alcotest"    {with-test}
+]
+
+synopsis: "Utils for Irmin tezos"
+description: """
+`Irmin-tezos-utils` defines useful binaries and libraries for
+an internal use of irmin, like inspecting tezos stores, pack
+files and such.
+"""

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -99,6 +99,18 @@ module type Sigs = sig
       (Key : Irmin.Key.S with type hash = Hash.t)
       (Commit : Irmin.Commit.Generic_key.S
                   with type node_key = Key.t
-                   and type commit_key = Key.t) :
-    S with type t = Commit.t and type hash = Hash.t and type key = Key.t
+                   and type commit_key = Key.t) : sig
+    include S with type t = Commit.t and type hash = Hash.t and type key = Key.t
+
+    module Commit_direct : sig
+      type address = Offset of int63 | Hash of hash [@@deriving irmin]
+
+      type t = {
+        node_offset : address;
+        parent_offsets : address list;
+        info : Commit.Info.t;
+      }
+      [@@deriving irmin]
+    end
+  end
 end

--- a/src/irmin-tezos-utils/dune
+++ b/src/irmin-tezos-utils/dune
@@ -1,0 +1,17 @@
+(executable
+ (public_name irmin-pack-inspect)
+ (package irmin-tezos-utils)
+ (name main)
+ (modules main parse show files import)
+ (libraries
+  irmin-pack
+  irmin-pack.unix
+  irmin-tezos
+  notty
+  notty.unix
+  index.unix
+  hex
+  ptime
+  cmdliner)
+ (preprocess
+  (pps ppx_repr)))

--- a/src/irmin-tezos-utils/files.ml
+++ b/src/irmin-tezos-utils/files.ml
@@ -1,0 +1,145 @@
+open Import
+module Kind = Irmin_pack.Pack_value.Kind
+
+module Varint = struct
+  type t = int [@@deriving repr ~decode_bin ~encode_bin]
+
+  (** LEB128 stores 7 bits per byte. An OCaml [int] has at most 63 bits.
+      [63 / 7] equals [9]. *)
+  let max_encoded_size = 9
+end
+
+module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
+  module Maker = Irmin_pack_unix.Maker (Conf)
+  module Store = Maker.Make (Schema)
+  module Hash = Store.Hash
+  module Key = Irmin_pack_unix.Pack_key.Make (Hash)
+  module Io = Irmin_pack_unix.Io.Unix
+  module Errs = Irmin_pack_unix.Io_errors.Make (Io)
+  module Control_file = Irmin_pack_unix.Control_file.Make (Io)
+  module Append_only_file = Irmin_pack_unix.Append_only_file.Make (Io) (Errs)
+  module Pack_index = Irmin_pack_unix.Index.Make (Hash)
+
+  module File_manager =
+    Irmin_pack_unix.File_manager.Make (Control_file) (Append_only_file)
+      (Append_only_file)
+      (Pack_index)
+      (Errs)
+
+  module Dispatcher = Irmin_pack_unix.Dispatcher.Make (File_manager)
+
+  module Inode = struct
+    module Value = Schema.Node (Key) (Key)
+    include Irmin_pack.Inode.Make_internal (Conf) (Hash) (Key) (Value)
+
+    type compress = Compress.t [@@deriving repr ~decode_bin]
+  end
+
+  module Commit = struct
+    module Value = struct
+      include Schema.Commit (Key) (Key)
+      module Info = Schema.Info
+    end
+
+    include Irmin_pack.Pack_value.Of_commit (Hash) (Key) (Value)
+
+    type compress = Commit_direct.t [@@deriving repr ~decode_bin]
+  end
+
+  type hash = Store.hash [@@deriving repr ~pp]
+  type key = Key.t [@@deriving repr ~pp]
+  type entry = [ `Contents | `Inode | `Commit ]
+
+  let max_bytes_needed_to_discover_length =
+    Hash.hash_size + 1 + Varint.max_encoded_size
+
+  let min_bytes_needed_to_discover_length = Hash.hash_size + 1
+
+  let decode_entry_header buffer =
+    let buffer = Bytes.unsafe_to_string buffer in
+    let i0 = 0 in
+
+    let imagic = i0 + Hash.hash_size in
+    let kind = Kind.of_magic_exn buffer.[imagic] in
+
+    let ilength = i0 + Hash.hash_size + 1 in
+    let pos_ref = ref ilength in
+    let suffix_length = Varint.decode_bin buffer pos_ref in
+    let length_length = !pos_ref - ilength in
+
+    (kind, Hash.hash_size + 1 + length_length + suffix_length)
+
+  let decode_entry_kind buffer =
+    let buffer = Bytes.unsafe_to_string buffer in
+    let i0 = 0 in
+    let imagic = i0 + Hash.hash_size in
+    Kind.of_magic_exn buffer.[imagic]
+
+  let decode_entry_len buffer =
+    let buffer = Bytes.unsafe_to_string buffer in
+    let i0 = 0 in
+    let ilength = i0 + Hash.hash_size + 1 in
+    let pos_ref = ref ilength in
+    let suffix_length = Varint.decode_bin buffer pos_ref in
+    let length_length = !pos_ref - ilength in
+    Hash.hash_size + 1 + length_length + suffix_length
+
+  let decode_entry dispatcher buffer off =
+    let accessor =
+      Dispatcher.create_accessor_from_range_exn dispatcher ~off
+        ~min_len:min_bytes_needed_to_discover_length
+        ~max_len:max_bytes_needed_to_discover_length
+    in
+    Dispatcher.read_exn dispatcher accessor buffer;
+    let kind, len = decode_entry_header buffer in
+    let accessor =
+      Dispatcher.create_accessor_exn dispatcher ~off ~len:Hash.hash_size
+    in
+    Dispatcher.read_exn dispatcher accessor buffer;
+    let hash = Bytes.sub_string buffer 0 Hash.hash_size in
+    let accessor = Dispatcher.create_accessor_exn dispatcher ~off ~len in
+    Dispatcher.read_exn dispatcher accessor buffer;
+    let content = Bytes.sub_string buffer 0 len in
+    (hash, kind, len, content)
+
+  let iter_store fm ~on_entry =
+    let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
+    let seq =
+      Dispatcher.create_sequential_accessor_seq dispatcher
+        ~min_header_len:min_bytes_needed_to_discover_length
+        ~max_header_len:max_bytes_needed_to_discover_length
+        ~read_len:decode_entry_len
+    in
+    let buffer = Bytes.create (4096 * 4096) in
+    let on_entry (off, accessor) =
+      Dispatcher.read_exn dispatcher accessor buffer;
+      let kind = decode_entry_kind buffer in
+      let entry =
+        match kind with
+        | Inode_v1_unstable | Inode_v1_stable | Commit_v1 -> assert false
+        | Dangling_parent_commit | Commit_v2 -> `Commit
+        | Contents -> `Contents
+        | Inode_v2_root | Inode_v2_nonroot -> `Inode
+      in
+      on_entry off entry
+    in
+    Seq.iter on_entry seq
+
+  let rec traverse_dict dict size buffer off acc =
+    if off < size then (
+      File_manager.Dict.read_exn dict buffer ~off ~len:4;
+      let len = Int32.to_int @@ Bytes.get_int32_be buffer 0 in
+      let off = Int63.(add off (of_int 4)) in
+      File_manager.Dict.read_exn dict buffer ~off ~len;
+      let str = Bytes.sub_string buffer 0 len in
+      let acc = str :: acc in
+      let off = Int63.(add off (of_int len)) in
+      traverse_dict dict size buffer off acc)
+    else acc
+
+  let load_dict (dict : File_manager.Dict.t) buffer =
+    let max_offset = File_manager.Dict.end_offset dict in
+    let off = Int63.zero in
+    let dict = traverse_dict dict max_offset buffer off [] in
+    List.rev dict
+end

--- a/src/irmin-tezos-utils/import.ml
+++ b/src/irmin-tezos-utils/import.ml
@@ -1,0 +1,5 @@
+module Int63 = struct
+  include Optint.Int63
+
+  let t = Irmin.Type.int63
+end

--- a/src/irmin-tezos-utils/main.ml
+++ b/src/irmin-tezos-utils/main.ml
@@ -1,0 +1,69 @@
+open Cmdliner
+
+(* Common arguments *)
+let store_path =
+  Arg.(
+    value
+    & opt string "."
+    & info [ "store_path" ]
+        ~doc:"the path to the irmin store files, default to `.`")
+
+let info_last_path =
+  Arg.(
+    value
+    & opt string "store.info.last"
+    & info [ "store_info_last" ]
+        ~doc:
+          "the path to the info file generated for last entries data, default \
+           to `store.info.last`")
+
+let info_next_path =
+  Arg.(
+    value
+    & opt string "store.info.next"
+    & info [ "store_info_next" ]
+        ~doc:
+          "the path to the info file generated for next entries data, default \
+           to `store.info.next`")
+
+let index_path =
+  Arg.(
+    value
+    & opt string "store.idx"
+    & info [ "store_idx" ]
+        ~doc:"the path to the index file generated, default to `store.index`")
+
+(* Command parse *)
+let parse_cmd =
+  let doc =
+    "parses a pack file and generates the associated .info & .idx files"
+  in
+  let info = Cmd.info "parse" ~doc in
+  Cmd.v info
+    Term.(
+      const Parse.main
+      $ store_path
+      $ info_last_path
+      $ info_next_path
+      $ index_path)
+
+(* Command show *)
+let show_cmd =
+  let doc = "graphical user interface for pack files inspection" in
+  let info = Cmd.info "show" ~doc in
+  Cmd.v info
+    Term.(
+      const Show.main
+      $ store_path
+      $ info_last_path
+      $ info_next_path
+      $ index_path)
+
+(* Main command *)
+let main_cmd =
+  let doc = "a visual tool for irmin pack files inspection" in
+  let info = Cmd.info "irmin-pack-inspect" ~version:"%%VERSION%%" ~doc in
+  let default = Term.(ret (const (`Help (`Pager, None)))) in
+  Cmd.group info ~default [ parse_cmd; show_cmd ]
+
+let () = exit (Cmd.eval ~catch:false main_cmd)

--- a/src/irmin-tezos-utils/parse.ml
+++ b/src/irmin-tezos-utils/parse.ml
@@ -1,0 +1,153 @@
+open Import
+open Files
+module Files = Make (Irmin_tezos.Conf) (Irmin_tezos.Schema)
+
+module Ring = struct
+  type t = { n : int; mutable i : int; a : int array }
+
+  let make n = { n; i = 0; a = Array.make n (-1) }
+
+  let add r x =
+    Array.set r.a r.i x;
+    r.i <- (r.i + 1) mod r.n
+
+  let get r i =
+    if i <= r.n then
+      let x = r.a.((r.i - i + r.n) mod r.n) in
+      if x <> -1 then Some x else None
+    else None
+end
+
+type ctx = { off : Int63.t; info : info }
+and info = { commits : int list; contents : int list; inodes : int list }
+
+let empty_info () = { commits = []; contents = []; inodes = [] }
+
+type info_ring = { commit : Ring.t; contents : Ring.t; inode : Ring.t }
+
+let info_ring () =
+  { commit = Ring.make 1000; contents = Ring.make 1000; inode = Ring.make 1000 }
+
+let ctx_buffer = Bytes.create (4096 * 4096)
+
+let dump_ctx fd ctx =
+  let idx = ref 0 in
+  let f s =
+    String.iteri (fun i c -> Bytes.set ctx_buffer (!idx + i) c) s;
+    idx := !idx + String.length s
+  in
+  let flag =
+    List.length ctx.info.commits
+    + Int.shift_left (List.length ctx.info.contents) 2
+    + Int.shift_left (List.length ctx.info.inodes) 4
+  in
+  Varint.encode_bin flag f;
+  List.iter (fun v -> Varint.encode_bin v f) ctx.info.commits;
+  List.iter (fun v -> Varint.encode_bin v f) ctx.info.contents;
+  List.iter (fun v -> Varint.encode_bin v f) ctx.info.inodes;
+  let _ = Unix.write fd ctx_buffer 0 !idx in
+  (!idx, ctx.off)
+
+let dump_idx fd i i2 off =
+  let idx = ref 0 in
+  let f s =
+    String.iteri (fun i c -> Bytes.set ctx_buffer (!idx + i) c) s;
+    idx := !idx + String.length s
+  in
+  Varint.encode_bin i f;
+  Varint.encode_bin i2 f;
+  Varint.encode_bin off f;
+  let _ = Unix.write fd ctx_buffer 0 !idx in
+  ()
+
+let dump_idxs fd n is is2 =
+  let idx = ref 0 in
+  let f s =
+    String.iteri (fun i c -> Bytes.set ctx_buffer (!idx + i) c) s;
+    idx := !idx + String.length s
+  in
+  Varint.encode_bin (n + 1) f;
+  let _ = Unix.write fd ctx_buffer 0 !idx in
+  let off = List.fold_left (fun acc (i, _) -> i + acc) 0 is2 in
+  let _ =
+    List.fold_left2
+      (fun (i, i2) (i', off) (i2', _) ->
+        dump_idx fd i (i2 - i2') (Int63.to_int off);
+        (i + i', i2 - i2'))
+      (0, off) is is2
+  in
+  ()
+
+let get_values r = List.filter_map (Ring.get r) [ 1; 10; 1000 ]
+
+let main store_path info_last_path info_next_path idx_path =
+  let conf = Irmin_pack.Conf.init store_path in
+  match Files.File_manager.open_ro conf with
+  | Error exn -> Fmt.pr "%a\n%!" Files.Errs.pp exn
+  | Ok fm ->
+      let info_fd =
+        Unix.openfile info_last_path Unix.[ O_RDWR; O_CREAT; O_TRUNC ] 0o644
+      in
+      let idxs = ref [] in
+      let offsets = ref [] in
+      let i = ref (-1) in
+      let last_info = ref (empty_info ()) in
+      let r = info_ring () in
+      let on_entry off entry =
+        incr i;
+        let ctx = { off; info = !last_info } in
+        (match entry with
+        | `Commit ->
+            Ring.add r.commit !i;
+            let commits = get_values r.commit in
+            last_info := { !last_info with commits }
+        | `Contents ->
+            Ring.add r.contents !i;
+            let contents = get_values r.contents in
+            last_info := { !last_info with contents }
+        | `Inode ->
+            Ring.add r.inode !i;
+            let inodes = get_values r.inode in
+            last_info := { !last_info with inodes });
+        let idx = dump_ctx info_fd ctx in
+        idxs := idx :: !idxs;
+        offsets := (entry, off) :: !offsets
+      in
+      Files.iter_store fm ~on_entry;
+      let entries = !i in
+      Unix.close info_fd;
+      let info_fd =
+        Unix.openfile info_next_path Unix.[ O_WRONLY; O_CREAT; O_TRUNC ] 0o644
+      in
+      let idxs2 = ref [] in
+      let i = ref (-1) in
+      let last_info = ref (empty_info ()) in
+      let r = info_ring () in
+      let get_next (entry, off) =
+        incr i;
+        let ctx = { off; info = !last_info } in
+        (match entry with
+        | `Commit ->
+            Ring.add r.commit (entries - !i);
+            let commits = get_values r.commit in
+            last_info := { !last_info with commits }
+        | `Contents ->
+            Ring.add r.contents (entries - !i);
+            let contents = get_values r.contents in
+            last_info := { !last_info with contents }
+        | `Inode ->
+            Ring.add r.inode (entries - !i);
+            let inodes = get_values r.inode in
+            last_info := { !last_info with inodes });
+        let idx = dump_ctx info_fd ctx in
+        idxs2 := idx :: !idxs2
+      in
+      List.iter get_next !offsets;
+      let idx_fd =
+        Unix.openfile idx_path Unix.[ O_WRONLY; O_CREAT; O_TRUNC ] 0o644
+      in
+      dump_idxs idx_fd entries (List.rev !idxs) !idxs2;
+      Unix.close idx_fd
+
+let main store_path info_last_path info_next_path index_path =
+  main store_path info_last_path info_next_path index_path

--- a/src/irmin-tezos-utils/show.ml
+++ b/src/irmin-tezos-utils/show.ml
@@ -1,0 +1,770 @@
+open Notty
+open Notty_unix
+open Import
+open Files
+module Files = Make (Irmin_tezos.Conf) (Irmin_tezos.Schema)
+
+type entry_content = {
+  hash : string;
+  kind : Kind.t;
+  off : Int63.t;
+  length : int;
+  contents : string;
+}
+
+type entry_ctx = { last : info; next : info }
+and info = { commit : int list; contents : int list; inode : int list }
+
+type context = {
+  info_last_fd : Unix.file_descr;
+  info_next_fd : Unix.file_descr;
+  idxs : (int * (Int63.t * Int63.t) * Int63.t) list;
+  fm : Files.File_manager.t;
+  dispatcher : Files.Dispatcher.t;
+  dict : string list;
+  max_entry : int;
+  max_offset : Int63.t;
+  mutable entry : int;
+  mutable entry_ctx : entry_ctx;
+  mutable entry_content : entry_content;
+  mutable x : int;
+  mutable y : int;
+}
+
+let buffer = Bytes.create (4096 * 4096)
+
+let get_entry c off =
+  let hash, kind, length, contents =
+    Files.decode_entry c.dispatcher buffer off
+  in
+  let hash = Result.get_ok @@ Base64.encode hash in
+  { hash; kind; off; length; contents }
+
+let read ~fd ~buffer ~fd_offset ~buffer_offset ~length =
+  let rec aux fd_offset buffer_offset length read_count =
+    let r =
+      Index_unix.Syscalls.pread ~fd ~fd_offset ~buffer ~buffer_offset ~length
+    in
+    let read_count = read_count + r in
+    if r = 0 then read_count (* end of file *)
+    else if r = length then read_count
+    else
+      (aux [@tailcall])
+        (Int63.add fd_offset (Int63.of_int r))
+        (buffer_offset + r) (length - r) read_count
+  in
+  aux fd_offset buffer_offset length 0
+
+let load_idxs fd =
+  let idx = ref 0 in
+  let _ =
+    read ~fd ~buffer ~fd_offset:Int63.zero ~buffer_offset:0
+      ~length:Varint.max_encoded_size
+  in
+  let buf = Bytes.unsafe_to_string buffer in
+  let max_entry = Varint.decode_bin buf idx in
+  let idxs =
+    List.init max_entry (fun i ->
+        let _ =
+          read ~fd ~buffer ~fd_offset:(Int63.of_int !idx) ~buffer_offset:0
+            ~length:(Varint.max_encoded_size * 3)
+        in
+        let buffer = Bytes.unsafe_to_string buffer in
+        let i' = ref 0 in
+        let off_last_info = Int63.of_int @@ Varint.decode_bin buffer i' in
+        let off_next_info = Int63.of_int @@ Varint.decode_bin buffer i' in
+        let off_pack = Int63.of_int @@ Varint.decode_bin buffer i' in
+        idx := !i' + !idx;
+        (i, (off_last_info, off_next_info), off_pack))
+  in
+  (max_entry, idxs)
+
+let load_entry fd_last fd_next (fd_offset_last, fd_offset_next) =
+  let _ =
+    read ~fd:fd_last ~buffer ~fd_offset:fd_offset_last ~buffer_offset:0
+      ~length:(Varint.max_encoded_size * 7)
+  in
+  let buf = Bytes.unsafe_to_string buffer in
+  let idx = ref 0 in
+  let flag = Varint.decode_bin buf idx in
+  let n = Int.logand flag 0b11 in
+  let commit = List.init n (fun _ -> Varint.decode_bin buf idx) in
+  let n = Int.shift_right_logical (Int.logand flag 0b1100) 2 in
+  let contents = List.init n (fun _ -> Varint.decode_bin buf idx) in
+  let n = Int.shift_right_logical (Int.logand flag 0b110000) 4 in
+  let inode = List.init n (fun _ -> Varint.decode_bin buf idx) in
+  let last = { commit; contents; inode } in
+  let _ =
+    read ~fd:fd_next ~buffer ~fd_offset:fd_offset_next ~buffer_offset:0
+      ~length:(Varint.max_encoded_size * 7)
+  in
+  let buf = Bytes.unsafe_to_string buffer in
+  let idx = ref 0 in
+  let flag = Varint.decode_bin buf idx in
+  let n = Int.logand flag 0b11 in
+  let commit = List.init n (fun _ -> Varint.decode_bin buf idx) in
+  let n = Int.shift_right_logical (Int.logand flag 0b1100) 2 in
+  let contents = List.init n (fun _ -> Varint.decode_bin buf idx) in
+  let n = Int.shift_right_logical (Int.logand flag 0b110000) 4 in
+  let inode = List.init n (fun _ -> Varint.decode_bin buf idx) in
+  let next = { commit; contents; inode } in
+  { last; next }
+
+let reload_context c i =
+  let _, off_info, off_pack = List.nth c.idxs i in
+  c.entry <- i;
+  c.entry_ctx <- load_entry c.info_last_fd c.info_next_fd off_info;
+  c.entry_content <- get_entry c off_pack
+
+let reload_context_with_off c off =
+  let entry, idx, _ =
+    Option.get
+    @@ List.find_opt (fun (_, _, off') -> Int63.equal off off') c.idxs
+  in
+  c.entry <- entry;
+  c.entry_ctx <- load_entry c.info_last_fd c.info_next_fd idx;
+  c.entry_content <- get_entry c off
+
+module Menu = struct
+  let button_attr b b' =
+    match (b, b') with
+    | true, true -> A.(bg lightwhite ++ fg black)
+    | true, false -> A.(fg lightwhite)
+    | false, true -> A.(fg @@ gray 16)
+    | false, false -> A.(fg @@ gray 8)
+
+  let button s a h =
+    let attr = button_attr a h in
+    I.string attr s
+
+  let back_str =
+    [|
+      ("◂──", "Go back by 1000 ");
+      ("◂─", "Go back by 10 ");
+      ("◂", "Go back by 1 ");
+    |]
+
+  let forth_str =
+    [|
+      ("▸", "Go forth by 1 ");
+      ("─▸", "Go forth by 10 ");
+      ("──▸", "Go forth by 1000 ");
+    |]
+
+  let gen_entry_buttons r c str =
+    let l = [ 1; 10; 1000 ] in
+    let f i c = reload_context c i in
+    Array.mapi
+      (fun i (button_txt, tooltip) ->
+        let i = if r then 2 - i else i in
+        let tooltip = tooltip ^ if i <> 0 then "entries" else "entry" in
+        let i = List.nth l i in
+        if r && c.entry - i >= 0 then
+          let e = c.entry - i in
+          (button button_txt true, f e, tooltip, Some e)
+        else if (not r) && c.entry + i < c.max_entry then
+          let e = c.entry + i in
+          (button button_txt true, f e, tooltip, Some e)
+        else (button button_txt false, (fun _ -> ()), tooltip, None))
+      str
+
+  let gen_buttons r s l str =
+    let f i c = if i <> -1 then reload_context c i in
+    Array.mapi
+      (fun i (button_txt, tooltip) ->
+        let i = if r then 2 - i else i in
+        let tooltip = tooltip ^ s ^ if i <> 0 then "s" else "" in
+        if i < List.length l then
+          let e = List.nth l i in
+          (button button_txt true, f e, tooltip, Some e)
+        else (button button_txt false, (fun _ -> ()), tooltip, None))
+      str
+
+  let text_button s = (button s true, (fun _ -> ()), s, None)
+
+  let b c =
+    [|
+      Array.concat
+        [
+          gen_entry_buttons true c back_str;
+          [| text_button "Entry  " |];
+          gen_entry_buttons false c forth_str;
+        ];
+      Array.concat
+        [
+          gen_buttons true "commit" c.entry_ctx.last.commit back_str;
+          [| text_button "Commit " |];
+          gen_buttons false "commit" c.entry_ctx.next.commit forth_str;
+        ];
+      Array.concat
+        [
+          gen_buttons true "content" c.entry_ctx.last.contents back_str;
+          [| text_button "Content" |];
+          gen_buttons false "content" c.entry_ctx.next.contents forth_str;
+        ];
+      Array.concat
+        [
+          gen_buttons true "inode" c.entry_ctx.last.inode back_str;
+          [| text_button "Inode  " |];
+          gen_buttons false "inode" c.entry_ctx.next.inode forth_str;
+        ];
+    |]
+
+  let buttons b ~x_off ~y_off x y =
+    let _, b =
+      Array.fold_left
+        (fun (y', acc) a ->
+          let l =
+            List.rev
+            @@ snd
+            @@ Array.fold_left
+                 (fun (x', acc) (f, _, _, _) ->
+                   (x' + 1, (f (x' = x && y' = y) |> I.pad ~l:1 ~t:0) :: acc))
+                 (0, []) a
+          in
+          (y' + 1, I.hcat l :: acc))
+        (0, []) b
+    in
+    I.(pad ~l:x_off ~t:y_off @@ vcat (List.rev b))
+
+  let bound m x = (x + m) mod m
+
+  let move b c = function
+    | `Left -> c.x <- bound (Array.length b.(c.y)) (c.x - 1)
+    | `Right -> c.x <- bound (Array.length b.(c.y)) (c.x + 1)
+    | `Up ->
+        c.y <- bound (Array.length b) (c.y - 1);
+        c.x <- bound (Array.length b.(c.y)) c.x
+    | `Down ->
+        c.y <- bound (Array.length b) (c.y + 1);
+        c.x <- bound (Array.length b.(c.y)) c.x
+end
+
+module Button = struct
+  type 'a t = { x : int; y : int; w : int; h : int; f : 'a }
+
+  let on_press (x, y) b =
+    if x >= b.x && x < b.x + b.w && y >= b.y && y < b.y + b.h then Some b.f
+    else None
+
+  let pad b x y = { b with x = b.x + x; y = b.y + y }
+end
+
+let menu_box h w =
+  let open I in
+  let bar = String.concat "" @@ List.init (w + 2) (fun _ -> "━") in
+  let t_bar = "┏" ^ bar ^ "┓" in
+  let m_bar = "┃" ^ String.make (w + 2) ' ' ^ "┃" in
+  let mf_bar = "┣" ^ bar ^ "┫" in
+  let b_bar = "┗" ^ bar ^ "┛" in
+  let middle =
+    I.vcat (List.init h (fun _ -> string A.(fg white ++ st bold) m_bar))
+  in
+  string A.(fg white ++ st bold) t_bar
+  <-> middle
+  <-> string A.(fg white ++ st bold) mf_bar
+  <-> string A.(fg white ++ st bold) m_bar
+  <-> string A.(fg white ++ st bold) b_bar
+
+let position_text c i =
+  match i with
+  | None -> I.empty
+  | Some i ->
+      let d = i - c.entry in
+      let entry_txt = if d = -1 || d = 1 then "entry" else "entries" in
+      let _, _, off_pack = List.nth c.idxs i in
+      let content = get_entry c off_pack in
+      let open I in
+      let color, text =
+        match content.kind with
+        | Commit_v1 | Commit_v2 -> (A.red, "Commit")
+        | Dangling_parent_commit -> (A.magenta, "Dangling commit")
+        | Contents -> (A.lightblue, "Contents")
+        | Inode_v1_unstable | Inode_v1_stable | Inode_v2_root | Inode_v2_nonroot
+          ->
+            (A.green, "Inode")
+      in
+      let arrow =
+        if d < 0 then
+          string A.(fg color ++ st bold) text
+          <|> string A.(fg lightwhite ++ st bold) " ◀━━━▪"
+        else
+          string A.(fg lightwhite ++ st bold) "▪━━━▶ "
+          <|> string A.(fg color ++ st bold) text
+      in
+      arrow
+      <-> void 0 1
+      <-> string
+            A.(fg lightwhite ++ st bold)
+            ("by " ^ Int.to_string (abs d) ^ " " ^ entry_txt)
+      <-> void 0 1
+      <-> string
+            A.(fg lightwhite ++ st bold)
+            ("to offset " ^ Int63.to_string off_pack)
+      |> pad ~l:30 ~t:1
+
+let position_box h w =
+  let open I in
+  let bar = String.concat "" @@ List.init (w + 2) (fun _ -> "━") in
+  let t_bar = "┏" ^ bar ^ "┓" in
+  let m_bar = "┃" ^ String.make (w + 2) ' ' ^ "┃" in
+  let b_bar = "┗" ^ bar ^ "┛" in
+  let middle =
+    I.vcat (List.init h (fun _ -> string A.(fg white ++ st bold) m_bar))
+  in
+  string A.(fg white ++ st bold) t_bar
+  <-> middle
+  <-> string A.(fg white ++ st bold) b_bar
+
+let show_commit c (commit : Files.Commit.Commit_direct.t) =
+  let node_txt = I.string A.(fg lightred ++ st bold) "Node:" in
+  let addr_show (addr : Files.Commit.Commit_direct.address) =
+    match addr with
+    | Offset addr -> (
+        let hit_or_miss =
+          List.find_opt (fun (_, _, off) -> Int63.equal addr off) c.idxs
+        in
+        match hit_or_miss with
+        | None ->
+            ( I.strf
+                ~attr:A.(fg lightwhite ++ st bold)
+                "Dangling entry (off %a)" Int63.pp addr,
+              [] )
+        | Some (idx, _, off_pack) ->
+            let img =
+              let content = get_entry c off_pack in
+              let open I in
+              let color, text =
+                match content.kind with
+                | Commit_v1 | Commit_v2 -> (A.red, "Commit")
+                | Dangling_parent_commit -> (A.magenta, "Dangling commit")
+                | Contents -> (A.lightblue, "Contents")
+                | Inode_v1_unstable | Inode_v1_stable | Inode_v2_root
+                | Inode_v2_nonroot ->
+                    (A.green, "Inode")
+              in
+              I.strf ~attr:A.(fg lightwhite ++ st bold) "Entry %d (" idx
+              <|> I.string A.(fg color ++ st bold) text
+              <|> I.strf
+                    ~attr:A.(fg lightwhite ++ st bold)
+                    ", off %a)" Int63.pp addr
+            in
+            ( img,
+              [
+                Button.
+                  {
+                    x = 0;
+                    y = 0;
+                    w = I.width img;
+                    h = 1;
+                    f = (fun c -> reload_context_with_off c addr);
+                  };
+              ] ))
+    | Hash _hash ->
+        (I.string A.(fg lightwhite ++ st bold) "Hash <should not happen>", [])
+  in
+  let node, node_button = addr_show commit.node_offset in
+  let parents_txt = I.string A.(fg lightred ++ st bold) "Parents:" in
+  let parents, parents_buttons =
+    match commit.parent_offsets with
+    | [] -> (I.string A.(fg lightwhite ++ st bold) "none", [])
+    | parents ->
+        let l_img, l_buttons =
+          List.split
+            (List.mapi
+               (fun i addr ->
+                 let node, node_button = addr_show addr in
+                 (node, List.map (fun b -> Button.pad b 0 i) node_button))
+               parents)
+        in
+        (I.hcat l_img, l_buttons)
+  in
+  let info_txt = I.string A.(fg lightred ++ st bold) "Info:" in
+  let info = commit.info in
+  let date =
+    Option.get
+    @@ Ptime.of_span
+    @@ Ptime.Span.of_int_s (Int64.to_int @@ Files.Store.Info.date info)
+  in
+  let info =
+    let open I in
+    string A.(fg lightwhite ++ st bold) "Author:"
+    <-> string A.(fg lightwhite ++ st bold) "Message:"
+    <-> string A.(fg lightwhite ++ st bold) "Date:"
+    <|> void 1 0
+    <|> (string A.(fg lightwhite ++ st bold) (Files.Store.Info.author info)
+        <-> string A.(fg lightwhite ++ st bold) (Files.Store.Info.message info)
+        <-> strf
+              ~attr:A.(fg lightwhite ++ st bold)
+              "%a" (Ptime.pp_human ()) date)
+  in
+  let open I in
+  let img = node_txt <-> (void 2 0 <|> node) <-> void 0 1 <-> parents_txt in
+  ( img
+    <-> (void 2 0 <|> parents)
+    <-> void 0 1
+    <-> info_txt
+    <-> (void 2 0 <|> info),
+    List.append
+      (List.map (fun b -> Button.pad b 2 1) node_button)
+      (List.map
+         (fun b -> Button.pad b 2 (I.height img))
+         (List.flatten parents_buttons)) )
+
+let show_inode c (inode : Files.Inode.compress) =
+  let open I in
+  let addr_show (addr : Files.Inode.Compress.address) =
+    match addr with
+    | Offset addr ->
+        let hit_or_miss =
+          List.find_opt (fun (_, _, off) -> Int63.equal addr off) c.idxs
+        in
+        let img =
+          match hit_or_miss with
+          | None ->
+              I.strf
+                ~attr:A.(fg lightwhite ++ st bold)
+                "Dangling entry (off %a)" Int63.pp addr
+          | Some (idx, _, off_pack) ->
+              let content = get_entry c off_pack in
+              let open I in
+              let color, text =
+                match content.kind with
+                | Commit_v1 | Commit_v2 -> (A.red, "Commit")
+                | Dangling_parent_commit -> (A.magenta, "Dangling commit")
+                | Contents -> (A.lightblue, "Contents")
+                | Inode_v1_unstable | Inode_v1_stable | Inode_v2_root
+                | Inode_v2_nonroot ->
+                    (A.green, "Inode")
+              in
+              I.strf ~attr:A.(fg lightwhite ++ st bold) "Entry %d (" idx
+              <|> I.string A.(fg color ++ st bold) text
+              <|> I.strf
+                    ~attr:A.(fg lightwhite ++ st bold)
+                    ", off %a)" Int63.pp addr
+        in
+
+        ( img,
+          [
+            Button.
+              {
+                x = 0;
+                y = 0;
+                w = I.width img;
+                h = 1;
+                f = (fun c -> reload_context_with_off c addr);
+              };
+          ] )
+    | Hash _hash ->
+        (I.string A.(fg lightwhite ++ st bold) "Hash <should not happen>", [])
+  in
+  let name (n : Files.Inode.Compress.name) =
+    match n with
+    | Indirect dict_key ->
+        let key = List.nth_opt c.dict dict_key in
+        strf
+          ~attr:A.(fg lightwhite ++ st bold)
+          "Indirect key: \'%a\' (%d)" (Fmt.option Fmt.string) key dict_key
+    | Direct step ->
+        strf ~attr:A.(fg lightwhite ++ st bold) "Direct key: %s" step
+  in
+  let value i (v : Files.Inode.Compress.value) =
+    let v, v_buttons =
+      match v with
+      | Contents (n, addr, ()) ->
+          let content, content_button = addr_show addr in
+          let img1 = string A.(fg lightred ++ st bold) "Contents:" in
+          let img2 = name n in
+          ( img1 <-> (void 2 0 <|> (img2 <-> content)),
+            List.map
+              (fun b -> Button.pad b 2 (I.height img1 + I.height img2))
+              content_button )
+      | Node (n, addr) ->
+          let node, node_button = addr_show addr in
+          let img1 = string A.(fg lightred ++ st bold) "Node:" in
+          let img2 = name n in
+          ( img1 <-> (void 2 0 <|> (img2 <-> node)),
+            List.map
+              (fun b -> Button.pad b 2 (I.height img1 + I.height img2))
+              node_button )
+    in
+    let img = strf ~attr:A.(fg lightred ++ st bold) "Value %d:" i in
+    ( img <-> (void 2 0 <|> v),
+      List.map (fun b -> Button.pad b 2 (I.height img)) v_buttons )
+  in
+  let ptr i (p : Files.Inode.Compress.ptr) =
+    let ptr, ptr_button = addr_show p.hash in
+    let img = strf ~attr:A.(fg lightred ++ st bold) "Ptr %d:" i <|> void 2 0 in
+    (img <|> ptr, List.map (fun b -> Button.pad b (I.width img) i) ptr_button)
+  in
+  let tree (t : Files.Inode.Compress.tree) =
+    let t_img, t_buttons = List.split (List.mapi ptr t.entries) in
+    let img =
+      string A.(fg lightred ++ st bold) "Tree:"
+      <-> (void 2 0
+          <|> strf ~attr:A.(fg lightwhite ++ st bold) "Depth: %d" t.depth)
+    in
+    ( img <-> vcat t_img,
+      List.map (fun b -> Button.pad b 0 (I.height img)) (List.flatten t_buttons)
+    )
+  in
+  let v (tv : Files.Inode.Compress.v) s =
+    let tv, tv_buttons =
+      match tv with
+      | Values l ->
+          let v, v_buttons = List.split (List.mapi value l) in
+          let _, v_buttons =
+            List.fold_left2
+              (fun (i, acc) img b ->
+                (i + I.height img, List.map (fun b -> Button.pad b 0 i) b :: acc))
+              (0, []) v v_buttons
+          in
+          (vcat v, List.flatten v_buttons)
+      | Tree t -> tree t
+    in
+    let img =
+      string A.(fg lightred ++ st bold) "Tagged:"
+      <-> (void 2 0 <|> string A.(fg lightwhite ++ st bold) s)
+      <-> void 0 1
+    in
+    (img <-> tv, List.map (fun b -> Button.pad b 0 (I.height img)) tv_buttons)
+  in
+  match inode.tv with
+  | V0_stable tv -> v tv "Stable"
+  | V0_unstable tv -> v tv "Unstable"
+  | V1_root tv -> v tv.v "Root"
+  | V1_nonroot tv -> v tv.v "Non root"
+
+let kind_color (kind : Kind.t) =
+  match kind with
+  | Commit_v1 | Commit_v2 -> A.red
+  | Dangling_parent_commit -> A.magenta
+  | Contents -> A.lightblue
+  | Inode_v1_unstable | Inode_v1_stable | Inode_v2_root | Inode_v2_nonroot ->
+      A.green
+
+let show_entry_content ~x_off ~y_off c =
+  let open I in
+  let hash =
+    I.string A.(fg lightred ++ st bold) "Hash:"
+    <-> (void 2 0 <|> I.string A.(fg lightwhite ++ st bold) c.entry_content.hash)
+  in
+  let kind =
+    I.string A.(fg lightred ++ st bold) "Kind:"
+    <-> (void 2 0
+        <|> I.strf
+              ~attr:A.(fg (kind_color c.entry_content.kind) ++ st bold)
+              "%a" Kind.pp c.entry_content.kind)
+  in
+  match c.entry_content.kind with
+  | Inode_v2_root | Inode_v2_nonroot ->
+      let decoded = I.string A.(fg lightred ++ st bold) "Decoded:" in
+      let inode, inode_buttons =
+        show_inode c
+        @@ Files.Inode.decode_bin_compress c.entry_content.contents (ref 0)
+      in
+      let hex = I.string A.(fg lightred ++ st bold) "Hexdump:" in
+      let entry_header = Files.Hash.hash_size + 1 in
+      let contents_len =
+        String.length c.entry_content.contents - entry_header
+      in
+      let contents =
+        String.sub c.entry_content.contents entry_header contents_len
+      in
+      let contents = Hex.hexdump_s @@ Hex.of_string contents in
+      let contents = String.split_on_char '\n' contents in
+      let entry_hexdump =
+        I.vcat
+        @@ List.map
+             (fun s ->
+               let s = Printf.sprintf "%S" s in
+               I.string A.(fg lightwhite ++ st bold) s)
+             contents
+      in
+      let img = hash <-> void 0 1 <-> kind <-> void 0 1 <-> decoded in
+      ( img
+        <-> (void 2 0 <|> inode)
+        <-> void 0 1
+        <-> hex
+        <-> (void 2 0 <|> entry_hexdump)
+        |> I.pad ~l:x_off ~t:y_off,
+        List.map
+          (fun b -> Button.pad b (x_off + 2) (y_off + I.height img))
+          inode_buttons )
+  | Commit_v2 | Dangling_parent_commit ->
+      let open I in
+      let entry_header = Files.Hash.hash_size + 2 in
+      let contents_len =
+        String.length c.entry_content.contents - entry_header
+      in
+      let contents =
+        String.sub c.entry_content.contents entry_header contents_len
+      in
+      let commit, commit_button =
+        show_commit c @@ Files.Commit.decode_bin_compress contents (ref 0)
+      in
+      let decoded = I.string A.(fg lightred ++ st bold) "Decoded:" in
+      let hex = I.string A.(fg lightred ++ st bold) "Hexdump:" in
+      let contents = Hex.hexdump_s @@ Hex.of_string contents in
+      let contents = String.split_on_char '\n' contents in
+      let entry_hexdump =
+        I.vcat
+        @@ List.map
+             (fun s ->
+               let s = Printf.sprintf "%S" s in
+               I.string A.(fg lightwhite ++ st bold) s)
+             contents
+      in
+      let img = hash <-> void 0 1 <-> kind <-> void 0 1 <-> decoded in
+      ( img
+        <-> (void 2 0 <|> commit)
+        <-> void 0 1
+        <-> hex
+        <-> (void 2 0 <|> entry_hexdump)
+        |> I.pad ~l:x_off ~t:y_off,
+        List.map
+          (fun b -> Button.pad b (x_off + 2) (y_off + I.height img))
+          commit_button )
+  | _ ->
+      let entry_header = Files.Hash.hash_size + 1 in
+      let contents_len =
+        String.length c.entry_content.contents - entry_header
+      in
+      let contents =
+        String.sub c.entry_content.contents entry_header contents_len
+      in
+      let decoded = I.string A.(fg lightred ++ st bold) "Decoded:" in
+      let entry_decoded = I.string A.(fg lightwhite ++ st bold) "n/a" in
+      let hex = I.string A.(fg lightred ++ st bold) "Hexdump:" in
+      let contents = Hex.hexdump_s @@ Hex.of_string contents in
+      let contents = String.split_on_char '\n' contents in
+      let entry_hexdump =
+        I.vcat
+        @@ List.map
+             (fun s ->
+               let s = Printf.sprintf "%S" s in
+               I.string A.(fg lightwhite ++ st bold) s)
+             contents
+      in
+      ( hash
+        <-> void 0 1
+        <-> kind
+        <-> void 0 1
+        <-> decoded
+        <-> (void 2 0 <|> entry_decoded)
+        <-> void 0 1
+        <-> hex
+        <-> (void 2 0 <|> entry_hexdump)
+        |> I.pad ~l:x_off ~t:y_off,
+        [] )
+
+let entry_pos c l t =
+  let open I in
+  string A.(fg lightyellow ++ st bold) "Entry:"
+  <|> void 1 0
+  <|> strf ~attr:A.(fg lightwhite ++ st bold) "%d/%d" c.entry (c.max_entry - 1)
+  </> void 30 0
+  <|> string A.(fg lightyellow ++ st bold) "Offset:"
+  <|> void 1 0
+  <|> strf
+        ~attr:A.(fg lightwhite ++ st bold)
+        "%a/%a" Int63.pp c.entry_content.off Int63.pp (Int63.pred c.max_offset)
+  |> pad ~l ~t
+
+let rec loop t c =
+  let buttons = Menu.b c in
+  let _, _, tooltip, move = buttons.(c.y).(c.x) in
+  let menu_text = Menu.buttons buttons ~x_off:1 ~y_off:1 c.x c.y in
+  let menu_box = menu_box (I.height menu_text - 1) (I.width menu_text - 2) in
+  let tooltip =
+    I.string A.(fg lightwhite ++ st bold) tooltip |> I.pad ~l:2 ~t:6
+  in
+  let position_text = position_text c move in
+  let position_box =
+    position_box (I.height menu_text + 1) (I.width position_text - 2)
+  in
+  let entries, entries_buttons = show_entry_content ~x_off:2 ~y_off:10 c in
+  let l =
+    [
+      menu_text;
+      tooltip;
+      menu_box;
+      position_text;
+      position_box;
+      entry_pos c 2 8;
+      entries;
+    ]
+  in
+  let b = I.zcat l in
+  Term.image t b;
+  match Term.event t with
+  | `End | `Key (`Escape, []) | `Key (`ASCII 'C', [ `Ctrl ]) -> ()
+  | `Key (`Arrow d, _) ->
+      Menu.move buttons c d;
+      loop t c
+  | `Key (`Enter, _) ->
+      let _, f, _, _ = buttons.(c.y).(c.x) in
+      f c;
+      loop t c
+  | `Mouse (`Press _, pos, _) ->
+      let l = List.filter_map (Button.on_press pos) entries_buttons in
+      List.iter (fun f -> f c) l;
+      loop t c
+  | _ -> loop t c
+
+let main store_path info_last_path info_next_path index_path =
+  let conf = Irmin_pack.Conf.init store_path in
+  let fm = Files.File_manager.open_ro conf |> Files.Errs.raise_if_error in
+  let dispatcher = Files.Dispatcher.v fm |> Files.Errs.raise_if_error in
+  let pl = Files.File_manager.Control.payload (Files.File_manager.control fm) in
+  let max_offset =
+    (* TODO: Rename [pl.entry_offset_suffix_end] to [suffix_length] *)
+    match pl.status with
+    | From_v1_v2_post_upgrade _ | From_v3_no_gc_yet
+    | From_v3_used_non_minimal_indexing_strategy ->
+        pl.entry_offset_suffix_end
+    | From_v3_gced x ->
+        Int63.add x.entry_offset_suffix_start pl.entry_offset_suffix_end
+    | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 | T11 | T12 | T13 | T14
+    | T15 ->
+        assert false
+  in
+
+  let dict = Files.File_manager.dict fm in
+  let dict = Files.load_dict dict buffer in
+  let info_last_fd =
+    Unix.openfile info_last_path Unix.[ O_RDONLY; O_CLOEXEC ] 0o644
+  in
+  let info_next_fd =
+    Unix.openfile info_next_path Unix.[ O_RDONLY; O_CLOEXEC ] 0o644
+  in
+  let idx_fd = Unix.openfile index_path Unix.[ O_RDONLY; O_CLOEXEC ] 0o644 in
+  (* let max_offset = Files.File_manager.Suffix.end_offset suffix in *)
+  let max_entry, idxs = load_idxs idx_fd in
+  Unix.close idx_fd;
+  let entry, off_info, off_pack = List.nth idxs 0 in
+  let entry_ctx = load_entry info_last_fd info_next_fd off_info in
+  let entry_content =
+    Obj.magic "TODO: cyclical deps between entry_content and context"
+  in
+  let context =
+    {
+      info_last_fd;
+      info_next_fd;
+      idxs;
+      fm;
+      dispatcher;
+      dict;
+      max_entry;
+      max_offset;
+      x = 3;
+      y = 0;
+      entry;
+      entry_ctx;
+      entry_content;
+    }
+  in
+  context.entry_content <- get_entry context off_pack;
+  loop (Term.create ()) context;
+  Unix.close info_last_fd;
+  Unix.close info_next_fd


### PR DESCRIPTION
This pull request aims to add a graphical ui tool to irmin for pack files. This tool comes into to 2 different binaries:
- The first one, `irmin-parse` iterates a first time on a pack file, parsing it and saving useful information in two `.info` and `.idx` files.
- The second one, `irmin-show`, uses those 2 files in addition to the pack file in order to provide a graphical interface allowing the user to navigate trough the entries of the said pack file.

The end goal is to make it easier to search for specific things in a pack file, for example in the long term, for corrupted information.

Because it did not have it's place in `irmin-unix`, I also created a more fitting `irmin-utils` package.

Right now, this project is an early bird and this pull request should stay as a draft until it is in a proper state, but the base of the project being already done, it will allow for feedback.

Latest screenshot:
![image](https://user-images.githubusercontent.com/24659882/180196748-9de24bc6-b7c6-4b3b-9835-e4c641e91d15.png)
