### PR TITLE
Finer-grained LRU purge

### DIFF
--- a/irmin.opam
+++ b/irmin.opam
@@ -34,6 +34,7 @@ depends: [
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
+  "qcheck-alcotest" {with-test}
   "vector" {with-test}
   "odoc" {(< "2.0.1" | > "2.0.2") & with-doc} # See https://github.com/ocaml/odoc/issues/793
   "bisect_ppx" {dev & >= "2.5.0"}

--- a/src/irmin-pack/unix/dispatcher.ml
+++ b/src/irmin-pack/unix/dispatcher.ml
@@ -33,11 +33,15 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
   let read_prefix = ref 0
   (*TODO move them in stats*)
 
-  type mapping_value = { poff : int63; len : int }
+  type mapping_value = { poff : int63; len : int } [@@deriving irmin ~pp]
   (** [poff] is a prefix offset (i.e. an offset in the prefix file), [len] is
       the length of the chunk starting at [poff]. *)
 
   type mapping = mapping_value Intmap.t
+
+  let pp_mapping ppf t =
+    Fmt.(Dump.list (Dump.pair Int63.pp pp_mapping_value))
+      ppf (Intmap.bindings t)
 
   type t = { fm : Fm.t; mutable mapping : mapping; root : string }
   (** [mapping] is a map from global offset to (offset,len) pairs in the prefix
@@ -65,6 +69,8 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
     in
     t.mapping <- mapping;
     Ok ()
+
+  let mapping t = t.mapping
 
   let v ~root fm =
     let open Result_syntax in

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -53,8 +53,11 @@ module type S = sig
 
   type mapping
 
+  val pp_mapping : mapping Fmt.t
   val load_mapping : Fm.Io.t -> (mapping, [> Fm.Errs.t ]) result
+  val mapping : t -> mapping
   val poff_of_entry_exn : mapping -> off:int63 -> len:int -> int63
+  val entry_offset_suffix_start : t -> int63
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/inode_intf.ml
+++ b/src/irmin-pack/unix/inode_intf.ml
@@ -56,7 +56,7 @@ module type Persistent = sig
 
   val to_snapshot : Raw.t -> Snapshot.inode
   val of_snapshot : 'a t -> index:(hash -> key) -> Snapshot.inode -> value
-  val purge_lru : 'a t -> unit
+  val purge_lru : (int63 -> bool) -> 'a t -> unit
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -479,7 +479,7 @@ struct
       We could clear the caches here but that really is not necessary. *)
   let close _ = Lwt.return ()
 
-  let purge_lru t = Lru.clear t.lru
+  let purge_lru f t = Lru.iter t.lru (fun k _ -> if f k then Lru.remove t.lru k)
 end
 
 module Make
@@ -510,5 +510,5 @@ struct
 
   let read_and_decode_entry_prefix = Inner.read_and_decode_entry_prefix
   let index_direct_with_kind t = Inner.index_direct_with_kind (get_open_exn t)
-  let purge_lru t = Inner.purge_lru (get_open_exn t)
+  let purge_lru f t = Inner.purge_lru f (get_open_exn t)
 end

--- a/src/irmin-pack/unix/pack_store_intf.ml
+++ b/src/irmin-pack/unix/pack_store_intf.ml
@@ -62,7 +62,7 @@ module type S = sig
   val index_direct_with_kind : 'a t -> hash -> (key * Pack_value.Kind.t) option
   (** Returns the key and the kind of an object indexed by hash. *)
 
-  val purge_lru : 'a t -> unit
+  val purge_lru : (int63 -> bool) -> 'a t -> unit
 end
 
 module type Sigs = sig

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -133,6 +133,7 @@ module Make (H : Hashtbl.HashedType) = struct
   let iter t f = Q.iter t.q (fun (k, v) -> f k v)
 
   let clear t =
+    t.w <- 0;
     HT.clear t.ht;
     Q.clear t.q
 end

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -57,6 +57,16 @@ module Make (H : Hashtbl.HashedType) = struct
     let node x = { value = x; prev = None; next = None }
     let create () = { first = None; last = None }
 
+    let iter t f =
+      let rec aux f = function
+        | Some n ->
+            let next = n.next in
+            f n.value;
+            aux f next
+        | _ -> ()
+      in
+      aux f t.first
+
     let clear t =
       t.first <- None;
       t.last <- None
@@ -119,6 +129,8 @@ module Make (H : Hashtbl.HashedType) = struct
     | true ->
         promote t k;
         true
+
+  let iter t f = Q.iter t.q (fun (k, v) -> f k v)
 
   let clear t =
     HT.clear t.ht;

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -23,4 +23,6 @@ module Make (H : Hashtbl.HashedType) : sig
   val find : 'a t -> H.t -> 'a
   val mem : 'a t -> H.t -> bool
   val clear : 'a t -> unit
+  val iter : 'a t -> (H.t -> 'a -> unit) -> unit
+  val remove : 'a t -> H.t -> unit
 end

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -14,4 +14,5 @@
   lwt.unix
   hex
   logs
