### PR TITLE
Enable libirmin for macos

### DIFF
--- a/libirmin.opam
+++ b/libirmin.opam
@@ -20,4 +20,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
 
-available: [ arch != "arm64" ] # disabled because of SEGFAULT
+# Disabled on arm64 linux and s390x because of a SEGFAULT in tests
+available: [ (arch != "arm64" | os = "macos") & arch != "s390x" ] 


### PR DESCRIPTION
I finally got around to running the libirmin tests on an arm64 macOS machine and it doesn't have the same issue as arm64 linux, so this PR enables libirmin for macOS.