### PR TITLE
irmin-pack: clarify uses of Bytes.unsafe_{to,of}_string

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -104,9 +104,11 @@ struct
     let key =
       match Conf.inode_child_order with
       | `Hash_bits ->
-          fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s)) (* possibly unsafe use of Bytes.unsafe_of_string? depends on what the rest of the code does; if we don't leak the bytes, and don't mutate them, maybe this is safe? not sure *)
+          fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s))
+          (* possibly unsafe use of Bytes.unsafe_of_string? depends on what the rest of the code does; if we don't leak the bytes, and don't mutate them, maybe this is safe? not sure *)
       | `Seeded_hash | `Custom _ ->
-          fun s -> Bytes.unsafe_of_string (step_to_bin_string s) (* as previous line - not sure *)
+          fun s -> Bytes.unsafe_of_string (step_to_bin_string s)
+    (* as previous line - not sure *)
 
     (* Assume [k = cryto_hash(step)] (see {!key}) and [Conf.entry] can
        can represented with [n] bits. Then, [hash_bits ~depth k] is

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -104,9 +104,9 @@ struct
     let key =
       match Conf.inode_child_order with
       | `Hash_bits ->
-          fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s))
+          fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s)) (* possibly unsafe use of Bytes.unsafe_of_string? depends on what the rest of the code does; if we don't leak the bytes, and don't mutate them, maybe this is safe? not sure *)
       | `Seeded_hash | `Custom _ ->
