### PR TITLE
bench: add split to irmin-pack trace replay

### DIFF
--- a/bench/irmin-pack/trace_replay_intf.ml
+++ b/bench/irmin-pack/trace_replay_intf.ml
@@ -101,6 +101,7 @@ module type Store = sig
   val create_repo :
     root:string -> store_config -> (Repo.t * on_commit * on_end) Lwt.t
 
+  val split : repo -> unit
   val gc_wait : repo -> unit Lwt.t
 
   type stats := Irmin_pack_unix.Stats.Latest_gc.stats

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -60,6 +60,8 @@ module type Store = sig
 
   type stats := Irmin_pack_unix.Stats.Latest_gc.stats
 
+  val split : repo -> unit
+
   val gc_run :
     ?finished:((stats, string) result -> unit Lwt.t) ->
     repo ->
@@ -221,6 +223,7 @@ module Make_store_mem (Conf : Irmin_pack.Conf.S) = struct
     let on_end () = Lwt.return_unit in
     Lwt.return (repo, on_commit, on_end)
 
+  let split _repo = ()
   let gc_wait _repo = Lwt.return_unit
   let gc_run ?finished:_ _repo _key = Lwt.return_unit
 end
@@ -248,6 +251,8 @@ module Make_store_pack (Conf : Irmin_pack.Conf.S) = struct
     let on_commit _ _ = Lwt.return_unit in
     let on_end () = Lwt.return_unit in
     Lwt.return (repo, on_commit, on_end)
+
+  let split = Store.split
 
   let gc_wait repo =
     let* r = Store.Gc.wait repo in

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -140,6 +140,7 @@ module Store_mem = struct
     let on_end () = Lwt.return_unit in
     Lwt.return (repo, on_commit, on_end)
 
+  let split _repo = ()
   let gc_wait _repo = Lwt.return_unit
   let gc_run ?finished:_ _repo _key = Lwt.return_unit
 end


### PR DESCRIPTION
This PR adds the new `split` function to the trace reply in `bench/irmin-pack`. 

We will likely want to update these benchmarks/trace replays to follow the changes that @Ngoguey42 is making to our `lib_context` replay benchmarks, but this change is needed to for the GC in the replay to continue working since `split` is needed for the new chunk-based GC to function correctly.