### PR TITLE
irmin-pack: use mmap for the mapping file

### DIFF
--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -40,8 +40,15 @@ module V3 = struct
   let sorted ~generation =
     toplevel ("store." ^ string_of_int generation ^ ".sorted")
 
-  let mapping ~generation =
-    toplevel ("store." ^ string_of_int generation ^ ".mapping")
+  let mapping =
+    (* if we use mmap for the mapping file, then the mapping file is not portable between
+       architectures with different endianness; to avoid the possibility that a
+       little-endian file is used on a big-endian arch (or vice versa) we use a filename
+       that is not portable between archs; since the common case is little endian, we make
+       this the "default" empty suffix, and for big endian we add ".be" *)
+    let empty_or_be = match Sys.big_endian with false -> "" | true -> ".be" in
+    fun ~generation ->
+      toplevel ("store." ^ string_of_int generation ^ ".mapping" ^ empty_or_be)
 
   let prefix ~generation =
     toplevel ("store." ^ string_of_int generation ^ ".prefix")

--- a/src/irmin-pack/unix/dispatcher.ml
+++ b/src/irmin-pack/unix/dispatcher.ml
@@ -33,42 +33,76 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
   let read_prefix = ref 0
   (*TODO move them in stats*)
 
-  type mapping_value = { poff : int63; len : int }
-  (** [poff] is a prefix offset (i.e. an offset in the prefix file), [len] is
-      the length of the chunk starting at [poff]. *)
+  type mapping = Mapping_file.mapping_as_int_bigarray
 
-  type mapping = mapping_value Intmap.t
+  module Mapping_util = struct
+    type entry = { off : int63; poff : int63; len : int }
+    (** [entry] is a type for the return value from {!find_nearest_leq}; see doc
+        for {!type:mapping} above. *)
+
+    let nearest_leq = Utils.nearest_leq
+
+    (** [find_nearest_leq ~mapping off] returns the entry in [mapping] whose
+        offset is the nearest [<=] the given [off] *)
+    let find_nearest_leq ~(mapping : mapping) off =
+      match mapping with
+      | Int_bigarray arr -> (
+          match BigArr1.dim arr with
+          | 0 ->
+              (* NOTE this is probably an error case; perhaps log an error *)
+              [%log.warn
+                "%s: mapping array had 0 length; this is probably an error"
+                  __FILE__];
+              None
+          | len -> (
+              assert (len mod 3 = 0);
+              (* see invariant-mapping-array *)
+              let actual_len = len / 3 in
+              (* see invariant-mapping-array: we want to perform binary search wrt. the
+                 first int in each consecutive triple *)
+              let get arr i = arr.{i * 3} in
+              match
+                nearest_leq ~arr ~get ~lo:0 ~hi:(actual_len - 1)
+                  ~key:(Int63.to_int off)
+              with
+              | `All_gt_key -> None
+              | `Some i ->
+                  (* NOTE the i returned is as seen via [get] above, i.e., we need to multiply
+                     by 3 to get the actual index in the array *)
+                  let off, poff, len =
+                    (arr.{3 * i}, arr.{(3 * i) + 1}, arr.{(3 * i) + 2})
+                  in
+                  Some { off = Int63.of_int off; poff = Int63.of_int poff; len }
+              ))
+  end
 
   type t = { fm : Fm.t; mutable mapping : mapping; root : string }
   (** [mapping] is a map from global offset to (offset,len) pairs in the prefix
       file *)
 
-  let load_mapping io =
+  let empty_mapping = Mapping_file.empty_mapping
+
+  let load_mapping path =
     let open Result_syntax in
-    let open Int63 in
-    let open Int63.Syntax in
-    let mapping = ref Intmap.empty in
-    let poff = ref zero in
-    let f ~off ~len =
-      mapping := Intmap.add off { poff = !poff; len } !mapping;
-      poff := !poff + of_int len
-    in
-    let* () = Mapping_file.iter io f in
-    Ok !mapping
+    let* arr = Mapping_file.load_mapping_as_mmap path in
+    (* NOTE arr is an array of tuples (off,poff,len); see invariant-mapping-array *)
+    Ok arr
 
   let reload t =
     let open Result_syntax in
     let* mapping =
       match Fm.mapping t.fm with
