### PR TITLE
irmin-pack: refactor high-level gc implementation

### DIFF
--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -221,7 +221,7 @@ struct
     let* r = Store.Gc.finalise_exn ?wait repo in
     match r with
     | `Idle | `Running -> Lwt.return false
-    | `Finalised -> Lwt.return true
+    | `Finalised _ -> Lwt.return true
 
   let gc repo key =
     let* (_launched : bool) = Store.Gc.start_exn ~unlink:true repo key in

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -209,7 +209,7 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
         Lwt.return_ok false
 
       let wait _ = Lwt.return_ok None
-      let is_finished _ = Lwt.return_ok true
+      let is_finished _ = true
     end
 
     let integrity_check_inodes ?heads:_ _ =

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -199,7 +199,7 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
     module Gc = struct
       type msg = [ `Msg of string ]
       type stats = { elapsed : float }
-      type process_state = [ `Idle | `Running | `Finalised ]
+      type process_state = [ `Idle | `Running | `Finalised of stats ]
 
       let start_exn = X.Repo.start_gc
       let finalise_exn = X.Repo.finalise_gc
@@ -208,7 +208,7 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
         ignore finished;
         Lwt.return_ok false
 
-      let wait _ = Lwt.return_ok ()
+      let wait _ = Lwt.return_ok None
       let is_finished _ = Lwt.return_ok true
     end
 

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -125,6 +125,8 @@ module type Specifics = sig
     val wait : repo -> (stats option, msg) result Lwt.t
     (** [wait repo] blocks until GC is finished or is idle.
 
+        If a GC finalises, its stats are returned.
+
         All exceptions that [Irmin_pack] knows how to handle are caught and
         returned as pretty-print error messages; others are re-raised. The error
         messages should be used only for informational purposes, like logging. *)

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -129,13 +129,9 @@ module type Specifics = sig
         returned as pretty-print error messages; others are re-raised. The error
         messages should be used only for informational purposes, like logging. *)
 
-    val is_finished : repo -> (bool, msg) result Lwt.t
-    (** [is_finished repo] is [Ok true] if a GC is finished (or idle) and
-        [Ok false] if a GC is running for the given [repo].
-
-        All exceptions that [Irmin_pack] knows how to handle are caught and
-        returned as pretty-print error messages; others are re-raised. The error
-        messages should be used only for informational purposes, like logging. *)
+    val is_finished : repo -> bool
+    (** [is_finished repo] is [true] if a GC is finished (or idle) and [false]
+        if a GC is running for the given [repo]. *)
   end
 end
 

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -58,6 +58,12 @@ module type Specifics = sig
   module Gc : sig
     (** GC *)
 
+    type stats = { elapsed : float }
+    (** Stats for a successful GC run *)
+
+    type process_state = [ `Idle | `Running | `Finalised of stats ]
+    (** The state of the GC process after calling {!finalise_exn} *)
+
     (** {2 Low-level API} *)
 
     val start_exn : ?unlink:bool -> repo -> commit_key -> bool Lwt.t
@@ -69,9 +75,6 @@ module type Specifics = sig
         useful for debugging. The default is [true].
 
         TODO: Detail exceptions raised. *)
