### PR TITLE
Cleanup residual files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   @icristescu)
   - Move unix specific details for `Pack_key` and `Pack_value` from `irmin-pack`
     to `irmin-pack.unix` (#2084, @metanivek)
+  - Remove unnecessary files at `open_rw` and after a failed GC (#2095, @art-w)
 
 ## 3.4.1 (2022-09-07)
 

--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -71,6 +71,7 @@ type classification =
   | `Prefix of int
   | `Reachable of int
   | `Sorted of int
+  | `Suffix of int
   | `V1_or_v2_pack ]
 [@@deriving irmin]
 
@@ -89,4 +90,6 @@ let classify_filename s : classification option =
       Some (`Mapping (int_of_string g))
   | [ "store"; g; "prefix" ] when is_number g ->
       Some (`Prefix (int_of_string g))
+  | [ "store"; g; "suffix" ] when is_number g ->
+      Some (`Suffix (int_of_string g))
   | _ -> None

--- a/src/irmin-pack/unix/async.ml
+++ b/src/irmin-pack/unix/async.ml
@@ -81,17 +81,17 @@ module Unix = struct
     | Lwt_unix.WSTOPPED n -> `Failure (Fmt.str "Stopped %d" n)
 
   let cancel t =
-    let () =
-      match t.status with
-      | `Running ->
-          let pid, _ = Unix.waitpid [ Unix.WNOHANG ] t.pid in
-          if pid = 0 then (
-            (* Child process is still running. *)
-            kill_no_err t.pid;
-            Exit.remove t.pid)
-      | _ -> ()
-    in
-    t.status <- `Cancelled
+    match t.status with
+    | `Running ->
+        let pid, _ = Unix.waitpid [ Unix.WNOHANG ] t.pid in
+        if pid = 0 then (
+          (* Child process is still running. *)
+          kill_no_err t.pid;
+          Exit.remove t.pid;
+          t.status <- `Cancelled;
+          true)
+        else false
+    | _ -> false
 
   let status t =
     match t.status with

--- a/src/irmin-pack/unix/async_intf.ml
+++ b/src/irmin-pack/unix/async_intf.ml
@@ -38,10 +38,10 @@ module type S = sig
 
       If not running, return the oucome of the task. *)
 
-  val cancel : t -> unit
-  (** If running, cancel the task.
+  val cancel : t -> bool
+  (** If running, cancel the task and return [true].
 
-      If not running, do nothing. *)
+      If not running, do nothing and return [false]. *)
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -353,7 +353,7 @@ module Maker (Config : Conf.S) = struct
                     [%log.err
                       "[pack] batch failed and flush failed. Silencing flush \
                        fail. (%a)"
-                      Errs.pp err]
+                      (Irmin.Type.pp Errs.t) err]
               in
               (* Kill gc process in at_exit. *)
               raise exn
@@ -534,8 +534,10 @@ module Maker (Config : Conf.S) = struct
         Lwt.return_error (`Msg error_msg)
 
       let map_errors context (error : Errs.t) =
-        let err = Fmt.str "%a" Errs.pp error in
-        let err_msg = Fmt.str "[%s] resulted in error: %s" context err in
+        let err_msg =
+          Fmt.str "[%s] resulted in error: %a" context (Irmin.Type.pp Errs.t)
+            error
+        in
         `Msg err_msg
 
       let finalise_exn = X.Repo.Gc.finalise_exn

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -227,9 +227,9 @@ module Maker (Config : Conf.S) = struct
           let cancel t =
             match t.running_gc with
             | Some { gc; _ } ->
-                Gc.cancel gc;
+                let cancelled = Gc.cancel gc in
                 t.running_gc <- None;
-                true
+                cancelled
             | None -> false
 
           let start ~unlink ~use_auto_finalisation t commit_key =
@@ -298,7 +298,9 @@ module Maker (Config : Conf.S) = struct
                 t.running_gc <- None;
                 Lwt.return x
             | Ok waited -> Lwt.return waited
-            | Error e -> Errs.raise_error e
+            | Error e ->
+                t.running_gc <- None;
+                Errs.raise_error e
 
           let is_finished t = Option.is_none t.running_gc
 

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -268,9 +268,7 @@ struct
       let* t = Io.open_ ~path ~readonly:true in
       Ok (Some t)
 
-  (** Remove any residual files not needed by the current generation. *)
-  let clean ~generation ~root =
-    let expected_files = Irmin_pack.Layout.V3.all ~generation ~root in
+  let cleanup ~root ~generation =
     let files = Array.to_list (Sys.readdir root) in
     let to_remove =
       List.filter
@@ -285,7 +283,6 @@ struct
       (fun residual ->
         let filename = Filename.concat root residual in
         [%log.debug "Remove residual file %s" filename];
-        assert (not (List.mem ~equal:String.equal residual expected_files));
         match Io.unlink filename with
         | Ok () -> ()
         | Error (`Sys_error error) ->
