### PR TITLE
irmin-pack: introduce volume control file

### DIFF
--- a/src/irmin-pack/unix/control_file.ml
+++ b/src/irmin-pack/unix/control_file.ml
@@ -16,114 +16,167 @@
 
 open Import
 include Control_file_intf
-
-module Plv3 = struct
-  include Payload_v3
-
-  let of_bin_string = Irmin.Type.of_bin_string t |> Irmin.Type.unstage
-end
-
-module Plv4 = struct
-  include Payload_v4
-
-  let of_bin_string = Irmin.Type.of_bin_string t |> Irmin.Type.unstage
-  let to_bin_string = Irmin.Type.to_bin_string t |> Irmin.Type.unstage
-end
-
 module Version = Irmin_pack.Version
 
-module Data (Io : Io.S) = struct
-  (** Type of what's encoded in the control file. The variant tag is encoded as
-      a [Version.t]. *)
-  type t = V3 of Plv3.t | V4 of Plv4.t
+module Checksum = struct
+  let calculate ~encode_bin ~set_checksum ~payload =
+    let open Checkseum in
+    let result = ref Adler32.default in
+    encode_bin (set_checksum payload Int63.zero) (fun str ->
+        result := Adler32.digest_string str 0 (String.length str) !result);
+    Int63.of_int (Optint.to_int !result)
 
-  let to_bin_string = function
-    | V3 _ -> assert false
-    | V4 payload -> Version.to_bin `V4 ^ Plv4.to_bin_string payload
+  let calculate_and_set ~encode_bin ~set_checksum ~payload =
+    calculate ~encode_bin ~set_checksum ~payload |> set_checksum payload
 
-  let of_bin_string s =
+  let is_valid ~encode_bin ~set_checksum ~get_checksum ~payload =
+    Int63.equal
+      (calculate ~encode_bin ~set_checksum ~payload)
+      (get_checksum payload)
+end
+
+module Serde = struct
+  module type S = sig
+    type payload
+
+    val of_bin_string :
+      string ->
+      ( payload,
+        [> `Corrupted_control_file | `Unknown_major_pack_version of string ] )
+      result
+
+    val to_bin_string : payload -> string
+  end
+
+  let extract_version_and_payload s =
     let open Result_syntax in
     let len = String.length s in
     let* left, right =
       try Ok (String.sub s 0 8, String.sub s 8 (len - 8))
       with Invalid_argument _ -> Error `Corrupted_control_file
     in
