### PR TITLE
Raise errors in gc worker

### DIFF
--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -24,6 +24,16 @@ let finalise finaliser f =
   finaliser res;
   res
 
+(** Finaliser for a function that might raise exceptions. *)
+let finalise_exn finaliser f =
+  try
+    let res = f () in
+    finaliser (Some res);
+    res
+  with exn ->
+    finaliser None;
+    raise exn
+
 type base_error =
   [ `Double_close
   | `File_exists of string

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -466,11 +466,14 @@ module Make (Io : Io.S) = struct
   let entry_poff arr i = arr.{entry_idx i + 1} |> conv_int64 |> Int63.of_int
   let entry_len arr i = arr.{entry_idx i + 2} |> conv_int64
 
-  let iter { arr; _ } f =
+  let iter_exn { arr; _ } f =
+    for i = 0 to entry_count arr - 1 do
+      f ~off:(entry_off arr i) ~len:(entry_len arr i)
+    done
+
+  let iter t f =
     Errs.catch (fun () ->
-        for i = 0 to entry_count arr - 1 do
-          f ~off:(entry_off arr i) ~len:(entry_len arr i)
-        done;
+        iter_exn t f;
         ())
 
   type entry = { off : int63; poff : int63; len : int }

--- a/src/irmin-pack/unix/mapping_file_intf.ml
+++ b/src/irmin-pack/unix/mapping_file_intf.ml
@@ -63,6 +63,9 @@ module type S = sig
       The exceptions raised by [f] are caught and returned (as long as they are
       known by [Errs]). *)
 
+  val iter_exn : t -> (off:int63 -> len:int -> unit) -> unit
+  (** Similar to [iter mapping f] but raises exceptions. *)
+
   type entry = { off : int63; poff : int63; len : int }
 
   val find_nearest_leq : t -> int63 -> entry option


### PR DESCRIPTION
From #2039: the gc worker routine raises errors instead of propagating a result. The errors are catched at the end and converted it in a result for `write_gc_output`.  