### PR TITLE
Add test for indexed parent in a gc

### DIFF
--- a/src/irmin-pack/unix/gc_worker.ml
+++ b/src/irmin-pack/unix/gc_worker.ml
@@ -114,9 +114,7 @@ module Make (Args : Gc_args.S) = struct
     let schedule_parent_exn key =
       match Pack_key.to_offset key with
       | Some offset -> schedule offset false
-      | None ->
-          raise
-            (Pack_error (`Node_or_contents_key_is_indexed (string_of_key key)))
+      | None -> ()
     in
     List.iter schedule_parent_exn (Commit_value.parents commit);
     schedule_kinded (`Node (Commit_value.node commit));

--- a/test/irmin-pack/test_snapshot.ml
+++ b/test/irmin-pack/test_snapshot.ml
@@ -251,6 +251,52 @@ let test_gced_store_on_disk () =
   let* () = S.Repo.close repo_export in
   S.Repo.close repo_import
 
+let test_export_import_reexport () =
+  rm_dir root_export;
+  rm_dir root_import;
+  (* export a snapshot. *)
+  let* repo_export =
+    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_export)
+  in
+  let tree = S.Tree.singleton [ "a" ] "y" in
+  let* parent_commit = S.Commit.v repo_export ~parents:[] ~info tree in
+  let parent_key =
+    Irmin_pack_unix.Pack_key.v_indexed (S.Commit.hash parent_commit)
+  in
+  let tree = S.Tree.singleton [ "a" ] "x" in
+  let* _ = S.Commit.v repo_export ~parents:[ parent_key ] ~info tree in
+  let root_key = S.Tree.key tree |> Option.get in
+  let buf = Buffer.create 0 in
+  let* _ = S.Snapshot.export repo_export (encode_with_size buf) ~root_key in
+  let* () = S.Repo.close repo_export in
+  (* buf contains the snapshot, we can rm root_export and import the snapshot in
+     a new store, with the key parent of type Indexed. *)
+  rm_dir root_export;
+  let* repo_import =
+    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_import)
+  in
+  let* _, key = Buffer.contents buf |> restore repo_import in
+  let key = Option.get key in
+  let* tree = S.Tree.of_key repo_import (`Node key) in
+  let tree = Option.get tree in
+  let* commit = S.Commit.v repo_import ~info ~parents:[ parent_key ] tree in
+  let commit_key = S.Commit.key commit in
+  let commit_hash = S.Commit.hash commit in
+  (* export the gc-based snapshot in a clean root_export. *)
+  let* () = S.create_one_commit_store repo_import commit_key root_export in
+  let* () = S.Repo.close repo_import in
+  (* open the new store and check that everything is readable. *)
+  let* repo_export =
+    S.Repo.v
+      (config ~readonly:false ~fresh:false ~indexing_strategy root_export)
+  in
+  let* commit = S.Commit.of_hash repo_export commit_hash in
+  let commit = Option.get commit in
+  let tree = S.Commit.tree commit in
+  let* got = S.Tree.find tree [ "a" ] in
+  Alcotest.(check (option string)) "find blob" (Some "x") got;
+  S.Repo.close repo_export
+
 let tests =
   let tc name f = Alcotest_lwt.test_case name `Quick (fun _switch () -> f ()) in
   [
@@ -260,4 +306,6 @@ let tests =
     tc "on disk always" test_on_disk_always;
     tc "gced store, in memory" test_gced_store_in_memory;
     tc "gced store, on disk" test_gced_store_on_disk;
+    tc "import old snapshot, export gc based snapshot "
+      test_export_import_reexport;
   ]


### PR DESCRIPTION
Similar to https://github.com/mirage/irmin/pull/2151. It fixes the gc worker for when one of the parents of the gc commit is of type Indexed. This occurs in V3 tezos snapshots.   