### PR TITLE
irmin-pack: improve resilience of gc wait

### DIFF
--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -56,7 +56,10 @@ module type Specifics = sig
       by a readonly instance.*)
 
   module Gc : sig
-    (** GC *)
+    (** GC
+
+        Two levels of API are provided for GC. View them as mutually exclusive.
+        Behavior when mixing usage of the APIs is undefined. *)
 
     (** {2 Low-level API} *)
 
@@ -84,7 +87,8 @@ module type Specifics = sig
 
         If [wait = true] (the default), the call blocks until the GC process
         finishes. If [wait = false], finalisation will occur if the process has
-        ended.
+        ended. Behavior is undefined if [finalise_exn] is called from multiple
+        threads with [wait = true].
 
         If there are no running GCs, the call is a no-op and it returns [`Idle].
 

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -702,20 +702,38 @@ module Maker (Config : Conf.S) = struct
         with exn -> catch_errors "Check GC" exn
 
       let wait repo =
-        try
-          let* _ = finalise_exn ~wait:true repo in
-          Lwt.return_ok ()
-        with exn -> catch_errors "Wait for GC" exn
+        (* Use a loop to check status to avoid issues with
+           multiple threads calling the underlying blocking
+           implementation. {!run} has the only thread that
+           is allowed to block. *)
+        let rec check () =
+          let* is_finished = is_finished repo in
+          match is_finished with
+          | Ok true -> Lwt.return_ok ()
+          | Ok false ->
+              let* () = Lwt_unix.sleep 0.1 in
+              check ()
+          | Error _ as e -> Lwt.return e
+        in
+        check ()
 
       let run ?(finished = fun _ -> ()) repo commit_key =
         let* started = start repo commit_key in
         match started with
         | Ok r ->
             if r then
-              (* start top-level Lwt thread to track finalisation *)
+              (* Start top-level Lwt thread to track finalisation *)
               Lwt.async (fun () ->
                   let c0 = Mtime_clock.counter () in
-                  let* results = wait repo in
+                  let* results =
+                    (* Instead of using {!wait}, call {!finalise_exn} directly
+                       with [~wait:true] to force a blocking call to the underlying
+                       implementation *)
+                    try
+                      let* _ = finalise_exn ~wait:true repo in
+                      Lwt.return_ok ()
+                    with exn -> catch_errors "Wait for GC" exn
+                  in
                   match results with
                   | Ok _ ->
                       let elapsed = Mtime_clock.count c0 |> Mtime.Span.to_ms in


### PR DESCRIPTION
I ran into an issue while working on [demo code](https://github.com/mirage/irmin/pull/1973/files#diff-1b8b4abba29eb6dc1a9794bc81cb79482e4572d0435f6b3571b433803d8245f0) for the new high-level GC API where calling `wait` would throw a `Unix.ECHILD` error. After some digging, it seems that the problem is with calling `Unix.waitpid` from multiple threads.

This PR changes the implementation of `wait` to mimic waiting by looping a status check instead and updates the documentation to clarify how to use the GC APIs.