### PR TITLE
irmin-pack: Add sequential accessors & clean dispatcher

### DIFF
--- a/src/irmin-pack/unix/dispatcher.ml
+++ b/src/irmin-pack/unix/dispatcher.ml
@@ -278,12 +278,12 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
     in
     let suffix_end_offset = Fm.Suffix.end_offset (Fm.suffix t.fm) in
     let entry_offset_suffix_start = entry_offset_suffix_start t in
-    let buf = Bytes.create max_header_len in
     let get_entry_accessor rem_len location poff =
       let accessor =
         create_sequential_accessor_from_range_exn location rem_len ~poff
           ~min_len:min_header_len ~max_len:max_header_len
       in
+      let buf = Bytes.create max_header_len in
       read_exn t accessor buf;
       let entry_len = read_len buf in
       ( entry_len,

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -31,7 +31,7 @@ module type S = sig
       finalisation, an accessor could no longer point to a valid area because
       the GC changes the domain of valid readable areas) *)
 
-  val v : root:string -> Fm.t -> (t, [> Fm.Errs.t ]) result
+  val v : Fm.t -> (t, [> Fm.Errs.t ]) result
 
   val create_accessor_exn : t -> off:int63 -> len:int -> accessor
   (** [create_accessor_exn] returns an accessor if [off] and [len] designate a
@@ -49,6 +49,38 @@ module type S = sig
   val shrink_accessor_exn : accessor -> new_len:int -> accessor
   (** [shrink_accessor_exn a ~new_len] is [a] where the length is smaller than
       in [a].*)
+
+  module Sequential : sig
+    val create_accessor_exn : int63 -> int63 -> off:int63 -> len:int -> accessor
+    (** [create_accessor_exn prefix_len suffix_len ~off ~len] returns an
+        accessor if [off] and [len] designate a readable area of the pack
+        files, otherwise it raises one of [Errors.Pack_error `Read_out_of_bounds].
+        [prefix_len] and [suffix_len] are directly given to the function as they
+        are computed by costly functions to call.
+        In the contrary of the above create_accessor_exn function, it does not
+        take "virtual" lengths (aka. lengths taking gc'ed chunks into account),
+        but physical lengths in argument. *)
+
+    val create_accessor_from_range_exn :
+      int63 -> int63 -> off:int63 -> min_len:int -> max_len:int -> accessor
+    (** [create_accessor_from_range_exn] is similar to
+        [create_accessor_exn] except that the precise length of the span will be
+        decided during the call. *)
+
+    val create_accessor_seq :
+      t ->
+      min_header_len:int ->
+      max_header_len:int ->
+      read_len:(bytes -> int) ->
+      (int63 * accessor) Seq.t
+    (** [create_accessor_seq ~min_header_len ~max_header_len ~read_len]
+        returns a sequence of accessors, which simulates iterating sequentially
+        trough the entries of a pack file. [min_header_len] & [max_header_len]
+        represents the minimum & maximum lengths required to read the header of
+        an entry. [read_len] will then be called with a buffer containing the
+        header of the entry and should return the total length of the entry (the
+        length of he header plus the length of the payload)*)
+  end
 
   val read_exn : t -> accessor -> bytes -> unit
   (** [read_exn] either reads in the prefix or the suffix file, depending on

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -50,37 +50,19 @@ module type S = sig
   (** [shrink_accessor_exn a ~new_len] is [a] where the length is smaller than
       in [a].*)
 
-  module Sequential : sig
-    val create_accessor_exn : int63 -> int63 -> off:int63 -> len:int -> accessor
-    (** [create_accessor_exn prefix_len suffix_len ~off ~len] returns an
-        accessor if [off] and [len] designate a readable area of the pack
-        files, otherwise it raises one of [Errors.Pack_error `Read_out_of_bounds].
-        [prefix_len] and [suffix_len] are directly given to the function as they
-        are computed by costly functions to call.
-        In the contrary of the above create_accessor_exn function, it does not
-        take "virtual" lengths (aka. lengths taking gc'ed chunks into account),
-        but physical lengths in argument. *)
-
-    val create_accessor_from_range_exn :
-      int63 -> int63 -> off:int63 -> min_len:int -> max_len:int -> accessor
-    (** [create_accessor_from_range_exn] is similar to
-        [create_accessor_exn] except that the precise length of the span will be
-        decided during the call. *)
-
-    val create_accessor_seq :
-      t ->
-      min_header_len:int ->
-      max_header_len:int ->
-      read_len:(bytes -> int) ->
-      (int63 * accessor) Seq.t
-    (** [create_accessor_seq ~min_header_len ~max_header_len ~read_len]
-        returns a sequence of accessors, which simulates iterating sequentially
-        trough the entries of a pack file. [min_header_len] & [max_header_len]
-        represents the minimum & maximum lengths required to read the header of
-        an entry. [read_len] will then be called with a buffer containing the
-        header of the entry and should return the total length of the entry (the
-        length of he header plus the length of the payload)*)
-  end
+  val create_sequential_accessor_seq :
+    t ->
+    min_header_len:int ->
+    max_header_len:int ->
+    read_len:(bytes -> int) ->
+    (int63 * accessor) Seq.t
+  (** [create_sequential_accessor_seq ~min_header_len ~max_header_len ~read_len]
+      returns a sequence of accessors, which simulates iterating sequentially
+      trough the entries of a pack file. [min_header_len] & [max_header_len]
+      represents the minimum & maximum lengths required to read the header of an
+      entry. [read_len] will then be called with a buffer containing the header
+      of the entry and should return the total length of the entry (the length
+      of he header plus the length of the payload)*)
 
   val read_exn : t -> accessor -> bytes -> unit
   (** [read_exn] either reads in the prefix or the suffix file, depending on

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -187,7 +187,7 @@ module Maker (Config : Conf.S) = struct
               | (`File | `Other), _ -> Errs.raise_error (`Not_a_directory root)
           in
           let dict = Dict.v fm |> Errs.raise_if_error in
-          let dispatcher = Dispatcher.v ~root fm |> Errs.raise_if_error in
+          let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
           let contents = Contents.CA.v ~config ~fm ~dict ~dispatcher in
           let node = Node.CA.v ~config ~fm ~dict ~dispatcher in
           let commit = Commit.CA.v ~config ~fm ~dict ~dispatcher in

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -163,7 +163,7 @@ module Worker = struct
           Fm.close fm |> Errs.log_if_error "GC: Close File_manager")
       @@ fun () ->
       let dict = Dict.v fm |> Errs.raise_if_error in
-      let dispatcher = Dispatcher.v ~root fm |> Errs.raise_if_error in
+      let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
       let node_store = Node_store.v ~config ~fm ~dict ~dispatcher in
       let commit_store = Commit_store.v ~config ~fm ~dict ~dispatcher in
 

--- a/src/irmin-pack/unix/snapshot.ml
+++ b/src/irmin-pack/unix/snapshot.ml
@@ -60,10 +60,7 @@ module Make (Args : Args) = struct
          files: suffix and control. We just open the file manager for
          simplicity. *)
       let fm = Fm.open_ro config |> Fm.Errs.raise_if_error in
-      let dispatcher =
-        let root = Conf.root config in
-        Dispatcher.v ~root fm |> Fm.Errs.raise_if_error
-      in
+      let dispatcher = Dispatcher.v fm |> Fm.Errs.raise_if_error in
       let log_size = Conf.index_log_size config in
       { fm; dispatcher; log_size; inode_pack; contents_pack }
 

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -153,7 +153,7 @@ struct
     let f = ref (fun () -> ()) in
     let config = config ~readonly ~fresh name in
     let fm = get_fm config in
-    let dispatcher = Dispatcher.v ~root:name fm |> Errs.raise_if_error in
+    let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
     (* open the index created by the fm. *)
     let index = File_manager.index fm in
     let dict = Dict.v fm |> Errs.raise_if_error in

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -120,7 +120,7 @@ struct
       let config = config ~indexing_strategy ~readonly:false ~fresh:true root in
       let fm = get_fm config in
       let dict = Dict.v fm |> Errs.raise_if_error in
-      let dispatcher = Dispatcher.v ~root fm |> Errs.raise_if_error in
+      let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
       let store = Inode.v ~config ~fm ~dict ~dispatcher in
       let store_contents = Contents_store.v ~config ~fm ~dict ~dispatcher in
       let+ foo, bar =


### PR DESCRIPTION
This PR adds:
- 2 accessors that uses physical offsets instead of the virtual offsets
- A generator for sequences of accessors that iterates trough all physical offsets of a pack file.
It also removes:
- The `root` filed of `Dispatcher.t`, as it is never used.