-  logs.fmt))
+  logs.fmt
+  qcheck-alcotest))

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -22,6 +22,7 @@ let lift_suite_to_lwt :
 
 let suite =
   [
+    ("lru", Test_lru.suite |> lift_suite_to_lwt);
     ("tree", Test_tree.suite);
     ("node", Test_node.suite |> lift_suite_to_lwt);
     ("hash", Test_hash.suite);

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -27,8 +27,6 @@ module M = struct
     let all = ref [] in
     iter t (fun k v -> all := (k, v) :: !all);
     List.sort compare !all
-
-  let clear t = iter t (fun k _ -> remove t k)
 end
 
 module M' = struct

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -1,0 +1,100 @@
+(*
+ * Copyright (c) 2013-2022 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module S = struct
+  type t = int [@@deriving irmin ~equal ~short_hash]
+
+  let hash t = short_hash t
+end
+
+module M = struct
+  include Irmin.Backend.Lru.Make (S)
+
+  let bindings t =
+    let all = ref [] in
+    iter t (fun k v -> all := (k, v) :: !all);
+    List.sort compare !all
+
+  let clear t = iter t (fun k _ -> remove t k)
+end
+
+module M' = struct
+  include Hashtbl.Make (S)
+
+  let bindings t =
+    let all = ref [] in
+    iter (fun k v -> all := (k, v) :: !all) t;
+    List.sort compare !all
+end
+
+type key = int
+type action = Add of key * int | Remove of key | Clear | Iter
+
+let add k v = Add (k, v)
+let remove k = Remove k
+let clear = Clear
+let iter = Iter
+
+let gen_action =
+  QCheck.Gen.(
+    frequency
+      [
+        (1, map2 add small_int nat);
+        (2, map remove small_int);
+        (3, pure clear);
+        (4, pure iter);
+      ])
+
+let print_action = function
+  | Add (k, v) -> Fmt.str "Add %d %d" k v
+  | Remove k -> Fmt.str "Remove %d" k
+  | Clear -> Fmt.str "Clear"
+  | Iter -> Fmt.str "Iter"
+
+let apply t = function
+  | Add (k, v) -> M.add t k v
+  | Remove k -> M.remove t k
+  | Clear -> M.clear t
+  | Iter -> M.iter t (fun k _ -> M.remove t k)
+
+let apply' t = function
+  | Add (k, v) -> M'.replace t k v
+  | Remove k -> M'.remove t k
+  | Clear -> M'.clear t
+  | Iter -> M'.iter (fun k _ -> M'.remove t k) t
+
+let run_aux create apply t =
+  let state = create 100 in
+  let rec aux = function
+    | [] -> ()
+    | h :: rest ->
+        apply state h;
+        aux rest
+  in
+  aux t;
+  state
+
+let run = run_aux M.create apply
+let run' = run_aux M'.create apply'
+let eq m m' = M.bindings m = M'.bindings m'
+let arbitrary_action = QCheck.make gen_action ~print:print_action
+
+let test =
+  QCheck.Test.make ~name:"Maps" ~count:10_000
+    QCheck.(list arbitrary_action)
+    (fun t -> eq (run t) (run' t))
+
+let suite = [ QCheck_alcotest.to_alcotest test ]


### PR DESCRIPTION
Try to selectively remove entries from the LRU that are not in the mapping file. That doesn't seem to pass the tests for a reason that I don't understand yet (`c1` seems to be present in the prefix!)