-      | None -> Ok Intmap.empty
-      | Some io -> load_mapping io
+      | None -> Ok empty_mapping
+      (* presumably this mapping is not used subsequently, i.e., the suffix file starts
+         from virtual offset 0, and the prefix will never be inspected *)
+      | Some path -> load_mapping path
     in
     t.mapping <- mapping;
     Ok ()
 
   let v ~root fm =
     let open Result_syntax in
-    let t = { fm; mapping = Intmap.empty; root } in
+    let t = { fm; mapping = empty_mapping; root } in
     Fm.register_mapping_consumer fm ~after_reload:(fun () -> reload t);
     let* () = reload t in
     Ok t
@@ -109,13 +143,11 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
      gced entry, or doing an invalid read. We expose two [read_exn] functions
      and we handled this upstream. *)
   let chunk_of_off_exn mapping off_start =
+    (* NOTE off_start is a virtual offset *)
     let open Int63 in
     let open Int63.Syntax in
-    match
-      Intmap.find_last_opt
-        (fun chunk_off_start -> chunk_off_start <= off_start)
-        mapping
-    with
+    let res = Mapping_util.find_nearest_leq ~mapping off_start in
+    match res with
     | None ->
         (* Case 1: The entry if before the very first chunk (or there are no
            chunks). Possibly the entry was gced. *)
@@ -124,9 +156,10 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
             Int63.pp off_start
         in
         raise (Errors.Pack_error (`Invalid_read_of_gced_object s))
-    | Some (chunk_off_start, chunk) ->
+    | Some (entry : Mapping_util.entry) ->
+        let chunk_off_start = entry.off in
         assert (chunk_off_start <= off_start);
-        let chunk_len = chunk.len in
+        let chunk_len = entry.len in
         let chunk_off_end = chunk_off_start + of_int chunk_len in
 
         (* Case 2: The entry starts after the chunk. Possibly the entry was
@@ -136,15 +169,15 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
            Fmt.str
              "offset %a is supposed to be contained in chunk \
               (off=%a,poff=%a,len=%d) but starts after chunk"
-             Int63.pp off_start Int63.pp chunk_off_start Int63.pp chunk.poff
-             chunk.len
+             Int63.pp off_start Int63.pp chunk_off_start Int63.pp entry.poff
+             entry.len
          in
          raise (Errors.Pack_error (`Invalid_read_of_gced_object s)));
 
         let shift_in_chunk = off_start - chunk_off_start in
         let max_entry_len = of_int chunk_len - shift_in_chunk in
 
-        (chunk, shift_in_chunk, max_entry_len)
+        (entry, shift_in_chunk, max_entry_len)
 
   (* After we find the chunk of an entry, we check that a read is possible in the
      chunk. If it's not, this is always an invalid read. *)

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -52,8 +52,12 @@ module type S = sig
       prefix, it will read the remaining in the prefix. *)
 
   type mapping
+  (** [mapping] implements a map from global offset to [(offset,len)] in the
+      prefix file *)
 
-  val load_mapping : Fm.Io.t -> (mapping, [> Fm.Errs.t ]) result
+  val load_mapping : string -> (mapping, [> Fm.Errs.t ]) result
+  (** [load_mapping path] loads the [mapping] from the given path and returns it *)
+
   val poff_of_entry_exn : mapping -> off:int63 -> len:int -> int63
 end
 

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -45,7 +45,7 @@ struct
     control : Control.t;
     mutable suffix : Suffix.t;
     mutable prefix : Prefix.t option;
-    mutable mapping : Mapping.t option;
+    mutable mapping : string option;
     index : Index.t;
     mutable mapping_consumers : after_reload_consumer list;
     mutable dict_consumers : after_reload_consumer list;
@@ -67,7 +67,6 @@ struct
     let* () = Dict.close t.dict in
     let* () = Control.close t.control in
     let* () = Suffix.close t.suffix in
-    let* () = Option.might Mapping.close t.mapping in
     let* () = Option.might Prefix.close t.prefix in
     let+ () = Index.close t.index in
     ()
@@ -216,15 +215,13 @@ struct
     match prefix0 with None -> Ok () | Some io -> Prefix.close io
 
   let reopen_mapping t ~generation =
