### PR TITLE
irmin-pack: use Lwt in gc finished callback

### DIFF
--- a/bench/irmin-pack/trace_replay.ml
+++ b/bench/irmin-pack/trace_replay.ml
@@ -416,7 +416,8 @@ module Make (Store : Store) = struct
                     let commit_duration = commit_idx - gc_start_commit_idx in
                     [%logs.app
                       "Gc ended after %d commits, %a" commit_duration
-                        (Repr.pp Store.gc_stats_t) stats]
+                        (Repr.pp Store.gc_stats_t) stats];
+                    Lwt.return_unit
                 | Error s -> failwith s
               in
               Store.gc_run ~finished repo gc_commit_key)

--- a/bench/irmin-pack/trace_replay_intf.ml
+++ b/bench/irmin-pack/trace_replay_intf.ml
@@ -114,7 +114,7 @@ module type Store = sig
   [@@deriving irmin]
 
   val gc_run :
-    ?finished:((gc_stats, string) result -> unit) ->
+    ?finished:((gc_stats, string) result -> unit Lwt.t) ->
     repo ->
     commit_key ->
     unit Lwt.t

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -69,7 +69,7 @@ module type Store = sig
   [@@deriving irmin]
 
   val gc_run :
-    ?finished:((gc_stats, string) result -> unit) ->
+    ?finished:((gc_stats, string) result -> unit Lwt.t) ->
     repo ->
     commit_key ->
     unit Lwt.t
@@ -246,7 +246,7 @@ struct
   }
   [@@deriving irmin]
 
-  let gc_run ?(finished = fun _ -> ()) repo key =
+  let gc_run ?(finished = fun _ -> Lwt.return_unit) repo key =
     let f (result : (Store.Gc.stats, Store.Gc.msg) result) =
       match result with
       | Error (`Msg err) -> finished @@ Error err

--- a/examples/gc.ml
+++ b/examples/gc.ml
@@ -105,7 +105,8 @@ let gc_all_but_head repo branch =
           "GC finished in %.4fs. Finalisation took %.4fs. Size of repo: %.2fMB.\n"
           r.duration r.finalisation_duration
           (megabytes_of_path Repo_config.root)
-    | Error (`Msg err) -> print_endline err
+        |> Lwt.return
+    | Error (`Msg err) -> print_endline err |> Lwt.return
   in
   let+ launched = Store.Gc.run ~finished repo head_key in
   match launched with

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -111,7 +111,7 @@ module type Specifics = sig
         logging *)
 
     val run :
-      ?finished:((stats, msg) result -> unit) ->
+      ?finished:((stats, msg) result -> unit Lwt.t) ->
       repo ->
       commit_key ->
       (bool, msg) result Lwt.t

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -39,7 +39,7 @@ module Store = struct
   }
   [@@deriving irmin]
 
-  let gc_run ?(finished = fun _ -> ()) repo key =
+  let gc_run ?(finished = fun _ -> Lwt.return_unit) repo key =
     let f (result : (Store.Gc.stats, Store.Gc.msg) result) =
       match result with
       | Error (`Msg err) -> finished @@ Error err
@@ -157,7 +157,7 @@ module Store_mem = struct
   }
   [@@deriving irmin]
 
-  let gc_run ?(finished = fun _ -> ()) repo key =
+  let gc_run ?(finished = fun _ -> Lwt.return_unit) repo key =
     let f (result : (Store.Gc.stats, Store.Gc.msg) result) =
       match result with
       | Error (`Msg err) -> finished @@ Error err


### PR DESCRIPTION
This PR updates the gc finished callback to allows callers to more easily use Lwt.