### PR TITLE
irmin-pack: Add Layout.classify_filename

### DIFF
--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -49,3 +49,44 @@ module V3 = struct
   let all ~generation ~root =
     [ suffix ~generation ~root; branch ~root; dict ~root; control ~root ]
 end
+
+(** [is_number] is a less generic than [Stdlib.int_of_string_opt]. It matches
+    this equivalent regex: {v "([1-9][0-9]*|0)" v}. *)
+let is_number s =
+  match String.to_seq s |> List.of_seq with
+  | [] -> false
+  | '0' :: _ :: _ -> false
+  | l ->
+      List.fold_left
+        (fun acc char ->
+          let is_digit = match char with '0' .. '9' -> true | _ -> false in
+          acc && is_digit)
+        true l
+
+type classification =
+  [ `Branch
+  | `Dict
+  | `Gc_result of int
+  | `Mapping of int
+  | `Prefix of int
+  | `Reachable of int
+  | `Sorted of int
+  | `V1_or_v2_pack ]
+[@@deriving irmin]
+
+let classify_filename s : classification option =
+  match String.split_on_char '.' s with
+  | [ "store"; "pack" ] -> Some `V1_or_v2_pack
+  | [ "store"; "branches" ] -> Some `Branch
+  | [ "store"; "dict" ] -> Some `Dict
+  | [ "store"; g; "out" ] when is_number g ->
+      Some (`Gc_result (int_of_string g))
+  | [ "store"; g; "reachable" ] when is_number g ->
+      Some (`Reachable (int_of_string g))
+  | [ "store"; g; "sorted" ] when is_number g ->
+      Some (`Sorted (int_of_string g))
+  | [ "store"; g; "mapping" ] when is_number g ->
+      Some (`Mapping (int_of_string g))
+  | [ "store"; g; "prefix" ] when is_number g ->
+      Some (`Prefix (int_of_string g))
+  | _ -> None

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -62,6 +62,8 @@ module Alcotest : sig
     'a ->
     'a ->
     unit
+
+  val testable_repr : 'a Irmin.Type.t -> 'a Alcotest.testable
 end
 
 module Index : module type of Irmin_pack_unix.Index.Make (Schema.Hash)


### PR DESCRIPTION
New function that will be useful to unlink unexpected files in a pack store