### PR TITLE
irmin-pack: use mmap to load the mapping file

### DIFF
--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -40,8 +40,15 @@ module V3 = struct
   let sorted ~generation =
     toplevel ("store." ^ string_of_int generation ^ ".sorted")
 
-  let mapping ~generation =
-    toplevel ("store." ^ string_of_int generation ^ ".mapping")
+  let mapping =
+    (* if we use mmap for the mapping file, then the mapping file is not portable between
+       architectures with different endianness; to avoid the possibility that a
+       little-endian file is used on a big-endian arch (or vice versa) we use a filename
+       that is not portable between archs; since the common case is little endian, we make
+       this the "default" empty suffix, and for big endian we add ".be" *)
+    let empty_or_be = match Sys.big_endian with false -> "" | true -> ".be" in
+    fun ~generation ->
+      toplevel ("store." ^ string_of_int generation ^ ".mapping" ^ empty_or_be)
 
   let prefix ~generation =
     toplevel ("store." ^ string_of_int generation ^ ".prefix")

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -52,8 +52,11 @@ module type S = sig
       prefix, it will read the remaining in the prefix. *)
 
   type mapping
+  (** [mapping] is a map from global offset to [(offset,len)] pairs in the prefix file *)
 
-  val load_mapping : Fm.Io.t -> (mapping, [> Fm.Errs.t ]) result
+  val load_mapping : string -> (mapping, [> Fm.Errs.t ]) result
+  (** [load_mapping path] loads the [mapping] from the given path and returns it *)
+
   val poff_of_entry_exn : mapping -> off:int63 -> len:int -> int63
 end
 

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -37,7 +37,10 @@ module type S = sig
   val dict : t -> Dict.t
   val suffix : t -> Suffix.t
   val index : t -> Index.t
-  val mapping : t -> Io.t option
+
+  val mapping : t -> string option
+  (** path to mapping file *)
+
   val prefix : t -> Io.t option
 
   type create_error :=

--- a/src/irmin-pack/unix/import.ml
+++ b/src/irmin-pack/unix/import.ml
@@ -55,3 +55,9 @@ module Result_syntax = struct
   let ( let+ ) res f = Result.map f res
   let ( let* ) res f = Result.bind res f
 end
+
+type int_bigarray = (int, Bigarray.int_elt, Bigarray.c_layout) Bigarray.Array1.t
+(** [int_bigarray] is the raw type for the mapping file data, exposed via mmap *)
+
+module BigArr1 = Bigarray.Array1
+(** Simple module alias *)

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -51,10 +51,6 @@ let chunk_sz = 1_000_000 / 8
 (* Set to 0 until we find decide what to do about sequential traversal of pack files *)
 let gap_tolerance = 0
 
-module BigArr1 = Bigarray.Array1
-
-type int_bigarray = (int, Bigarray.int_elt, Bigarray.c_layout) Bigarray.Array1.t
-
 module Int_mmap : sig
   type t = private {
     fn : string;
@@ -365,36 +361,32 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
     Int_mmap.close file0;
     Io.Unix.unlink path0 |> ignore;
 
-    (* Create [file2] *)
-    let file2_ref = ref None in
-    let auto_flush_callback () =
-      match !file2_ref with
-      | None -> assert false
-      | Some x -> Ao.flush x |> Errs.raise_if_error
-    in
-    let* file2 =
-      Ao.create_rw ~path:path2 ~overwrite:true ~auto_flush_threshold:1_000_000
-        ~auto_flush_callback
-    in
-    file2_ref := Some file2;
-
-    (* Fill and close [file2]. *)
+    (* Create [file2]; currently this uses mmap format *)
+    let module Util = struct
+      (** [output_int_ne oc i] writes [i] to [oc] using native endian format,
+          suitable for reading by mmap; not thread safe - shared buffer *)
+      let output_int_ne =
+        let buf = Bytes.create 8 in
+        fun oc i ->
+          Bytes.set_int64_ne buf 0 (Int64.of_int i);
+          (* NOTE Stdlib.output_binary_int always uses big-endian, but mmap is (presumably)
+             arch dependent, hence we use set_int64_ne *)
+          Stdlib.output_bytes oc buf;
+          ()
+    end in
+    let file2 = Stdlib.open_out_bin path2 in
+    (* Fill and close [file2] *)
     let register_entry ~off ~len =
-      (* Write [off, len] with repr because it will be read with repr. *)
-
-      (* if off < 500 then *)
-      (* Fmt.epr "\nregister_entry < 500: %d %d\n%!" off len; *)
-      (* Fmt.epr "register_entry of middle file: %d %d\n%!" off len; *)
-      let off = Int63.of_int off in
-      let len = Int63.of_int len in
-      encode_bin_pair (off, len) (Ao.append_exn file2)
+      Util.output_int_ne file2 off;
+      Util.output_int_ne file2 len;
+      ()
     in
     let* () =
       Errs.catch (fun () ->
           calculate_extents_oc ~src_is_sorted:() ~src:file1.arr ~register_entry)
     in
-    let* () = Ao.flush file2 in
-    let* () = Ao.close file2 in
+    let _ = Stdlib.flush file2 in
+    let _ = Stdlib.close_out file2 in
 
     (* Close and unlink [file1] *)
     Int_mmap.close file1;
@@ -402,58 +394,19 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) = struct
 
     Ok ()
 
