### PR TITLE
irmin-pack: improve resilience of gc wait

### DIFF
--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -56,7 +56,10 @@ module type Specifics = sig
       by a readonly instance.*)
 
   module Gc : sig
-    (** GC *)
+    (** GC
+
+        Two levels of API are provided for GC. View them as mutually exclusive.
+        Behavior when mixing usage of the APIs is undefined. *)
 
     (** {2 Low-level API} *)
 
@@ -84,7 +87,8 @@ module type Specifics = sig
 
         If [wait = true] (the default), the call blocks until the GC process
         finishes. If [wait = false], finalisation will occur if the process has
-        ended.
+        ended. Behavior is undefined if [finalise_exn] is called from multiple
+        threads with [wait = true].
 
         If there are no running GCs, the call is a no-op and it returns [`Idle].
 
@@ -108,8 +112,10 @@ module type Specifics = sig
         discarding all data prior to [commit_key]. If a GC process is already
         running, a new one will not be started.
 
-        [run] will also finalise the GC process automaticlly. For more detailed
-        control, see {!start_exn} and {!finalise_exn}.
+        [run] will also finalise the GC process automatically. To ensure proper
+        finalisation, make sure your program provides time for Lwt to give CPU
+        time to the background finaliser, using [Lwt.pause] if needed. For more
+        detailed control, see {!start_exn} and {!finalise_exn}.
 
         When the GC process is finalised, [finished] is called with the result
         of finalisation.


### PR DESCRIPTION
This is a re-opening of #1981 after a lengthier discussion with @tomjridge.

Two changes in this PR:

1. The high-level `wait` api no longer uses the blocking version of `finalise_exn` since that can cause `Unix.ECHILD` exceptions from the underlying Lwt implementation. Instead, it now polls for completion.
2. Documentation is updated to clarify usage of the GC apis provided. The reason I closed the previous PR is because of behavior I saw when using the high-level api in the replay benchmarks, but with @tomjridge's help, that was diagnosed as a problem of the replay code not giving Lwt a chance to run our background finaliser. A note is added in `run` documentation about this problem. A future PR that uses the high-level api in the replay benchmark will demonstrate the fix needed (using `Lwt.pause`).