-    let open Result_syntax in
-    let* mapping1 =
-      let path = Irmin_pack.Layout.V3.mapping ~root:t.root ~generation in
-      [%log.debug "reload: generation changed, opening %s" path];
-      Mapping.open_ ~readonly:true ~path
-    in
-    let mapping0 = t.mapping in
-    t.mapping <- Some mapping1;
-    match mapping0 with None -> Ok () | Some io -> Mapping.close io
+    let path = Irmin_pack.Layout.V3.mapping ~root:t.root ~generation in
+    [%log.debug "reload: generation changed, opening %s" path];
+    (* NOTE the log line assumes the generation has changed; thus, even though t.mapping
+       may be None for generation 0, by this point generation > 0 *)
+    assert (generation > 0);
+    t.mapping <- Some path;
+    ()
 
   let reopen_suffix t ~generation ~end_offset =
     let open Result_syntax in
@@ -307,9 +304,10 @@ struct
       let path = Irmin_pack.Layout.V3.prefix ~root ~generation in
       only_open_after_gc ~generation ~path
     in
-    let* mapping =
-      let path = Irmin_pack.Layout.V3.mapping ~root ~generation in
-      only_open_after_gc ~generation ~path
+    let mapping =
+      match generation with
+      | 0 -> None (* generation 0 has no mapping *)
+      | _ -> Some (Irmin_pack.Layout.V3.mapping ~root ~generation)
     in
     let* dict =
       let path = Irmin_pack.Layout.V3.dict ~root in
@@ -380,7 +378,7 @@ struct
         else
           let end_offset = pl1.entry_offset_suffix_end in
           let* () = reopen_suffix t ~generation:gen1 ~end_offset in
-          let* () = reopen_mapping t ~generation:gen1 in
+          let () = reopen_mapping t ~generation:gen1 in
           let* () = reopen_prefix t ~generation:gen1 in
           Ok ()
       in
@@ -592,9 +590,10 @@ struct
       let path = Irmin_pack.Layout.V3.prefix ~root ~generation in
       only_open_after_gc ~path ~generation
     in
-    let* mapping =
-      let path = Irmin_pack.Layout.V3.mapping ~root ~generation in
-      only_open_after_gc ~path ~generation
+    let mapping =
+      match generation with
+      | 0 -> None (* generation 0 has no mapping *)
+      | _ -> Some (Irmin_pack.Layout.V3.mapping ~root ~generation)
     in
     let* dict =
       let path = Irmin_pack.Layout.V3.dict ~root in
@@ -662,7 +661,7 @@ struct
     let c0 = Mtime_clock.counter () in
     (* Step 1. Reopen files *)
     let* () = reopen_prefix t ~generation in
-    let* () = reopen_mapping t ~generation in
+    let () = reopen_mapping t ~generation in
     (* When opening the suffix in append_only we need to provide a (real) suffix
        offset, computed from the global ones. *)
     let open Int63.Syntax in

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -37,7 +37,10 @@ module type S = sig
   val dict : t -> Dict.t
   val suffix : t -> Suffix.t
   val index : t -> Index.t
-  val mapping : t -> Io.t option
+
+  val mapping : t -> string option
+  (** path to mapping file *)
+
   val prefix : t -> Io.t option
 
   type create_error :=

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -275,14 +275,9 @@ module Make (Args : Args) : S with module Args := Args = struct
       ()
     in
 
-    let path = Irmin_pack.Layout.V3.mapping ~root ~generation in
-    let* mapping = Io.open_ ~path ~readonly:true in
+    let mapping_path = Irmin_pack.Layout.V3.mapping ~root ~generation in
+    let* mapping = Mapping_file.load_mapping_as_mmap mapping_path in
     let* () =
-      Errors.finalise (fun _ ->
-          Io.close mapping |> Errs.log_if_error "GC: Close mapping")
-      @@ fun () ->
-      ();
-
       (* Step 4. Create the new prefix. *)
       let prefix_ref = ref None in
       let auto_flush_callback () =
@@ -312,14 +307,14 @@ module Make (Args : Args) : S with module Args := Args = struct
           let len = Int63.of_int len in
           transfer_append_exn ~read_exn ~append_exn ~off ~len buffer
         in
