### PR TITLE
irmin-pack: fsync after snapshot import

### DIFF
--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -220,6 +220,7 @@ module Maker (Config : Conf.S) = struct
           File_manager.reload ~hook t.fm |> Errs.raise_if_error
 
         let flush t = File_manager.flush ?hook:None t.fm |> Errs.raise_if_error
+        let fsync t = File_manager.fsync t.fm |> Errs.raise_if_error
         let reload t = File_manager.reload t.fm |> Errs.raise_if_error
 
         module Gc = struct
@@ -502,6 +503,7 @@ module Maker (Config : Conf.S) = struct
     let stats = Stats.run
     let reload = X.Repo.reload
     let flush = X.Repo.flush
+    let fsync = X.Repo.fsync
 
     module Gc = struct
       type msg = [ `Msg of string ]
@@ -645,6 +647,7 @@ module Maker (Config : Conf.S) = struct
 
         let close process repo =
           flush repo;
+          fsync repo;
           Import.close process
       end
     end

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -195,6 +195,18 @@ struct
     Stats.incr_fm_field Flush;
     flush_index_and_its_deps ?hook t
 
+  (* Explicit fsync ********************************************************* *)
+
+  let fsync t =
+    let open Result_syntax in
+    let* _ = Dict.fsync t.dict in
+    let* _ = Suffix.fsync t.suffix in
+    let* _ = Control.fsync t.control in
+    let* _ =
+      match t.prefix with None -> Ok () | Some prefix -> Prefix.fsync prefix
+    in
+    Index.flush ~with_fsync:true t.index
+
   (* Constructors *********************************************************** *)
 
   let reopen_prefix t ~generation =

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -200,6 +200,16 @@ module type S = sig
   (** Execute the flush routine. Note that this routine may be automatically
       triggered when buffers are filled. *)
 
+  type fsync_error := flush_error
+
+  val fsync : t -> (unit, [> fsync_error ]) result
+  (** [fsync] executes an fsync for all files of the file manager.
+
+      Note: This function exists primarily for operations like snapshot imports.
+      If fsync is enabled for the store (see {!Irmin_pack.Config.use_fsync}),
+      calls to {!flush} will also call fsync and therefore there is little need
+      to call this function directly. *)
+
   type reload_stages := [ `After_index | `After_control | `After_suffix ]
 
   val reload : ?hook:reload_stages hook -> t -> (unit, [> Errs.t ]) result


### PR DESCRIPTION
This PR is for https://github.com/mirage/irmin/issues/1971:

> call fsync after snapshot import;

I'm not sure if exposing an `fsync` function on `File_manager` is the best approach for ensuring an fsync at the end of snapshot import, but it is the most direct approach I could see. Feedback welcome, as always!