### PR TITLE
irmin-pack: only auto finalise high level gc api

### DIFF
--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -70,6 +70,9 @@ module type Specifics = sig
     (** [start_exn] tries to start the GC process and returns true if the GC is
         launched. If a GC is already running, a new one is not started.
 
+        The GC process will not be automatically finalised. The caller is
+        responsible for calling {!finalise_exn}.
+
         If [unlink] is false then temporary files and files from the previous
         generation will be kept on disk after the GC finished. This option is
         useful for debugging. The default is [true].


### PR DESCRIPTION
This PR changes the gc api so that only the high level api auto-finalizes. Closes #2011 

1. Make clearer distinction between high and low level apis; low is for more control and hence manual finalization makes sense
2. Fix tests that fail intermittently because they have been written with the low level api and expect objects to gc at certain times

