### PR TITLE
irmin-pack: add fsync to gc process

### DIFF
--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -715,6 +715,7 @@ struct
     let* io = Io.create ~path ~overwrite:true in
     let out = Errs.to_json_string output in
     let* () = Io.write_string io ~off:Int63.zero out in
+    let* () = Io.fsync io in
     Io.close io
 
   type read_gc_output_error =

--- a/src/irmin-pack/unix/import.ml
+++ b/src/irmin-pack/unix/import.ml
@@ -53,7 +53,8 @@ module Indexable = Irmin_pack.Indexable
 
 module Result_syntax = struct
   let ( let+ ) res f = Result.map f res
-  let ( let* ) res f = Result.bind res f
+  let ( let* ) = Result.bind
+  let ( >>= ) = Result.bind
 end
 
 (** Essentially the Y combinator; useful for anonymous recursive functions. The

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -431,6 +431,7 @@ module Make (Io : Io.S) = struct
           calculate_extents_oc ~src_is_sorted:() ~src:file1.arr ~register_entry)
     in
     let* () = Ao.flush file2 in
+    let* () = Ao.fsync file2 in
     let* () = Ao.close file2 in
 
     (* Close and unlink [file1] *)


### PR DESCRIPTION
This PR adds fsync calls to the end of the GC process for the suffix and the results file to ensure flushes are persisted to disk.

Should this code take into consideration the `use_fsync` configuration flag (it does not currently)? I am taking a perspective that the GC process is an internal/separate procedure that does not necessarily have to follow that config value and so it can choose to have safer guarantees, but I do not feel too strongly about this stance.

Related to #1971 