### PR TITLE
Gc-based snapshots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
     latest gc was called on. (#2110, @icristescu)
   - Add `split` to create a new suffix chunk. Subsequent writes will append to
     this chunk until `split` is called again. (#2118, @icristescu)
+  - Add `create_one_commit_store` to create a new store from the existing one,
+    containing only one commit. (#2125, @icristescu)
 
 ### Changed
 

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -71,7 +71,8 @@ type base_error =
   | `Invalid_read_of_gced_object of string
   | `Inconsistent_store
   | `Split_forbidden_during_batch
-  | `Multiple_empty_chunks ]
+  | `Multiple_empty_chunks
+  | `Forbidden_during_gc ]
 [@@deriving irmin ~pp]
 (** [base_error] is the type of most errors that can occur in a [result], except
     for errors that have associated exceptions (see below) and backend-specific

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -256,6 +256,19 @@ module type S = sig
   val generation : t -> int
   val gc_allowed : t -> bool
   val split : t -> (unit, [> Errs.t ]) result
+
+  val create_one_commit_store :
+    t ->
+    Irmin.Backend.Conf.t ->
+    generation:int ->
+    latest_gc_target_offset:int63 ->
+    suffix_start_offset:int63 ->
+    Index.key Pack_key.t ->
+    (unit, [> open_rw_error | close_error ]) result
+  (** [create_one_commit_store t conf generation new_store_root key] is called
+      when creating a new store at [new_store_root] from the existing one,
+      containing only one commit, specified by the [key]. Ths new store will use
+      configuration options from [conf] and set to [generation]. *)
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/gc.mli
+++ b/src/irmin-pack/unix/gc.mli
@@ -25,6 +25,7 @@ module Make (Args : Gc_args.S) : sig
 
   val v :
     root:string ->
+    new_files_path:string ->
     generation:int ->
     unlink:bool ->
     dispatcher:Args.Dispatcher.t ->
@@ -51,5 +52,12 @@ module Make (Args : Gc_args.S) : sig
       finalises. *)
 
   val cancel : t -> bool
+
+  val finalise_without_swap : t -> (int63 * int63) Lwt.t
+  (** Waits for the current gc to finish and returns immediately without
+      swapping the files and doing the other finalisation steps from [finalise].
+
+      It returns the [latest_gc_target_offset] and the
+      [new_suffix_start_offset]. *)
 end
 with module Args = Args

--- a/src/irmin-pack/unix/gc_worker.mli
+++ b/src/irmin-pack/unix/gc_worker.mli
@@ -23,7 +23,12 @@ module Make (Args : Gc_args.S) : sig
   module Args : Gc_args.S
 
   val run_and_output_result :
-    generation:int -> string -> Args.key -> int63 -> unit
+    generation:int ->
+    new_files_path:string ->
+    string ->
+    Args.key ->
+    int63 ->
+    unit
 
   type suffix_params = {
     start_offset : int63;

--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -267,6 +267,12 @@ module Unix = struct
       Ok ()
     with Sys_error msg -> Error (`Sys_error msg)
 
+  let copy_file ~src ~dst =
+    let cmd = Filename.quote_command "cp" [ "-p"; src; dst ] in
+    match Sys.command cmd with
+    | 0 -> Ok ()
+    | n -> Error (`Sys_error (Int.to_string n))
+
   let mkdir path =
     match (classify_path (Filename.dirname path), classify_path path) with
     | `Directory, `No_such_file_or_directory -> (

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -75,7 +75,8 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Ro_not_allowed
     | `Io_misc of Io.misc_error
     | `Split_forbidden_during_batch
-    | `Multiple_empty_chunks ]
+    | `Multiple_empty_chunks
+    | `Forbidden_during_gc ]
   [@@deriving irmin]
 
   let raise_error = function

--- a/src/irmin-pack/unix/io_intf.ml
+++ b/src/irmin-pack/unix/io_intf.ml
@@ -78,6 +78,9 @@ module type S = sig
   val move_file :
     src:string -> dst:string -> (unit, [> `Sys_error of string ]) result
 
+  val copy_file :
+    src:string -> dst:string -> (unit, [> `Sys_error of string ]) result
+
   val mkdir : string -> (unit, [> mkdir_error ]) result
   val unlink : string -> (unit, [> `Sys_error of string ]) result
 

--- a/src/irmin-pack/unix/s.ml
+++ b/src/irmin-pack/unix/s.ml
@@ -53,6 +53,15 @@ module type S = sig
 
       TODO: Detail exceptions raised. *)
 
+  val create_one_commit_store : repo -> commit_key -> string -> unit Lwt.t
+  (** [create_one_commit_store t key path] creates a new store at [path] from
+      the existing one, containing only one commit, specified by the [key]. Note
+      that this operation is blocking.
+
+      It requires that the files existing on disk when the operation is
+      launched, remain on disk until the operation completes. In particular, a
+      Gc running in a different process could remove files from disk. *)
+
   module Gc : sig
     (** GC *)
 

--- a/test/irmin-pack/test_gc.mli
+++ b/test/irmin-pack/test_gc.mli
@@ -26,6 +26,10 @@ module Split : sig
   val tests : unit Alcotest_lwt.test_case list
 end
 
+module Snapshot : sig
+  val tests : unit Alcotest_lwt.test_case list
+end
+
 module Store : sig
   module S : Irmin_pack.S
 

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -553,4 +553,5 @@ let misc =
     ("layout", Layout.tests);
     ("dispatcher", Test_dispatcher.tests);
     ("corrupted", Test_corrupted.tests);
+    ("snapshot_gc", Test_gc.Snapshot.tests);
   ]


### PR DESCRIPTION
After discussions with @vect0r-vicall, I'm working on a new snapshot export that:
- calls gc on the commit for which we want to create the snapshot;
- copies the resulting prefix, mapping (and dict is needed too) to a new directory; 
- that directory is the new snapshot format 

The import:
- opens a new store from a prefix, mapping and a dict, by creating a new control file;
- add the commit to a fresh index. 

This is WIP, but I would appreciate any feedback, in case I missed something. Things that I see to improve are:
- instead of manipulating the type snap in the code, we could write to a file;
- the control file after a snapshot import looks a lot like after a gc - we could introduce an extra status to differentiate the two
- a better management for dict?

 