### PR TITLE
Expose GC cancel function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 - **irmin-graphql**
   -  Expose `test_set_and_get` function as a new mutation (#2075, @patricoferris)
 
+- **irmin-pack**
+  - Expose `Gc.cancel` to abort a running GC (#2101, @art-w)
+
 ### Changed
 
 - **irmin-pack**

--- a/src/irmin-pack/unix/ext.ml
+++ b/src/irmin-pack/unix/ext.ml
@@ -575,6 +575,7 @@ module Maker (Config : Conf.S) = struct
         | Error _ as e -> Lwt.return e
 
       let is_allowed repo = File_manager.gc_allowed repo.X.Repo.fm
+      let cancel repo = X.Repo.Gc.cancel repo
     end
 
     module Traverse_pack_file = Traverse_pack_file.Make (struct

--- a/src/irmin-pack/unix/s.ml
+++ b/src/irmin-pack/unix/s.ml
@@ -127,6 +127,10 @@ module type S = sig
         returned as pretty-print error messages; others are re-raised. The error
         messages should be used only for informational purposes, like logging. *)
 
+    val cancel : repo -> bool
+    (** [cancel repo] aborts the current GC and returns [true], or returns
+        [false] if no GC was running. *)
+
     val is_finished : repo -> bool
     (** [is_finished repo] is [true] if a GC is finished (or idle) and [false]
         if a GC is running for the given [repo]. *)


### PR DESCRIPTION
The function already existed and just needed some exposure :) (see https://github.com/mirage/irmin/issues/2098)
... but I sneaked a [commit](https://github.com/mirage/irmin/pull/2095/commits/85b9cf89a73d12c6b509725e33ae1841cc20d4b7) in https://github.com/mirage/irmin/pull/2095 to cleanup after a GC cancellation. The existing unit test reimplements a `kill_gc` function and can be simplified once one of those PR is merged. It was also tested manually by calling it within the Tezos replay trace.