-  let iter io f =
-    let buffer = Bytes.create (16 * 1000) in
-    let buffer_off = ref 0 in
+  let load_mapping_as_mmap path =
+    let mmap = Int_mmap.open_ ~fn:path ~sz:(-1) in
+    let arr = mmap.arr in
+    (* we expect the arr to hold (off,len) pairs, so size should be even *)
+    assert (BigArr1.dim arr mod 2 = 0);
+    Int_mmap.close mmap;
+    arr
 
-    let open Int63.Syntax in
-    let open Int63 in
-    let min a b = if a < b then a else b in
-    let entry_bytes = of_int 16 in
-    let max_entries_per_batch = of_int 1000 in
-
-    (* let max_bytes_per_batch = max_entries_per_batch * entry_bytes in *)
-    let open Result_syntax in
-    let* byte_count = Io.Unix.read_size io in
-    let entry_count = byte_count / entry_bytes in
-    (* Fmt.epr "\nbyte_count:%#d entry_count:%#d\n%!" (to_int byte_count) (to_int entry_count); *)
-    let* () =
-      if entry_count * entry_bytes <> byte_count then
-        Error (`Corrupted_mapping_file "unexpected file size")
-      else Ok ()
-    in
-
-    let rec load_batch i last_yielded_end_offset =
-      let entries_left = entry_count - i in
-      (* Fmt.epr "load_batch i:%#d, entries_left:%#d \n%!" (to_int i) (to_int entries_left); *)
-      if entries_left = zero then ()
-      else
-        let entries_in_batch = min entries_left max_entries_per_batch in
-        let off = i * entry_bytes in
-        let len = to_int (entries_in_batch * entry_bytes) in
-        Io.Unix.read_exn io ~off ~len buffer;
-        buffer_off := 0;
-        yield_entries i (i + entries_in_batch) last_yielded_end_offset
-    and yield_entries i end_i last_yielded_end_offset =
-      if i = end_i then load_batch i last_yielded_end_offset
-      else
-        let off, len =
-          (* Decoding a pair of int can't fail *)
-          (* Bytes.unsafe_to_string usage: possibly safe TODO justify safety, or convert
-             to Bytes.to_string *)
-          decode_bin_pair (Bytes.unsafe_to_string buffer) buffer_off
-        in
-        let () =
-          if off < last_yielded_end_offset then
-            let msg =
-              Fmt.str "Found off:%a len:%a but the previous entry ends as at %a"
-                Int63.pp off Int63.pp len Int63.pp last_yielded_end_offset
-            in
-            raise (Errors.Pack_error (`Corrupted_mapping_file msg))
-        in
-        f ~off ~len:(to_int len);
-        let last_yielded_end_offset = off + len in
-        yield_entries (succ i) end_i last_yielded_end_offset
-    in
-    Errs.catch (fun () -> load_batch zero zero)
+  let iter_mmap arr f =
+    let sz = BigArr1.dim arr in
+    assert (sz mod 2 = 0);
+    for i = 0 to (sz / 2) - 1 do
+      f ~off:(arr.{2 * i} |> Int63.of_int) ~len:arr.{(2 * i) + 1}
+    done;
+    ()
 end

--- a/src/irmin-pack/unix/mapping_file.mli
+++ b/src/irmin-pack/unix/mapping_file.mli
@@ -36,14 +36,13 @@ module Make (Errs : Io_errors.S with module Io = Io.Unix) : sig
       Creates temporary files in [root] that are unlinked before the function
       returns. *)
 
-  val iter :
-    Io.Unix.t -> (off:int63 -> len:int -> unit) -> (unit, [> Errs.t ]) result
-  (** [iter ~path f] Iterate over the entries of the mapping file at [path].
+  val load_mapping_as_mmap : string -> int_bigarray
+  (** [load_mapping_as_mmap path] returns an mmap-backed [int_bigarray];
+      assuming the path is for a mapping file previously created via [create],
+      the array should hold pairs of [(off,len)] data *)
 
-      It is guaranteed for the offsets to be iterated in monotonic order.
-
-      It is guaranteed that entries don't overlap.
-
-      The exceptions raised by [f] are caught and returned (as long as they are
-      known by [Errs]. *)
+  val iter_mmap : int_bigarray -> (off:int63 -> len:int -> unit) -> unit
+  (** [iter_mmap arr f] calls [f] on each [(off,len)] pair in [arr], starting
+      from the beginning of [arr]. This is a common pattern in the rest of the
+      code, so exposed as a helper function here. *)
 end


### PR DESCRIPTION
This commit changes the mapping file to use mmap on load. The code to
save the mapping has also changed, to take account of mmap format.

mmap files are not portable across architectures with different
endianness. Almost surely users are on little-endian machines. However,
to protect against a user copying a little-endian context to a
big-endian machine, the mapping file name has been changed to include
the endianness of the host machine.