### PR TITLE
irmin-graphql: add contents_hash query to graphql API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 
 - **irmin-graphql**
   -  Expose `test_set_and_get` function as a new mutation (#2075, @patricoferris)
+  -  Add `contents_hash` function to get a value's hash (#2099, @patricoferris)
 
 ### Changed
 

--- a/src/irmin-graphql/server.ml
+++ b/src/irmin-graphql/server.ml
@@ -918,6 +918,11 @@ struct
             ~typ:Types.Contents.schema_typ
             ~args:Arg.[ arg "hash" ~typ:(non_null Input.hash) ]
             ~resolve:(fun _ _src k -> Store.Contents.of_hash s k >|= Result.ok);
+          io_field "contents_hash" ~doc:"Get the hash of some contents"
+            ~typ:(non_null Types.Hash.schema_typ)
+            ~args:Arg.[ arg "value" ~typ:(non_null Input.value) ]
+            ~resolve:(fun _ _src c ->
+              Lwt.return (Store.Contents.hash c) >|= Result.ok);
           io_field "commit_of_key" ~doc:"Find commit by key"
             ~typ:store_schema.commit
             ~args:Arg.[ arg "key" ~typ:(non_null Input.commit_key) ]

--- a/test/irmin-graphql/test.ml
+++ b/test/irmin-graphql/test.ml
@@ -212,6 +212,20 @@ let test_mutation_test_set_and_get : test_case =
   Alcotest.(check string) "Contents equal stored value" "baz" value;
   Alcotest.(check string) "Same commit message" message exec_message
 
+let test_contents_hash : test_case =
+ fun _store ->
+  let v = "bar" in
+  let m =
+    query
+    @@ func "contents_hash" ~params:[ ("value", string v) ]
+    @@ field "hash"
+  in
+  let+ hash = exec m Json.to_string in
+  let actual_hash =
+    Store.Contents.hash v |> Irmin.Type.to_string Store.Hash.t
+  in
+  Alcotest.(check string) "Content hash equal" actual_hash hash
+
 let test_update_tree : test_case =
  fun store ->
   let* commit = Store.Head.get store in
@@ -318,6 +332,7 @@ let suite store =
         test_case "get_tree-list" test_get_tree_list;
         test_case "get_last_modified" test_get_last_modified;
         test_case "commit" test_commit;
+        test_case "contents_hash" test_contents_hash;
         test_case "mutation" test_mutation;
         test_case "mutation_test-set-and-get" test_mutation_test_set_and_get;
         test_case "update_tree" test_update_tree;


### PR DESCRIPTION
This PR adds a simple query to ask the Irmin store to return the hash of some contents supplied as an argument. This is particularly useful if you want to refer to some piece of data by its hash but are not yet ready to store the value.