### PR TITLE
irmin-pack: change ocaml to >= 4.12.0

### DIFF
--- a/irmin-pack.opam
+++ b/irmin-pack.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"        {>= "4.08.0"}
+  "ocaml"        {>= "4.12.0"}
   "dune"         {>= "2.9.0"}
   "irmin"        {= version}
   "ppx_irmin"    {= version}


### PR DESCRIPTION
This PR raises the lower bound for `irmin-pack`. https://github.com/mirage/irmin/pull/2163 introduced `Unix._exit`, which is only available since 4.12.

The lower bounds for OCaml versions in Irmin packages tends to be very conservative, but I think it is okay to bump `irmin-pack`, especially since we are considering going to `>= 5.0` at some point.