-          fun s -> Bytes.unsafe_of_string (step_to_bin_string s)
+          fun s -> Bytes.unsafe_of_string (step_to_bin_string s) (* as previous line - not sure *)
 
     (* Assume [k = cryto_hash(step)] (see {!key}) and [Conf.entry] can
        can represented with [n] bits. Then, [hash_bits ~depth k] is

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -104,11 +104,13 @@ struct
     let key =
       match Conf.inode_child_order with
       | `Hash_bits ->
+          (* Bytes.unsafe_of_string usage: possibly safe TODO justify safety, or switch to
+             use the safe Bytes.of_string *)
           fun s -> Bytes.unsafe_of_string (hash_to_bin_string (Step.hash s))
-          (* possibly unsafe use of Bytes.unsafe_of_string? depends on what the rest of the code does; if we don't leak the bytes, and don't mutate them, maybe this is safe? not sure *)
       | `Seeded_hash | `Custom _ ->
+          (* Bytes.unsafe_of_string usage: possibly safe TODO justify safety, or switch to
+             use the safe Bytes.of_string *)
           fun s -> Bytes.unsafe_of_string (step_to_bin_string s)
-    (* as previous line - not sure *)
 
     (* Assume [k = cryto_hash(step)] (see {!key}) and [Conf.entry] can
        can represented with [n] bits. Then, [hash_bits ~depth k] is

--- a/src/irmin-pack/unix/atomic_write.ml
+++ b/src/irmin-pack/unix/atomic_write.ml
@@ -33,7 +33,16 @@ module Make_persistent (K : Irmin.Type.S) (V : Value.S) = struct
     assert (n = 4);
     (file_pos := Int63.Syntax.(!file_pos + Int63.of_int 4));
     let pos_ref = ref 0 in
-    let v = decode_bin (Bytes.unsafe_to_string buf (* safe: buf is local, not leaked, not modified after call to decode_bin *)) pos_ref in 
+    (* Bytes.unsafe_to_string usage: We assume Io_legacy.read_block returns unique
+       ownership of buf back to this function (this assumption holds currently; subsequent
+       modifications of that code need to ensure this remains the case); then in call to
+       Bytes.unsafe_to_string we give up ownership of buf (we do not modify the buffer
+       afterwards) and get ownership of resulting string; so this use is safe. *)
+    let v =
+      decode_bin
+        (Bytes.unsafe_to_string buf (* safe: see comment above *))
+        pos_ref
+    in
     assert (!pos_ref = 4);
     Int32.to_int v
 

--- a/src/irmin-pack/unix/atomic_write.ml
+++ b/src/irmin-pack/unix/atomic_write.ml
@@ -33,7 +33,7 @@ module Make_persistent (K : Irmin.Type.S) (V : Value.S) = struct
     assert (n = 4);
     (file_pos := Int63.Syntax.(!file_pos + Int63.of_int 4));
     let pos_ref = ref 0 in
-    let v = decode_bin (Bytes.unsafe_to_string buf) pos_ref in
+    let v = decode_bin (Bytes.unsafe_to_string buf (* safe: buf is local, not leaked, not modified after call to decode_bin *)) pos_ref in 
     assert (!pos_ref = 4);
     Int32.to_int v
 

--- a/src/irmin-pack/unix/atomic_write.ml
+++ b/src/irmin-pack/unix/atomic_write.ml
@@ -38,11 +38,7 @@ module Make_persistent (K : Irmin.Type.S) (V : Value.S) = struct
        modifications of that code need to ensure this remains the case); then in call to
        Bytes.unsafe_to_string we give up ownership of buf (we do not modify the buffer
        afterwards) and get ownership of resulting string; so this use is safe. *)
-    let v =
-      decode_bin
-        (Bytes.unsafe_to_string buf (* safe: see comment above *))
-        pos_ref
-    in
+    let v = decode_bin (Bytes.unsafe_to_string buf) pos_ref in
     assert (!pos_ref = 4);
     Int32.to_int v
 

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -117,8 +117,10 @@ module Make (Args : Args) : S with module Args := Args = struct
       let len' = Int63.to_int len in
       read_exn ~off ~len:len' buffer;
       let () =
-        if len = buffer_size then append_exn (Bytes.unsafe_to_string buffer) (* likely unsafe: buffer passed in, subject to mutations; append_exn retains ref to string; buffer can then be mutated, altering string value in append_exn cache *)
-        else append_exn (String.sub (Bytes.unsafe_to_string buffer) 0 len') (* likely unsafe, as previous line *)
+        if len = buffer_size then append_exn (Bytes.unsafe_to_string buffer)
+          (* likely unsafe: buffer passed in, subject to mutations; append_exn retains ref to string; buffer can then be mutated, altering string value in append_exn cache *)
+        else append_exn (String.sub (Bytes.unsafe_to_string buffer) 0 len')
+        (* likely unsafe, as previous line *)
       in
       let len_remaining = len_remaining - len in
       if len_remaining > Int63.zero then aux (off + len) len_remaining
@@ -179,7 +181,12 @@ module Make (Args : Args) : S with module Args := Args = struct
     read_exn ~off ~len buffer;
     let poff = Dispatcher.poff_of_entry_exn ~off ~len mapping in
     Bytes.set buffer Hash.hash_size magic_parent;
-    write_exn ~off:poff ~len (Bytes.unsafe_to_string buffer) (* safe: buffer created locally, not leaked, not modified after call to write_exn *)
+    (* Bytes.unsafe_to_string usage: We assume read_exn returns unique ownership of buffer
+       to this function. Then at the call to Bytes.unsafe_to_string we give up unique
+       ownership to buffer (we do not modify it thereafter) in return for ownership of the
+       resulting string, which we pass to write_exn. This usage is safe. *)
+    write_exn ~off:poff ~len (Bytes.unsafe_to_string buffer)
+  (* safe: see comment above *)
 
   let create_new_suffix ~root ~generation =
     let open Result_syntax in

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -117,8 +117,8 @@ module Make (Args : Args) : S with module Args := Args = struct
       let len' = Int63.to_int len in
       read_exn ~off ~len:len' buffer;
       let () =
-        if len = buffer_size then append_exn (Bytes.unsafe_to_string buffer)
-        else append_exn (String.sub (Bytes.unsafe_to_string buffer) 0 len')
+        if len = buffer_size then append_exn (Bytes.unsafe_to_string buffer) (* likely unsafe: buffer passed in, subject to mutations; append_exn retains ref to string; buffer can then be mutated, altering string value in append_exn cache *)
+        else append_exn (String.sub (Bytes.unsafe_to_string buffer) 0 len') (* likely unsafe, as previous line *)
       in
       let len_remaining = len_remaining - len in
       if len_remaining > Int63.zero then aux (off + len) len_remaining
@@ -179,7 +179,7 @@ module Make (Args : Args) : S with module Args := Args = struct
     read_exn ~off ~len buffer;
     let poff = Dispatcher.poff_of_entry_exn ~off ~len mapping in
     Bytes.set buffer Hash.hash_size magic_parent;
-    write_exn ~off:poff ~len (Bytes.unsafe_to_string buffer)
+    write_exn ~off:poff ~len (Bytes.unsafe_to_string buffer) (* safe: buffer created locally, not leaked, not modified after call to write_exn *)
 
   let create_new_suffix ~root ~generation =
     let open Result_syntax in

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -184,7 +184,6 @@ module Make (Args : Args) : S with module Args := Args = struct
        ownership to buffer (we do not modify it thereafter) in return for ownership of the
        resulting string, which we pass to write_exn. This usage is safe. *)
     write_exn ~off:poff ~len (Bytes.unsafe_to_string buffer)
-  (* safe: see comment above *)
 
   let create_new_suffix ~root ~generation =
     let open Result_syntax in

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -117,10 +117,8 @@ module Make (Args : Args) : S with module Args := Args = struct
       let len' = Int63.to_int len in
       read_exn ~off ~len:len' buffer;
       let () =
-        if len = buffer_size then append_exn (Bytes.unsafe_to_string buffer)
-          (* likely unsafe: buffer passed in, subject to mutations; append_exn retains ref to string; buffer can then be mutated, altering string value in append_exn cache *)
-        else append_exn (String.sub (Bytes.unsafe_to_string buffer) 0 len')
-        (* likely unsafe, as previous line *)
+        if len = buffer_size then append_exn (Bytes.to_string buffer)
+        else append_exn (String.sub (Bytes.to_string buffer) 0 len')
       in
       let len_remaining = len_remaining - len in
       if len_remaining > Int63.zero then aux (off + len) len_remaining

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -161,7 +161,7 @@ module Unix = struct
         (* Bytes.unsafe_of_string usage: s has shared ownership; we assume that
            Util.really_write does not mutate buf (i.e., only needs shared ownership). This
            usage is safe. *)
-        let buf = Bytes.unsafe_of_string s (* safe: see comment above *) in
+        let buf = Bytes.unsafe_of_string s in
         let () = Util.really_write t.fd off buf 0 len in
         Index.Stats.add_write len;
         ()
@@ -205,7 +205,6 @@ module Unix = struct
          at the call to Bytes.unsafe_to_string we give up unique ownership of buf for
          ownership of the string. This is safe. *)
       Ok (Bytes.unsafe_to_string buf)
-      (* safe: see comment above *)
     with
     | Errors.Pack_error ((`Invalid_argument | `Read_out_of_bounds) as e) ->
         Error e

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -160,7 +160,7 @@ module Unix = struct
     | _ ->
         (* really_write and following do not mutate the given buffer, so
            Bytes.unsafe_of_string is actually safe *)
-        let buf = Bytes.unsafe_of_string s in
+        let buf = Bytes.unsafe_of_string s (* safe - see comment 1 line above *) in
         let () = Util.really_write t.fd off buf 0 len in
         Index.Stats.add_write len;
         ()

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -199,7 +199,7 @@ module Unix = struct
     let buf = Bytes.create len in
     try
       read_exn t ~off ~len buf;
-      Ok (Bytes.unsafe_to_string buf)
+      Ok (Bytes.unsafe_to_string buf) (* safe: buf local, not leaked, not modified after return *)
     with
     | Errors.Pack_error ((`Invalid_argument | `Read_out_of_bounds) as e) ->
         Error e

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -158,11 +158,10 @@ module Unix = struct
     | true, _ -> raise Errors.Closed
     | _, true -> raise Errors.RO_not_allowed
     | _ ->
-        (* really_write and following do not mutate the given buffer, so
-           Bytes.unsafe_of_string is actually safe *)
-        let buf =
-          Bytes.unsafe_of_string s (* safe - see comment 1 line above *)
-        in
+        (* Bytes.unsafe_of_string usage: s has shared ownership; we assume that
+           Util.really_write does not mutate buf (i.e., only needs shared ownership). This
+           usage is safe. *)
+        let buf = Bytes.unsafe_of_string s (* safe: see comment above *) in
         let () = Util.really_write t.fd off buf 0 len in
         Index.Stats.add_write len;
         ()

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -346,7 +346,8 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
        *   Fmt.epr "register_entry < 500: %d %d\n%!" (Int63.to_int off) len; *)
       Bytes.set_int64_ne buffer 0 (Int63.to_int64 off);
       Bytes.set_int64_ne buffer 8 (Int64.of_int len);
-      Ao.append_exn file0 (Bytes.unsafe_to_string buffer) (* clearly unsafe!!! *)
+      Ao.append_exn file0 (Bytes.unsafe_to_string buffer)
+      (* clearly unsafe!!! *)
     in
     let* () = Errs.catch (fun () -> register_entries ~register_entry) in
     let* () = Ao.flush file0 in
@@ -436,7 +437,8 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
       else
         let off, len =
           (* Decoding a pair of int can't fail *)
-          decode_bin_pair (Bytes.unsafe_to_string buffer) buffer_off (* possibly safe; depends on implementation of decode_bin_pair and all other libraries involved *)
+          decode_bin_pair (Bytes.unsafe_to_string buffer) buffer_off
+          (* possibly safe; depends on implementation of decode_bin_pair and all other libraries involved *)
         in
         let () =
           if off < last_yielded_end_offset then

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -338,16 +338,18 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
     file0_ref := Some file0;
 
     (* Fill and close [file0] *)
-    let buffer = Bytes.create 16 in
     let register_entry ~off ~len =
       (* Write [off, len] in native-endian encoding because it will be read
          with mmap. *)
       (* if Int63.to_int off < 500 then
        *   Fmt.epr "register_entry < 500: %d %d\n%!" (Int63.to_int off) len; *)
+      let buffer = Bytes.create 16 in
       Bytes.set_int64_ne buffer 0 (Int63.to_int64 off);
       Bytes.set_int64_ne buffer 8 (Int64.of_int len);
+      (* Bytes.unsafe_to_string usage: buffer is uniquely owned; we assume
+         Bytes.set_int64_ne returns unique ownership; we give up ownership of buffer in
+         conversion to string. This is safe. *)
       Ao.append_exn file0 (Bytes.unsafe_to_string buffer)
-      (* clearly unsafe!!! *)
     in
     let* () = Errs.catch (fun () -> register_entries ~register_entry) in
     let* () = Ao.flush file0 in
@@ -437,8 +439,9 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
       else
         let off, len =
           (* Decoding a pair of int can't fail *)
+          (* Bytes.unsafe_to_string usage: possibly safe TODO justify safety, or convert
+             to Bytes.to_string *)
           decode_bin_pair (Bytes.unsafe_to_string buffer) buffer_off
-          (* possibly safe; depends on implementation of decode_bin_pair and all other libraries involved *)
         in
         let () =
           if off < last_yielded_end_offset then

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -346,7 +346,7 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
        *   Fmt.epr "register_entry < 500: %d %d\n%!" (Int63.to_int off) len; *)
       Bytes.set_int64_ne buffer 0 (Int63.to_int64 off);
       Bytes.set_int64_ne buffer 8 (Int64.of_int len);
-      Ao.append_exn file0 (Bytes.unsafe_to_string buffer)
+      Ao.append_exn file0 (Bytes.unsafe_to_string buffer) (* clearly unsafe!!! *)
     in
     let* () = Errs.catch (fun () -> register_entries ~register_entry) in
     let* () = Ao.flush file0 in
@@ -436,7 +436,7 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
       else
         let off, len =
           (* Decoding a pair of int can't fail *)
-          decode_bin_pair (Bytes.unsafe_to_string buffer) buffer_off
+          decode_bin_pair (Bytes.unsafe_to_string buffer) buffer_off (* possibly safe; depends on implementation of decode_bin_pair and all other libraries involved *)
         in
         let () =
           if off < last_yielded_end_offset then

--- a/src/irmin-pack/unix/pack_index.ml
+++ b/src/irmin-pack/unix/pack_index.ml
@@ -43,12 +43,13 @@ module Make (K : Irmin.Hash.S) = struct
          functions above return unique ownership of buf. Then in the call to
          Bytes.unsafe_to_string we give up unique ownership of buf for ownership of the
          resulting string. This is safe. *)
-      Bytes.unsafe_to_string buf (* safe: see comment above *)
+      Bytes.unsafe_to_string buf
 
     let decode s pos : t =
       (* Bytes.unsafe_of_string usage: s is shared ownership; buf is shared ownership (we
-         cannot mutate buf); we assume the Bytes.get... functions require only shared
-         ownership. This usage is safe. *)
+         cannot mutate buf) and the lifetime of buf ends on return from this function; we
+         assume the Bytes.get... functions require only shared ownership. This usage is
+         safe. *)
       let buf = Bytes.unsafe_of_string s in
       let off = Bytes.get_int64_be buf pos |> Int63.of_int64 in
       let len = Bytes.get_int32_be buf (pos + 8) |> Int32.to_int in

--- a/src/irmin-pack/unix/pack_index.ml
+++ b/src/irmin-pack/unix/pack_index.ml
@@ -46,8 +46,10 @@ module Make (K : Irmin.Hash.S) = struct
       Bytes.unsafe_to_string buf (* safe: see comment above *)
 
     let decode s pos : t =
+      (* Bytes.unsafe_of_string usage: s is shared ownership; buf is shared ownership (we
+         cannot mutate buf); we assume the Bytes.get... functions require only shared
+         ownership. This usage is safe. *)
       let buf = Bytes.unsafe_of_string s in
-      (* safe: buf only used for reading locally within this function *)
       let off = Bytes.get_int64_be buf pos |> Int63.of_int64 in
       let len = Bytes.get_int32_be buf (pos + 8) |> Int32.to_int in
       let kind = Bytes.get buf (pos + 12) |> Pack_value.Kind.of_magic_exn in

--- a/src/irmin-pack/unix/pack_index.ml
+++ b/src/irmin-pack/unix/pack_index.ml
@@ -39,10 +39,10 @@ module Make (K : Irmin.Hash.S) = struct
       Bytes.set_int64_be buf 0 (Int63.to_int64 off);
       Bytes.set_int32_be buf 8 (Int32.of_int len);
       Bytes.set buf 12 (Pack_value.Kind.to_magic kind);
-      Bytes.unsafe_to_string buf
+      Bytes.unsafe_to_string buf (* safe: buf created locally, mutated, not leaked outside function *)
 
     let decode s pos : t =
-      let buf = Bytes.unsafe_of_string s in
+      let buf = Bytes.unsafe_of_string s in (* safe: buf only used for reading locally within this function *)
       let off = Bytes.get_int64_be buf pos |> Int63.of_int64 in
       let len = Bytes.get_int32_be buf (pos + 8) |> Int32.to_int in
       let kind = Bytes.get buf (pos + 12) |> Pack_value.Kind.of_magic_exn in

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -161,7 +161,13 @@ struct
         "Attempted to read an entry at offset %a in the pack file, but got \
          only %d bytes"
         Int63.pp off bytes_read;
-    let hash = decode_bin_hash (Bytes.unsafe_to_string buf (* possibly unsafe; but if we assume buf is not mutated after "bytes_read" above, and given buf is created at the beginning of this function, this might actually be safe; TODO provide a clear reason that this is safe *)) (ref 0) in
+    let hash =
+      decode_bin_hash
+        (Bytes.unsafe_to_string
+           buf
+           (* possibly unsafe; but if we assume buf is not mutated after "bytes_read" above, and given buf is created at the beginning of this function, this might actually be safe; TODO provide a clear reason that this is safe *))
+        (ref 0)
+    in
     let kind = Pack_value.Kind.of_magic_exn (Bytes.get buf Hash.hash_size) in
     let size_of_value_and_length_header =
       match Val.length_header kind with
@@ -173,7 +179,10 @@ struct
              correctly): *)
           let pos_ref = ref length_header_start in
           let length_header =
-            Varint.decode_bin (Bytes.unsafe_to_string buf) (* as above, this is potentially safe, but need clear reasoning *) pos_ref
+            Varint.decode_bin
+              (Bytes.unsafe_to_string buf)
+              (* as above, this is potentially safe, but need clear reasoning *)
+              pos_ref
           in
           let length_header_length = !pos_ref - length_header_start in
           Some (length_header_length + length_header)
@@ -195,7 +204,15 @@ struct
     let found = Dispatcher.read_if_not_gced t.dispatcher ~off ~len buf in
     if (not found) || gced buf then None
     else
-      let hash = decode_bin_hash (Bytes.unsafe_to_string buf (* safe: buf local to function, not mutated after initially filled *) ) (ref 0) in 
+      (* Bytes.unsafe_to_string usafe: buf is create in this function, uniquely owned; we
+         assume Dispatcher.read_if_not_gced returns unique ownership; then call to
+         Bytes.unsafe_to_string gives up ownerhsip of buf for ownership of resulting
+         string. This is safe. *)
+      let hash =
+        decode_bin_hash
+          (Bytes.unsafe_to_string buf (* safe: see comment above *))
+          (ref 0)
+      in
       Some hash
 
   let pack_file_contains_key t k =
@@ -296,7 +313,8 @@ struct
       let dict = Dict.find t.dict in
       let v =
         Val.decode_bin ~key_of_offset ~key_of_hash ~dict
-          (Bytes.unsafe_to_string buf) (* safe? buf created, filled, not changed subsequently, not leaked outside this function so no subsequent mutations *)
+          (Bytes.unsafe_to_string buf)
+          (* safe? buf created, filled, not changed subsequently, not leaked outside this function so no subsequent mutations *)
           (ref 0)
       in
       Some v

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -208,11 +208,7 @@ struct
          assume Dispatcher.read_if_not_gced returns unique ownership; then call to
          Bytes.unsafe_to_string gives up ownerhsip of buf for ownership of resulting
          string. This is safe. *)
-      let hash =
-        decode_bin_hash
-          (Bytes.unsafe_to_string buf (* safe: see comment above *))
-          (ref 0)
-      in
+      let hash = decode_bin_hash (Bytes.unsafe_to_string buf) (ref 0) in
       Some hash
 
   let pack_file_contains_key t k =
@@ -312,9 +308,11 @@ struct
       let key_of_hash = Pack_key.v_indexed in
       let dict = Dict.find t.dict in
       let v =
+        (* Bytes.unsafe_to_string usage: buf created, uniquely owned; after creation, we
+           assume Dispatcher.read_if_not_gced returns unique ownership; we give up unique
+           ownership in call to Bytes.unsafe_to_string. This is safe. *)
         Val.decode_bin ~key_of_offset ~key_of_hash ~dict
           (Bytes.unsafe_to_string buf)
-          (* safe? buf created, filled, not changed subsequently, not leaked outside this function so no subsequent mutations *)
           (ref 0)
       in
       Some v

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -232,14 +232,13 @@ module Make (Args : Args) = struct
         (* Bytes.unsafe_to_string usage: buf is local, uniquely owned; we assume the
            Bytes.set... functions return unique ownership; then Bytes.unsafe_to_string
            gives up unique ownership of buf. This is safe. *)
-        Bytes.unsafe_to_string buf (* safe: see comment above *)
+        Bytes.unsafe_to_string buf
 
       let decode s pos : t =
         (* Bytes.unsafe_of_string usage: s is shared; buf is shared (we cannot mutate it);
            we assume Bytes.get_... functions need shared ownership only. This usage is
            safe. *)
         let buf = Bytes.unsafe_of_string s in
-        (* safe: buf is created locally, not mutated, not leaked *)
         let off = Bytes.get_int64_be buf pos |> Int63.of_int64 in
         let len = Bytes.get_int32_be buf (pos + 8) |> Int32.to_int in
         (off, len)

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -229,7 +229,7 @@ module Make (Args : Args) = struct
         Bytes.unsafe_to_string buf (* safe: buf local to this function; buf not mutated after return *)
 
       let decode s pos : t =
-        let buf = Bytes.unsafe_of_string s in
+        let buf = Bytes.unsafe_of_string s in (* safe: buf is created locally, not mutated, not leaked *)
         let off = Bytes.get_int64_be buf pos |> Int63.of_int64 in
         let len = Bytes.get_int32_be buf (pos + 8) |> Int32.to_int in
         (off, len)

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -235,6 +235,9 @@ module Make (Args : Args) = struct
         Bytes.unsafe_to_string buf (* safe: see comment above *)
 
       let decode s pos : t =
+        (* Bytes.unsafe_of_string usage: s is shared; buf is shared (we cannot mutate it);
+           we assume Bytes.get_... functions need shared ownership only. This usage is
+           safe. *)
         let buf = Bytes.unsafe_of_string s in
         (* safe: buf is created locally, not mutated, not leaked *)
         let off = Bytes.get_int64_be buf pos |> Int63.of_int64 in

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -231,7 +231,8 @@ module Make (Args : Args) = struct
         Bytes.set_int32_be buf 8 (Int32.of_int len);
         (* Bytes.unsafe_to_string usage: buf is local, uniquely owned; we assume the
            Bytes.set... functions return unique ownership; then Bytes.unsafe_to_string
-           gives up unique ownership of buf. This is safe. *)
+           gives up unique ownership of buf to get shared ownership of the resulting
+           string, which is then returned. buf is no longer accessible. This is safe. *)
         Bytes.unsafe_to_string buf
 
       let decode s pos : t =

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -105,7 +105,7 @@ module Make (Args : Args) = struct
       in
       let entry_of_hash hash = key_of_hash hash t.inode_pack in
       Inode.Raw.decode_children_offsets ~entry_of_offset ~entry_of_hash
-        (Bytes.unsafe_to_string buf)
+        (Bytes.unsafe_to_string buf) (* safe - buf local to this function, ownership handed to Inode.Raw.decode_children_offsets; nothing can mutate buf subsequently *)
         (ref 0)
 
     type visit = { visited : Hash.t -> bool; set_visit : Hash.t -> unit }
@@ -226,7 +226,7 @@ module Make (Args : Args) = struct
         let buf = Bytes.create encoded_size in
         Bytes.set_int64_be buf 0 (Int63.to_int64 off);
         Bytes.set_int32_be buf 8 (Int32.of_int len);
-        Bytes.unsafe_to_string buf
+        Bytes.unsafe_to_string buf (* safe: buf local to this function; buf not mutated after return *)
 
       let decode s pos : t =
         let buf = Bytes.unsafe_of_string s in

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -253,9 +253,11 @@ end = struct
       else
         let buffer_off, off, missing_hash =
           match
+            (* Bytes.unsafe_to_string usage: possibly safe, depending on details of
+               implementation of decode_entry_exn TODO either justify clearly that this is
+               safe, or change to use safe Bytes.to_string *)
             decode_entry_exn ~off
               ~buffer:(Bytes.unsafe_to_string !buffer)
-                (* could be safe or unsafe; depends on implementation of decode_entry_exn *)
               ~buffer_off
           with
           | { key; data } ->

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -254,7 +254,8 @@ end = struct
         let buffer_off, off, missing_hash =
           match
             decode_entry_exn ~off
-              ~buffer:(Bytes.unsafe_to_string !buffer) (* could be safe or unsafe; depends on implementation of decode_entry_exn *)
+              ~buffer:(Bytes.unsafe_to_string !buffer)
+                (* could be safe or unsafe; depends on implementation of decode_entry_exn *)
               ~buffer_off
           with
           | { key; data } ->

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -254,7 +254,7 @@ end = struct
         let buffer_off, off, missing_hash =
           match
             decode_entry_exn ~off
-              ~buffer:(Bytes.unsafe_to_string !buffer)
+              ~buffer:(Bytes.unsafe_to_string !buffer) (* could be safe or unsafe; depends on implementation of decode_entry_exn *)
               ~buffer_off
           with
           | { key; data } ->


### PR DESCRIPTION
We have had serious bugs in the past related to our use of Bytes.unsafe functions (see eg #1814, #1815).

In #1967 it was found that recent code made use of Bytes.unsafe_to_string that looked clearly unsafe.

This draft PR contains recent work to clarify occurrences of Bytes.unsafe_to_string within irmin-pack.

For most occurrences, I have added a comment justifying why the use is safe. The comments follow the terminology of the OCaml documentation https://v2.ocaml.org/api/Bytes.html#unsafe which uses terms "unique ownership" and "shared ownership". The OCaml documentation needs to be understood first, before one can properly assess whether the uses of Bytes.unsafe functions are actually safe or not.

For some occurrences in the code, it is not clear if the use is safe or not. I have added a comment with text and a TODO marker to indicate that more work needs to be done.

For one occurrence, I changed the location of the buffer to make the call obviously safe. This should not affect performance. Similarly, in one place I changed Bytes.unsafe_to_string to Bytes.to_string, where I thought the performance would not be affected.
