### PR TITLE
irmin-pack: fix silent mode for integrity checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - **irmin-pack**
   - Unhandled exceptions in GC worker process are now reported as a failure
     (#2163, @metanivek)
+  - Fix the silent mode for the integrity checks. (#2179, @icristescu)
 
 ## 3.5.1
 

--- a/src/irmin-pack/unix/checks_intf.ml
+++ b/src/irmin-pack/unix/checks_intf.ml
@@ -61,10 +61,12 @@ module type S = sig
     include
       Subcommand
         with type run :=
+          ?ppf:Format.formatter ->
           root:string ->
           auto_repair:bool ->
           always:bool ->
           heads:string list option ->
+          unit ->
           unit Lwt.t
 
     val handle_result :
@@ -177,6 +179,7 @@ module type Sigs = sig
       ([> `No_error ], [> `Cannot_fix of string ]) result Lwt.t
 
     val check_inodes :
+      ?ppf:Format.formatter ->
       iter:
         (pred_node:
            (X.Repo.t ->

--- a/src/irmin-pack/unix/utils.ml
+++ b/src/irmin-pack/unix/utils.ml
@@ -19,7 +19,9 @@ open Import
 module Object_counter : sig
   type t
 
-  val start : unit -> t * ((unit -> unit) * (unit -> unit) * (unit -> unit))
+  val start :
+    Format.formatter -> t * ((unit -> unit) * (unit -> unit) * (unit -> unit))
+
   val finalise : t -> unit
   val finalise_with_stats : t -> int * int * int
 end = struct
@@ -32,7 +34,8 @@ end = struct
       }
         -> t
 
-  let start () =
+  let start ppf =
+    let config = Progress.Config.v ~ppf () in
     let nb_commits = ref 0 in
     let nb_nodes = ref 0 in
     let nb_contents = ref 0 in
@@ -44,7 +47,7 @@ end = struct
       in
       using count_to_string string
     in
-    let display = Progress.Display.start (Progress.Multi.line bar) in
+    let display = Progress.Display.start ~config (Progress.Multi.line bar) in
     let [ reporter ] = Progress.Display.reporters display in
     let update_fn count () =
       incr count;


### PR DESCRIPTION
This is a fix for https://github.com/mirage/irmin/issues/2170.

The user can ask for silent integrity checks by not providing a `ppf` argument. But there was a bug, the progress bars in integrity checks were not using the same ppf as the one set by the user. 

Manually tested this using  `dune exec -- ./test/irmin-tezos/irmin_fsck.exe integrity-check ...`.

