### PR TITLE
Clarify merge_into documentation

### DIFF
--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -941,9 +941,9 @@ module type S_generic_key = sig
   (** The type for merge functions. *)
 
   val merge_into : into:t -> t merge
-  (** [merge_into ~into i t] merges [t]'s current branch into [x]'s current
-      branch using the info [i]. After that operation, the two stores are still
-      independent. Similar to [git merge <branch>]. *)
+  (** [merge_into ~into:x ~info:i t] merges [t]'s current branch into [x]'s
+      current branch using the info [i]. After that operation, the two stores
+      are still independent. Similar to [git merge <branch>]. *)
 
   val merge_with_branch : t -> branch merge
   (** Same as {!val-merge} but with a branch ID. *)


### PR DESCRIPTION
Just a little extra naming in the documentation for `merge_into`. I hit this twice and because of the way LSP shows the type I always end up digging into the source code to know what I need to add. This is what it currently looks like for me:

<img width="726" alt="Screenshot 2022-12-09 at 13 46 57" src="https://user-images.githubusercontent.com/20166594/206716667-91c95303-2189-4150-b390-c5a98461bd66.png">
