### PR TITLE
bench: use high-level gc api

### DIFF
--- a/bench/irmin-pack/trace_replay_intf.ml
+++ b/bench/irmin-pack/trace_replay_intf.ml
@@ -101,8 +101,15 @@ module type Store = sig
   val create_repo :
     root:string -> store_config -> (Repo.t * on_commit * on_end) Lwt.t
 
-  val gc : repo -> commit_key -> unit Lwt.t
-  val finalise_gc : ?wait:bool -> repo -> bool Lwt.t
+  val gc_wait : repo -> unit Lwt.t
+
+  val gc_is_finished : repo -> bool Lwt.t
+
+  val gc_run :
+    ?finished:((float, string) result -> unit) ->
+    repo ->
+    commit_key ->
+    unit Lwt.t
 end
 
 module type Sigs = sig

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -58,8 +58,15 @@ module type Store = sig
   val create_repo :
     root:string -> store_config -> (Repo.t * on_commit * on_end) Lwt.t
 
-  val gc : repo -> commit_key -> unit Lwt.t
-  val finalise_gc : ?wait:bool -> repo -> bool Lwt.t
+  val gc_run :
+    ?finished:((float, string) result -> unit) ->
+    repo ->
+    commit_key ->
+    unit Lwt.t
+
+  val gc_is_finished : repo -> bool Lwt.t
+
+  val gc_wait : repo -> unit Lwt.t
 end
 
 let pp_inode_config ppf (entries, stable_hash) =
@@ -217,15 +224,26 @@ struct
     let on_end () = Lwt.return_unit in
     Lwt.return (repo, on_commit, on_end)
 
-  let finalise_gc ?wait repo =
-    let* r = Store.Gc.finalise_exn ?wait repo in
+  let gc_is_finished repo =
+    let* r = Store.Gc.is_finished repo in
     match r with
-    | `Idle | `Running -> Lwt.return false
-    | `Finalised -> Lwt.return true
+    | Error (`Msg err) -> failwith err
+    | Ok x -> Lwt.return x
+  
+  let gc_wait repo =
+    let* r = Store.Gc.wait repo in
+    match r with Ok _ -> Lwt.return_unit | Error (`Msg err) -> failwith err
 
-  let gc repo key =
-    let* (_launched : bool) = Store.Gc.start_exn ~unlink:true repo key in
-    Lwt.return_unit
+  let gc_run ?(finished = fun _ -> ()) repo key =
+    let f (result : (Store.Gc.stats, Store.Gc.msg) result) =
+      match result with
+      | Error (`Msg err) -> finished @@ Error err
+      | Ok s -> finished @@ Ok s.elapsed
+    in
+    let* launched = Store.Gc.run ~finished:f repo key in
+    match launched with
+    | Ok _ -> Lwt.return_unit
+    | Error (`Msg err) -> failwith err
 end
 
 module Make_store_mem = Make_basic (Irmin_pack_mem.Maker)

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -56,7 +56,10 @@ module type Specifics = sig
       by a readonly instance.*)
 
   module Gc : sig
-    (** GC *)
+    (** GC
+
+        Two levels of API are provided for GC. View them as mutually exclusive.
+        Behavior when mixing usage of the APIs is undefined. *)
 
     (** {2 Low-level API} *)
 
@@ -84,7 +87,8 @@ module type Specifics = sig
 
         If [wait = true] (the default), the call blocks until the GC process
         finishes. If [wait = false], finalisation will occur if the process has
-        ended.
+        ended. Behavior is undefined if [finalise_exn] is called from multiple
+        threads with [wait = true].
 
         If there are no running GCs, the call is a no-op and it returns [`Idle].
 
@@ -108,8 +112,10 @@ module type Specifics = sig
         discarding all data prior to [commit_key]. If a GC process is already
         running, a new one will not be started.
 
-        [run] will also finalise the GC process automaticlly. For more detailed
-        control, see {!start_exn} and {!finalise_exn}.
+        [run] will also finalise the GC process automatically. To ensure proper
+        finalisation, make sure your program provides time for Lwt to give CPU
+        time to the background finaliser, using [Lwt.pause] if needed. For more
+        detailed control, see {!start_exn} and {!finalise_exn}.
 
         When the GC process is finalised, [finished] is called with the result
         of finalisation.


### PR DESCRIPTION
This changes the replay code to use the high-level gc api. I'm opening as a draft because, while it works, a change needed to ensure gc finalization (adding `Lwt.pause`) breaks the progress printing of the replay.

This builds on #1984, which is not yet merged, so [only the most recent commit](https://github.com/mirage/irmin/pull/1985/commits/2f0b02b37beab295bad6327077361090d6423cd4) contains the actual changes.