### PR TITLE
irmin-pack: fix file manager cleanup

### DIFF
--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -792,7 +792,7 @@ struct
   let cleanup t =
     let root = t.root in
     let pl : Payload.t = Control.payload t.control in
-    let generation = generation t - 1 in
+    let generation = generation t in
     let chunk_start_idx = pl.chunk_start_idx in
     let chunk_num = pl.chunk_num in
     cleanup ~root ~generation ~chunk_start_idx ~chunk_num


### PR DESCRIPTION
While working on https://github.com/mirage/irmin/pull/2135 I noticed a strange thing in its store directory -- there was no prefix and mapping file at the end of a run! 

It turns out that as a part of the [PR that introduced `split`](https://github.com/mirage/irmin/pull/2118), we accidentally pass the wrong `generation` value to the file manager's `cleanup` function. This code seems to have been lifted from the GC process, which needed to subtract 1 from its `generation` since it was working on the next `generation`; however, in the context of the file manager, we need to use the currently saved `generation`. This PR fixes this issue.

Aside: I wasn't sure exactly where to place the test, so I put it alongside the other GC close/kill tests in the "concurrent gc" module.