### PR TITLE
irmin-pack: Clean file manager functors

### DIFF
--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -21,20 +21,19 @@ include File_manager_intf
 let legacy_io_header_size = 16
 
 module Make
-    (Control : Control_file.S with module Io = Io.Unix)
-    (Dict : Append_only_file.S with module Io = Control.Io)
-    (Suffix : Chunked_suffix.S with module Io = Control.Io)
-    (Index : Pack_index.S)
-    (Errs : Io_errors.S with module Io = Control.Io) =
+    (Io : Io.S)
+    (Index : Pack_index.S with module Io = Io)
+    (Mapping_file : Mapping_file.S with module Io = Io)
+    (Errs : Io_errors.S with module Io = Io) =
 struct
-  module Io = Control.Io
-  module Control = Control
-  module Dict = Dict
-  module Suffix = Suffix
+  module Io = Errs.Io
   module Index = Index
-  module Errs = Errs
+  module Mapping_file = Mapping_file
+  module Errs = Io_errors.Make (Io)
+  module Control = Control_file.Make (Io)
+  module Dict = Append_only_file.Make (Io) (Errs)
+  module Suffix = Chunked_suffix.Make (Io) (Errs)
   module Prefix = Io
-  module Mapping_file = Mapping_file.Make (Io)
 
   type after_reload_consumer = { after_reload : unit -> (unit, Errs.t) result }
   type after_flush_consumer = { after_flush : unit -> unit }

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -259,15 +259,13 @@ module type Sigs = sig
   module type S = S
 
   module Make
-      (Control : Control_file.S with module Io = Io.Unix)
-      (Dict : Append_only_file.S with module Io = Control.Io)
-      (Suffix : Chunked_suffix.S with module Io = Control.Io)
-      (Index : Pack_index.S)
-      (Errs : Io_errors.S with module Io = Control.Io) :
+      (Io : Io.S)
+      (Index : Pack_index.S with module Io = Io)
+      (Mapping_file : Mapping_file.S with module Io = Io)
+      (Errs : Io_errors.S with module Io = Io) :
     S
-      with module Io = Control.Io
-       and module Control = Control
-       and module Dict = Dict
-       and module Suffix = Suffix
+      with module Io = Io
        and module Index = Index
+       and module Mapping_file = Mapping_file
+       and module Errs = Errs
 end

--- a/src/irmin-pack/unix/pack_index.ml
+++ b/src/irmin-pack/unix/pack_index.ml
@@ -62,6 +62,7 @@ module Make (K : Irmin.Hash.S) = struct
   module I = Index
   module Index = Index_unix.Make (Key) (Val) (Index.Cache.Unbounded)
   include Index
+  module Io = Io.Unix
 
   let v_exn =
     let cache = None in

--- a/src/irmin-pack/unix/pack_index_intf.ml
+++ b/src/irmin-pack/unix/pack_index_intf.ml
@@ -25,6 +25,7 @@ module type S = sig
   type value = int63 * int * Pack_value.Kind.t
 
   include Index.S with type value := value and type t := t and type key := key
+  module Io : Io.S
 
   val v_exn :
     ?flush_callback:(unit -> unit) ->
@@ -36,13 +37,10 @@ module type S = sig
     string ->
     t
 
-  type create_error :=
-    [ `Index_failure of string | `Io_misc of Io.Unix.misc_error ]
+  type create_error := [ `Index_failure of string | `Io_misc of Io.misc_error ]
 
   type write_error :=
-    [ `Index_failure of string
-    | `Io_misc of Io.Unix.misc_error
-    | `Ro_not_allowed ]
+    [ `Index_failure of string | `Io_misc of Io.misc_error | `Ro_not_allowed ]
 
   val v :
     ?flush_callback:(unit -> unit) ->
@@ -73,5 +71,5 @@ end
 module type Sigs = sig
   module type S = S
 
-  module Make (K : Irmin.Hash.S) : S with type key = K.t
+  module Make (K : Irmin.Hash.S) : S with type key = K.t and module Io = Io.Unix
 end

--- a/src/irmin-tezos-utils/files.ml
+++ b/src/irmin-tezos-utils/files.ml
@@ -16,15 +16,11 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
   module Key = Irmin_pack_unix.Pack_key.Make (Hash)
   module Io = Irmin_pack_unix.Io.Unix
   module Errs = Irmin_pack_unix.Io_errors.Make (Io)
