### PR TITLE
irmin: add `Storage` module for creating custom storage layer backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+### Added
+
+- **irmin**
+  - Add `Storage` module for creating custom storage layers (#2047, @metanivek)
+  
+### Changed
+
+### Fixed
+
 ## 3.4.0 (2022-08-25)
 
 ### Added

--- a/examples/custom_storage.ml
+++ b/examples/custom_storage.ml
@@ -1,0 +1,101 @@
+(*
+ * Copyright (c) 2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Lwt.Syntax
+
+(** Create a configuration module for our storage. Here we demonstrate a simple
+    configuration for setting the initial size of the hash table. *)
+
+module Hashtbl_config = struct
+  module Conf = Irmin.Backend.Conf
+
+  let spec = Conf.Spec.v "hashtbl"
+  let init_size = Conf.key ~spec "init-size" Irmin.Type.int 8
+  let empty = Conf.empty spec
+end
+
+(** Create a {!Irmin.Storage.Make} functor for our hash table storage. *)
+
+module Hashtbl_storage : Irmin.Storage.Make =
+functor
+  (Key : Irmin.Type.S)
+  (Value : Irmin.Type.S)
+  ->
+  struct
+    module Tbl = Hashtbl.Make (struct
+      type t = Key.t
+
+      let equal a b = Irmin.Type.(unstage (equal Key.t)) a b
+      let hash k = Irmin.Type.(unstage (short_hash Key.t)) k
+    end)
+
+    (** Types *)
+
+    type t = { t : Value.t Tbl.t; l : Mutex.t }
+    type key = Key.t
+    type value = Value.t
+
+    (** Initialisation / Closing *)
+
+    let v config =
+      let init_size = Irmin.Backend.Conf.get config Hashtbl_config.init_size in
+      { t = Tbl.create init_size; l = Mutex.create () } |> Lwt.return
+
+    let close _t = Lwt.return_unit
+
+    (** Operations *)
+
+    let set { t; _ } key value = Tbl.replace t key value |> Lwt.return
+    let mem { t; _ } key = Tbl.mem t key |> Lwt.return
+    let find { t; _ } key = Tbl.find_opt t key |> Lwt.return
+    let keys { t; _ } = Tbl.to_seq_keys t |> List.of_seq |> Lwt.return
+    let remove { t; _ } key = Tbl.remove t key |> Lwt.return
+    let clear { t; _ } = Tbl.clear t |> Lwt.return
+
+    let batch t f =
+      Mutex.lock t.l;
+      let+ x =
+        Lwt.catch
+          (fun () -> f t)
+          (fun exn ->
+            Mutex.unlock t.l;
+            raise exn)
+      in
+      Mutex.unlock t.l;
+      x
+  end
+
+(** Create an Irmin store using our hash table with a specified hash type and
+    content type. Irmin will create one {!Irmin.Content_addressable} store for
+    storing data (keys, content, commits) and one {!Irmin.Atomic_write} store
+    for storing branches. Each store will have its own hash table. *)
+
+module Store =
+  Irmin.Of_storage (Hashtbl_storage) (Irmin.Hash.SHA256) (Irmin.Contents.String)
+
+let config ?(config = Hashtbl_config.empty) ?(init_size = 42) () =
+  Irmin.Backend.Conf.add config Hashtbl_config.init_size init_size
+
+let main () =
+  let* repo = Store.Repo.v (config ()) in
+  let* main = Store.main repo in
+  let info () = Store.Info.v 0L in
+  let key = "Hello" in
+  let* () = Store.set_exn main [ key ] ~info "world!" in
+  let* v = Store.get main [ key ] in
+  Printf.printf "%s, %s" key v |> Lwt.return
+
+let () = Lwt_main.run @@ main ()

--- a/examples/dune
+++ b/examples/dune
@@ -9,6 +9,7 @@
   custom_merge
   push
   custom_graphql
+  custom_storage
   fold
   gc)
  (libraries
@@ -37,7 +38,8 @@
   custom_merge.exe
   custom_graphql.exe
   fold.exe
-  gc.exe))
+  gc.exe
+  custom_storage.exe))
 
 (alias
  (name runtest)

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -224,3 +224,21 @@ let remote_store (type t) (module M : Generic_key.S with type t = t) (t : t) =
 module Metadata = Metadata
 module Json_tree = Store.Json_tree
 module Export_for_backends = Export_for_backends
+module Storage = Storage
+
+module Of_storage (M : Storage.Make) (H : Hash.S) (V : Contents.S) = struct
+  module CA = Storage.Content_addressable (M)
+  module AW = Storage.Atomic_write (M)
+  module Maker = Maker (CA) (AW)
+
+  include Maker.Make (struct
+    module Hash = H
+    module Contents = V
+    module Info = Info.Default
+    module Metadata = Metadata.None
+    module Path = Path.String_list
+    module Branch = Branch.String
+    module Node = Node.Make (Hash) (Path) (Metadata)
+    module Commit = Commit.Make (Hash)
+  end)
+end

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -481,6 +481,12 @@ module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
 module KV_maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
   KV_maker with type endpoint = unit and type metadata = unit
 
+module Storage = Storage
+
+(** Key-value store creator using {!Storage.Make}. *)
+module Of_storage (M : Storage.Make) (H : Hash.S) (V : Contents.S) :
+  KV with type hash = H.t and module Schema.Contents = V
+
 (** Advanced store creator. *)
 module Of_backend (B : Backend.S) :
   Generic_key.S

--- a/src/irmin/storage.ml
+++ b/src/irmin/storage.ml
@@ -1,0 +1,146 @@
+(*
+ * Copyright (c) 2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Import
+include Storage_intf
+
+module Read_only (M : Make) =
+functor
+  (K : Type.S)
+  (V : Type.S)
+  ->
+  struct
+    module S = M (K) (V)
+
+    type 'a t = S.t
+    type key = S.key
+    type value = S.value
+
+    let v = S.v
+    let mem = S.mem
+    let find = S.find
+    let close = S.close
+  end
+
+module Content_addressable (M : Make) : Content_addressable.Maker =
+functor
+  (H : Hash.S)
+  (V : Type.S)
+  ->
+  struct
+    include Read_only (M) (H) (V)
+    module H = Hash.Typed (H) (V)
+
+    let batch = S.batch
+
+    let add t value =
+      let key = H.hash value in
+      let+ () = S.set t key value in
+      key
+
+    let equal_hash = Type.(equal H.t |> unstage)
+    let pp_hash = Type.(pp H.t)
+
+    let unsafe_add t k v =
+      let+ hash' = add t v in
+      if equal_hash k hash' then ()
+      else
+        Fmt.failwith
+          "[unsafe_append] %a is not a valid key. Expecting %a instead.\n"
+          pp_hash k pp_hash hash'
+  end
+
+module Append_only (M : Make) : Append_only.Maker =
+functor
+  (Key : Type.S)
+  (Value : Type.S)
+  ->
+  struct
+    include Read_only (M) (Key) (Value)
+
+    let batch = S.batch
+    let add = S.set
+  end
+
+module Atomic_write (M : Make) : Atomic_write.Maker =
+functor
+  (Key : Type.S)
+  (Value : Type.S)
+  ->
+  struct
+    module S = M (Key) (Value)
+    module W = Watch.Make (Key) (Value)
+    module L = Lock.Make (Key)
+
+    type t = { t : S.t; w : W.t; l : L.t }
+    type key = S.key
+    type value = S.value
+    type watch = W.watch
+
+    let watches = W.v ()
+    let lock = L.v ()
+
+    let v config =
+      let* t = S.v config in
+      Lwt.return { t; w = watches; l = lock }
+
+    let find { t; _ } = S.find t
+    let mem { t; _ } = S.mem t
+
+    module Internal = struct
+      let set t w key value =
+        let* () = S.set t key value in
+        W.notify w key (Some value)
+
+      let remove t w key =
+        let* () = S.remove t key in
+        W.notify w key None
+    end
+
+    let list { t; _ } = S.keys t
+
+    let set { t; l; w } key value =
+      L.with_lock l key @@ fun () -> Internal.set t w key value
+
+    let remove { t; l; w } key =
+      L.with_lock l key @@ fun () -> Internal.remove t w key
+
+    let test_and_set =
+      let value_equal = Type.(unstage (equal (option Value.t))) in
+      fun { t; l; w } key ~test ~set:set_value ->
+        L.with_lock l key @@ fun () ->
+        let* v = S.find t key in
+        if value_equal v test then
+          let* () =
+            match set_value with
+            | Some set_value -> Internal.set t w key set_value
+            | None -> Internal.remove t w key
+          in
+          Lwt.return_true
+        else Lwt.return_false
+
+    let watch_key { w; _ } key = W.watch_key w key
+    let watch { w; _ } = W.watch w
+    let unwatch { w; _ } = W.unwatch w
+
+    let clear { t; w; _ } =
+      let* () = W.clear w in
+      S.clear t
+
+    let close { t; w; _ } =
+      let* () = W.clear w in
+      S.close t
+  end

--- a/src/irmin/storage.mli
+++ b/src/irmin/storage.mli
@@ -1,0 +1,23 @@
+(*
+ * Copyright (c) 2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+include Storage_intf.Sigs
+(** @inline *)
+
+module Read_only (M : Make) : Read_only.Maker
+module Content_addressable (M : Make) : Content_addressable.Maker
+module Append_only (M : Make) : Append_only.Maker
+module Atomic_write (M : Make) : Atomic_write.Maker

--- a/src/irmin/storage_intf.ml
+++ b/src/irmin/storage_intf.ml
@@ -1,0 +1,62 @@
+(*
+ * Copyright (c) 2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module type S = sig
+  type t
+  type key
+  type value
+
+  val v : Conf.t -> t Lwt.t
+  (** [v config] initialises a storage layer, with the configuration [config]. *)
+
+  val mem : t -> key -> bool Lwt.t
+  (** [mem t k] is true iff [k] is present in [t]. *)
+
+  val find : t -> key -> value option Lwt.t
+  (** [find t k] is [Some v] if [k] is associated to [v] in [t] and [None] is
+      [k] is not present in [t]. *)
+
+  val keys : t -> key list Lwt.t
+  (** [keys t] it the list of keys in [t]. *)
+
+  val set : t -> key -> value -> unit Lwt.t
+  (** [set t k v] sets the contents of [k] to [v] in [t]. *)
+
+  val remove : t -> key -> unit Lwt.t
+  (** [remove t k] removes the key [k] in [t]. *)
+
+  val batch : t -> (t -> 'a Lwt.t) -> 'a Lwt.t
+  (** [batch t f] applies the operations in [f] in a batch. The exact guarantees
+      depend on the implementation. *)
+
+  val clear : t -> unit Lwt.t
+  (** [clear t] clears the storage. This operation is expected to be slow. *)
+
+  val close : t -> unit Lwt.t
+  (** [close t] frees up all the resources associated with [t]. *)
+end
+
+module type Make = functor (Key : Type.S) (Value : Type.S) ->
+  S with type key = Key.t and type value = Value.t
+
+module type Sigs = sig
+  module type S = S
+  (** [S] is a storage layer that can be used to build Irmin stores. *)
+
+  module type Make = Make
+  (** [Make] parameterizes a storage layer over a key [Key] and a value [Value].
+      This is the signature to implement when building custom storage for Irmin. *)
+end


### PR DESCRIPTION
While working through the tutorial for creating custom storage, I saw an opportunity to provide a more direct way for users to create Irmin stores from a given storage layer. This PR adds a ~`Simple_storage`~ `Storage` module and an example demonstrating its usage. You still need to have some Irmin logic in your storage, but I think it is minimal and much improved.
