### PR TITLE
irmin-pack: move sigs to unix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 - **irmin-graphql**
   -  Expose `test_set_and_get` function as a new mutation (#2075, @patricoferris)
 
+### Changed
+
+- **irmin-pack**
+  - `irmin_pack_mem` no longer exposes disk specifics functions (#2081,
+  @icristescu)
+
 ## 3.4.1 (2022-09-07)
 
 ### Added

--- a/src/irmin-pack/irmin_pack.ml
+++ b/src/irmin-pack/irmin_pack.ml
@@ -18,8 +18,6 @@ include Irmin_pack_intf
 
 let config = Conf.init
 
-exception RO_not_allowed = S.RO_not_allowed
-
 module Indexing_strategy = Indexing_strategy
 module Indexable = Indexable
 module Atomic_write = Atomic_write
@@ -33,4 +31,3 @@ module Layout = Layout
 module Inode = Inode
 module Pack_key = Pack_key
 module Pack_value = Pack_value
-module S = S

--- a/src/irmin-pack/unix/checks_intf.ml
+++ b/src/irmin-pack/unix/checks_intf.ml
@@ -106,7 +106,7 @@ end
 
 module type Store = sig
   include Irmin.S
-  include Irmin_pack.S with type repo := repo and type commit := commit
+  include S.S with type repo := repo and type commit := commit
 end
 
 type integrity_error = [ `Wrong_hash | `Absent_value ]

--- a/src/irmin-pack/unix/inode_intf.ml
+++ b/src/irmin-pack/unix/inode_intf.ml
@@ -31,7 +31,7 @@ module type Persistent = sig
     dispatcher:dispatcher ->
     read t
 
-  include Irmin_pack.S.Checkable with type 'a t := 'a t and type hash := hash
+  include Irmin_pack.Checkable with type 'a t := 'a t and type hash := hash
 
   (* val reload : 'a t -> unit *)
   val integrity_check_inodes : [ `Read ] t -> key -> (unit, string) result Lwt.t

--- a/src/irmin-pack/unix/irmin_pack_unix.ml
+++ b/src/irmin-pack/unix/irmin_pack_unix.ml
@@ -34,6 +34,8 @@ module Maker = Ext.Maker
 module Mapping_file = Mapping_file
 module Utils = Utils
 
+module type S = S.S
+
 module KV (Config : Irmin_pack.Conf.S) = struct
   type endpoint = unit
   type hash = Irmin.Schema.default_hash

--- a/src/irmin-pack/unix/pack_store_intf.ml
+++ b/src/irmin-pack/unix/pack_store_intf.ml
@@ -38,7 +38,7 @@ module type S = sig
   val cast : read t -> read_write t
 
   (** @inline *)
-  include Irmin_pack.S.Checkable with type 'a t := 'a t and type hash := hash
+  include Irmin_pack.Checkable with type 'a t := 'a t and type hash := hash
 
   module Entry_prefix : sig
     type t = {

--- a/src/irmin-pack/unix/s.ml
+++ b/src/irmin-pack/unix/s.ml
@@ -16,24 +16,9 @@
 
 open! Import
 
-exception RO_not_allowed
-
-module type Checkable = sig
-  type 'a t
-  type hash
-
-  val integrity_check :
-    offset:int63 ->
-    length:int ->
-    hash ->
-    _ t ->
-    (unit, [ `Wrong_hash | `Absent_value ]) result
-end
-
-(** [Irmin-pack]-specific extensions to the [Store] module type. *)
-module type Specifics = sig
-  type repo
-  type commit_key
+(** [Irmin-pack-unix]-specific extensions to the [Store] module type. *)
+module type S = sig
+  include Irmin.Generic_key.S
 
   val integrity_check :
     ?ppf:Format.formatter ->
@@ -149,11 +134,6 @@ module type Specifics = sig
     val is_allowed : repo -> bool
     (** [is_allowed repo] returns true if a gc can be run on the store. *)
   end
-end
-
-module type S = sig
-  include Irmin.Generic_key.S
-  include Specifics with type repo := repo and type commit_key := commit_key
 
   val integrity_check_inodes :
     ?heads:commit list ->

--- a/src/irmin-tezos/irmin_tezos.mli
+++ b/src/irmin-tezos/irmin_tezos.mli
@@ -18,7 +18,7 @@ module Schema = Schema
 module Conf : Irmin_pack.Conf.S
 
 module Store :
-  Irmin_pack.S
+  Irmin_pack_unix.S
     with type Schema.Hash.t = Schema.Hash.t
      and type Schema.Branch.t = Schema.Branch.t
      and type Schema.Metadata.t = Schema.Metadata.t

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -143,11 +143,9 @@ module Store_mem = struct
     let on_end () = Lwt.return_unit in
     Lwt.return (repo, on_commit, on_end)
 
-  let gc_wait repo =
-    let* r = Store.Gc.wait repo in
-    match r with Ok _ -> Lwt.return_unit | Error (`Msg err) -> failwith err
+  let gc_wait _repo = Lwt.return_unit
 
-  type gc_stats = Store.Gc.stats = {
+  type gc_stats = {
     duration : float;
     finalisation_duration : float;
     read_gc_output_duration : float;
@@ -157,17 +155,7 @@ module Store_mem = struct
   }
   [@@deriving irmin]
 
-  let gc_run ?(finished = fun _ -> Lwt.return_unit) repo key =
-    let f (result : (Store.Gc.stats, Store.Gc.msg) result) =
-      match result with
-      | Error (`Msg err) -> finished @@ Error err
-      | Ok _ as s -> finished @@ s
-    in
-    let* launched = Store.Gc.run ~finished:f repo key in
-    match launched with
-    | Ok true -> Lwt.return_unit
-    | Ok false -> [%logs.app "GC skipped"] |> Lwt.return
-    | Error (`Msg err) -> failwith err
+  let gc_run ?finished:_ _repo _key = Lwt.return_unit
 end
 
 module Replay_mem = Irmin_traces.Trace_replay.Make (Store_mem)


### PR DESCRIPTION
The signatures in irmin-pack/s.ml were common to both the in memory and on disk stores, but are actually sigs only for the on disk store (their implementation in irmin_pack_mem were empty). This PR moves most of the s.ml to the unix sub package. 

The downside is the duplication of the Maker functor, since it has different `S` types for the in-memory and on disk stores.   

Part of #2039.

   