### PR TITLE
irmin-pack: Cleanups related to offsets

### DIFF
--- a/src/irmin-pack/unix/append_only_file.ml
+++ b/src/irmin-pack/unix/append_only_file.ml
@@ -23,7 +23,7 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
 
   type t = {
     io : Io.t;
-    mutable persisted_end_offset : int63;
+    mutable persisted_end_poff : int63;
     dead_header_size : int63;
     rw_perm : rw_perm option;
   }
@@ -40,63 +40,63 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
   let create_rw ~path ~overwrite ~auto_flush_threshold ~auto_flush_procedure =
     let open Result_syntax in
     let+ io = Io.create ~path ~overwrite in
-    let persisted_end_offset = Int63.zero in
+    let persisted_end_poff = Int63.zero in
     let buf = Buffer.create 0 in
     {
       io;
-      persisted_end_offset;
+      persisted_end_poff;
       dead_header_size = Int63.zero;
       rw_perm = Some { buf; auto_flush_threshold; auto_flush_procedure };
     }
 
   (** A store is consistent if the real offset of the suffix/dict files is the
       one recorded in the control file. When opening the store, the offset from
-      the control file is passed as the [end_offset] argument to the [open_ro],
-      [open_rw] functions. The [end_offset] from the control file is then used
-      as the real offset.
+      the control file is passed as the [end_poff] argument to the [open_ro],
+      [open_rw] functions. The [end_poff] from the control file is then used as
+      the real offset.
 
-      In case of a crash, we can only recover if the [end_offset] is smaller
-      than the real offset. We cannot recover otherwise, because we have no
+      In case of a crash, we can only recover if the [end_poff] is smaller than
+      the real offset. We cannot recover otherwise, because we have no
       guarantees that the last object fsynced to disk is written entirely to
       disk. *)
-  let check_consistent_store ~end_offset ~dead_header_size io =
+  let check_consistent_store ~end_poff ~dead_header_size io =
     let open Result_syntax in
     let* real_offset = Io.read_size io in
     let dead_header_size = Int63.of_int dead_header_size in
     let real_offset_without_header =
       Int63.Syntax.(real_offset - dead_header_size)
     in
-    if real_offset_without_header < end_offset then Error `Inconsistent_store
+    if real_offset_without_header < end_poff then Error `Inconsistent_store
     else (
-      if real_offset_without_header > end_offset then
+      if real_offset_without_header > end_poff then
         [%log.warn
           "The end offset in the control file %a is smaller than the offset on \
            disk %a for %s; the store was closed in a inconsistent state."
-          Int63.pp end_offset Int63.pp real_offset_without_header (Io.path io)];
+          Int63.pp end_poff Int63.pp real_offset_without_header (Io.path io)];
       Ok ())
 
-  let open_rw ~path ~end_offset ~dead_header_size ~auto_flush_threshold
+  let open_rw ~path ~end_poff ~dead_header_size ~auto_flush_threshold
       ~auto_flush_procedure =
     let open Result_syntax in
     let* io = Io.open_ ~path ~readonly:false in
-    let+ () = check_consistent_store ~end_offset ~dead_header_size io in
-    let persisted_end_offset = end_offset in
+    let+ () = check_consistent_store ~end_poff ~dead_header_size io in
+    let persisted_end_poff = end_poff in
     let dead_header_size = Int63.of_int dead_header_size in
     let buf = Buffer.create 0 in
     {
       io;
-      persisted_end_offset;
+      persisted_end_poff;
       dead_header_size;
       rw_perm = Some { buf; auto_flush_threshold; auto_flush_procedure };
     }
 
-  let open_ro ~path ~end_offset ~dead_header_size =
+  let open_ro ~path ~end_poff ~dead_header_size =
     let open Result_syntax in
     let* io = Io.open_ ~path ~readonly:true in
-    let+ () = check_consistent_store ~end_offset ~dead_header_size io in
-    let persisted_end_offset = end_offset in
+    let+ () = check_consistent_store ~end_poff ~dead_header_size io in
+    let persisted_end_poff = end_poff in
     let dead_header_size = Int63.of_int dead_header_size in