-    let* version =
+    let+ version =
       match Version.of_bin left with
       | None -> Error (`Unknown_major_pack_version left)
-      | Some `V3 when len > Io.page_size -> Error `Corrupted_control_file
-      | Some `V3 -> Ok `V3
-      | Some `V4 -> Ok `V4
-      | Some (`V1 | `V2) -> assert false
+      | Some (`V1 | `V2) -> assert false (* TODO: create specific error *)
+      | Some ((`V3 | `V4) as x) ->
+          if len > Io.Unix.page_size then
+            (* TODO: make this a more specific error *)
+            Error `Corrupted_control_file
+          else Ok x
     in
-    match version with
-    | `V3 -> (
-        match Plv3.of_bin_string right with
-        | Ok x -> Ok (V3 x)
-        | Error _ -> Error `Corrupted_control_file)
-    | `V4 -> (
-        match Plv4.of_bin_string right with
-        | Ok x -> Ok (V4 x)
-        | Error _ -> Error `Corrupted_control_file)
+    (version, right)
+
+  module Upper : S with type payload = Payload.Upper.Latest.t = struct
+    module Data = struct
+      module Plv3 = struct
+        include Payload.Upper.V3
+
+        let of_bin_string = Irmin.Type.of_bin_string t |> Irmin.Type.unstage
+      end
+
+      module Plv4 = struct
+        include Payload.Upper.V4
+
+        let of_bin_string = Irmin.Type.of_bin_string t |> Irmin.Type.unstage
+        let to_bin_string = Irmin.Type.to_bin_string t |> Irmin.Type.unstage
+      end
+
+      (** Type of what's encoded in the upper layer control file. The variant
+          tag is encoded as a [Version.t]. *)
+      type t = V3 of Plv3.t | V4 of Plv4.t
+
+      let to_bin_string = function
+        | V3 _ -> assert false
+        | V4 payload -> Version.to_bin `V4 ^ Plv4.to_bin_string payload
+
+      let of_bin_string s =
+        let open Result_syntax in
+        let* version, payload = extract_version_and_payload s in
+        match version with
+        | `V3 -> (
+            match Plv3.of_bin_string payload with
+            | Ok x -> Ok (V3 x)
+            | Error _ -> Error `Corrupted_control_file)
+        | `V4 -> (
+            match Plv4.of_bin_string payload with
+            | Ok x -> Ok (V4 x)
+            | Error _ -> Error `Corrupted_control_file)
+    end
+
+    module Latest = Data.Plv4
+
+    type payload = Latest.t
+
+    let upgrade_from_v3 (pl : Payload.Upper.V3.t) : payload =
+      let chunk_start_idx = ref 0 in
+      let status =
+        match pl.status with
+        | From_v1_v2_post_upgrade x -> Latest.From_v1_v2_post_upgrade x
+        | From_v3_no_gc_yet -> No_gc_yet
+        | From_v3_used_non_minimal_indexing_strategy ->
+            Used_non_minimal_indexing_strategy
+        | From_v3_gced x ->
+            chunk_start_idx := x.generation;
+            Gced
+              {
+                suffix_start_offset = x.suffix_start_offset;
+                generation = x.generation;
+                latest_gc_target_offset = x.suffix_start_offset;
+                suffix_dead_bytes = Int63.zero;
+              }
+        | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 | T11 | T12 | T13
+        | T14 | T15 ->
+            (* Unreachable *)
+            assert false
+      in
+      {
+        dict_end_poff = pl.dict_end_poff;
+        (* When upgrading from v3 to v4, there is only one (appendable) chunk,
+           which is the existing suffix, so we set the new [appendable_chunk_poff]
+           to [pl.suffix_end_poff]. *)
+        appendable_chunk_poff = pl.suffix_end_poff;
+        status;
+        upgraded_from_v3_to_v4 = true;
+        checksum = Int63.zero;
+        chunk_start_idx = !chunk_start_idx;
+        chunk_num = 1;
+      }
+
+    let checksum_encode_bin = Irmin.Type.(unstage (pre_hash Latest.t))
+    let set_checksum payload checksum = Latest.{ payload with checksum }
+    let get_checksum payload = payload.Latest.checksum
+
+    let of_bin_string string =
+      let open Result_syntax in
+      let* payload = Data.of_bin_string string in
+      match payload with
+      | V3 payload -> Ok (upgrade_from_v3 payload)
+      | V4 payload ->
+          if
+            Checksum.is_valid ~payload ~encode_bin:checksum_encode_bin
+              ~set_checksum ~get_checksum
+          then Ok payload
+          else Error `Corrupted_control_file
+
+    let to_bin_string payload =
+      let payload =
+        Checksum.calculate_and_set ~encode_bin:checksum_encode_bin ~set_checksum
+          ~payload
+      in
+      let s = Data.(to_bin_string (V4 payload)) in
+      s
+  end
 end
 
-module Make (Io : Io.S) = struct
+module Make (Serde : Serde.S) (Io : Io.S) = struct
   module Io = Io
-  module Data = Data (Io)
 
-  type t = { io : Io.t; mutable payload : Latest_payload.t }
-
-  let pre_hash_payload = Irmin.Type.(unstage (pre_hash Latest_payload.t))
-
-  let checksum payload =
-    let open Checkseum in
-    let result = ref Adler32.default in
-    pre_hash_payload { payload with checksum = Int63.zero } (fun str ->
-        result := Adler32.digest_string str 0 (String.length str) !result);
-    Int63.of_int (Optint.to_int !result)
-
-  let checksum_is_valid payload =
-    Int63.equal (checksum payload) payload.checksum
-
-  let upgrade_v3_to_v4 (pl : Payload_v3.t) : Payload_v4.t =
-    let chunk_start_idx = ref 0 in
-    let status =
-      match pl.status with
-      | From_v1_v2_post_upgrade x -> Payload_v4.From_v1_v2_post_upgrade x
-      | From_v3_no_gc_yet -> No_gc_yet
-      | From_v3_used_non_minimal_indexing_strategy ->
-          Used_non_minimal_indexing_strategy
-      | From_v3_gced x ->
-          chunk_start_idx := x.generation;
-          Gced
-            {
-              suffix_start_offset = x.suffix_start_offset;
-              generation = x.generation;
-              latest_gc_target_offset = x.suffix_start_offset;
-              suffix_dead_bytes = Int63.zero;
-            }
-      | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 | T11 | T12 | T13 | T14
-      | T15 ->
-          (* Unreachable *)
-          assert false
-    in
-    {
-      dict_end_poff = pl.dict_end_poff;
-      (* When upgrading from v3 to v4, there is only one (appendable) chunk,
-         which is the existing suffix, so we set the new [appendable_chunk_poff]
-         to [pl.suffix_end_poff]. *)
-      appendable_chunk_poff = pl.suffix_end_poff;
-      status;
-      upgraded_from_v3_to_v4 = true;
-      checksum = Int63.zero;
-      chunk_start_idx = !chunk_start_idx;
-      chunk_num = 1;
-    }
+  type payload = Serde.payload
+  type t = { io : Io.t; mutable payload : payload }
 
   let write io payload =
-    let payload = { payload with Payload_v4.checksum = checksum payload } in
-    let s = Data.(to_bin_string (V4 payload)) in
-
+    let s = Serde.to_bin_string payload in
     (* The data must fit inside a single page for atomic updates of the file.
        This is only true for some file systems. This system will have to be
        reworked for [V4]. *)
@@ -135,19 +188,10 @@ module Make (Io : Io.S) = struct
     let open Result_syntax in
     let* string = Io.read_all_to_string io in
     (* Since the control file is expected to fit in a page,
-       [read_all_to_string] should be atomic for most filesystems.
+       [read_all_to_string] should be atomic for most filesystems. *)
+    Serde.of_bin_string string
 
-       If [string] is larger than a page, it either means that the file can be
-       corrupted or that the major version is not supported. Either way it will
-       be detected by [Data.of_bin_string] or have an invalid checksum. *)
-    let* payload = Data.of_bin_string string in
-    match payload with
-    | V3 payload -> Ok (upgrade_v3_to_v4 payload)
-    | V4 payload ->
-        if checksum_is_valid payload then Ok payload
-        else Error `Corrupted_control_file
-
-  let create_rw ~path ~overwrite payload =
+  let create_rw ~path ~overwrite (payload : payload) =
     let open Result_syntax in
     let* io = Io.create ~path ~overwrite in
     let+ () = write io payload in
@@ -177,3 +221,5 @@ module Make (Io : Io.S) = struct
 
   let fsync t = Io.fsync t.io
 end
+
+module Upper = Make (Serde.Upper)

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -15,181 +15,191 @@
  *)
 open! Import
 
-module Payload_v3 = struct
-  type from_v1_v2_post_upgrade = { entry_offset_at_upgrade_to_v3 : int63 }
-  [@@deriving irmin]
-  (** [entry_offset_at_upgrade_to_v3] is the offset of the first entry that is
-      known to have been created using [irmin_pack_version = `V2] or more. The
-      entries before that point may be v1 entries. V1 entries need an entry in
-      index because it is the only place their lenght is stored. *)
+module Payload = struct
+  module Upper = struct
+    module V3 = struct
+      type from_v1_v2_post_upgrade = { entry_offset_at_upgrade_to_v3 : int63 }
+      [@@deriving irmin]
+      (** [entry_offset_at_upgrade_to_v3] is the offset of the first entry that
+          is known to have been created using [irmin_pack_version = `V2] or
+          more. The entries before that point may be v1 entries. V1 entries need
+          an entry in index because it is the only place their lenght is stored. *)
 
-  type from_v3_gced = { suffix_start_offset : int63; generation : int }
-  [@@deriving irmin]
-  (** [suffix_start_offset] is 0 if the suffix file was never garbage collected.
-      Otherwise it is the offset of the very first entry of the suffix file.
-      Note that offsets in the suffix file are virtual. The garbage collections
-      don't reset the offsets.
+      type from_v3_gced = { suffix_start_offset : int63; generation : int }
+      [@@deriving irmin]
+      (** [suffix_start_offset] is 0 if the suffix file was never garbage
+          collected. Otherwise it is the offset of the very first entry of the
+          suffix file. Note that offsets in the suffix file are virtual. The
+          garbage collections don't reset the offsets.
 
-      [generation] is the number of past GCs. A suffix file, a prefix file and a
-      mapping containing that integer in their filename exist. *)
+          [generation] is the number of past GCs. A suffix file, a prefix file
+          and a mapping containing that integer in their filename exist. *)
 
-  (** [From_v1_v2_post_upgrade] corresponds to a pack store that was upgraded to
-      [`V3]. It contains infos related to backward compatibility. GCs are
-      forbidden on it.
+      (** [From_v1_v2_post_upgrade] corresponds to a pack store that was
+          upgraded to [`V3]. It contains infos related to backward
+          compatibility. GCs are forbidden on it.
 
-      [From_v3_no_gc_yet] corresponds to a pack store that was created using
-      [`V3] code. It never underwent a GC.
+          [From_v3_no_gc_yet] corresponds to a pack store that was created using
+          [`V3] code. It never underwent a GC.
 
-      [From_v3_used_non_minimal_indexing_strategy] corresponds to a pack store
-      that was created using [`V3] code. It never underwent a GC and it will
-      never be possible to GC it because entries were pushed using a non-minimal
-      indexing strategy.
+          [From_v3_used_non_minimal_indexing_strategy] corresponds to a pack
+          store that was created using [`V3] code. It never underwent a GC and
+          it will never be possible to GC it because entries were pushed using a
+          non-minimal indexing strategy.
 
-      [From_v3_gced] is a store that was GCed at least once.
+          [From_v3_gced] is a store that was GCed at least once.
 
-      The [T*] tags are provisional tags that the binary decoder is aware of and
-      that may in the future be used to add features to the [`V3] payload. *)
-  type status =
-    | From_v1_v2_post_upgrade of from_v1_v2_post_upgrade
-    | From_v3_no_gc_yet
-    | From_v3_used_non_minimal_indexing_strategy
-    | From_v3_gced of from_v3_gced
-    | T1
-    | T2
-    | T3
-    | T4
-    | T5
-    | T6
-    | T7
-    | T8
-    | T9
-    | T10
-    | T11
-    | T12
-    | T13
-    | T14
-    | T15
-  [@@deriving irmin]
+          The [T*] tags are provisional tags that the binary decoder is aware of
+          and that may in the future be used to add features to the [`V3]
+          payload. *)
+      type status =
+        | From_v1_v2_post_upgrade of from_v1_v2_post_upgrade
+        | From_v3_no_gc_yet
+        | From_v3_used_non_minimal_indexing_strategy
+        | From_v3_gced of from_v3_gced
+        | T1
+        | T2
+        | T3
+        | T4
+        | T5
+        | T6
+        | T7
+        | T8
+        | T9
+        | T10
+        | T11
+        | T12
+        | T13
+        | T14
+        | T15
+      [@@deriving irmin]
 
-  type t = {
-    dict_end_poff : int63;
-    suffix_end_poff : int63;
-    status : status; (* must be last to allow extensions *)
-  }
-  [@@deriving irmin]
-  (** The [`V3] payload of the irmin-pack control file. [`V3] is a major
-      version. If [`V4] ever exists, it will have its own dedicated payload, but
-      the [`V3] definition will still have to stick in the codebase for backward
-      compatibilty of old pack stores.
+      type t = {
+        dict_end_poff : int63;
+        suffix_end_poff : int63;
+        status : status; (* must be last to allow extensions *)
+      }
+      [@@deriving irmin]
+      (** The [`V3] payload of the irmin-pack control file. [`V3] is a major
+          version. If [`V4] ever exists, it will have its own dedicated payload,
+          but the [`V3] definition will still have to stick in the codebase for
+          backward compatibilty of old pack stores.
 
-      A store may only change its major version during an [open_rw] in
-      [File_manager]. Note that upgrading a major version is the only reason why
-      [open_rw] would modify files in an irmin-pack directory.
+          A store may only change its major version during an [open_rw] in
+          [File_manager]. Note that upgrading a major version is the only reason
+          why [open_rw] would modify files in an irmin-pack directory.
 
-      For a given major version, the format of a payload may change, but only in
-      a backward compatible way. I.e., all versions of irmin-pack should forever
-      be able to decode a [`V3] control file, it allows for control file
-      corruption and out-of-date code to be distinguishable.
+          For a given major version, the format of a payload may change, but
+          only in a backward compatible way. I.e., all versions of irmin-pack
+          should forever be able to decode a [`V3] control file, it allows for
+          control file corruption and out-of-date code to be distinguishable.
 
-      It is legal for the payload decoder to not fully consume the input buffer.
-      Remaining bytes means that the definition of a payload was changed.
+          It is legal for the payload decoder to not fully consume the input
+          buffer. Remaining bytes means that the definition of a payload was
+          changed.
 
-      {3 Fields}
+          {3 Fields}
 
-      [dict_end_poff] is the offset in the dict file just after the last valid
-      dict bytes. The next data to be pushed to the dict will be pushed at this
-      offset.
+          [dict_end_poff] is the offset in the dict file just after the last
+          valid dict bytes. The next data to be pushed to the dict will be
+          pushed at this offset.
 
-      [suffix_end_poff] is similar to [dict_end_poff] but for the suffix file.
+          [suffix_end_poff] is similar to [dict_end_poff] but for the suffix
+          file.
 
-      [status] is a variant that encode the state of the irmin-pack directory.
-      This field MUST be the last field of the record, in order to allow
-      extensions *)
+          [status] is a variant that encode the state of the irmin-pack
+          directory. This field MUST be the last field of the record, in order
+          to allow extensions *)
+    end
+
+    module V4 = struct
+      type gced = {
+        suffix_start_offset : int63;
+        generation : int;
+        latest_gc_target_offset : int63;
+        suffix_dead_bytes : int63;
+      }
+      [@@deriving irmin]
+      (** Similar to [from_v3_gced]. New fields:
+
+          [latest_gc_target_offset] is the commit on which the latest gc was
+          called on.
+
+          [suffix_dead_bytes] is the number of bytes at the beginning of the
+          suffix that should be considered unreachable after a GC. *)
+
+      (** [From_v1_v2_post_upgrade] similar to [V3.From_v1_v2_post_upgrade]
+
+          [No_gc_yet] corresponds to a pack store that was created using [`V3]
+          or above. It never underwent a GC.
+
+          [Used_non_minimal_indexing_strategy] corresponds to a pack store that
+          was created using [`V3] or above. It never underwent a GC and it will
+          never be possible to GC it because entries were pushed using a
+          non-minimal indexing strategy.
+
+          [Gced] is a [`V3] or [`V4] store that was GCed at least once.
+
+          The [T*] tags are provisional tags that the binary decoder is aware of
+          and that may in the future be used to add features to the [`V4]
+          payload. *)
+      type status =
+        | From_v1_v2_post_upgrade of V3.from_v1_v2_post_upgrade
+        | No_gc_yet
+        | Used_non_minimal_indexing_strategy
+        | Gced of gced
+        | T1
+        | T2
+        | T3
+        | T4
+        | T5
+        | T6
+        | T7
+        | T8
+        | T9
+        | T10
+        | T11
+        | T12
+        | T13
+        | T14
+        | T15
+      [@@deriving irmin]
+
+      type t = {
+        dict_end_poff : int63;
+        appendable_chunk_poff : int63;
+        upgraded_from_v3_to_v4 : bool;
+        checksum : int63;
+        chunk_start_idx : int;
+        chunk_num : int;
+        status : status; (* must be last to allow extensions *)
+      }
+      [@@deriving irmin]
+      (** The same as {!V3.t}, with the following modifications:
+
+          New fields
+
+          - [upgraded_from_v3_to_v4] recalls if the store was originally created
+            in [`V3].
+          - [chunk_start_idx] is the index for the starting chunk of the suffix
+          - [chunk_num] is the number of chunks in the suffix
+          - [checksum] for storing a checksum of the payload
+          - [appendable_chunk_poff] is a value used by the chunked suffix. See
+            {!Chunked_suffix.S.appendable_chunk_poff} for more details.
+
+          Removed fields
+
+          - [suffix_end_poff] is replaced by [appendable_chunk_poff] *)
+    end
+
+    module Latest = V4
+  end
 end
 
-module Payload_v4 = struct
-  type gced = {
-    suffix_start_offset : int63;
-    generation : int;
-    latest_gc_target_offset : int63;
-    suffix_dead_bytes : int63;
-  }
-  [@@deriving irmin]
-  (** Similar to [from_v3_gced]. New fields:
 
-      [latest_gc_target_offset] is the commit on which the latest gc was called
-      on.
-
-      [suffix_dead_bytes] is the number of bytes at the beginning of the suffix
-      that should be considered unreachable after a GC. *)
-
-  (** [From_v1_v2_post_upgrade] similar to [Payload_v3.From_v1_v2_post_upgrade]
-
-      [No_gc_yet] corresponds to a pack store that was created using [`V3] or
-      above. It never underwent a GC.
-
-      [Used_non_minimal_indexing_strategy] corresponds to a pack store that was
-      created using [`V3] or above. It never underwent a GC and it will never be
-      possible to GC it because entries were pushed using a non-minimal indexing
-      strategy.
-
-      [Gced] is a [`V3] or [`V4] store that was GCed at least once.
-
-      The [T*] tags are provisional tags that the binary decoder is aware of and
-      that may in the future be used to add features to the [`V4] payload. *)
-  type status =
-    | From_v1_v2_post_upgrade of Payload_v3.from_v1_v2_post_upgrade
-    | No_gc_yet
-    | Used_non_minimal_indexing_strategy
-    | Gced of gced
-    | T1
-    | T2
-    | T3
-    | T4
-    | T5
-    | T6
-    | T7
-    | T8
-    | T9
-    | T10
-    | T11
-    | T12
-    | T13
-    | T14
-    | T15
-  [@@deriving irmin]
-
-  type t = {
-    dict_end_poff : int63;
-    appendable_chunk_poff : int63;
-    upgraded_from_v3_to_v4 : bool;
-    checksum : int63;
-    chunk_start_idx : int;
-    chunk_num : int;
-    status : status; (* must be last to allow extensions *)
-  }
-  [@@deriving irmin]
-  (** The same as {!Payload_v3.t}, with the following modifications:
-
-      New fields
-
-      - [upgraded_from_v3_to_v4] recalls if the store was originally created in
-        [`V3].
-      - [chunk_start_idx] is the index for the starting chunk of the suffix
-      - [chunk_num] is the number of chunks in the suffix
-      - [checksum] for storing a checksum of the payload
-      - [appendable_chunk_poff] is a value used by the chunked suffix. See
-        {!Chunked_suffix.S.appendable_chunk_poff} for more details.
-
-      Removed fields
-
-      - [suffix_end_poff] is replaced by [appendable_chunk_poff] *)
-end
-
-module Latest_payload = Payload_v4
 
 module type S = sig
-  (** Abstraction for irmin-pack's control file.
+  (** Abstraction for an irmin-pack control file.
 
       It is parameterized with [Io], a file system abstraction (e.g. unix,
       mirage, eio_linux).
@@ -198,12 +208,13 @@ module type S = sig
 
   module Io : Io.S
 
+  type payload
   type t
 
   val create_rw :
     path:string ->
     overwrite:bool ->
-    Latest_payload.t ->
+    payload ->
     (t, [> Io.create_error | Io.write_error ]) result
   (** Create a rw instance of [t] by creating a control file. *)
 
@@ -220,7 +231,7 @@ module type S = sig
 
   val close : t -> (unit, [> Io.close_error ]) result
 
-  val payload : t -> Latest_payload.t
+  val payload : t -> payload
   (** [payload t] is the payload in [t].
 
       That function doesn't perform IO.
@@ -253,7 +264,7 @@ module type S = sig
       If the file changed since the last read, the payload in [t] is updated to
       match the content of the file. *)
 
-  val set_payload : t -> Latest_payload.t -> (unit, [> Io.write_error ]) result
+  val set_payload : t -> payload -> (unit, [> Io.write_error ]) result
   (** {3 RW mode}
 
       Write a new payload on disk.
@@ -274,12 +285,14 @@ module type S = sig
       Always returns [Error `Ro_not_allowed]. *)
 end
 
