### PR TITLE
irmin-pack: ensure safe `Bytes.unsafe_to_string`

### DIFF
--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -412,11 +412,12 @@ module Make (Io : Io.S) = struct
 
     (* Fill and close [file2] *)
     let poff = ref 0 in
-    let encode =
+    let encode i =
       let buf = Bytes.create 8 in
-      fun i ->
-        Bytes.set_int64_le buf 0 (Int64.of_int i);
-        Bytes.unsafe_to_string buf
+      Bytes.set_int64_le buf 0 (Int64.of_int i);
+      (* Bytes.unsafe_to_string is safe since [buf] will not be modified after
+         this function returns. We give up ownership. *)
+      Bytes.unsafe_to_string buf
     in
     let register_entry ~off ~len =
       Ao.append_exn file2 (encode off);


### PR DESCRIPTION
I spotted this while looking at something else. It is safe currently due to the implementation of `Append_only_file` (outside of tests passing -- it uses `Buffer.add_string` -> `Bytes.(unsafe_)blit_string` which copies the string), but it is safer to use a unique ownership model in case either our implementation changes or OCaml's does.