### PR TITLE
irmin-pack: Add more stats in gc finalise

### DIFF
--- a/bench/irmin-pack/trace_replay.ml
+++ b/bench/irmin-pack/trace_replay.ml
@@ -415,9 +415,8 @@ module Make (Store : Store) = struct
                     let commit_idx = t.latest_commit_idx in
                     let commit_duration = commit_idx - gc_start_commit_idx in
                     [%logs.app
-                      "Gc ended after %d commits, gc took %.4fms, finalisation \
-                       took %.4fms"
-                      commit_duration stats.duration stats.finalisation_duration]
+                      "Gc ended after %d commits, %a" commit_duration
+                        (Repr.pp Store.gc_stats_t) stats]
                 | Error s -> failwith s
               in
               Store.gc_run ~finished repo gc_commit_key)

--- a/bench/irmin-pack/trace_replay_intf.ml
+++ b/bench/irmin-pack/trace_replay_intf.ml
@@ -103,7 +103,15 @@ module type Store = sig
 
   val gc_wait : repo -> unit Lwt.t
 
-  type gc_stats = { duration : float; finalisation_duration : float }
+  type gc_stats = {
+    duration : float;
+    finalisation_duration : float;
+    read_gc_output_duration : float;
+    transfer_latest_newies_duration : float;
+    swap_duration : float;
+    unlink_duration : float;
+  }
+  [@@deriving irmin]
 
   val gc_run :
     ?finished:((gc_stats, string) result -> unit) ->

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -58,7 +58,15 @@ module type Store = sig
   val create_repo :
     root:string -> store_config -> (Repo.t * on_commit * on_end) Lwt.t
 
-  type gc_stats = { duration : float; finalisation_duration : float }
+  type gc_stats = {
+    duration : float;
+    finalisation_duration : float;
+    read_gc_output_duration : float;
+    transfer_latest_newies_duration : float;
+    swap_duration : float;
+    unlink_duration : float;
+  }
+  [@@deriving irmin]
 
   val gc_run :
     ?finished:((gc_stats, string) result -> unit) ->
@@ -231,7 +239,12 @@ struct
   type gc_stats = Store.Gc.stats = {
     duration : float;
     finalisation_duration : float;
+    read_gc_output_duration : float;
+    transfer_latest_newies_duration : float;
+    swap_duration : float;
+    unlink_duration : float;
   }
+  [@@deriving irmin]
 
   let gc_run ?(finished = fun _ -> ()) repo key =
     let f (result : (Store.Gc.stats, Store.Gc.msg) result) =

--- a/examples/gc.ml
+++ b/examples/gc.ml
@@ -102,8 +102,7 @@ let gc_all_but_head repo branch =
   let finished = function
     | Ok (r : Store.Gc.stats) ->
         Printf.printf
-          "GC finished in %.4fms. Finalisation took %.4fms. Size of repo: \
-           %.2fMB.\n"
+          "GC finished in %.4fs. Finalisation took %.4fs. Size of repo: %.2fMB.\n"
           r.duration r.finalisation_duration
           (megabytes_of_path Repo_config.root)
     | Error (`Msg err) -> print_endline err

--- a/src/irmin-pack/mem/irmin_pack_mem.ml
+++ b/src/irmin-pack/mem/irmin_pack_mem.ml
@@ -198,7 +198,17 @@ module Maker (Config : Irmin_pack.Conf.S) = struct
 
     module Gc = struct
       type msg = [ `Msg of string ]
-      type stats = { duration : float; finalisation_duration : float }
+
+      type stats = {
+        duration : float;
+        finalisation_duration : float;
+        read_gc_output_duration : float;
+        transfer_latest_newies_duration : float;
+        swap_duration : float;
+        unlink_duration : float;
+      }
+      [@@deriving irmin]
+
       type process_state = [ `Idle | `Running | `Finalised of stats ]
 
       let start_exn = X.Repo.start_gc

--- a/src/irmin-pack/s.ml
+++ b/src/irmin-pack/s.ml
@@ -58,8 +58,16 @@ module type Specifics = sig
   module Gc : sig
     (** GC *)
 
-    type stats = { duration : float; finalisation_duration : float }
-    (** Stats for a successful GC run. Times are in milliseconds. *)
+    type stats = {
+      duration : float;
+      finalisation_duration : float;
+      read_gc_output_duration : float;
+      transfer_latest_newies_duration : float;
+      swap_duration : float;
+      unlink_duration : float;
+    }
+    [@@deriving irmin]
+    (** Stats for a successful GC run. Times are in seconds. *)
 
     type process_state = [ `Idle | `Running | `Finalised of stats ]
     (** The state of the GC process after calling {!finalise_exn} *)

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -32,7 +32,12 @@ module Store = struct
   type gc_stats = Store.Gc.stats = {
     duration : float;
     finalisation_duration : float;
+    read_gc_output_duration : float;
+    transfer_latest_newies_duration : float;
+    swap_duration : float;
+    unlink_duration : float;
   }
+  [@@deriving irmin]
 
   let gc_run ?(finished = fun _ -> ()) repo key =
     let f (result : (Store.Gc.stats, Store.Gc.msg) result) =
@@ -145,7 +150,12 @@ module Store_mem = struct
   type gc_stats = Store.Gc.stats = {
     duration : float;
     finalisation_duration : float;
+    read_gc_output_duration : float;
+    transfer_latest_newies_duration : float;
+    swap_duration : float;
+    unlink_duration : float;
   }
+  [@@deriving irmin]
 
   let gc_run ?(finished = fun _ -> ()) repo key =
     let f (result : (Store.Gc.stats, Store.Gc.msg) result) =


### PR DESCRIPTION
This PR adds 4 new fields in gc stats, it adds a repr deriver for it and it changes all timers to `s` from `ms` and `us`. 