### PR TITLE
irmin-pack: stats are not option in run callback

### DIFF
--- a/examples/gc.ml
+++ b/examples/gc.ml
@@ -100,10 +100,9 @@ let gc_all_but_head repo branch =
   let* head = Store.Head.get branch in
   let head_key = Store.Commit.key head in
   let finished = function
-    | Ok (Some (r : Store.Gc.stats)) ->
+    | Ok (r : Store.Gc.stats) ->
         Printf.printf "GC finished in %.4fms. Size of repo: %.2fMB.\n" r.elapsed
           (megabytes_of_path Repo_config.root)
-    | Ok None -> Printf.printf "GC finished without stats\n"
     | Error (`Msg err) -> print_endline err
   in
   let+ launched = Store.Gc.run ~finished repo head_key in

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -103,7 +103,7 @@ module type Specifics = sig
         logging *)
 
     val run :
-      ?finished:((stats option, msg) result -> unit) ->
+      ?finished:((stats, msg) result -> unit) ->
       repo ->
       commit_key ->
       (bool, msg) result Lwt.t

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -151,8 +151,8 @@ module Maker (Config : Conf.S) = struct
         unlink : bool;
         offset : int63;
         elapsed : unit -> float;
-        resolver : (gc_stats option, Errs.t) result Lwt.u;
-        promise : (gc_stats option, Errs.t) result Lwt.t;
+        resolver : (gc_stats, Errs.t) result Lwt.u;
+        promise : (gc_stats, Errs.t) result Lwt.t;
         use_auto_finalisation : bool;
       }
 
@@ -498,7 +498,7 @@ module Maker (Config : Conf.S) = struct
                             (Int63.sub new_suffix_end_offset copy_end_offset)];
                         let elapsed = elapsed () in
                         let stats = { elapsed } in
-                        let () = Lwt.wakeup_later resolver (Ok (Some stats)) in
+                        let () = Lwt.wakeup_later resolver (Ok stats) in
                         Ok (`Finalised stats)
                     | _ ->
                         let err = gc_errors status gc_output in


### PR DESCRIPTION
This PR fixes unneeded type wrapper for stats in the `run` callback. Thanks @Ngoguey42 for spotting!