### PR TITLE
small cleanups

### DIFF
--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -207,9 +207,6 @@ module type S = sig
 
       Is a no-op if the control file did not change. *)
 
-  val register_mapping_consumer :
-    t -> after_reload:(unit -> (unit, Errs.t) result) -> unit
-
   val register_dict_consumer :
     t -> after_reload:(unit -> (unit, Errs.t) result) -> unit
 


### PR DESCRIPTION
IIRC, we used to reload the mapping file in the dispatcher, and for that we needed a `register_mapping_consumers`. Now the dispatcher [gets the updated mapping from the file manager at every read](https://github.com/mirage/irmin/blob/main/src/irmin-pack/unix/dispatcher.ml#L135), so there is no need for `mapping_consumers`.

Part of #2039.