+module type Upper = sig
+  include S with type payload := Payload.Upper.Latest.t
+end
 module type Sigs = sig
-  module Latest_payload = Payload_v4
-  module Payload_v3 = Payload_v3
-  module Payload_v4 = Payload_v4
+  module Payload = Payload
 
   module type S = S
+  module type Upper = Upper
 
-  module Make (Io : Io.S) : S with module Io = Io
+  module Upper (Io : Io.S) : Upper with module Io = Io
 end

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -194,9 +194,34 @@ module Payload = struct
 
     module Latest = V4
   end
+
+  module Volume = struct
+    module V4 = struct
+      type t = {
+        start_offset : int63;
+        end_offset : int63;
+        mapping_end_poff : int63;
+        data_end_poff : int63;
+        checksum : int63;
+      }
+      [@@deriving irmin]
+      (** The payload for a control file of a volume.
+
+          Fields
+
+          - [start_offset] is the global offset for the start of the volume's
+            data. Used for routing reads.
+          - [end_offset] is the global offset for the end of the volume's data.
+            Used for routing reads.
+          - [mapping_end_poff] is the end offset for the mapping file. Used when
+            writing.
+          - [data_end_poff] is the end offset for the data file. Used for
+            writing. *)
+    end
+
+    module Latest = V4
+  end
 end
