### PR TITLE
Checksum control file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 - **irmin-pack**
   - Upgraded on-disk format to version 4. (#2110, @icristescu)
+  - Detecting control file corruption with a checksum (#2119, @art-w)
 
 ### Fixed
 

--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -24,6 +24,7 @@ depends: [
   "mtime"
   "cmdliner"
   "optint"       {>= "0.1.0"}
+  "checkseum"
   "irmin-test"   {with-test & = version}
   "alcotest-lwt" {with-test}
   "astring"      {with-test}

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -152,8 +152,9 @@ module Payload_v4 = struct
   type t = {
     dict_end_poff : int63;
     suffix_end_poff : int63;
-    status : status;
     upgraded_from_v3_to_v4 : bool;
+    checksum : int63;
+    status : status;
   }
   [@@deriving irmin]
   (** Similar to [`V3] payload. [upgraded_from_v3_to_v4] recalls if the store

--- a/src/irmin-pack/unix/dune
+++ b/src/irmin-pack/unix/dune
@@ -13,6 +13,8 @@
   mtime
   cmdliner
   optint
+  checkseum
+  checkseum.ocaml
   rusage)
  (preprocess
   (pps ppx_irmin.internal))

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -450,6 +450,7 @@ struct
         {
           dict_end_poff = z;
           suffix_end_poff = z;
+          checksum = z;
           status;
           upgraded_from_v3_to_v4 = false;
         }
@@ -540,6 +541,7 @@ struct
         {
           dict_end_poff;
           suffix_end_poff;
+          checksum = Int63.zero;
           status;
           upgraded_from_v3_to_v4 = false;
         }

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -15,7 +15,8 @@
   test_flush_reload
   test_mapping
   test_nearest_leq
-  test_dispatcher)
+  test_dispatcher
+  test_corrupted)
  (libraries
   alcotest
   fmt

--- a/test/irmin-pack/test_corrupted.ml
+++ b/test/irmin-pack/test_corrupted.ml
@@ -1,0 +1,87 @@
+(*
+ * Copyright (c) 2022-2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+open Common
+
+let root = Filename.concat "_build" "test-corrupted"
+
+module Conf = Irmin_tezos.Conf
+
+module Store = struct
+  module Maker = Irmin_pack_unix.Maker (Conf)
+  include Maker.Make (Schema)
+end
+
+let config ?(readonly = false) ?(fresh = true) root =
+  Irmin_pack.config ~readonly ?index_log_size ~fresh root
+
+let info () = Store.Info.empty
+
+let read_file path =
+  let ch = open_in_bin path in
+  Fun.protect
+    (fun () ->
+      let len = in_channel_length ch in
+      really_input_string ch len)
+    ~finally:(fun () -> close_in ch)
+
+let write_file path contents =
+  let ch = open_out_bin path in
+  Fun.protect
+    (fun () -> output_string ch contents)
+    ~finally:(fun () ->
+      flush ch;
+      close_out ch)
+
+let test_corrupted_control_file () =
+  rm_dir root;
+  let control_file_path = Filename.concat root "store.control" in
+  let* repo = Store.Repo.v (config ~fresh:true root) in
+  let control_file_blob0 = read_file control_file_path in
+  let* store = Store.main repo in
+  let* () = Store.set_exn ~info store [ "a" ] "b" in
+  let* () = Store.Repo.close repo in
+  let control_file_blob1 = read_file control_file_path in
+  assert (not (String.equal control_file_blob0 control_file_blob1));
+  assert (String.length control_file_blob0 = String.length control_file_blob1);
+  let split_write_at = 3 * String.length control_file_blob1 / 4 in
+  let control_file_mix =
+    String.sub control_file_blob1 0 split_write_at
+    ^ String.sub control_file_blob0 split_write_at
+        (String.length control_file_blob0 - split_write_at)
+  in
+  assert (String.length control_file_mix = String.length control_file_blob1);
+  assert (not (String.equal control_file_blob0 control_file_mix));
+  assert (not (String.equal control_file_blob1 control_file_mix));
+  write_file control_file_path control_file_mix;
+  let* error =
+    Lwt.catch
+      (fun () ->
+        let+ r = Store.Repo.v (config ~fresh:false root) in
+        Ok r)
+      (fun exn -> Lwt.return (Error exn))
+  in
+  Alcotest.(check bool)
+    "is corrupted" true
+    (error = Error (Irmin_pack_unix.Errors.Pack_error `Corrupted_control_file));
+  Lwt.return_unit
+
+let tests =
+  [
+    Alcotest_lwt.test_case "Corrupted control file" `Quick (fun _switch ->
+        test_corrupted_control_file);
+  ]

--- a/test/irmin-pack/test_corrupted.mli
+++ b/test/irmin-pack/test_corrupted.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) 2022-2022 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -551,4 +551,5 @@ let misc =
     ("test_nearest_leq", Test_nearest_leq.tests);
     ("layout", Layout.tests);
     ("dispatcher", Test_dispatcher.tests);
+    ("corrupted", Test_corrupted.tests);
   ]


### PR DESCRIPTION
This adds a small checksum to the control file payload to verify that we are not reading a partially written file (highly unlikely!.. but decoding such a broken control file always works so it's a bit hard to tell)
I've added a dependency to `checkseum`... but the checksum can be done differently if that's not desirable!