### PR TITLE
irmin-pack: improve inode error message

### DIFF
--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -688,7 +688,8 @@ struct
             | { target = Lazy key } as t -> (
                 if not force then raise_dangling_hash context (Key.to_hash key);
                 match find ~expected_depth key with
-                | None -> Fmt.failwith "%a: unknown key" pp_key key
+                | None ->
+                    Fmt.failwith "%a: unknown inode key (%s)" pp_key key context
                 | Some x ->
                     if cache then t.target <- Lazy_loaded x;
                     x))


### PR DESCRIPTION
While debugging an issue that triggered this exception, I saw an opportunity to modify it to (hopefully) help us in the future.

This PR makes two changes to improve the log message that comes from this exception:
1. Specify this is an inode key. Based on context of the issue, the initial assumption upon seeing the error in a log was that it was a commit key. Oops. I finally realized it was not when I grepped the code.
2. Include context. This code already supports specifying a context, so lets include it!