### PR TITLE
irmin-pack: removed unused Gced kind for pack entries

### DIFF
--- a/src/irmin-pack/indexing_strategy.ml
+++ b/src/irmin-pack/indexing_strategy.ml
@@ -38,7 +38,7 @@ let minimal : t =
          indexed (as they may be referenced via hash by other V0 objects), and
          this must be accounted for when reconstructing the index. *)
       true
-  | Gced | Dangling_parent_commit -> assert false
+  | Dangling_parent_commit -> assert false
 
 let minimal_with_contents : t =
  fun ~value_length:_ -> function
@@ -47,6 +47,6 @@ let minimal_with_contents : t =
   | Inode_v2_nonroot -> false
   | Contents -> true
   | Commit_v1 | Inode_v1_unstable | Inode_v1_stable -> true
-  | Gced | Dangling_parent_commit -> assert false
+  | Dangling_parent_commit -> assert false
 
 let default = always

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -467,7 +467,7 @@ struct
           V1_nonroot { length; v }
       | Commit_v1 | Commit_v2 -> assert false
       | Contents -> assert false
-      | Gced | Dangling_parent_commit -> assert false
+      | Dangling_parent_commit -> assert false
 
     let size_of_tv =
       let of_encoding s off =
@@ -480,7 +480,7 @@ struct
             let len = decode_bin_int s offref in
             len - H.hash_size
         | Commit_v1 | Commit_v2 | Contents -> assert false
-        | Gced | Dangling_parent_commit -> assert false
+        | Dangling_parent_commit -> assert false
       in
       Irmin.Type.Size.custom_dynamic ~of_encoding ()
 

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -26,7 +26,6 @@ module Kind = struct
     | Inode_v1_stable
     | Inode_v2_root
     | Inode_v2_nonroot
-    | Gced
     | Dangling_parent_commit
 
   let to_magic = function
@@ -37,7 +36,6 @@ module Kind = struct
     | Inode_v1_stable -> 'N'
     | Inode_v2_root -> 'R'
     | Inode_v2_nonroot -> 'O'
-    | Gced -> 'Z'
     | Dangling_parent_commit -> 'P'
 
   let of_magic_exn = function
@@ -48,7 +46,6 @@ module Kind = struct
     | 'N' -> Inode_v1_stable
     | 'R' -> Inode_v2_root
     | 'O' -> Inode_v2_nonroot
-    | 'Z' -> Gced
     | 'P' -> Dangling_parent_commit
     | c -> Fmt.failwith "Kind.of_magic: unexpected magic char %C" c
 
@@ -61,7 +58,6 @@ module Kind = struct
       Inode_v1_stable;
       Inode_v2_root;
       Inode_v2_nonroot;
-      Gced;
       Dangling_parent_commit;
     ]
 
@@ -73,8 +69,7 @@ module Kind = struct
     | Inode_v1_stable -> 4
     | Inode_v2_root -> 5
     | Inode_v2_nonroot -> 6
-    | Gced -> 7
-    | Dangling_parent_commit -> 8
+    | Dangling_parent_commit -> 7
 
   let pp =
     Fmt.of_to_string (function
@@ -85,7 +80,6 @@ module Kind = struct
       | Inode_v1_stable -> "Inode_v1_stable"
       | Inode_v2_root -> "Inode_v2_root"
       | Inode_v2_nonroot -> "Inode_v2_nonroot"
-      | Gced -> "Gced"
       | Dangling_parent_commit -> "Dangling_parent_commit")
 
   let length_header_exn : t -> length_header =
@@ -97,7 +91,6 @@ module Kind = struct
     | Contents ->
         Fmt.failwith
           "Can't determine length header for user-defined codec Contents"
-    | Gced -> assert false
 
   let t = Irmin.Type.map ~pp Irmin.Type.char of_magic_exn to_magic
 end

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -73,7 +73,6 @@ module type Sigs = sig
       | Inode_v1_stable
       | Inode_v2_root
       | Inode_v2_nonroot
-      | Gced
       | Dangling_parent_commit
     [@@deriving irmin]
 

--- a/src/irmin-pack/unix/checks.ml
+++ b/src/irmin-pack/unix/checks.ml
@@ -79,7 +79,7 @@ module Make (Store : Store) = struct
           ->
             progress_nodes ()
         | Commit_v1 | Commit_v2 -> progress_commits ()
-        | Gced | Dangling_parent_commit -> assert false
+        | Dangling_parent_commit -> assert false
       in
       Index.iter f index;
       let nb_contents, nb_nodes, nb_commits =
@@ -368,7 +368,7 @@ module Index (Index : Pack_index.S) = struct
       | Commit_v1 | Commit_v2 ->
           progress_commits ();
           check ~kind:`Commit ~offset ~length k
-      | Gced | Dangling_parent_commit -> assert false
+      | Dangling_parent_commit -> assert false
     in
     let result =
       if auto_repair then

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -159,9 +159,6 @@ module Make (Args : Args) : S with module Args := Args = struct
     in
     iter_from_node_key_exn node_key node_store ~f k
 
-  (* TODO remove it*)
-  let _magic_gced = Pack_value.Kind.to_magic Pack_value.Kind.Gced
-
   (* Dangling_parent_commit are the parents of the gced commit. They are kept on
      disk in order to correctly deserialised the gced commit. *)
   let magic_parent =

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -187,7 +187,7 @@ struct
      object. *)
   let gced buf =
     let kind = Pack_value.Kind.of_magic_exn (Bytes.get buf Hash.hash_size) in
-    kind = Pack_value.Kind.Gced || kind = Pack_value.Kind.Dangling_parent_commit
+    kind = Pack_value.Kind.Dangling_parent_commit
 
   let io_read_and_decode_hash_if_not_gced ~off t =
     let len = Hash.hash_size + 1 in

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -170,7 +170,7 @@ module Make (Args : Args) = struct
                   (* The traversal starts with a node, it never iters over
                      commits. *)
                   assert false
-              | Gced | Dangling_parent_commit -> assert false)
+              | Dangling_parent_commit -> assert false)
       in
       (* In case the root node of a tree is indexed, we need to convert it to a
          direct key first. *)

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -192,7 +192,7 @@ end = struct
     | Commit_v1 | Commit_v2 -> Commit.decode_bin_length
     | Inode_v1_stable | Inode_v1_unstable | Inode_v2_root | Inode_v2_nonroot ->
         Inode.decode_bin_length
-    | Gced | Dangling_parent_commit -> assert false
+    | Dangling_parent_commit -> assert false
 
   let decode_entry_exn ~off ~buffer ~buffer_off =
     try


### PR DESCRIPTION
Fix #1956