### PR TITLE
irmin-pack: Add rusage to opam file

### DIFF
--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -25,6 +25,7 @@ depends: [
   "cmdliner"
   "optint"       {>= "0.1.0"}
   "checkseum"
+  "rusage"
   "irmin-test"   {with-test & = version}
   "alcotest-lwt" {with-test}
   "astring"      {with-test}


### PR DESCRIPTION
The `rusage` package is used by `irmin-pack.unix` (https://github.com/mirage/irmin/blob/main/src/irmin-pack/unix/dune#L18) and should probably be added to the `irmin-pack.opam` file.