-
-
 
 module type S = sig
   (** Abstraction for an irmin-pack control file.
@@ -288,11 +313,18 @@ end
 module type Upper = sig
   include S with type payload := Payload.Upper.Latest.t
 end
+
+module type Volume = sig
+  include S with type payload := Payload.Volume.Latest.t
+end
+
 module type Sigs = sig
   module Payload = Payload
 
   module type S = S
   module type Upper = Upper
+  module type Volume = Volume
 
   module Upper (Io : Io.S) : Upper with module Io = Io
+  module Volume (Io : Io.S) : Volume with module Io = Io
 end

--- a/src/irmin-pack/unix/dispatcher.ml
+++ b/src/irmin-pack/unix/dispatcher.ml
@@ -16,7 +16,7 @@
 
 open Import
 include Dispatcher_intf
-module Payload = Control_file.Latest_payload
+module Payload = Control_file.Payload.Upper.Latest
 
 (* The following [with module Io = Io.Unix] forces unix *)
 module Make (Fm : File_manager.S with module Io = Io.Unix) :

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -15,7 +15,7 @@
  *)
 
 open Import
-module Payload = Control_file.Latest_payload
+module Payload = Control_file.Payload.Upper.Latest
 include File_manager_intf
 
 let legacy_io_header_size = 16