-  module Control_file = Irmin_pack_unix.Control_file.Make (Io)
-  module Append_only_file = Irmin_pack_unix.Append_only_file.Make (Io) (Errs)
-  module Suffix = Irmin_pack_unix.Chunked_suffix.Make (Io) (Errs)
   module Pack_index = Irmin_pack_unix.Index.Make (Hash)
+  module Mapping_file = Irmin_pack_unix.Mapping_file.Make (Io)
 
   module File_manager =
-    Irmin_pack_unix.File_manager.Make (Control_file) (Append_only_file) (Suffix)
-      (Pack_index)
-      (Errs)
+    Irmin_pack_unix.File_manager.Make (Io) (Pack_index) (Mapping_file) (Errs)
 
   module Dispatcher = Irmin_pack_unix.Dispatcher.Make (File_manager)
 

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -79,12 +79,10 @@ module Index = Irmin_pack_unix.Index.Make (Schema.Hash)
 module Key = Irmin_pack_unix.Pack_key.Make (Schema.Hash)
 module Io = Irmin_pack_unix.Io.Unix
 module Errs = Irmin_pack_unix.Io_errors.Make (Io)
-module Control = Irmin_pack_unix.Control_file.Make (Io)
-module Aof = Irmin_pack_unix.Append_only_file.Make (Io) (Errs)
-module Suffix = Irmin_pack_unix.Chunked_suffix.Make (Io) (Errs)
+module Mapping_file = Irmin_pack_unix.Mapping_file.Make (Io)
 
 module File_manager =
-  Irmin_pack_unix.File_manager.Make (Control) (Aof) (Suffix) (Index) (Errs)
+  Irmin_pack_unix.File_manager.Make (Io) (Index) (Mapping_file) (Errs)
 
 module Dict = Irmin_pack_unix.Dict.Make (File_manager)
 module Dispatcher = Irmin_pack_unix.Dispatcher.Make (File_manager)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -45,12 +45,10 @@ struct
 
   module Io = Irmin_pack_unix.Io.Unix
   module Errs = Irmin_pack_unix.Io_errors.Make (Io)
-  module Control = Irmin_pack_unix.Control_file.Make (Io)
-  module Aof = Irmin_pack_unix.Append_only_file.Make (Io) (Errs)
-  module Suffix = Irmin_pack_unix.Chunked_suffix.Make (Io) (Errs)
+  module Mapping_file = Irmin_pack_unix.Mapping_file.Make (Io)
 
   module File_manager =
-    Irmin_pack_unix.File_manager.Make (Control) (Aof) (Suffix) (Index) (Errs)
+    Irmin_pack_unix.File_manager.Make (Io) (Index) (Mapping_file) (Errs)
 
   module Dict = Irmin_pack_unix.Dict.Make (File_manager)
   module Dispatcher = Irmin_pack_unix.Dispatcher.Make (File_manager)

--- a/test/irmin-pack/test_pack_version_bump.ml
+++ b/test/irmin-pack/test_pack_version_bump.ml
@@ -29,12 +29,10 @@ module Private = struct
   module Index = Irmin_pack_unix.Index.Make (Schema.Hash)
   module Io = Irmin_pack_unix.Io.Unix
   module Errs = Irmin_pack_unix.Io_errors.Make (Io)
-  module Control = Irmin_pack_unix.Control_file.Make (Io)
-  module Aof = Irmin_pack_unix.Append_only_file.Make (Io) (Errs)
-  module Suffix = Irmin_pack_unix.Chunked_suffix.Make (Io) (Errs)
+  module Mapping_file = Irmin_pack_unix.Mapping_file.Make (Io)
 
   module File_manager =
-    Irmin_pack_unix.File_manager.Make (Control) (Aof) (Suffix) (Index) (Errs)
+    Irmin_pack_unix.File_manager.Make (Io) (Index) (Mapping_file) (Errs)
 end
 
 module Util = struct


### PR DESCRIPTION
This simple PR cleans the functors of the File_manager module. It removes the need of a reference to Unix in said module.

It was first part of a bigger work, to abstract the offsets. However it appeared that it would be way more complicated and annoying to do.
Therefore, in the meantime, I decided to push this first modification as a separate work