### PR TITLE
irmin-pack: rename `end_poff` for chunked suffix

### DIFF
--- a/src/irmin-pack/unix/control_file.ml
+++ b/src/irmin-pack/unix/control_file.ml
@@ -109,7 +109,10 @@ module Make (Io : Io.S) = struct
     in
     {
       dict_end_poff = pl.dict_end_poff;
-      suffix_end_poff = pl.suffix_end_poff;
+      (* When upgrading from v3 to v4, there is only one (appendable) chunk,
+         which is the existing suffix, so we set the new [appendable_chunk_poff]
+         to [pl.suffix_end_poff]. *)
+      appendable_chunk_poff = pl.suffix_end_poff;
       status;
       upgraded_from_v3_to_v4 = true;
       checksum = Int63.zero;

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -161,11 +161,7 @@ module Payload_v4 = struct
 
   type t = {
     dict_end_poff : int63;
-    (* TODO: rename [suffix_end_poff] to something that clearly communicates its role.
-
-       See corresponding todo in {!Chunked_suffix}.
-    *)
-    suffix_end_poff : int63;
+    appendable_chunk_poff : int63;
     upgraded_from_v3_to_v4 : bool;
     checksum : int63;
     chunk_start_idx : int;
@@ -173,14 +169,21 @@ module Payload_v4 = struct
     status : status; (* must be last to allow extensions *)
   }
   [@@deriving irmin]
-  (** Similar to [`V3] payload. New fields:
+  (** The same as {!Payload_v3.t}, with the following modifications:
 
-      [upgraded_from_v3_to_v4] recalls if the store was originally created in
-      [`V3].
+      New fields
 
-      [chunk_start_idx] is the index for the starting chunk of the suffix
+      - [upgraded_from_v3_to_v4] recalls if the store was originally created in
+        [`V3].
+      - [chunk_start_idx] is the index for the starting chunk of the suffix
+      - [chunk_num] is the number of chunks in the suffix
+      - [checksum] for storing a checksum of the payload
+      - [appendable_chunk_poff] is a value used by the chunked suffix. See
+        {!Chunked_suffix.S.appendable_chunk_poff} for more details.
 
-      [chunk_num] is the number of chunks in the suffix *)
+      Removed fields
+
+      - [suffix_end_poff] is replaced by [appendable_chunk_poff] *)
 end
 
 module Latest_payload = Payload_v4


### PR DESCRIPTION
This PR addresses some naming confusion while developing the new chunked suffix through renaming and cleanup.

Previously, we used `end_poff` for a couple of things:
1. To know the end offset for the suffix (synonymous with its length)
2. To keep track in the control file (`suffix_end_off`) the last known offset we flushed for consistency checks and coordination with read-only stores

With the introduction of a chunked suffix, we no longer have a single "end poff" -- we have as many as there are chunks, but we still have the above needs. To this end, this PR does two primary things (along with associated cleanup):
1. Renames `Chunked_suffix.length` to `Chunked_suffix.end_soff` to reinforce our growing usage of `soff` as a "suffix offset"
2. Renames `Chunked_suffix.end_poff` and `Control_file.Payload_v4.suffix_end_poff` to `appendable_chunk_poff` to clarify what value we are actually storing.