-    { io; persisted_end_offset; dead_header_size; rw_perm = None }
+    { io; persisted_end_poff; dead_header_size; rw_perm = None }
 
   let empty_buffer = function
     | { rw_perm = Some { buf; _ }; _ } when Buffer.length buf > 0 -> false
@@ -112,18 +112,18 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
     | { rw_perm = None; _ } -> None
     | { rw_perm = Some rw_perm; _ } -> Some rw_perm.auto_flush_threshold
 
-  let end_offset t =
+  let end_poff t =
     match t.rw_perm with
-    | None -> t.persisted_end_offset
+    | None -> t.persisted_end_poff
     | Some rw_perm ->
         let open Int63.Syntax in
-        t.persisted_end_offset + (Buffer.length rw_perm.buf |> Int63.of_int)
+        t.persisted_end_poff + (Buffer.length rw_perm.buf |> Int63.of_int)
 
-  let refresh_end_offset t new_end_offset =
+  let refresh_end_poff t new_end_poff =
     match t.rw_perm with
     | Some _ -> Error `Rw_not_allowed
     | None ->
-        t.persisted_end_offset <- new_end_offset;
+        t.persisted_end_poff <- new_end_poff;
         Ok ()
 
   let flush t =
@@ -133,10 +133,10 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
         let open Result_syntax in
         let open Int63.Syntax in
         let s = Buffer.contents rw_perm.buf in
-        let off = t.persisted_end_offset + t.dead_header_size in
+        let off = t.persisted_end_poff + t.dead_header_size in
         let+ () = Io.write_string t.io ~off s in
-        t.persisted_end_offset <-
-          t.persisted_end_offset + (String.length s |> Int63.of_int);
+        t.persisted_end_poff <-
+          t.persisted_end_poff + (String.length s |> Int63.of_int);
         (* [truncate] is semantically identical to [clear], except that
            [truncate] doesn't deallocate the internal buffer. We use
            [clear] in legacy_io. *)
@@ -147,7 +147,7 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
   let read_exn t ~off ~len b =
     let open Int63.Syntax in
     let off' = off + Int63.of_int len in
-    if off' > t.persisted_end_offset then
+    if off' > t.persisted_end_poff then
       raise (Errors.Pack_error `Read_out_of_bounds);
     let off = off + t.dead_header_size in
     Io.read_exn t.io ~off ~len b
@@ -155,7 +155,7 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
   let read_to_string t ~off ~len =
     let open Int63.Syntax in
     let off' = off + Int63.of_int len in
-    if off' > t.persisted_end_offset then Error `Read_out_of_bounds
+    if off' > t.persisted_end_poff then Error `Read_out_of_bounds
     else
       let off = off + t.dead_header_size in
       Io.read_to_string t.io ~off ~len

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -23,12 +23,12 @@ module Payload_v3 = struct
       entries before that point may be v1 entries. V1 entries need an entry in
       index because it is the only place their lenght is stored. *)
 
-  type from_v3_gced = { entry_offset_suffix_start : int63; generation : int }
+  type from_v3_gced = { suffix_start_offset : int63; generation : int }
   [@@deriving irmin]
