### PR TITLE
irmin-pack: change append only auto flush callback to pass `t`

### DIFF
--- a/src/irmin-pack/unix/append_only_file.ml
+++ b/src/irmin-pack/unix/append_only_file.ml
@@ -20,19 +20,19 @@ include Append_only_file_intf
 module Make (Io : Io.S) = struct
   module Io = Io
 
-  type rw_perm = {
-    buf : Buffer.t;
-    auto_flush_threshold : int;
-    auto_flush_callback : unit -> unit;
-  }
-  (** [rw_perm] contains the data necessary to operate in readwrite mode. *)
-
   type t = {
     io : Io.t;
     mutable persisted_end_offset : int63;
     dead_header_size : int63;
     rw_perm : rw_perm option;
   }
+
+  and rw_perm = {
+    buf : Buffer.t;
+    auto_flush_threshold : int;
+    auto_flush_callback : t -> unit;
+  }
+  (** [rw_perm] contains the data necessary to operate in readwrite mode. *)
 
   let create_rw ~path ~overwrite ~auto_flush_threshold ~auto_flush_callback =
     let open Result_syntax in
@@ -164,6 +164,6 @@ module Make (Io : Io.S) = struct
         assert (Buffer.length rw_perm.buf < rw_perm.auto_flush_threshold);
         Buffer.add_string rw_perm.buf s;
         if Buffer.length rw_perm.buf >= rw_perm.auto_flush_threshold then (
-          rw_perm.auto_flush_callback ();
+          rw_perm.auto_flush_callback t;
           assert (empty_buffer t))
 end

--- a/src/irmin-pack/unix/append_only_file_intf.ml
+++ b/src/irmin-pack/unix/append_only_file_intf.ml
@@ -33,7 +33,7 @@ module type S = sig
     path:string ->
     overwrite:bool ->
     auto_flush_threshold:int ->
-    auto_flush_callback:(unit -> unit) ->
+    auto_flush_callback:(t -> unit) ->
     (t, [> Io.create_error ]) result
   (** Create a rw instance of [t] by creating the file. *)
 
@@ -42,7 +42,7 @@ module type S = sig
     end_offset:int63 ->
     dead_header_size:int ->
     auto_flush_threshold:int ->
-    auto_flush_callback:(unit -> unit) ->
+    auto_flush_callback:(t -> unit) ->
     ( t,
       [> Io.open_error
       | `Closed

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -337,17 +337,11 @@ module Maker (Config : Conf.S) = struct
                0. *)
             let dead_header_size = 0 in
             let auto_flush_threshold = 1_000_000 in
-            let suffix_ref = ref None in
-            let auto_flush_callback () =
-              match !suffix_ref with
-              | None -> assert false
-              | Some x -> Aof.flush x |> Errs.raise_if_error
-            in
+            let auto_flush_callback x = Aof.flush x |> Errs.raise_if_error in
             let* suffix =
               Aof.open_rw ~path ~end_offset ~dead_header_size
                 ~auto_flush_callback ~auto_flush_threshold
             in
-            suffix_ref := Some suffix;
             Ok suffix
 
           let transfer_latest_newies ~generation ~right_start_offset

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -247,7 +247,7 @@ struct
           | None -> assert false
           | Some x -> x
         in
-        let cb () = suffix_requires_a_flush_exn t in
+        let cb _ = suffix_requires_a_flush_exn t in
         Suffix.open_rw ~path ~end_offset ~dead_header_size ~auto_flush_threshold
           ~auto_flush_callback:cb
     in
@@ -303,7 +303,7 @@ struct
       let auto_flush_threshold =
         Irmin_pack.Conf.suffix_auto_flush_threshold config
       in
-      let cb () = suffix_requires_a_flush_exn (get_instance ()) in
+      let cb _ = suffix_requires_a_flush_exn (get_instance ()) in
       make_suffix ~path ~auto_flush_threshold ~auto_flush_callback:cb
     in
     let* prefix =
@@ -316,7 +316,7 @@ struct
       let auto_flush_threshold =
         Irmin_pack.Conf.dict_auto_flush_threshold config
       in
-      let cb () = dict_requires_a_flush_exn (get_instance ()) in
+      let cb _ = dict_requires_a_flush_exn (get_instance ()) in
       make_dict ~path ~auto_flush_threshold ~auto_flush_callback:cb
     in
     let* index =

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -371,17 +371,11 @@ module Make (Io : Io.S) = struct
     Io.unlink path2 |> ignore;
 
     (* Create [file0] *)
-    let file0_ref = ref None in
-    let auto_flush_callback () =
-      match !file0_ref with
-      | None -> assert false
-      | Some x -> Ao.flush x |> Errs.raise_if_error
-    in
+    let auto_flush_callback x = Ao.flush x |> Errs.raise_if_error in
     let* file0 =
       Ao.create_rw ~path:path0 ~overwrite:true ~auto_flush_threshold:1_000_000
         ~auto_flush_callback
     in
-    file0_ref := Some file0;
 
     (* Fill and close [file0] *)
     let register_entry ~off ~len =
@@ -412,17 +406,11 @@ module Make (Io : Io.S) = struct
     Io.unlink path0 |> ignore;
 
     (* Create [file2] *)
-    let file2_ref = ref None in
-    let auto_flush_callback () =
-      match !file2_ref with
-      | None -> assert false
-      | Some x -> Ao.flush x |> Errs.raise_if_error
-    in
+    let auto_flush_callback x = Ao.flush x |> Errs.raise_if_error in
     let* file2 =
       Ao.create_rw ~path:path2 ~overwrite:true ~auto_flush_threshold:1_000_000
         ~auto_flush_callback
     in
-    file2_ref := Some file2;
 
     (* Fill and close [file2] *)
     let poff = ref 0 in


### PR DESCRIPTION
This PR changes the append file autoflush callback to pass `t` instead of `unit` to facilitate calls to `flush` and cleans up some code.