### PR TITLE
Fix LRU.clear

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- **irmin**
+  - Fix a bug in Irmin.LRU.clear that disables the cache completly
+    after a clear. This is not used in any production code as only
+    the GC is clearing LRU so far (#1998, @samoht)
+
 ## 3.3.1 (2022-06-22)
 
 ### Fixed

--- a/irmin.opam
+++ b/irmin.opam
@@ -34,6 +34,7 @@ depends: [
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}
+  "qcheck-alcotest" {with-test}
   "vector" {with-test}
   "odoc" {(< "2.0.1" | > "2.0.2") & with-doc} # See https://github.com/ocaml/odoc/issues/793
   "bisect_ppx" {dev & >= "2.5.0"}

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -133,6 +133,7 @@ module Make (H : Hashtbl.HashedType) = struct
   let iter t f = Q.iter t.q (fun (k, v) -> f k v)
 
   let clear t =
+    t.w <- 0;
     HT.clear t.ht;
     Q.clear t.q
 end

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -57,6 +57,16 @@ module Make (H : Hashtbl.HashedType) = struct
     let node x = { value = x; prev = None; next = None }
     let create () = { first = None; last = None }
 
+    let iter t f =
+      let rec aux f = function
+        | Some n ->
+            let next = n.next in
+            f n.value;
+            aux f next
+        | _ -> ()
+      in
+      aux f t.first
+
     let clear t =
       t.first <- None;
       t.last <- None
@@ -119,6 +129,8 @@ module Make (H : Hashtbl.HashedType) = struct
     | true ->
         promote t k;
         true
+
+  let iter t f = Q.iter t.q (fun (k, v) -> f k v)
 
   let clear t =
     HT.clear t.ht;

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -23,4 +23,5 @@ module Make (H : Hashtbl.HashedType) : sig
   val find : 'a t -> H.t -> 'a
   val mem : 'a t -> H.t -> bool
   val clear : 'a t -> unit
+  val iter : 'a t -> (H.t -> 'a -> unit) -> unit
 end

--- a/test/irmin/dune
+++ b/test/irmin/dune
@@ -14,4 +14,5 @@
   lwt.unix
   hex
   logs
-  logs.fmt))
+  logs.fmt
+  qcheck-alcotest))

--- a/test/irmin/test.ml
+++ b/test/irmin/test.ml
@@ -22,6 +22,7 @@ let lift_suite_to_lwt :
 
 let suite =
   [
+    ("lru", Test_lru.suite |> lift_suite_to_lwt);
     ("tree", Test_tree.suite);
     ("node", Test_node.suite |> lift_suite_to_lwt);
     ("hash", Test_hash.suite);

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -1,0 +1,78 @@
+(*
+ * Copyright (c) 2013-2022 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module S = struct
+  type t = int [@@deriving irmin ~equal ~short_hash]
+
+  let hash t = short_hash t
+end
+
+module M = struct
+  include Irmin.Backend.Lru.Make (S)
+
+  let bindings t =
+    let all = ref [] in
+    iter t (fun k v -> all := (k, v) :: !all);
+    List.sort compare !all
+end
+
+module M' = struct
+  include Hashtbl.Make (S)
+
+  let bindings t =
+    let all = ref [] in
+    iter (fun k v -> all := (k, v) :: !all) t;
+    List.sort compare !all
+end
+
+type key = int
+type action = Add of key * int | Clear
+
+let add k v = Add (k, v)
+let clear = Clear
+
+let gen_action =
+  QCheck.Gen.(frequency [ (5, map2 add small_int nat); (1, pure clear) ])
+
+let print_action = function
+  | Add (k, v) -> Fmt.str "add %d %d" k v
+  | Clear -> Fmt.str "clear"
+
+let apply t = function Add (k, v) -> M.add t k v | Clear -> M.clear t
+let apply' t = function Add (k, v) -> M'.replace t k v | Clear -> M'.clear t
+
+let run_aux create apply t =
+  let state = create 100 in
+  let rec aux = function
+    | [] -> ()
+    | h :: rest ->
+        apply state h;
+        aux rest
+  in
+  aux t;
+  state
+
+let run = run_aux M.create apply
+let run' = run_aux M'.create apply'
+let eq m m' = M.bindings m = M'.bindings m'
+let arbitrary_action = QCheck.make gen_action ~print:print_action
+
+let test =
+  QCheck.Test.make ~name:"Maps" ~count:10_000
+    QCheck.(list arbitrary_action)
+    (fun t -> eq (run t) (run' t))
+
+let suite = [ QCheck_alcotest.to_alcotest test ]


### PR DESCRIPTION
Because of this bug, once an LRU cache is full and cleared it cannot be filled again with any new data... so it becomes rather useless. Found while trying to debug #1993 