### PR TITLE
irmin-pack: treat unhandled exception in async task as a failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@
   - Improve GC reachability traversal to optimize memory, speed and remove
     the need for temporary files. (#2085, @art-w)
 
+### Fixed
+- **irmin-pack**
+  - Unhandled exceptions in GC worker process are now reported as a failure
+    (#2163, @metanivek)
+
 ## 3.5.1
 
 ### Fixed

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -16,7 +16,8 @@
   test_mapping
   test_nearest_leq
   test_dispatcher
-  test_corrupted)
+  test_corrupted
+  test_async)
  (libraries
   alcotest
   fmt

--- a/test/irmin-pack/test_async.ml
+++ b/test/irmin-pack/test_async.ml
@@ -1,0 +1,43 @@
+(*
+ * Copyright (c) 2023-2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+open Common
+module Async = Irmin_pack_unix.Async.Unix
+
+let check_outcome = Alcotest.check_repr Async.outcome_t
+
+let test_success () =
+  let f () = assert true in
+  let task = Async.async f in
+  let* result = Async.await task in
+  check_outcome "should succeed" result `Success;
+  Lwt.return_unit
+
+let test_exception_in_task () =
+  let f () = assert false in
+  let task = Async.async f in
+  let* result = Async.await task in
+  check_outcome "should fail" result (`Failure "Unhandled exception");
+  Lwt.return_unit
+
+let tests =
+  [
+    Alcotest_lwt.test_case "Successful task" `Quick (fun _switch ->
+        test_success);
+    Alcotest_lwt.test_case "Exception occurs in task" `Quick (fun _switch ->
+        test_exception_in_task);
+  ]

--- a/test/irmin-pack/test_async.mli
+++ b/test/irmin-pack/test_async.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) 2023-2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -554,4 +554,5 @@ let misc =
     ("dispatcher", Test_dispatcher.tests);
     ("corrupted", Test_corrupted.tests);
     ("snapshot_gc", Test_gc.Snapshot.tests);
+    ("async tasks", Test_async.tests);
   ]


### PR DESCRIPTION
This fixes a bug where unhandled exceptions for an async task were treated as a `Succes` instead of `Failure`. I discovered this while looking into #2161.

This PR addresses this issue by:

1. Change to using exit codes instead of signals to determine success or not.
2. Return a specific exit code to indicate an unhandled exception.

Previously, we used `SIGKILL` to prevent `at_exit` hooks from executing. I preserved this functionality but ~~left a comment in the code since~~ I'm not sure if we need or want to do this or not. The benefit I see is that you don't accidentally run exit hooks from the parent process, which seems beneficial when running within applications that we do not control (like octez). A drawback is that _maybe_ the logs aren't flushed, which would mean things like the error about the unhandled exception will not appear in logs, but I don't think this is something we can directly control outside of just `Stdlib.flush_all ()` and a prayer :angel:. I welcome thoughts and opinions on this!