### PR TITLE
irmin-pack: remove unecessary calls to Index.find

### DIFF
--- a/src/irmin-pack/indexing_strategy.ml
+++ b/src/irmin-pack/indexing_strategy.ml
@@ -50,3 +50,4 @@ let minimal_with_contents : t =
   | Dangling_parent_commit -> assert false
 
 let default = always
+let is_minimal x = x == minimal

--- a/src/irmin-pack/indexing_strategy.mli
+++ b/src/irmin-pack/indexing_strategy.mli
@@ -42,3 +42,6 @@ val default : t
 (** [default] is the indexing strategy used by [irmin-pack] instances that do
     not explicitly set an indexing strategy in {!Irmin_pack.config}. Currently
     set to {!always}. *)
+
+val is_minimal : t -> bool
+(** [is_minimal t] is true if [t] is {!minimal}. *)

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -420,6 +420,14 @@ struct
     Lwt.try_bind (fun () -> f (cast t)) on_success on_fail
 
   let unsafe_append ~ensure_unique ~overcommit t hash v =
+    let kind = Val.kind v in
+    let use_index =
+      (* the index is required for non-minimal indexing strategies and
+         for commits. *)
+      (not (Irmin_pack.Indexing_strategy.is_minimal t.indexing_strategy))
+      || kind = Commit_v1
+      || kind = Commit_v2
+    in
     let unguarded_append () =
       [%log.debug "[pack] append %a" pp_hash hash];
       let offset_of_key k =
@@ -449,7 +457,6 @@ struct
       let len = Int63.to_int (Dispatcher.end_offset t.dispatcher - off) in
       let key = Pack_key.v_direct ~hash ~offset:off ~length:len in
       let () =
-        let kind = Val.kind v in
         let should_index = t.indexing_strategy ~value_length:len kind in
         if should_index then
           Index.add ~overcommit (Fm.index t.fm) hash (off, len, kind)
@@ -459,7 +466,7 @@ struct
       [%log.debug "[pack] append done %a <- %a" pp_hash hash pp_key key];
       key
     in
-    match ensure_unique with
+    match ensure_unique && use_index with
     | false -> unguarded_append ()
     | true -> (
         match index_direct t hash with


### PR DESCRIPTION
In minimal indexing mode we don't need to check the index file too often

This removes a few calls to index in the benchmarks:

before:
```
+009us [DEBUG] irmin-pack.unix [pack] batch start
+012us [DEBUG] irmin-pack.unix index CoVkT31UeHdS8o4MMQtzR5jmdxZ5PHo9C1P7LLvn9sSvYub5tB3q
+040us [DEBUG] index [root] find CoVkT31UeHdS8o4MMQtzR5jmdxZ5PHo9C1P7LLvn9sSvYub5tB3q
+023us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoVkT31UeHdS8o4MMQtzR5jmdxZ5PHo9C1P7LLvn9sSvYub5tB3q",0,41]}
+028us [DEBUG] irmin.pack save depth:0
+010us [DEBUG] irmin-pack.unix index CoUr3AHPmaXCuYL2ps3bcKXwex2QmngoT9Z8LhhMWdLw8RTWZbGc
+010us [DEBUG] index [root] find CoUr3AHPmaXCuYL2ps3bcKXwex2QmngoT9Z8LhhMWdLw8RTWZbGc
+011us [DEBUG] irmin-pack.unix [dict] index "version"
+010us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoUr3AHPmaXCuYL2ps3bcKXwex2QmngoT9Z8LhhMWdLw8RTWZbGc",41,46]}
+018us [DEBUG] irmin-pack.unix index CoWMouGpUV1DJEMBUvZRToG6e2H2JK7FbW2xxMMyECWfvJZ4pNfZ
+009us [DEBUG] index [root] find CoWMouGpUV1DJEMBUvZRToG6e2H2JK7FbW2xxMMyECWfvJZ4pNfZ
+011us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoWMouGpUV1DJEMBUvZRToG6e2H2JK7FbW2xxMMyECWfvJZ4pNfZ",87,66]}
+015us [DEBUG] irmin-pack.unix index CoVa898LzEftSsbRB5gHhNtRqUwsVDoS1gw6fs4LtNQQDgzjXzfh
+010us [DEBUG] index [root] find CoVa898LzEftSsbRB5gHhNtRqUwsVDoS1gw6fs4LtNQQDgzjXzfh
+010us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoVa898LzEftSsbRB5gHhNtRqUwsVDoS1gw6fs4LtNQQDgzjXzfh",153,35]}
+016us [DEBUG] irmin.pack save depth:0
+008us [DEBUG] irmin-pack.unix index CoVmWcmHnA6efWzV8PS7fdVSX2EaJsLCU5uj231DpzizqSv8b271
+010us [DEBUG] index [root] find CoVmWcmHnA6efWzV8PS7fdVSX2EaJsLCU5uj231DpzizqSv8b271
+010us [DEBUG] irmin-pack.unix [dict] index "test_chain"
+006us [DEBUG] irmin-pack.unix [dict] index "protocol"
+005us [DEBUG] irmin-pack.unix [dict] index "data"
+007us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoVmWcmHnA6efWzV8PS7fdVSX2EaJsLCU5uj231DpzizqSv8b271",188,66]}
+017us [DEBUG] irmin-pack.unix index CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj
+010us [DEBUG] index [root] find CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj
+015us [DEBUG] index [root] replace CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj [254,66,"D"]
+019us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj",254,66]}
+014us [INFO] irmin-pack.unix [pack] batch completed in 0.35ms
```

after:

```
+009us [DEBUG] irmin-pack.unix [pack] batch start
+018us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoVkT31UeHdS8o4MMQtzR5jmdxZ5PHo9C1P7LLvn9sSvYub5tB3q",0,41]}
+052us [DEBUG] irmin.pack save depth:0
+012us [DEBUG] irmin-pack.unix [dict] index "version"
+011us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoUr3AHPmaXCuYL2ps3bcKXwex2QmngoT9Z8LhhMWdLw8RTWZbGc",41,46]}
+019us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoWMouGpUV1DJEMBUvZRToG6e2H2JK7FbW2xxMMyECWfvJZ4pNfZ",87,66]}
+016us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoVa898LzEftSsbRB5gHhNtRqUwsVDoS1gw6fs4LtNQQDgzjXzfh",153,35]}
+016us [DEBUG] irmin.pack save depth:0
+008us [DEBUG] irmin-pack.unix [dict] index "test_chain"
+006us [DEBUG] irmin-pack.unix [dict] index "protocol"
+005us [DEBUG] irmin-pack.unix [dict] index "data"
+006us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoVmWcmHnA6efWzV8PS7fdVSX2EaJsLCU5uj231DpzizqSv8b271",188,66]}
+018us [DEBUG] irmin-pack.unix index CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj
+011us [DEBUG] index [root] find CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj
+018us [DEBUG] index [root] replace CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj [254,66,"D"]
+017us [DEBUG] irmin-pack.unix [pack] append {"Direct":["CoV8SQumiVU9saiu3FVNeDNewJaJH8yWdsGF3WLdsRr2P9S7MzCj",254,66]}
+014us [INFO] irmin-pack.unix [pack] batch completed in 0.24ms
```