### PR TITLE
Accessor in dispatcher

### DIFF
--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -98,7 +98,8 @@ module Make (Args : Args) = struct
     (* Get the childrens offsets and then read their keys at that offset. *)
     let decode_children_offsets ~off ~len t =
       let buf = Bytes.create len in
-      Dispatcher.read_exn t.dispatcher ~off ~len buf;
+      let accessor = Dispatcher.create_accessor_exn t.dispatcher ~off ~len in
+      Dispatcher.read_exn t.dispatcher accessor buf;
       let entry_of_offset offset =
         [%log.debug "key_of_offset: %a" Int63.pp offset];
         io_read_and_decode_entry_prefix ~off:offset t


### PR DESCRIPTION
This is the first step necessary for my fix of #2067

It splits the dispatcher's reading process into 2 distinct phases: first make sure that `offset, length` make sense and then read.

In pack_store, this will simplify checking that keys are valid by relying on an `accessor_of_key` function (not yet implemented).
