### PR TITLE
Io: abstract away fork/waitpid

### DIFF
--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -688,6 +688,10 @@ struct
     let* () = Io.write_string io ~off:Int63.zero out in
     Io.close io
 
+  type read_gc_output_error =
+    [ `Corrupted_gc_result_file of string | `Gc_process_error of string ]
+  [@@deriving irmin]
+
   let read_gc_output ~root ~generation =
     let open Result_syntax in
     let read_file () =

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -180,8 +180,9 @@ module type S = sig
   (** Used by the gc process at the end to write its output in
       store.<generation>.out. *)
 
-  type read_gc_output_error :=
+  type read_gc_output_error =
     [ `Corrupted_gc_result_file of string | `Gc_process_error of string ]
+  [@@deriving irmin]
 
   val read_gc_output :
     root:string -> generation:int -> (int63, [> read_gc_output_error ]) result

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -240,4 +240,100 @@ module Unix = struct
       Sys.remove path;
       Ok ()
     with Sys_error msg -> Error (`Sys_error msg)
+
+  (* Async using fork/waitpid*)
+
+  module Exit = struct
+    let proc_list = ref []
+    let m = Mutex.create ()
+
+    let add gc =
+      Mutex.lock m;
+      proc_list := gc :: !proc_list;
+      Mutex.unlock m
+
+    let remove gc =
+      Mutex.lock m;
+      proc_list := List.filter (fun gc' -> gc <> gc') !proc_list;
+      Mutex.unlock m
+
+    let clean_up () =
+      List.iter
+        (fun gc ->
+          try Unix.kill gc 9
+          with Unix.Unix_error (e, s1, s2) ->
+            [%log.warn
+              "Killing gc process with pid %d failed with error (%s, %s, %s)" gc
+                (Unix.error_message e) s1 s2])
+        !proc_list
+  end
+
+  (* Register function to be called when process terminates. If there is a gc
+     process running, make sure to terminate it. *)
+  let () = at_exit Exit.clean_up
+
+  type status = [ `Running | `Success | `Cancelled | `Failure of string ]
+  [@@deriving irmin]
+
+  type task = { pid : int; mutable status : status }
+
+  let async f =
+    Stdlib.flush_all ();
+    match Lwt_unix.fork () with
+    | 0 ->
+        Lwt_main.Exit_hooks.remove_all ();
+        Lwt_main.abandon_yielded_and_paused ();
+        f ();
+        (* Once the gc is finished, the child process kills itself to
+           avoid calling at_exit functions in upstream code. *)
+        Unix.kill (Unix.getpid ()) 9;
+        assert false (* unreachable *)
+    | pid ->
+        Exit.add pid;
+        { pid; status = `Running }
+
+  let status_of_process_status = function
+    | Lwt_unix.WSIGNALED -7 ->
+        `Success (* the child is killing itself when it's done *)
+    | Lwt_unix.WSIGNALED n -> `Failure (Fmt.str "Signaled %d" n)
+    | Lwt_unix.WEXITED n -> `Failure (Fmt.str "Exited %d" n)
+    | Lwt_unix.WSTOPPED n -> `Failure (Fmt.str "Stopped %d" n)
+
+  let cancel t =
+    let () =
+      match t.status with
+      | `Running ->
+          let pid, _ = Unix.waitpid [ Unix.WNOHANG ] t.pid in
+          (* Do not block if no child has died yet. In this case the waitpid
+             returns immediately with a pid equal to 0. *)
+          if pid = 0 then (
+            Unix.kill t.pid 9;
+            Exit.remove t.pid)
+      | _ -> ()
+    in
+    t.status <- `Cancelled
+
+  let status t : status =
+    match t.status with
+    | `Running ->
+        let pid, status = Unix.waitpid [ Unix.WNOHANG ] t.pid in
+        (* Do not block if no child has died yet. In this case the waitpid
+           returns immediately with a pid equal to 0. *)
+        if pid = 0 then `Running
+        else
+          let s = status_of_process_status status in
+          Exit.remove pid;
+          t.status <- s;
+          s
+    | s -> s
+
+  let await t =
+    match t.status with
+    | `Running ->
+        let+ pid, status = Lwt_unix.waitpid [] t.pid in
+        let s = status_of_process_status status in
+        Exit.remove pid;
+        t.status <- s;
+        s
+    | s -> Lwt.return s
 end

--- a/src/irmin-pack/unix/io_intf.ml
+++ b/src/irmin-pack/unix/io_intf.ml
@@ -125,6 +125,18 @@ module type S = sig
 
   val catch_misc_error :
     (unit -> 'a) -> ('a, [> `Io_misc of misc_error ]) result
+
+  (** Simple async/await *)
+
+  type task
+
+  type status = [ `Running | `Success | `Cancelled | `Failure of string ]
+  [@@deriving irmin]
+
+  val async : (unit -> unit) -> task
+  val await : task -> status Lwt.t
+  val status : task -> status
+  val cancel : task -> unit
 end
 
 module type Sigs = sig

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -717,9 +717,9 @@ module Concurrent_gc = struct
     let repo : S.Repo.t = t.repo in
     match (repo.during_gc : S.X.during_gc option) with
     | None -> Alcotest.failf "during_gc missing after call to start"
-    | Some { pid; _ } -> (
+    | Some { task; _ } -> (
         try
-          Unix.kill pid 9;
+          Irmin_pack_unix.Io.Unix.cancel task;
           true
         with Unix.Unix_error (Unix.ESRCH, "kill", _) -> false)
 
@@ -733,7 +733,7 @@ module Concurrent_gc = struct
         Alcotest.check_raises_lwt "Gc process killed"
           (Irmin_pack_unix.Errors.Pack_error
              (`Gc_process_died_without_result_file
-               "Signaled -7 \"No_such_file_or_directory\""))
+               "cancelled \"No_such_file_or_directory\""))
           (fun () -> finalise_gc t)
       else Lwt.return_unit
     in


### PR DESCRIPTION
On top of #1950 

That's the first step of using a different mechanism to synchronise the GC process with a different mechanism (for instance, but using `Lwt_preemptive.detach` or `Lwt_domain.detach` in OCaml 5).