### PR TITLE
Fix opam CI issues for 3.4 release

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -41,7 +41,7 @@
 
 (alias
  (name runtest)
- (package irmin-git)
+ (package irmin-cli)
  (deps
   readme.exe
   trees.exe

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -30,6 +30,7 @@ depends: [
   "lwt"             {>= "5.3.0"}
   "uri"
   "irmin-git"       {with-test & = version}
+  "irmin-fs"        {with-test & = version}
   "irmin-test"      {with-test & = version}
   "git-unix"        {with-test & >= "3.5.0"}
   "digestif"        {with-test & >= "0.9.0"}

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -20,7 +20,7 @@ depends: [
   "index"        {>= "1.6.0"}
   "fmt"
   "logs"
-  "lwt"          {>= "5.3.0"}
+  "lwt"          {>= "5.4.0"}
   "mtime"
   "cmdliner"
   "optint"       {>= "0.1.0"}


### PR DESCRIPTION
Fixing https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/86edb716fb2d6c72d682d932dc577323c383fa0f

- Fix `Unbound value Lwt_main.abandon_yielded_and_paused` by changing `irmin-pack`'s Lwt version dep to `>= 5.4.0` ([5.4.0 release notes](https://github.com/ocsigen/lwt/releases/tag/5.4.0))
- Fix `Error: Library "irmin-pack.unix" not found.` for `irmin-git.3.4.0` by changing the `runtest` stanza in example's dune file to `irmin-cli`, which depends on `irmin-pack`.
- Fix `Error: Library "irmin-fs.unix" not found.` for `irmin-http.3.4.0` by adding `irmin-fs` as a test dep