### PR TITLE
irmin-pack: do not cache when hashing inodes

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1206,7 +1206,7 @@ struct
         let v_ref =
           Val_ref.of_hash
             (lazy
-              (let vs = seq layout t in
+              (let vs = seq layout ~cache:false t in
                Node.hash (Node.of_seq vs)))
         in
         { v_ref; v = t.v; root = true }


### PR DESCRIPTION
They will most probably be discarded right away as the hash are forced
during Tree.export and cache are usually cleared just after this.