@@ -309,7 +306,7 @@ struct
       | T15 ->
           assert false
     in
-    clean ~generation ~root;
+    cleanup ~root ~generation;
     (* 1. Create a ref for dependency injections for auto flushes *)
     let instance = ref None in
     let get_instance () =

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -234,6 +234,10 @@ module type S = sig
   val version : root:string -> (Import.Version.t, [> version_error ]) result
   (** [version ~root] is the version of the pack stores at [root]. *)
 
+  val cleanup : root:string -> generation:int -> unit
+  (** [cleanup ~root ~generation] removes any residual files in directory [root]
+      not needed by the current [generation]. *)
+
   val swap :
     t ->
     generation:int ->

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -37,6 +37,8 @@ module Worker = struct
       len:int63 ->
       bytes ->
       unit
+
+    type gc_output = (int63, Args.Errs.t) result [@@deriving irmin]
   end
 
   module Make (Args : Args) : S with module Args := Args = struct
@@ -326,11 +328,13 @@ module Worker = struct
       (* Step 8. Inform the caller of the end_offset copied. *)
       offs
 
+    type gc_output = (int63, Args.Errs.t) result [@@deriving irmin]
+
     let write_gc_output ~root ~generation output =
       let open Result_syntax in
       let path = Irmin_pack.Layout.V3.gc_result ~root ~generation in
       let* io = Io.create ~path ~overwrite:true in
-      let out = Errs.to_json_string output in
+      let out = Irmin.Type.to_json_string gc_output_t output in
       let* () = Io.write_string io ~off:Int63.zero out in
       let* () = Io.fsync io in
       Io.close io
@@ -381,7 +385,7 @@ module Make (Args : Args) = struct
             [%log.warn
               "Unlinking temporary files from previous failed gc. Failed with \
                error %a"
-              Errs.pp err]
+              (Irmin.Type.pp Errs.t) err]
     in
     (* Unlink next gc's result file, in case it is on disk, for instance
        after a failed gc. *)
@@ -512,7 +516,8 @@ module Make (Args : Args) = struct
     match result with
     | Error e ->
         [%log.warn
-          "Unlinking temporary files after gc, failed with error %a" Errs.pp e]
+          "Unlinking temporary files after gc, failed with error %a"
+            (Irmin.Type.pp Errs.t) e]
     | Ok () -> ()
 
   let gc_errors status gc_output =
@@ -540,9 +545,14 @@ module Make (Args : Args) = struct
       let* () = Io.close io in
       Ok string
     in