-        let* () = Mapping_file.iter mapping f in
+        let* () = Mapping_file.iter_mmap mapping f in
         Ao.flush prefix
       in
       (* Step 5.2. Transfer again the parent commits but with a modified
          magic. Load the mapping in memory to do a safe localisation of the
          parent commits. Reopen the new prefix, this time _not_ in append-only
          as we have to modify data inside the file. *)
-      let* in_memory_map = Dispatcher.load_mapping mapping in
+      let* in_memory_map = Dispatcher.load_mapping mapping_path in
       let read_exn = Dispatcher.read_exn dispatcher in
       let* prefix =
         let path = Irmin_pack.Layout.V3.prefix ~root ~generation in

--- a/src/irmin-pack/unix/import.ml
+++ b/src/irmin-pack/unix/import.ml
@@ -55,3 +55,19 @@ module Result_syntax = struct
   let ( let+ ) res f = Result.map f res
   let ( let* ) res f = Result.bind res f
 end
+
+type int_bigarray = (int, Bigarray.int_elt, Bigarray.c_layout) Bigarray.Array1.t
+(** [int_bigarray] is the raw type for the mapping file data, exposed via mmap *)
+
+module BigArr1 = Bigarray.Array1
+(** Simple module alias *)
+
+(** Essentially the Y combinator; useful for anonymous recursive functions. The
+    k argument is the recursive call. Example:
+
+    {[
+      iter_k (fun ~k n -> if n = 0 then 1 else n * k (n - 1))
+    ]} *)
+let iter_k f (x : 'a) =
+  let rec k x = f ~k x in
+  k x

--- a/src/irmin-pack/unix/irmin_pack_unix.ml
+++ b/src/irmin-pack/unix/irmin_pack_unix.ml
@@ -31,6 +31,7 @@ module Append_only_file = Append_only_file
 module File_manager = File_manager
 module Maker = Ext.Maker
 module Mapping_file = Mapping_file
+module Utils = Utils
 
 module KV (Config : Irmin_pack.Conf.S) = struct
   type endpoint = unit

--- a/src/irmin-pack/unix/utils.ml
+++ b/src/irmin-pack/unix/utils.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Import
+
 module Object_counter : sig
   type t
 
@@ -60,3 +62,40 @@ end = struct
     finalise t_outer;
     (!(t.nb_contents), !(t.nb_nodes), !(t.nb_commits))
 end
+
+(** [nearest_leq ~arr ~get ~lo ~hi ~key] returns the nearest entry in the sorted
+    [arr] that is [<=] the given key. Routine is based on binary search. *)
+let nearest_leq ~arr ~get ~lo ~hi ~key =
+  assert (lo <= hi);
+  match get arr lo <= key with
+  | false ->
+      (* trivial case: arr[lo] > key; so all arr entries greater than key, since arr is
+         sorted *)
+      `All_gt_key
+  | true -> (
+      (* NOTE arr[lo] <= key *)
+      (* trivial case: arr[hi] <= key; then within the range lo,hi the nearest leq entry
+         is at index hi *)
+      match get arr hi <= key with
+      | true -> `Some hi
+      | false ->
+          (* NOTE key < arr[hi] *)
+          (lo, hi)
+          |> iter_k (fun ~k:kont (lo, hi) ->
+                 (* loop invariants *)
+                 assert (get arr lo <= key && key < get arr hi);
+                 assert (lo < hi);
+                 (* follows from arr[lo] <= key < arr[hi] *)
+                 match lo + 1 = hi with
+                 | true -> `Some lo
+                 | false -> (
+                     (* NOTE at least one entry between arr[lo] and arr[hi] *)
+                     assert (lo + 2 <= hi);
+                     let mid = (lo + hi) / 2 in
+                     let arr_mid = get arr mid in
+                     match arr_mid <= key with
+                     | true -> kont (mid, hi)
+                     | false ->
+                         (* NOTE we can't call kont with mid-1 because we need the loop invariant
+                            (key < arr[hi]) to hold *)
+                         kont (lo, mid))))

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -13,7 +13,8 @@
   test_upgrade
   test_gc
   test_flush_reload
-  test_mapping)
+  test_mapping
+  test_nearest_leq)
  (libraries
   alcotest
   fmt

--- a/test/irmin-pack/test_mapping.ml
+++ b/test/irmin-pack/test_mapping.ml
@@ -34,11 +34,12 @@ let process_on_disk pairs =
     Mapping_file.create ~root:test_dir ~generation:0 ~register_entries
     |> Errs.raise_if_error
   in
-  let io = Io.open_ ~path:mapping_path ~readonly:true |> Errs.raise_if_error in
+  let mf =
+    Mapping_file.load_mapping_as_mmap mapping_path |> Errs.raise_if_error
+  in
   let l = ref [] in
   let f ~off ~len = l := (Int63.to_int off, len) :: !l in
-  Mapping_file.iter io f |> Errs.raise_if_error;
-  Io.close io |> ignore;
+  Mapping_file.iter_mmap mf f |> Errs.raise_if_error;
   !l |> List.rev
 
 (** Emulate the behaviour of the [Mapping_file] routines to process [pairs] *)

--- a/test/irmin-pack/test_nearest_leq.ml
+++ b/test/irmin-pack/test_nearest_leq.ml
@@ -1,0 +1,29 @@
+open Irmin_pack_unix
+
+let nearest_leq = Utils.nearest_leq
+
+let test_nearest_leq () =
+  let arr = Array.of_list [ 1; 3; 5; 7 ] in
+  let get arr i = arr.(i) in
+  let lo, hi = (0, Array.length arr - 1) in
+  let nearest_leq_ key = nearest_leq ~arr ~get ~lo ~hi ~key in
+  assert (nearest_leq_ 0 = `All_gt_key);
+  assert (nearest_leq_ 1 = `Some 0);
+  assert (nearest_leq_ 2 = `Some 0);
+  assert (nearest_leq_ 3 = `Some 1);
+  assert (nearest_leq_ 3 = `Some 1);
+  assert (nearest_leq_ 4 = `Some 1);
+  assert (nearest_leq_ 5 = `Some 2);
+  assert (nearest_leq_ 6 = `Some 2);
+  assert (nearest_leq_ 7 = `Some 3);
+  assert (nearest_leq_ 8 = `Some 3);
+  assert (nearest_leq_ 100 = `Some 3);
+  ()
+
+let tests : unit Alcotest_lwt.test_case list =
+  Alcotest_lwt.
+    [
+      test_case "test_nearest_leq.1" `Quick (fun _switch () ->
+          test_nearest_leq ();
+          Lwt.return ());
+    ]

--- a/test/irmin-pack/test_nearest_leq.mli
+++ b/test/irmin-pack/test_nearest_leq.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -512,4 +512,5 @@ let misc =
     ("concurrent gc", Test_gc.Concurrent_gc.tests);
     ("flush", Test_flush_reload.tests);
     ("mapping", Test_mapping.tests);
+    ("test_nearest_leq", Test_nearest_leq.tests);
   ]


### PR DESCRIPTION
This commit changes the mapping file to use mmap on load. The code to
save the mapping has also changed, to take account of mmap format. In
hangzhou benchmarks, this substantially improves the time taken for the
main process to switch to the new prefix/suffix created by the GC
process. For example, the maximum switch time during the benchmark was
0.5s, for a 166MB mapping file (with gap_tolerance=0), with the load of
the mapping file itself being effectively instantaneous.

mmap files are not portable across architectures with different
endianness. Almost surely users are on little-endian machines. However,
to protect against a user copying a little-endian context to a
big-endian machine, the mapping file name has been changed to include
the endianness of the host machine.

We use binary search within the mmap array, rather than constructing an
explicit OCaml Map.t. This makes the load time effectively instant,
whilst also substantially reducing the memory usage (we don't have to
maintain an explicit tree in memory). Read-only processes which also use
the mmap should share the same memory, further reducing the overall
memory usage when running multiple processes.

For the mapping_file we add a private type to enforce invariants on
mmap'ed data (that the array has a size a multiple of 3, since the array
holds 3-tuples).

There is an additional test for [nearest_leq], which implements binary
search directly on an array to find the nearest key
less-than-or-equal-to a given key.

The existing [test_mapping] has been fixed to take account of the new
mapping-as-mmap implementation.

This replaces a previous PR #1966, and hopefully addresses most of the
comments from there.