### PR TITLE
Update opam deps for git-unix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@
   - Change on-disk layout of the suffix from a single file to a multiple,
     chunked file design (#2115, @metanivek)
 
+- **irmin-git**
+  - Upgrade `irmin-git` to `git-unix.3.10.0`. (#2127, @icristescu)
+
+- **irmin-http**
+  - Upgrade `irmin-http` to `git-unix.3.10.0`. (#2127, @icristescu)
+
+- **irmin-graphql**
+  - Upgrade `irmin-graphql` to `git-unix.3.10.0`. (#2127, @icristescu)
+
+- **irmin-cli**
+  - Upgrade `irmin-cli` to `git-unix.3.10.0`. (#2127, @icristescu)
+
 ### Fixed
 
 - **irmin-pack**

--- a/irmin-cli.opam
+++ b/irmin-cli.opam
@@ -25,7 +25,7 @@ depends: [
   "irmin-pack"    {= version}
   "irmin-graphql" {= version}
   "irmin-tezos"   {= version}
-  "git-unix"      {>= "3.7.0"}
+  "git-unix"      {>= "3.10.0"}
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "3.0.0"}

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -20,7 +20,7 @@ depends: [
   "irmin"      {= version}
   "ppx_irmin"  {= version}
   "git"        {>= "3.7.0"}
-  "git-unix"   {>= "3.7.0"}
+  "git-unix"   {>= "3.10.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/irmin-graphql.opam
+++ b/irmin-graphql.opam
@@ -24,7 +24,7 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "cohttp-lwt-unix"
-  "git-unix"        {>= "3.7.0"}
+  "git-unix"        {>= "3.10.0"}
   "fmt"
   "lwt"             {>= "5.3.0"}
   "alcotest-lwt"    {with-test & >= "1.1.0"}

--- a/irmin-http.opam
+++ b/irmin-http.opam
@@ -32,7 +32,7 @@ depends: [
   "irmin-git"       {with-test & = version}
   "irmin-fs"        {with-test & = version}
   "irmin-test"      {with-test & = version}
-  "git-unix"        {with-test & >= "3.5.0"}
+  "git-unix"        {with-test & >= "3.10.0"}
   "digestif"        {with-test & >= "0.9.0"}
 ]
 


### PR DESCRIPTION
What I think happens in the bug exposed by the opam-repo CI in https://github.com/ocaml/opam-repository/pull/22321 is the following:

h2.0.9.0 is the lower bound for h2 that works on ocaml5
paf.0.0.7 has h2 < 0.9.0
paf.0.1.0 and upwards have h2 >= 0.9.0 
git-paf.3.9.1 has  paf >=0.0.7 & <0.2.0 
git-paf.3.10.0 has paf >= 0.2.0
git-mirage, and finally git-unix have the constraint "git-paf" {= version}

Thanks @MisterDA for helping me figure it out. 