-
-    type process_state = [ `Idle | `Running | `Finalised ]
-    (** The state of the GC process after calling {!finalise_exn} *)
 
     val finalise_exn : ?wait:bool -> repo -> process_state Lwt.t
     (** [finalise_exn ?wait repo] waits for the GC process to finish in order to
@@ -96,11 +99,8 @@ module type Specifics = sig
     (** Pretty-print error messages meant for informational purposes, like
         logging *)
 
-    type stats = { elapsed : float }
-    (** Stats for a successful GC run *)
-
     val run :
-      ?finished:((stats, msg) result -> unit) ->
+      ?finished:((stats option, msg) result -> unit) ->
       repo ->
       commit_key ->
       (bool, msg) result Lwt.t
@@ -122,7 +122,7 @@ module type Specifics = sig
         returned as pretty-print error messages; others are re-raised. The error
         messages should be used only for informational purposes, like logging. *)
 
-    val wait : repo -> (unit, msg) result Lwt.t
+    val wait : repo -> (stats option, msg) result Lwt.t
     (** [wait repo] blocks until GC is finished or is idle.
 
         All exceptions that [Irmin_pack] knows how to handle are caught and

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -540,6 +540,8 @@ module Maker (Config : Conf.S) = struct
             match result with
             | Ok waited -> Lwt.return waited
             | Error e -> Errs.raise_error e
+
+          let is_finished t = Option.is_none t.during_gc
         end
       end
     end
@@ -702,13 +704,7 @@ module Maker (Config : Conf.S) = struct
           Lwt.return_ok started
         with exn -> catch_errors "Start GC" exn
 
-      let is_finished repo =
-        try
-          let* finished = finalise_exn ~wait:false repo in
-          match finished with
-          | `Idle | `Finalised _ -> Lwt.return_ok true
-          | `Running -> Lwt.return_ok false
-        with exn -> catch_errors "Check GC" exn
+      let is_finished = X.Repo.Gc.is_finished
 
       let wait repo =
         try

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -29,7 +29,7 @@ module Store = struct
     let* r = Store.Gc.finalise_exn ?wait repo in
     match r with
     | `Idle | `Running -> Lwt.return false
-    | `Finalised -> Lwt.return true
+    | `Finalised _ -> Lwt.return true
 
   let gc repo key =
     let* launched = Store.Gc.start_exn ~unlink:true repo key in
@@ -134,7 +134,7 @@ module Store_mem = struct
     let* r = Store.Gc.finalise_exn ?wait repo in
     match r with
     | `Idle | `Running -> Lwt.return false
-    | `Finalised -> Lwt.return true
+    | `Finalised _ -> Lwt.return true
 
   let gc repo key =
     let* launched = Store.Gc.start_exn ~unlink:true repo key in

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -60,8 +60,9 @@ include struct
   let finalise_gc t =
     let* result = S.Gc.finalise_exn ~wait:true t.repo in
     match result with
-    | `Idle | `Running -> Alcotest.fail "expected finalised gc"
-    | `Finalised _ -> Lwt.return_unit
+    | `Running -> Alcotest.fail "expected finalised gc"
+    (* consider `Idle as success because gc can finalise during commit as well *)
+    | `Idle | `Finalised _ -> Lwt.return_unit
 
   let commit t =
     let parents = List.map S.Commit.key t.parents in

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -61,7 +61,7 @@ include struct
     let* result = S.Gc.finalise_exn ~wait:true t.repo in
     match result with
     | `Idle | `Running -> Alcotest.fail "expected finalised gc"
-    | `Finalised -> Lwt.return_unit
+    | `Finalised _ -> Lwt.return_unit
 
   let commit t =
     let parents = List.map S.Commit.key t.parents in
@@ -727,7 +727,7 @@ module Concurrent_gc = struct
     let* result = S.Gc.finalise_exn_with_hook ~wait:true ~hook t.repo in
     match result with
     | `Idle | `Running -> Alcotest.fail "expected finalised gc"
-    | `Finalised ->
+    | `Finalised _ ->
         let c3 = Option.get !c3 in
         let* () = check_3 t c3 in
         S.Repo.close t.repo

--- a/test/irmin-pack/test_snapshot.ml
+++ b/test/irmin-pack/test_snapshot.ml
@@ -179,7 +179,7 @@ let finalise_gc repo =
   let* result = S.Gc.finalise_exn ~wait:true repo in
   match result with
   | `Idle | `Running -> Alcotest.fail "expected finalised gc"
-  | `Finalised -> Lwt.return_unit
+  | `Finalised _ -> Lwt.return_unit
 
 let test_gc ~repo_export ~repo_import ?on_disk expected_visited =
   (* create the store *)

--- a/test/irmin-pack/test_upgrade.ml
+++ b/test/irmin-pack/test_upgrade.ml
@@ -246,7 +246,7 @@ module Store = struct
     let* result = S.Gc.finalise_exn ~wait:true repo in
     match result with
     | `Idle | `Running -> Alcotest.fail "expected finalised gc"
-    | `Finalised -> Lwt.return_unit
+    | `Finalised _ -> Lwt.return_unit
 
   let dict_find_opt (repo : S.repo) step = S.Dict.find repo.dict step
 


### PR DESCRIPTION
This PR does several things

- Moves stats tracking to the internal gc process instead of just at the high-level api boundary
- Introduces a promise for a running gc that can be used for callbacks and waiting
- Fixes an issue previously discovered with `wait` (see #1984) ~but by binding to the gc promise instead of using a polling loop~ by making it the only high-level api place that uses `finalise_exn ~wait:true`
- Fixes issue with `run` (see #1985) but by attaching a callback to the gc promise instead of using a combination of `Lwt.async` and `Lwt.pause`. (I have a local version of the tree benchmark working correctly with the changes introduced here that I will PR later)
- To ensure finalisation happens (since we have removed an explicit waiting finalisation through a mechanism like `Lwt.async`), a non-blocking finalisation is called on every commit (similar to [some previous code](https://github.com/icristescu/irmin/blob/tmp_non-blocking-dummy-gc/src/irmin-pack/unix/ext.ml#L398))
- A few small clean up tasks (code, renames, and docs)

This PR can be reviewed all as one or commit-by-commit. ~The only note on commit-by-commit is that some of the changes introduced in the stats commit were removed in subsequent commits.~