@@ -30,7 +30,7 @@ struct
   module Index = Index
   module Mapping_file = Mapping_file
   module Errs = Io_errors.Make (Io)
-  module Control = Control_file.Make (Io)
+  module Control = Control_file.Upper (Io)
   module Dict = Append_only_file.Make (Io) (Errs)
   module Suffix = Chunked_suffix.Make (Io) (Errs)
   module Prefix = Io

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -59,7 +59,7 @@ module type S = sig
       3. and 5. are highly critical. *)
 
   module Io : Io.S
-  module Control : Control_file.S with module Io = Io
+  module Control : Control_file.Upper with module Io = Io
   module Dict : Append_only_file.S with module Io = Io
   module Suffix : Chunked_suffix.S with module Io = Io
   module Index : Pack_index.S

--- a/src/irmin-pack/unix/gc_worker.ml
+++ b/src/irmin-pack/unix/gc_worker.ml
@@ -15,7 +15,7 @@
  *)
 
 open! Import
-module Payload = Control_file.Latest_payload
+module Payload = Control_file.Payload.Upper.Latest
 
 exception Pack_error = Errors.Pack_error
 

--- a/src/irmin-pack/unix/gc_worker.mli
+++ b/src/irmin-pack/unix/gc_worker.mli
@@ -17,7 +17,7 @@
 (** Code for running in an async GC worker thread. *)
 
 open! Import
-module Payload = Control_file.Latest_payload
+module Payload = Control_file.Payload.Upper.Latest
 
 module Make (Args : Gc_args.S) : sig
   module Args : Gc_args.S


### PR DESCRIPTION
This PR refactors control file to support more than one type of control file and adds the initial version of a volume control file. 

I left TODOs for things that we will need to address before release, but I'll re-iterate them here with some added thoughts/context:
- update volume to V5 when we bump the pack store version
- make a more specific error for `Corrupted_control_file` so that we can know _which_ control file is at fault. This can likely be as simple as giving a string that we put a message into.
- add specific error for when the length is longer than a page size. Currently, this is also `Corrupted_control_file` but it seems better to be specific with this error. Also, we should add path information to the error.
- add an error for V1|V2 instead of assert false. This isn't strictly necessary but a thing I spotted while working with this code that I think could be improved.