### PR TITLE
irmin.unix: Remove irmin-watcher dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
   
 ### Changed
 
+- **irmin**
+  - Removed `Irmin_unix.set_listen_dir_hook` (#2071, @zshipko)
+
 ### Fixed
 
 ## 3.4.0 (2022-08-25)

--- a/examples/config.ml
+++ b/examples/config.ml
@@ -19,4 +19,4 @@ let root = "/tmp/irmin/test"
 let init () =
   let _ = Sys.command (Printf.sprintf "rm -rf %s" root) in
   let _ = Sys.command (Printf.sprintf "mkdir -p %s" root) in
-  Irmin_unix.set_listen_dir_hook ()
+  Irmin.Backend.Watch.set_listen_dir_hook Irmin_watcher.hook

--- a/examples/dune
+++ b/examples/dune
@@ -20,6 +20,7 @@
   irmin-git.unix
   irmin-graphql.unix
   irmin-pack.unix
+  irmin-watcher
   lwt
   lwt.unix)
  (preprocess

--- a/irmin.opam
+++ b/irmin.opam
@@ -30,7 +30,6 @@ depends: [
   "mtime" {>= "1.0.0"}
   "bigstringaf" { >= "0.2.0" }
   "ppx_irmin" {= version}
-  "irmin-watcher" {>= "0.2.0"}
   "hex"      {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "alcotest-lwt" {with-test}

--- a/src/irmin/unix/dune
+++ b/src/irmin/unix/dune
@@ -1,7 +1,7 @@
 (library
  (name irmin_unix)
  (public_name irmin.unix)
- (libraries irmin unix irmin-watcher)
+ (libraries irmin unix)
  (preprocess
   (pps ppx_irmin.internal))
  (instrumentation

--- a/src/irmin/unix/irmin_unix.ml
+++ b/src/irmin/unix/irmin_unix.ml
@@ -18,6 +18,3 @@ module Info = Info.Make
 module I = Info (Irmin.Info.Default)
 
 let info = I.v
-
-let set_listen_dir_hook () =
-  Irmin.Backend.Watch.set_listen_dir_hook Irmin_watcher.hook

--- a/src/irmin/unix/irmin_unix.mli
+++ b/src/irmin/unix/irmin_unix.mli
@@ -28,7 +28,3 @@ val info :
     date} set to [Unix.gettimeoday ()] and the {{!Irmin.Info.S.author} author}
     built using [Unix.gethostname()] and [Unix.getpid()] if [author] is not
     provided. *)
-
-val set_listen_dir_hook : unit -> unit
-(** Install {!Irmin_watcher.hook} as the listen hook for watching changes in
-    directories. *)


### PR DESCRIPTION
- Removes `set_listen_dir_hook` from `Irmin_unix`
    - This will be moved to `irmin-watcher`
- Removes `irmin-watcher` dependency from `irmin.unix` 