### PR TITLE
irmin-pack: GC reachability on V0 objects

### DIFF
--- a/src/irmin-pack/unix/gc_args.ml
+++ b/src/irmin-pack/unix/gc_args.ml
@@ -61,6 +61,8 @@ module type S = sig
     val key_of_offset : [< read ] t -> int63 -> key
     val unsafe_find_no_prefetch : 'a t -> key -> Node_value.t option
     val purge_lru : 'a t -> unit
+    val get_offset_exn : 'a t -> key -> int63
+    val get_length_exn : 'a t -> key -> int
   end
 
   module Commit_value : sig

--- a/src/irmin-pack/unix/gc_worker.ml
+++ b/src/irmin-pack/unix/gc_worker.ml
@@ -75,11 +75,7 @@ module Make (Args : Gc_args.S) = struct
       if not (Priority_queue.is_empty todos) then (
         let offset, has_children = Priority_queue.pop todos in
         let node_key = Node_store.key_of_offset node_store offset in
-        let length =
-          match Pack_key.inspect node_key with
-          | Direct { length; _ } -> length
-          | Indexed _ -> assert false
-        in
+        let length = Node_store.get_length_exn node_store node_key in
         f ~off:offset ~len:length;
         if has_children then iter_node node_key;
         loop ())
@@ -96,28 +92,18 @@ module Make (Args : Gc_args.S) = struct
         | `Contents key -> (key, false)
         | `Inode key | `Node key -> (key, true)
       in
-      let offset =
-        match Pack_key.to_offset key with
-        | Some offset -> offset
-        | None ->
-            raise
-              (Pack_error (`Node_or_contents_key_is_indexed (string_of_key key)))
-      in
-      schedule offset has_children
-    and schedule offset has_children =
-      Priority_queue.add todos offset has_children
+      schedule key has_children
+    and schedule key has_children =
+      match Node_store.get_offset_exn node_store key with
+      | offset -> Priority_queue.add todos offset has_children
+      | exception Pack_store.Dangling_hash -> ()
     in
     (* Include the commit parents in the reachable file.
        The parent(s) of [commit] must be included in the iteration
        because, when decoding the [Commit_value.t] at [commit], the
        parents will have to be read in order to produce a key for them. *)
