### PR TITLE
irmin-pack: update latest version and add doc

### DIFF
--- a/src/irmin-pack/version.ml
+++ b/src/irmin-pack/version.ml
@@ -19,7 +19,7 @@
 
 type t = [ `V1 | `V2 | `V3 | `V4 ] [@@deriving irmin]
 
-let latest = `V3
+let latest = `V4
 
 let enum =
   [ (`V1, "00000001"); (`V2, "00000002"); (`V3, "00000003"); (`V4, "00000004") ]

--- a/src/irmin-pack/version.mli
+++ b/src/irmin-pack/version.mli
@@ -24,7 +24,10 @@
     to be contained in the header of other files (e.g. the version of the store
     used to be stored in each files, it is now solely stored in the control
     file). The upgrade of a store to [`V3] was done silently when opening a
-    store in rw mode. *)
+    store in rw mode.
+
+    [`V4] introduced the chunked suffix. Upgrade from [`V3] happened on first
+    write to the control file. *)
 
 type t = [ `V1 | `V2 | `V3 | `V4 ] [@@deriving irmin]
 (** The type for version numbers. *)


### PR DESCRIPTION
While gathering information about various versions used in `irmin-pack`, I noticed that `Version.latest` hadn't been updated when adding `V4`. This value being out of sync does not cause any issues since it is not used in the code base, thankfully, but should be fixed regardless. I also added a small doc comment for `V4` to the header, in the spirit of prior comments.