-    let wrap_error err = `Corrupted_gc_result_file (Fmt.str "%a" Errs.pp err) in
-    let* s = read_file () |> Result.map_error wrap_error in
-    Errs.of_json_string s |> Result.map_error wrap_error
+    let read_error err =
+      `Corrupted_gc_result_file (Irmin.Type.to_string Errs.t err)
+    in
+    let gc_error err = `Gc_process_error (Irmin.Type.to_string Errs.t err) in
+    let* s = read_file () |> Result.map_error read_error in
+    match Irmin.Type.of_json_string Worker.gc_output_t s with
+    | Error (`Msg error) -> Error (`Corrupted_gc_result_file error)
+    | Ok ok -> ok |> Result.map_error gc_error
 
   let clean_after_abort t =
     Fm.cleanup ~root:t.root ~generation:(t.generation - 1)

--- a/src/irmin-pack/unix/gc_intf.ml
+++ b/src/irmin-pack/unix/gc_intf.ml
@@ -120,7 +120,7 @@ module type S = sig
   (** Attaches a callback to the GC process, which will be called when the GC
       finalises. *)
 
-  val cancel : t -> unit
+  val cancel : t -> bool
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/mapping_file_intf.ml
+++ b/src/irmin-pack/unix/mapping_file_intf.ml
@@ -37,7 +37,7 @@ module type S = sig
     root:string ->
     generation:int ->
     register_entries:(register_entry:(off:int63 -> len:int -> unit) -> unit) ->
-    (t, [> Errs.t ]) result
+    (t, Errs.t) result
   (** [create] creates inside the directory [root] a mapping file. It never
       raises exceptions.
 
@@ -53,7 +53,7 @@ module type S = sig
   val open_map : root:string -> generation:int -> (t, [> open_error ]) result
   (** [open_map ~root ~generation] opens a mapping file. *)
 
-  val iter : t -> (off:int63 -> len:int -> unit) -> (unit, [> Errs.t ]) result
+  val iter : t -> (off:int63 -> len:int -> unit) -> (unit, Errs.t) result
   (** [iter mapping f] calls [f] on each [(off,len)] pair in [mapping].
 
       It is guaranteed for the offsets to be iterated in monotonic order.

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -411,7 +411,7 @@ struct
         | Error err ->
             [%log.err
               "[pack] batch failed and flush failed. Silencing flush fail. (%a)"
-                Errs.pp err]
+                (Irmin.Type.pp Errs.t) err]
       in
       raise exn
     in

--- a/src/irmin-tezos-utils/parse.ml
+++ b/src/irmin-tezos-utils/parse.ml
@@ -83,7 +83,7 @@ let get_values r = List.filter_map (Ring.get r) [ 1; 10; 1000 ]
 let main store_path info_last_path info_next_path idx_path =
   let conf = Irmin_pack.Conf.init store_path in
   match Files.File_manager.open_ro conf with
-  | Error exn -> Fmt.pr "%a\n%!" Files.Errs.pp exn
+  | Error exn -> Fmt.pr "%a\n%!" (Irmin.Type.pp Files.Errs.t) exn
   | Ok fm ->
       let info_fd =
         Unix.openfile info_last_path Unix.[ O_RDWR; O_CREAT; O_TRUNC ] 0o644

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -52,9 +52,9 @@ module Store = struct
 
   let info = S.Info.empty
 
-  let start_gc t commit =
+  let start_gc ?(unlink = false) t commit =
     let commit_key = S.Commit.key commit in
-    let* _launched = S.Gc.start_exn ~unlink:false t.repo commit_key in
+    let* _launched = S.Gc.start_exn ~unlink t.repo commit_key in
     Lwt.return_unit
 
   let finalise_gc t =
@@ -320,20 +320,36 @@ module Gc = struct
     let* t = init () in
     let store_name = t.root in
     let* t, c1 = commit_1 t in
-    let* () = start_gc t c1 in
+    let* () = start_gc ~unlink:false t c1 in
     let* () = finalise_gc t in
     let* t = checkout_exn t c1 in
     let* t, c2 = commit_2 t in
     let* () = S.Repo.close t.repo in
+    Alcotest.(check bool)
+      "unlink:false" true
+      (Sys.file_exists (Filename.concat store_name "store.0.suffix"));
+    let* t = init ~readonly:true ~fresh:false ~root:store_name () in
+    let* () = S.Repo.close t.repo in
+    Alcotest.(check bool)
+      "RO no clean up" true
+      (Sys.file_exists (Filename.concat store_name "store.0.suffix"));
+    let* t = init ~readonly:false ~fresh:false ~root:store_name () in
+    let* () = S.Repo.close t.repo in
+    Alcotest.(check bool)
+      "RW cleaned up" false
+      (Sys.file_exists (Filename.concat store_name "store.0.suffix"));
     let* t = init ~readonly:false ~fresh:false ~root:store_name () in
     let* () = check_1 t c1 in
     let* () = check_2 t c2 in
     let* () = S.Repo.close t.repo in
     let* t = init ~readonly:false ~fresh:false ~root:store_name () in
     [%log.debug "Gc c1, keep c2"];
-    let* () = start_gc t c2 in
+    let* () = start_gc ~unlink:true t c2 in
     let* () = finalise_gc t in
     let* () = S.Repo.close t.repo in
+    Alcotest.(check bool)
+      "unlink:true" false
+      (Sys.file_exists (Filename.concat store_name "store.1.suffix"));
     let* t = init ~readonly:false ~fresh:false ~root:store_name () in
     let* () = check_not_found t c1 "removed c1" in
     let* () = check_2 t c2 in

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -742,9 +742,7 @@ module Concurrent_gc = struct
     match (repo.running_gc : S.X.Repo.running_gc option) with
     | None -> Alcotest.failf "running_gc missing after call to start"
     | Some { gc; _ } -> (
-        try
-          S.X.Gc.cancel gc;
-          true
+        try S.X.Gc.cancel gc
         with Unix.Unix_error (Unix.ESRCH, "kill", _) -> false)
 
   let test_kill_gc_and_finalise () =

--- a/test/irmin-pack/test_gc.mli
+++ b/test/irmin-pack/test_gc.mli
@@ -30,7 +30,7 @@ module Store : sig
   val config : string -> Irmin.config
   val init_with_config : Irmin.config -> t Lwt.t
   val close : t -> unit Lwt.t
-  val start_gc : t -> S.commit -> unit Lwt.t
+  val start_gc : ?unlink:bool -> t -> S.commit -> unit Lwt.t
   val finalise_gc : t -> unit Lwt.t
   val commit_1 : t -> (t * S.commit) Lwt.t
   val commit_2 : t -> (t * S.commit) Lwt.t

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -513,6 +513,7 @@ module Layout = struct
     c (Some (`Sorted 10)) (V3.sorted ~generation:10 ~root:"" |> classif);
     c (Some (`Mapping 100)) (V3.mapping ~generation:100 ~root:"" |> classif);
     c (Some (`Prefix 1000)) (V3.prefix ~generation:1000 ~root:"" |> classif);
+    c (Some (`Suffix 42)) (V3.suffix ~generation:42 ~root:"" |> classif);
     c None (V3.prefix ~generation:(-1) ~root:"" |> classif);
     c None (classif "store.toto");
     c None (classif "store.");


### PR DESCRIPTION
This PR removes files from the store that are not needed by the current generation:
- At `open_rw`, to clean up a harshly closed store on reboot
- After a GC crash, to get rid of the failed new generation

I'm not quite sure how to unit test the GC failures but there were two issues hiding in there:
- The GC worker writes its result `Ok final_offset | Error ...` in a temporary file. The `File_manager.read_gc_output` was unable to parse the error case in general as `repr` didn't quite like the polymorphic variants union (so the json decoding was crashing deep into `repr` internals)
- `lib_context` keeps on calling `finalise ~wait:false` to know the status of the GC. On a GC crash, the error handling was not marking the GC as finished and so the next `finalise` would attempt to wakeup a second time the `resolver`.