-  (** [entry_offset_suffix_start] is 0 if the suffix file was never garbage
-      collected. Otherwise it is the offset of the very first entry of the
-      suffix file. Note that offsets in the suffix file are virtual. The garbage
-      collections don't reset the offsets.
+  (** [suffix_start_offset] is 0 if the suffix file was never garbage collected.
+      Otherwise it is the offset of the very first entry of the suffix file.
+      Note that offsets in the suffix file are virtual. The garbage collections
+      don't reset the offsets.
 
       [generation] is the number of past GCs. A suffix file, a prefix file and a
       mapping containing that integer in their filename exist. *)
@@ -71,11 +71,7 @@ module Payload_v3 = struct
     | T15
   [@@deriving irmin]
 
-  type t = {
-    dict_offset_end : int63;
-    entry_offset_suffix_end : int63;
-    status : status;
-  }
+  type t = { dict_end_poff : int63; suffix_end_poff : int63; status : status }
   [@@deriving irmin]
   (** The [`V3] payload of the irmin-pack control file. [`V3] is a major
       version. If [`V4] ever exists, it will have its own dedicated payload, but
@@ -96,12 +92,11 @@ module Payload_v3 = struct
 
       {3 Fields}
 
-      [dict_offset_end] is the offset in the dict file just after the last valid
+      [dict_end_poff] is the offset in the dict file just after the last valid
       dict bytes. The next data to be pushed to the dict will be pushed at this
       offset.
 
-      [entry_offset_suffix_end] is similar to [dict_offset_end] but for the
-      suffix file.
+      [suffix_end_poff] is similar to [dict_end_poff] but for the suffix file.
 
       [status] is a variant that encode the state of the irmin-pack directory.
       This field MUST be the last field of the record, in order to allow

--- a/src/irmin-pack/unix/dict.ml
+++ b/src/irmin-pack/unix/dict.ml
@@ -30,7 +30,7 @@ module Make (Fm : File_manager.S) = struct
 
   module File = struct
     let append_exn t = Fm.Dict.append_exn (Fm.dict t.fm)
-    let offset t = Fm.Dict.end_offset (Fm.dict t.fm)
+    let offset t = Fm.Dict.end_poff (Fm.dict t.fm)
     let read_to_string t = Fm.Dict.read_to_string (Fm.dict t.fm)
   end
 

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -73,8 +73,8 @@ module type S = sig
       prefix doesn't start at 0. It counts the entries not yet flushed from the
       prefix. *)
 
-  val offset_of_suffix_off : t -> int63 -> int63
-  (** [offset_of_suffix_off t suffix_off] converts a suffix offset into a
+  val offset_of_suffix_poff : t -> int63 -> int63
+  (** [offset_of_suffix_poff t suffix_off] converts a suffix offset into a
       (global) offset. *)
 
   val read_in_prefix_and_suffix_exn : t -> off:int63 -> len:int -> bytes -> unit

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -107,7 +107,7 @@ struct
       let* () = if t.use_fsync then Dict.fsync t.dict else Ok () in
       let* () =
         let pl : Payload.t = Control.payload t.control in
-        let pl = { pl with dict_offset_end = Dict.end_offset t.dict } in
+        let pl = { pl with dict_end_poff = Dict.end_poff t.dict } in
         Control.set_payload t.control pl
       in
       let+ () = if t.use_fsync then Control.fsync t.control else Ok () in
@@ -146,11 +146,7 @@ struct
               assert false
         in
         let pl =
-          {
-            pl with
-            entry_offset_suffix_end = Suffix.end_offset t.suffix;
-            status;
-          }
+          { pl with suffix_end_poff = Suffix.end_poff t.suffix; status }
         in
         Control.set_payload t.control pl
       in
@@ -235,18 +231,18 @@ struct
     t.mapping <- mapping;
     Ok ()
 
-  let reopen_suffix t ~generation ~end_offset =
+  let reopen_suffix t ~generation ~end_poff =
     let open Result_syntax in
     (* Invariant: reopen suffix is only called on V3 suffix files, for which
        dead_header_size is 0. *)
     let dead_header_size = 0 in
     [%log.debug
-      "reopen_suffix gen:%d end_offset:%d" generation (Int63.to_int end_offset)];
+      "reopen_suffix gen:%d end_poff:%d" generation (Int63.to_int end_poff)];
     let readonly = Suffix.readonly t.suffix in
     let* suffix1 =
       let path = Irmin_pack.Layout.V3.suffix ~root:t.root ~generation in
       [%log.debug "reload: generation changed, opening %s" path];
-      if readonly then Suffix.open_ro ~path ~end_offset ~dead_header_size
+      if readonly then Suffix.open_ro ~path ~end_poff ~dead_header_size
       else
         let auto_flush_threshold =
           match Suffix.auto_flush_threshold t.suffix with
@@ -254,7 +250,7 @@ struct
           | Some x -> x
         in
         let cb _ = suffix_requires_a_flush_exn t in
-        Suffix.open_rw ~path ~end_offset ~dead_header_size ~auto_flush_threshold
+        Suffix.open_rw ~path ~end_poff ~dead_header_size ~auto_flush_threshold
           ~auto_flush_procedure:(`External cb)
     in
     let suffix0 = t.suffix in
@@ -385,18 +381,16 @@ struct
         let gen1 = generation pl1.status in
         if gen0 = gen1 then Ok ()
         else
-          let end_offset = pl1.entry_offset_suffix_end in
-          let* () = reopen_suffix t ~generation:gen1 ~end_offset in
+          let end_poff = pl1.suffix_end_poff in
+          let* () = reopen_suffix t ~generation:gen1 ~end_poff in
           let* () = reopen_mapping t ~generation:gen1 in
           let* () = reopen_prefix t ~generation:gen1 in
           Ok ()
       in
       (* Step 4. Update end offsets *)
-      let* () =
-        Suffix.refresh_end_offset t.suffix pl1.entry_offset_suffix_end
-      in
+      let* () = Suffix.refresh_end_poff t.suffix pl1.suffix_end_poff in
       (match hook with Some h -> h `After_suffix | None -> ());
-      let* () = Dict.refresh_end_offset t.dict pl1.dict_offset_end in
+      let* () = Dict.refresh_end_poff t.dict pl1.dict_end_poff in
       (* Step 5. Notify the dict consumers that they must reload *)
       let* () =
         let res =
@@ -427,7 +421,7 @@ struct
       let status = From_v3_no_gc_yet in
       let pl =
         let z = Int63.zero in
-        { dict_offset_end = z; entry_offset_suffix_end = z; status }
+        { dict_end_poff = z; suffix_end_poff = z; status }
       in
       create_control_file ~overwrite config pl
     in
@@ -461,13 +455,9 @@ struct
       | T15 ->
           Error `V3_store_from_the_future
     in
-    let make_dict =
-      let end_offset = pl.dict_offset_end in
-      Dict.open_rw ~end_offset ~dead_header_size
-    in
+    let make_dict = Dict.open_rw ~end_poff:pl.dict_end_poff ~dead_header_size in
     let make_suffix =
-      let end_offset = pl.entry_offset_suffix_end in
-      Suffix.open_rw ~end_offset ~dead_header_size
+      Suffix.open_rw ~end_poff:pl.suffix_end_poff ~dead_header_size
     in
     let make_index ~flush_callback ~readonly ~throttle ~log_size root =
       Index.v ~fresh:false ~flush_callback ~readonly ~throttle ~log_size root
@@ -503,8 +493,8 @@ struct
     let root = Irmin_pack.Conf.root config in
     let src = Irmin_pack.Layout.V1_and_v2.pack ~root in
     let dst = Irmin_pack.Layout.V3.suffix ~root ~generation:0 in
-    let* entry_offset_suffix_end = read_offset_from_legacy_file src in
-    let* dict_offset_end =
+    let* suffix_end_poff = read_offset_from_legacy_file src in
+    let* dict_end_poff =
       let path = Irmin_pack.Layout.V3.dict ~root in
       read_offset_from_legacy_file path
     in
@@ -513,9 +503,9 @@ struct
       let open Payload in
       let status =
         From_v1_v2_post_upgrade
-          { entry_offset_at_upgrade_to_v3 = entry_offset_suffix_end }
+          { entry_offset_at_upgrade_to_v3 = suffix_end_poff }
       in
-      let pl = { dict_offset_end; entry_offset_suffix_end; status } in
+      let pl = { dict_end_poff; suffix_end_poff; status } in
       create_control_file ~overwrite:false config pl
     in
     let* () = Control.close control in
@@ -579,8 +569,7 @@ struct
     (* 2. Open the other files *)
     let* suffix =
       let path = Irmin_pack.Layout.V3.suffix ~root ~generation in
-      let end_offset = pl.entry_offset_suffix_end in
-      Suffix.open_ro ~path ~end_offset ~dead_header_size
+      Suffix.open_ro ~path ~end_poff:pl.suffix_end_poff ~dead_header_size
     in
     let* prefix =
       let path = Irmin_pack.Layout.V3.prefix ~root ~generation in
@@ -589,8 +578,7 @@ struct
     let* mapping = open_mapping ~root ~generation in
     let* dict =
       let path = Irmin_pack.Layout.V3.dict ~root in
-      let end_offset = pl.dict_offset_end in
-      Dict.open_ro ~path ~end_offset ~dead_header_size
+      Dict.open_ro ~path ~end_poff:pl.dict_end_poff ~dead_header_size
     in
     let* index =
       let log_size = Conf.index_log_size config in
@@ -643,12 +631,12 @@ struct
             | `Unknown_major_pack_version _ ) as e ->
             e)
 
-  let swap t ~generation ~right_start_offset ~right_end_offset =
+  let swap t ~generation ~new_suffix_start_offset ~new_suffix_end_offset =
     let open Result_syntax in
     [%log.debug
       "Gc in main: swap %d %#d %#d" generation
-        (Int63.to_int right_start_offset)
-        (Int63.to_int right_end_offset)];
+        (Int63.to_int new_suffix_start_offset)
+        (Int63.to_int new_suffix_end_offset)];
     let c0 = Mtime_clock.counter () in
 
     (* Step 1. Reopen files *)
@@ -656,11 +644,11 @@ struct
     let* () = reopen_mapping t ~generation in
     (* Opening the suffix requires passing it its length. We compute it from the
        global offsets *)
-    let suffix_end_offset =
+    let suffix_end_poff =
       let open Int63.Syntax in
-      right_end_offset - right_start_offset
+      new_suffix_end_offset - new_suffix_start_offset
     in
-    let* () = reopen_suffix t ~generation ~end_offset:suffix_end_offset in
+    let* () = reopen_suffix t ~generation ~end_poff:suffix_end_poff in
     let span1 = Mtime_clock.count c0 |> Mtime.Span.to_us in
 
     (* Step 2. Update the control file *)
@@ -676,10 +664,10 @@ struct
           | T14 | T15 ->
               assert false
           | From_v3_gced _ | From_v3_no_gc_yet ->
-              let entry_offset_suffix_start = right_start_offset in
-              From_v3_gced { entry_offset_suffix_start; generation }
+              let suffix_start_offset = new_suffix_start_offset in
+              From_v3_gced { suffix_start_offset; generation }
         in
-        { pl with status; entry_offset_suffix_end = suffix_end_offset }
+        { pl with status; suffix_end_poff }
       in
       [%log.debug "GC: writing new control_file"];
       Control.set_payload t.control pl

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -237,12 +237,12 @@ module type S = sig
   val swap :
     t ->
     generation:int ->
-    right_start_offset:int63 ->
-    right_end_offset:int63 ->
+    new_suffix_start_offset:int63 ->
+    new_suffix_end_offset:int63 ->
     (unit, [> Errs.t ]) result
   (** Swaps to using files from the GC [generation]. The offsets
-      [right_start_offset] and [right_end_offset] are used to properly load the
-      suffix. The control file is also updated. *)
+      [new_suffix_start_offset] and [new_suffix_end_offset] are used to properly
+      load the suffix. The control file is also updated. *)
 
   val readonly : t -> bool
   val generation : t -> int

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -31,7 +31,7 @@ module Worker = struct
     val run_and_output_result : generation:int -> string -> Args.key -> int63
 
     val transfer_append_exn :
-      read_exn:(off:int63 -> len:int -> bytes -> unit) ->
+      dispatcher:Args.Dispatcher.t ->
       append_exn:(string -> unit) ->
       off:int63 ->
       len:int63 ->
@@ -65,8 +65,9 @@ module Worker = struct
 
     let string_of_key = Irmin.Type.to_string key_t
 
-    let transfer_append_exn ~read_exn ~append_exn ~(off : int63) ~(len : int63)
-        buffer =
+    let transfer_append_exn ~dispatcher ~append_exn ~(off : int63)
+        ~(len : int63) buffer =
+      let read_exn = Dispatcher.read_in_prefix_and_suffix_exn dispatcher in
       let buffer_size = Bytes.length buffer |> Int63.of_int in
       let rec aux off len_remaining =
         let open Int63.Syntax in
@@ -244,11 +245,10 @@ module Worker = struct
           [%log.debug "GC: transfering to the new prefix"];
           let buffer = Bytes.create buffer_size in
           (* Step 5.1. Transfer all. *)
-          let read_exn = Dispatcher.read_in_prefix_and_suffix_exn dispatcher in
           let append_exn = Ao.append_exn prefix in
           let f ~off ~len =
             let len = Int63.of_int len in
-            transfer_append_exn ~read_exn ~append_exn ~off ~len buffer
+            transfer_append_exn ~dispatcher ~append_exn ~off ~len buffer
           in
           let () = Mapping_file.iter_exn mapping f in
           Ao.flush prefix |> Errs.raise_if_error
@@ -286,12 +286,8 @@ module Worker = struct
           >>= (fun _ -> Ao.close suffix)
           |> Errs.log_if_error "GC: Close suffix")
       @@ fun () ->
-      let read_exn ~off ~len buf =
-        let accessor = Dispatcher.create_accessor_exn dispatcher ~off ~len in
-        Dispatcher.read_exn dispatcher accessor buf
-      in
       let append_exn = Ao.append_exn suffix in
-      let transfer_exn = transfer_append_exn ~read_exn ~append_exn buffer in
+      let transfer_exn = transfer_append_exn ~dispatcher ~append_exn buffer in
 
       (* Step 7. Transfer to the next suffix. *)
       [%log.debug "GC: transfering to the new suffix"];
@@ -304,8 +300,7 @@ module Worker = struct
           let () = Fm.reload fm |> Errs.raise_if_error in
           let pl : Payload.t = Fm.Control.payload (Fm.control fm) in
           let end_offset =
-            Dispatcher.offset_of_suffix_off dispatcher
-              pl.entry_offset_suffix_end
+            Dispatcher.offset_of_suffix_poff dispatcher pl.suffix_end_poff
           in
           let len = Int63.Syntax.(end_offset - off) in
           [%log.debug
@@ -320,11 +315,13 @@ module Worker = struct
             let off = Int63.Syntax.(off + len) in
             transfer_loop ~off (i - 1)
       in
-      let offs = transfer_loop ~off:commit_offset num_iterations in
+      let new_suffix_end_offset =
+        transfer_loop ~off:commit_offset num_iterations
+      in
       Ao.flush suffix |> Errs.raise_if_error;
 
       (* Step 8. Inform the caller of the end_offset copied. *)
-      offs
+      new_suffix_end_offset
 
     let write_gc_output ~root ~generation output =
       let open Result_syntax in
@@ -418,7 +415,7 @@ module Make (Args : Args) = struct
       stats = None;
     }
 
-  let open_new_suffix ~end_offset { root; generation; _ } =
+  let open_new_suffix ~end_poff { root; generation; _ } =
     let open Result_syntax in
     let path = Irmin_pack.Layout.V3.suffix ~root ~generation in
     (* As the new suffix is necessarily in V3, the dead_header_size is
@@ -426,47 +423,43 @@ module Make (Args : Args) = struct
     let dead_header_size = 0 in
     let auto_flush_threshold = 1_000_000 in
     let* suffix =
-      Ao.open_rw ~path ~end_offset ~dead_header_size
+      Ao.open_rw ~path ~end_poff ~dead_header_size
         ~auto_flush_procedure:`Internal ~auto_flush_threshold
     in
     Ok suffix
 
-  let transfer_latest_newies ~right_start_offset ~copy_end_offset t =
+  let transfer_latest_newies ~new_suffix_start_offset ~new_suffix_end_offset t =
     [%log.debug "Gc in main: transfer latest newies"];
     let open Result_syntax in
     let open Int63.Syntax in
-    let old_end_offset = Dispatcher.end_offset t.dispatcher in
-    let remaining = old_end_offset - copy_end_offset in
-    (* When opening the suffix in append_only we need to provide a
-       (real) suffix offset, computed from the global ones. *)
-    let suffix_end_offset = copy_end_offset - right_start_offset in
-    let* new_suffix = open_new_suffix ~end_offset:suffix_end_offset t in
+    let old_suffix_end_offset = Dispatcher.end_offset t.dispatcher in
+    let remaining = old_suffix_end_offset - new_suffix_end_offset in
+    (* When opening the suffix we need to provide a physical offset. We compute
+       it from the global ones. *)
+    let suffix_end_poff = new_suffix_end_offset - new_suffix_start_offset in
+    let* new_suffix = open_new_suffix ~end_poff:suffix_end_poff t in
     Errors.finalise (fun _ ->
         Ao.close new_suffix
         |> Errs.log_if_error "GC: Close suffix after copy latest newies")
     @@ fun () ->
     let buffer = Bytes.create 8192 in
-    let read_exn ~off ~len buf =
-      let accessor = Dispatcher.create_accessor_exn t.dispatcher ~off ~len in
-      Dispatcher.read_exn t.dispatcher accessor buf
-    in
     let append_exn = Ao.append_exn new_suffix in
     let flush_and_raise () = Ao.flush new_suffix |> Errs.raise_if_error in
     let* () =
       Errs.catch (fun () ->
-          Worker.transfer_append_exn ~read_exn ~append_exn ~off:copy_end_offset
-            ~len:remaining buffer;
+          Worker.transfer_append_exn ~dispatcher:t.dispatcher ~append_exn
+            ~off:new_suffix_end_offset ~len:remaining buffer;
           flush_and_raise ())
     in
-    Ok old_end_offset
+    Ok old_suffix_end_offset
 
-  let swap_and_purge ~right_start_offset ~right_end_offset t =
+  let swap_and_purge ~new_suffix_start_offset ~new_suffix_end_offset t =
     let open Result_syntax in
     let c0 = Mtime_clock.counter () in
 
     let* () =
-      Fm.swap t.fm ~generation:t.generation ~right_start_offset
-        ~right_end_offset
+      Fm.swap t.fm ~generation:t.generation ~new_suffix_start_offset
+        ~new_suffix_end_offset
     in
     let span1 = Mtime_clock.count c0 |> Mtime.Span.to_s in
 
@@ -577,19 +570,19 @@ module Make (Args : Args) = struct
           let result =
             let open Result_syntax in
             match (status, gc_output) with
-            | `Success, Ok copy_end_offset ->
+            | `Success, Ok new_suffix_end_offset_before ->
                 let* new_suffix_end_offset =
                   time (fun t ->
                       s := { !s with transfer_latest_newies_duration = t })
                   @@ fun () ->
-                  transfer_latest_newies ~right_start_offset:t.offset
-                    ~copy_end_offset t
+                  transfer_latest_newies ~new_suffix_start_offset:t.offset
+                    ~new_suffix_end_offset:new_suffix_end_offset_before t
                 in
                 let* () =
                   time (fun t -> s := { !s with swap_duration = t })
                   @@ fun () ->
-                  swap_and_purge ~right_start_offset:t.offset
-                    ~right_end_offset:new_suffix_end_offset t
+                  swap_and_purge ~new_suffix_start_offset:t.offset
+                    ~new_suffix_end_offset t
                 in
                 (if t.unlink then
                  time (fun t -> s := { !s with unlink_duration = t })
@@ -606,7 +599,8 @@ module Make (Args : Args) = struct
 
                 [%log.debug
                   "Gc ended. %a, newies bytes:%a" pp_stats !s Int63.pp
-                    (Int63.sub new_suffix_end_offset copy_end_offset)];
+                    (Int63.sub new_suffix_end_offset
+                       new_suffix_end_offset_before)];
                 let () = Lwt.wakeup_later t.resolver (Ok !s) in
                 Ok (`Finalised !s)
             | _ ->

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -216,7 +216,7 @@ end = struct
   let io_read_at_most ~off ~len b suffix =
     let bytes_after_off =
       let open Int63.Syntax in
-      File_manager.Suffix.end_offset suffix - off
+      File_manager.Suffix.end_poff suffix - off
     in
     let len =
       let open Int63.Syntax in
@@ -316,7 +316,7 @@ end = struct
     let run_duration = Mtime_clock.counter () in
     let fm = File_manager.open_ro config |> Errs.raise_if_error in
     let suffix = File_manager.suffix fm in
-    let total = File_manager.Suffix.end_offset suffix in
+    let total = File_manager.Suffix.end_poff suffix in
     let stats, missing_hash =
       let bar =
         let open Progress.Line.Using_int63 in

--- a/src/irmin-tezos-utils/dune
+++ b/src/irmin-tezos-utils/dune
@@ -15,3 +15,9 @@
   cmdliner)
  (preprocess
   (pps ppx_repr)))
+
+(rule
+ (alias runtest)
+ (package irmin-tezos-utils)
+ (deps main.exe)
+ (action (progn)))

--- a/src/irmin-tezos-utils/files.ml
+++ b/src/irmin-tezos-utils/files.ml
@@ -138,7 +138,7 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
     else acc
 
   let load_dict (dict : File_manager.Dict.t) buffer =
-    let max_offset = File_manager.Dict.end_offset dict in
+    let max_offset = File_manager.Dict.end_poff dict in
     let off = Int63.zero in
     let dict = traverse_dict dict max_offset buffer off [] in
     List.rev dict

--- a/src/irmin-tezos-utils/show.ml
+++ b/src/irmin-tezos-utils/show.ml
@@ -718,13 +718,12 @@ let main store_path info_last_path info_next_path index_path =
   let dispatcher = Files.Dispatcher.v fm |> Files.Errs.raise_if_error in
   let pl = Files.File_manager.Control.payload (Files.File_manager.control fm) in
   let max_offset =
-    (* TODO: Rename [pl.entry_offset_suffix_end] to [suffix_length] *)
+    (* TODO: Rename [pl.suffix_end_poff] to [suffix_length] *)
     match pl.status with
     | From_v1_v2_post_upgrade _ | From_v3_no_gc_yet
     | From_v3_used_non_minimal_indexing_strategy ->
-        pl.entry_offset_suffix_end
-    | From_v3_gced x ->
-        Int63.add x.entry_offset_suffix_start pl.entry_offset_suffix_end
+        pl.suffix_end_poff
+    | From_v3_gced x -> Int63.add x.suffix_start_offset pl.suffix_end_poff
     | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 | T11 | T12 | T13 | T14
     | T15 ->
         assert false


### PR DESCRIPTION
This PR normalises the offset variable names given the latest vocabulary that the team has converged to.

It also changes GC's `transfer_append_exn` to take the dispatcher directly. 

### Renames
```
Usage of `poff` for physical offsets:
- persisted_end_offset -> persisted_end_poff
- end_offset -> end_poff
- refresh_end_offset -> refresh_end_poff
- dict_offset_end -> dict_end_poff
- offset_of_suffix_off -> offset_of_suffix_poff 

Removal of `right` which meant "right of the commit offset":
- right_start_offset -> new_suffix_start_offset
- right_end_offset -> new_suffix_end_offset

Fix of this CF's field. It doesn't contain a global offset, it contains physical offset
- entry_offset_suffix_end -> suffix_end_poff

Some other renames:
- entry_offset_suffix_start -> suffix_start_offset
- old_end_offset -> old_suffix_end_offset
- offs -> new_suffix_end_offset
- copy_end_offset -> new_suffix_end_offset_before
```