-    let schedule_parent_exn key =
-      match Pack_key.to_offset key with
-      | Some offset -> schedule offset false
-      | None -> ()
-    in
-    List.iter schedule_parent_exn (Commit_value.parents commit);
-    schedule_kinded (`Node (Commit_value.node commit));
+    List.iter (fun key -> schedule key false) (Commit_value.parents commit);
+    schedule (Commit_value.node commit) true;
     loop ()
 
   (* Dangling_parent_commit are the parents of the gced commit. They are kept on
@@ -236,14 +222,11 @@ module Make (Args : Gc_args.S) = struct
         stats := Gc_stats.Worker.incr_objects_traversed !stats;
         register_entry ~off ~len
       in
-      let register_object_exn key =
-        match Pack_key.inspect key with
-        | Direct { offset; length; _ } -> register_entry ~off:offset ~len:length
-        | Indexed _ -> ()
-      in
 
       (* Step 3.3 Put the commit in the reachable file. *)
-      register_object_exn commit_key;
+      let off = Node_store.get_offset_exn node_store commit_key in
+      let len = Node_store.get_length_exn node_store commit_key in
+      register_entry ~off ~len;
 
       (* Step 3.4 Put the nodes and contents in the reachable file. *)
       stats :=

--- a/src/irmin-pack/unix/inode.ml
+++ b/src/irmin-pack/unix/inode.ml
@@ -68,4 +68,7 @@ struct
         in
         let v = Inter.Val.of_raw find v in
         Some v
+
+  let get_offset_exn t k = Pack.get_offset_exn t k
+  let get_length_exn t k = Pack.get_length_exn t k
 end

--- a/src/irmin-pack/unix/inode_intf.ml
+++ b/src/irmin-pack/unix/inode_intf.ml
@@ -59,6 +59,8 @@ module type Persistent = sig
   val purge_lru : 'a t -> unit
   val key_of_offset : 'a t -> int63 -> key
   val unsafe_find_no_prefetch : 'a t -> key -> value option
+  val get_offset_exn : 'a t -> key -> int63
+  val get_length_exn : 'a t -> key -> int
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/pack_key.ml
+++ b/src/irmin-pack/unix/pack_key.ml
@@ -51,6 +51,12 @@ let to_offset (State t) =
   | Offset offset -> Some offset
   | Indexed _ -> None
 
+let to_length (State t) =
+  match t.state with
+  | Direct t -> Some t.length
+  | Offset _ -> None
+  | Indexed _ -> None
+
 let promote_exn (State t) ~offset ~length =
   match t.state with
   | Direct _ -> failwith "Attempted to promote a key that is already Direct"

--- a/src/irmin-pack/unix/pack_key_intf.ml
+++ b/src/irmin-pack/unix/pack_key_intf.ml
@@ -88,6 +88,7 @@ module type Sigs = sig
   val v_offset : int63 -> 'h t
   val promote_exn : 'h t -> offset:int63 -> length:int -> unit
   val to_offset : 'h t -> int63 option
+  val to_length : 'h t -> int option
 
   module type S = sig
     type hash

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -70,16 +70,33 @@ struct
   type key = Key.t [@@deriving irmin ~pp]
   type value = Val.t [@@deriving irmin ~pp]
 
-  let accessor_of_key t k =
+  let get_location_exn t k =
     match Pack_key.inspect k with
+    | Direct { offset = off; length = len; _ } -> (off, len)
     | Indexed hash -> (
         match Index.find (Fm.index t.fm) hash with
         | None -> raise Dangling_hash
         | Some (off, len, _kind) ->
             Pack_key.promote_exn k ~offset:off ~length:len;
-            Dispatcher.create_accessor_exn t.dispatcher ~off ~len)
-    | Direct { offset = off; length = len; _ } ->
-        Dispatcher.create_accessor_exn t.dispatcher ~off ~len
+            (off, len))
+
+  let get_offset_exn t k =
+    match Pack_key.to_offset k with
+    | Some off -> off
+    | None ->
+        let off, _ = get_location_exn t k in
+        off
+
+  let get_length_exn t k =
+    match Pack_key.to_length k with
+    | Some len -> len
+    | None ->
+        let _, len = get_location_exn t k in
+        len
+
+  let accessor_of_key t k =
+    let off, len = get_location_exn t k in
+    Dispatcher.create_accessor_exn t.dispatcher ~off ~len
 
   let len_of_direct_key k =
     match Pack_key.inspect k with
@@ -517,4 +534,7 @@ struct
 
   let unsafe_find_no_prefetch t key =
     Inner.unsafe_find_no_prefetch (get_if_open_exn t) key
+
+  let get_offset_exn t key = Inner.get_offset_exn (get_if_open_exn t) key
+  let get_length_exn t key = Inner.get_length_exn (get_if_open_exn t) key
 end

--- a/src/irmin-pack/unix/pack_store_intf.ml
+++ b/src/irmin-pack/unix/pack_store_intf.ml
@@ -74,10 +74,17 @@ module type S = sig
       only contain their [offset] and are not usable without calling
       [key_of_offset] first. This function only exists to optimize the GC
       reachability traversal. *)
+
+  val get_offset_exn : 'a t -> key -> int63
+  (** Returns the offset associated with the key. *)
+
+  val get_length_exn : 'a t -> key -> int
+  (** Returns the length of the object associated with the key. *)
 end
 
 module type Sigs = sig
   exception Invalid_read of string
+  exception Dangling_hash
 
   module type S = S
 


### PR DESCRIPTION
For the archive nodes, we will need the GC snapshot to be able to traverse the V0 objects to construct a fresh prefix. The PR is there to document the issues/fixes for doing so, and gather feedback in case I missed something:
- The length of a V0 object can be found in the `index` (while V1 objects' length can be found in the header of the object in the prefix/suffix data files)
- The presence of a V0 object is a strong hint that the store should not be garbage collected (or we risk creating dangling pointers in commits following the GC commit), but it should be fine for the snapshot to extract a full prefix :)
- The PR is only touching the traversal right now (in case someone signals a huge flaw in the logic!), there might still be some places in the GC that insists on having a V1 object (but it shouldn't be a big issue)
- But the code needs more tests, I'm not quite sure how to produce those V0 objects as they are deprecated!