### PR TITLE
irmin-pack: update GC to work with chunked suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
   - Detecting control file corruption with a checksum (#2119, @art-w)
   - Change on-disk layout of the suffix from a single file to a multiple,
     chunked file design (#2115, @metanivek)
+  - Modify GC to work with new chunked suffix. See `examples/gc.ml` for a
+    demonstration of how it works with the new `split` function. (#2126,
+    @metanivek)
 
 ### Fixed
 

--- a/src/irmin-pack/unix/chunked_suffix_intf.ml
+++ b/src/irmin-pack/unix/chunked_suffix_intf.ml
@@ -78,6 +78,8 @@ module type S = sig
     t ->
     (unit, [> add_new_error ]) result
 
+  val start_idx : t -> int
+  val chunk_num : t -> int
   val close : t -> (unit, [> Io.close_error | `Pending_flush ]) result
   val empty_buffer : t -> bool
   val flush : t -> (unit, [> Io.write_error ]) result
@@ -98,6 +100,17 @@ module type S = sig
   val refresh_end_poff : t -> int63 -> (unit, [> `Rw_not_allowed ]) result
   val readonly : t -> bool
   val auto_flush_threshold : t -> int option
+
+  val fold_chunks :
+    (acc:'a ->
+    idx:int ->
+    start_suffix_off:int63 ->
+    end_suffix_off:int63 ->
+    is_appendable:bool ->
+    'a) ->
+    'a ->
+    t ->
+    'a
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -84,9 +84,13 @@ module type S = sig
   (** [suffix_start_offset] is the offsets of the first pack entry in the
       suffix. All pack entries in the prefix fit below [suffix_start_offset]. *)
 
-  val offset_of_suffix_poff : t -> int63 -> int63
-  (** [offset_of_suffix_poff t suffix_off] converts a suffix offset into a
-      (global) offset. *)
+  val offset_of_soff : t -> int63 -> int63
+  (** [offset_of_soff t suffix_off] converts a suffix offset into a (global)
+      offset. *)
+
+  val soff_of_offset : t -> int63 -> int63
+  (** [soff_of_offset t global_offset] converts a global offset to a suffix
+      offset. *)
 
   val read_bytes_exn : t -> f:(string -> unit) -> off:int63 -> len:int63 -> unit
   (** [read_bytes_exn] reads a slice of the global offset space defined by [off]

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -241,13 +241,16 @@ module type S = sig
   val swap :
     t ->
     generation:int ->
-    new_suffix_start_offset:int63 ->
-    new_suffix_end_offset:int63 ->
+    suffix_start_offset:int63 ->
+    chunk_start_idx:int ->
+    chunk_num:int ->
+    suffix_dead_bytes:int63 ->
     latest_gc_target_offset:int63 ->
     (unit, [> Errs.t ]) result
-  (** Swaps to using files from the GC [generation]. The offsets
-      [new_suffix_start_offset] and [new_suffix_end_offset] are used to properly
-      load the suffix. The control file is also updated. *)
+  (** Swaps to using files from the GC [generation]. The values
+      [suffix_start_offset], [chunk_start_idx], [chunk_num], and
+      [suffix_dead_bytes] are used to properly load and read the suffix after a
+      GC. The control file is also updated on disk. *)
 
   val readonly : t -> bool
   val generation : t -> int

--- a/src/irmin-pack/unix/gc_worker.mli
+++ b/src/irmin-pack/unix/gc_worker.mli
@@ -25,7 +25,20 @@ module Make (Args : Gc_args.S) : sig
   val run_and_output_result :
     generation:int -> string -> Args.key -> int63 -> unit
 
-  type gc_output = (Stats.Latest_gc.worker, Args.Errs.t) result
+  type suffix_params = {
+    start_offset : int63;
+    chunk_start_idx : int;
+    dead_bytes : int63;
+  }
   [@@deriving irmin]
+
+  type gc_results = {
+    suffix_params : suffix_params;
+    removable_chunk_idxs : int list;
+    stats : Stats.Latest_gc.worker;
+  }
+  [@@deriving irmin]
+
+  type gc_output = (gc_results, Args.Errs.t) result [@@deriving irmin]
 end
 with module Args := Args

--- a/src/irmin-pack/unix/import.ml
+++ b/src/irmin-pack/unix/import.ml
@@ -34,6 +34,14 @@ module Array = struct
     loop 0
 end
 
+module List = struct
+  include List
+
+  let rec iter_result f = function
+    | [] -> Ok ()
+    | hd :: tl -> Result.bind (f hd) (fun () -> iter_result f tl)
+end
+
 module Int63 = struct
   include Optint.Int63
 


### PR DESCRIPTION
This PR is a part of #2096. It modifies the GC procedure to work with the new chunked suffix.

Chunked suffix GC is different from current (Irmin 3.4) GC in the following ways:

- The GC no longer necessarily removes bytes _on disk_ from the beginning of the suffix. Bytes are removed on disk only when chunks are strictly before the split point of the GC. 
- Even though these bytes may still exist on disk, the dispatcher continues to direct reads before the split point to the prefix. A new field, `suffix_dead_bytes`, is used by the dispatcher to properly read from the suffix.
- If you only have one chunk (that is, you never call `split`), no data will ever be removed during GC.