### PR TITLE
Fix snapshots export for commits with indexed parents 

### DIFF
--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -61,7 +61,6 @@ type base_error =
   | `Dangling_key of string
   | `Gc_disallowed
   | `Node_or_contents_key_is_indexed of string
-  | `Commit_parent_key_is_indexed of string
   | `Gc_process_error of string
   | `Corrupted_gc_result_file of string
   | `Gc_process_died_without_result_file of string

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -290,7 +290,6 @@ module Make (Args : Gc_args.S) = struct
     | `Success, Ok _ ->
         Lwt.return (t.latest_gc_target_offset, t.new_suffix_start_offset)
     | _ ->
-        let gc_output = read_gc_output ~root:t.root ~generation:t.generation in
         let r = gc_errors status gc_output |> Errs.raise_if_error in
         Lwt.return r
 

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -285,8 +285,9 @@ module Make (Args : Gc_args.S) = struct
 
   let finalise_without_swap t =
     let* status = Async.await t.task in
-    match status with
-    | `Success ->
+    let gc_output = read_gc_output ~root:t.root ~generation:t.generation in
+    match (status, gc_output) with
+    | `Success, Ok _ ->
         Lwt.return (t.latest_gc_target_offset, t.new_suffix_start_offset)
     | _ ->
         let gc_output = read_gc_output ~root:t.root ~generation:t.generation in

--- a/src/irmin-pack/unix/gc_worker.ml
+++ b/src/irmin-pack/unix/gc_worker.ml
@@ -371,6 +371,7 @@ module Make (Args : Gc_args.S) = struct
           run ~generation ~new_files_path root commit_key
             new_suffix_start_offset)
     in
+    Errs.log_if_error "gc run" result;
     let write_result = write_gc_output ~root ~generation result in
     write_result |> Errs.log_if_error "writing gc output"
   (* No need to raise or log if [result] is [Error _], we've written it in

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -28,7 +28,7 @@ module type S = sig
   val log_error : string -> [< t ] -> unit
   val catch : (unit -> 'a) -> ('a, t) result
   val raise_if_error : ('a, [< t ]) result -> 'a
-  val log_if_error : string -> (unit, [< t ]) result -> unit
+  val log_if_error : string -> ('a, [< t ]) result -> unit
 end
 
 module Make (Io : Io.S) : S with module Io = Io = struct

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -62,7 +62,6 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Dangling_key of string
     | `Gc_disallowed
     | `Node_or_contents_key_is_indexed of string
-    | `Commit_parent_key_is_indexed of string
     | `Gc_process_error of string
     | `Corrupted_gc_result_file of string
     | `Gc_process_died_without_result_file of string


### PR DESCRIPTION
This fixes two issues for the `create_one_commit_store` function: 
- report errors that appeared in the gc process 
- allow the function to work when the gc commit is indexed.  