### PR TITLE
irmin-tezos: make the cram tests more robust

### DIFF
--- a/test/irmin-tezos/stat.t/run.t
+++ b/test/irmin-tezos/stat.t/run.t
@@ -1,9 +1,5 @@
 Running stat on a v3 store
-  $ STORE=PACK ../irmin_fsck.exe stat ../data/pack 2>&1 | cat -e
-  >> Getting statistics for store: `../data/pack'$
-  $
-  ^[[?25l                                                                               ^M                                                                               ^M$
-  ^[[?25h{$
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/pack 2>&1 | cat -e | tail -n 10
     "hash_size": {$
       "Bytes": 64$
     },$
@@ -16,7 +12,7 @@ Running stat on a v3 store
   }
 
 Running index-integrity-check on a v3 store minimal
-  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/pack --color=never 2>&1 | cat -e | tail -n 10
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/pack 2>&1 | cat -e | tail -n 10
     { "Commit_v1" = 0;$
       "Commit_v2" = 3;$
       "Contents" = 3;$


### PR DESCRIPTION
This is to avoid issues such as https://ci.ocamllabs.io/github/mirage/irmin/commit/f37ff1987d5a5e8a42fc4cbb45231cea62e84442/variant/debian-11-4.14+flambda_opam-2.1