### PR TITLE
irmin-pack: introduce lower layer + volumes

### DIFF
--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -74,6 +74,17 @@ module V4 = struct
     toplevel ("store." ^ string_of_int generation ^ ".prefix")
 end
 
+module V5 = struct
+  include V4
+
+  module Volume = struct
+    let directory ~idx = toplevel ("volume." ^ string_of_int idx)
+    let control = toplevel "volume.control"
+    let mapping = toplevel "volume.mapping"
+    let data = toplevel "volume.data"
+  end
+end
+
 (** [is_number] is a less generic than [Stdlib.int_of_string_opt]. It matches
     this equivalent regex: {v "([1-9][0-9]*|0)" v}. *)
 let is_number s =

--- a/src/irmin-pack/unix/control_file.ml
+++ b/src/irmin-pack/unix/control_file.ml
@@ -271,6 +271,13 @@ module Make (Serde : Serde.S) (Io : Io.S) = struct
       let+ payload = read t.io in
       t.payload <- payload
 
+  let read_payload ~path =
+    let open Result_syntax in
+    let* t = open_ ~path ~readonly:true in
+    let payload = payload t in
+    let+ () = close t in
+    payload
+
   let set_payload t payload =
     let open Result_syntax in
     let+ () = write t.io payload in

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -256,6 +256,12 @@ module type S = sig
 
   val close : t -> (unit, [> Io.close_error ]) result
 
+  val read_payload :
+    path:string -> (payload, [> open_error | Io.close_error ]) result
+  (** [read_payload ~path] reads the payload at [path]. It is a convenient way
+      to read the payload without needing to call {!open_}, {!payload},
+      {!close}. *)
+
   val payload : t -> payload
   (** [payload t] is the payload in [t].
 

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -71,7 +71,9 @@ type base_error =
   | `Split_forbidden_during_batch
   | `Split_disallowed
   | `Multiple_empty_chunks
-  | `Forbidden_during_gc ]
+  | `Forbidden_during_gc
+  | `Multiple_empty_volumes
+  | `Volume_missing of string ]
 [@@deriving irmin ~pp]
 (** [base_error] is the type of most errors that can occur in a [result], except
     for errors that have associated exceptions (see below) and backend-specific

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -75,7 +75,9 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Split_forbidden_during_batch
     | `Split_disallowed
     | `Multiple_empty_chunks
-    | `Forbidden_during_gc ]
+    | `Forbidden_during_gc
+    | `Multiple_empty_volumes
+    | `Volume_missing of string ]
   [@@deriving irmin]
 
   let raise_error = function

--- a/src/irmin-pack/unix/irmin_pack_unix.ml
+++ b/src/irmin-pack/unix/irmin_pack_unix.ml
@@ -57,4 +57,5 @@ module Append_only_file = Append_only_file
 module Chunked_suffix = Chunked_suffix
 module Sparse_file = Sparse_file
 module File_manager = File_manager
+module Lower = Lower
 module Utils = Utils

--- a/src/irmin-pack/unix/irmin_pack_unix.mli
+++ b/src/irmin-pack/unix/irmin_pack_unix.mli
@@ -62,4 +62,5 @@ module Append_only_file = Append_only_file
 module Chunked_suffix = Chunked_suffix
 module Sparse_file = Sparse_file
 module File_manager = File_manager
+module Lower = Lower
 module Utils = Utils

--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -1,0 +1,181 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Import
+include Lower_intf
+
+module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
+  module Io = Io
+  module Errs = Errs
+  module Control = Control_file.Volume (Io)
+
+  type t = {
+    mutable readonly : bool;
+    path : string;
+    control : Control_file.Payload.Volume.Latest.t option;
+  }
+
+  type open_error =
+    [ Io.open_error
+    | `Closed
+    | `Double_close
+    | `Corrupted_control_file
+    | `Unknown_major_pack_version of string ]
+
+  let v ~readonly volume_path =
+    let open Result_syntax in
+    let* control =
+      let path = Irmin_pack.Layout.V5.Volume.control ~root:volume_path in
+      match Io.classify_path path with
+      | `File ->
+          let+ payload = Control.read_payload ~path in
+          Some payload
+      | `Directory | `Other | `No_such_file_or_directory -> Ok None
+    in
+    Ok { readonly; path = volume_path; control }
+
+  let set_readonly ~readonly t =
+    if t.readonly = readonly then Ok ()
+    else
+      (* TODO actually reopen based on readonly flag once
+         sparse file is in place *)
+      Ok (t.readonly <- readonly)
+
+  let create_empty volume_path =
+    let open Result_syntax in
+    (* 0. Validate volume directory does not already exist *)
+    let* () =
+      match Io.classify_path volume_path with
+      | `Directory | `File | `Other -> Error (`File_exists volume_path)
+      | `No_such_file_or_directory -> Ok ()
+    in
+    (* 1. Make directory *)
+    let* () = Io.mkdir volume_path in
+    (* 2. Make empty mapping *)
+    let* () =
+      Irmin_pack.Layout.V5.Volume.(
+        Io.create ~path:(mapping ~root:volume_path) ~overwrite:true)
+      >>= Io.close
+    in
+    (* 3. Make empty data *)
+    let* () =
+      Irmin_pack.Layout.V5.Volume.(
+        Io.create ~path:(data ~root:volume_path) ~overwrite:true)
+      >>= Io.close
+    in
+    (* TODO: handle failure to create all artifacts, either here or in a cleanup
+       when the store starts. *)
+    v ~readonly:false volume_path
+
+  let path t = t.path
+  let control t = t.control
+  let empty_state t = if Option.is_none t.control then `Empty t else `Nonempty t
+
+  let is_empty t =
+    match empty_state t with `Empty _ -> true | `Nonempty _ -> false
+
+  let nonempty_control (`Nonempty t) =
+    match t.control with
+    | None -> failwith "Nonempty volume has no control"
+    | Some cf -> cf
+
+  let start_offset t = (nonempty_control t).start_offset
+  let end_offset t = (nonempty_control t).end_offset
+
+  let contains ~offset t =
+    match empty_state t with
+    | `Empty _ -> false
+    | `Nonempty _ as t ->
+        let open Int63.Syntax in
+        start_offset t <= offset && offset < end_offset t
+end
+
+module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
+  module Io = Io
+  module Errs = Errs
+  module Volume = Make_volume (Io) (Errs)
+
+  type t = { root : string; readonly : bool; mutable volumes : Volume.t array }
+  type open_error = [ Volume.open_error | `Volume_missing of string ]
+  type close_error = [ | Io.close_error ]
+
+  type add_error =
+    [ open_error
+    | `Ro_not_allowed
+    | `Multiple_empty_volumes
+    | `File_exists of string
+    | `Invalid_parent_directory ]
+
+  exception LoadVolumeError of open_error
+
+  let load_volumes ~volume_num t =
+    let open Result_syntax in
+    let* volumes =
+      let root = t.root in
+      let volume i =
+        let readonly = t.readonly || i < volume_num - 1 in
+        let path = Irmin_pack.Layout.V5.Volume.directory ~root ~idx:i in
+        match Io.classify_path path with
+        | `File | `Other | `No_such_file_or_directory ->
+            raise (LoadVolumeError (`Volume_missing path))
+        | `Directory -> (
+            match Volume.v ~readonly path with
+            | Error e -> raise (LoadVolumeError e)
+            | Ok v -> v)
+      in
+      try Ok (Array.init volume_num volume)
+      with LoadVolumeError err -> Error (err : open_error :> [> open_error ])
+    in
+    t.volumes <- volumes;
+    Ok t
+
+  let v ~readonly ~volume_num root =
+    load_volumes ~volume_num { root; readonly; volumes = [||] }
+
+  let reload ~volume_num t =
+    let open Result_syntax in
+    let* _ = load_volumes ~volume_num t in
+    Ok ()
+
+  let close _t =
+    (* TODO: update when actual fds are kept open *)
+    Ok ()
+
+  let volume_num t = Array.length t.volumes
+
+  let appendable_volume t =
+    match volume_num t with 0 -> None | num -> Some t.volumes.(num - 1)
+
+  let add_volume t =
+    let open Result_syntax in
+    let* () = if t.readonly then Error `Ro_not_allowed else Ok () in
+    let* () =
+      match appendable_volume t with
+      | None -> Ok ()
+      | Some v ->
+          if Volume.is_empty v then Error `Multiple_empty_volumes
+          else Volume.set_readonly ~readonly:true v
+    in
+    let volume_path =
+      let next_idx = volume_num t in
+      Irmin_pack.Layout.V5.Volume.directory ~root:t.root ~idx:next_idx
+    in
+    let* vol = Volume.create_empty volume_path in
+    t.volumes <- Array.append t.volumes [| vol |];
+    Ok vol
+
+  let find_volume ~offset t = Array.find_opt (Volume.contains ~offset) t.volumes
+end

--- a/src/irmin-pack/unix/lower.mli
+++ b/src/irmin-pack/unix/lower.mli
@@ -1,0 +1,18 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+include Lower_intf.Sigs
+(** @inline *)

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -1,0 +1,108 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+
+module type Volume = sig
+  module Io : Io.S
+  module Errs : Io_errors.S
+
+  type t
+
+  type open_error =
+    [ Io.open_error
+    | `Closed
+    | `Double_close
+    | `Corrupted_control_file
+    | `Unknown_major_pack_version of string ]
+
+  val v : readonly:bool -> string -> (t, [> open_error ]) result
+  (** [v ~readonly path] loads the volume at [path].
+
+      If [readonly] is true, no write operations are allowed. *)
+
+  val path : t -> string
+  (** [path t] is the directory that contains the volume. *)
+
+  val is_empty : t -> bool
+  (** [is_empty t] returns whether [t] is empty or not. *)
+
+  val control : t -> Control_file.Payload.Volume.Latest.t option
+  (** [control t] returns the control file payload for the volume. *)
+end
+
+module type S = sig
+  module Io : Io.S
+  module Errs : Io_errors.S
+  module Volume : Volume
+
+  type t
+  type open_error = [ Volume.open_error | `Volume_missing of string ]
+  type close_error = [ | Io.close_error ]
+
+  type add_error =
+    [ open_error
+    | `Ro_not_allowed
+    | `Multiple_empty_volumes
+    | `File_exists of string
+    | `Invalid_parent_directory ]
+
+  val v :
+    readonly:bool -> volume_num:int -> string -> (t, [> open_error ]) result
+  (** [v ~readonly ~volume_num lower_root] loads all volumes located in the
+      directory [lower_root].
+
+      [volume_num] is the number of volumes that are expected in [lower_root]. 0
+      is valid for an empty lower.
+
+      [Error `Volume_missing path] is returned if an expected volume is not on
+      disk, with the path to first volume that is missing. This can happen if
+      [volume_num] is larger than the number of volumes on disk, or if one of
+      the volume directories has been renamed accidentally.
+
+      If [readonly] is false, no write operations are allowed. *)
+
+  val reload : volume_num:int -> t -> (unit, [> open_error ]) result
+  (** [reload ~volume_num t] reloads volumes located in the root directory of
+      [t], using [volume_num] as the expected number of volumes. *)
+
+  val close : t -> (unit, [> close_error ]) result
+  (** [close t] closes all resources opened by [t]. *)
+
+  val volume_num : t -> int
+  (** [volume_num t] returns the number of volumes in the lower [t]. *)
+
+  val add_volume : t -> (Volume.t, [> add_error ]) result
+  (** [add_volume t] adds a new empty volume to [t].
+
+      If there is already an empty volume, [Error `Multiple_empty_volumes] is
+      returned. Only one empty volume is allowed.
+
+      If [t] is read-only, [Error `Ro_not_allowed] is returned. *)
+
+  val find_volume : offset:int63 -> t -> Volume.t option
+  (** [find_volume ~offset t] returns the {!Volume} that contains [offset]. *)
+end
+
+module type Sigs = sig
+  module type S = S
+
+  module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) :
+    Volume with module Io = Io and module Errs = Errs
+
+  module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) :
+    S with module Io = Io and module Errs = Errs
+end

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -18,7 +18,8 @@
   test_dispatcher
   test_corrupted
   test_async
-  test_indexing_strategy)
+  test_indexing_strategy
+  test_lower)
  (libraries
   alcotest
   fmt

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -1,0 +1,137 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+open Common
+module Io = Irmin_pack_unix.Io.Unix
+module Control = Irmin_pack_unix.Control_file.Volume (Io)
+module Errs = Irmin_pack_unix.Io_errors.Make (Io)
+module Lower = Irmin_pack_unix.Lower.Make (Io) (Errs)
+
+let ( let$ ) res f = f @@ Result.get_ok res
+
+let rec unlink path =
+  match Irmin_pack_unix.Io.Unix.classify_path path with
+  | `No_such_file_or_directory -> ()
+  | `Directory ->
+      Sys.readdir path
+      |> Array.map (fun p -> Filename.concat path p)
+      |> Array.iter unlink;
+      Unix.rmdir path
+  | _ -> Unix.unlink path
+
+let create_lower_root =
+  let counter = ref 0 in
+  fun () ->
+    let lower_root = "test_lower_" ^ string_of_int !counter in
+    incr counter;
+    let lower_path = Filename.concat "_build" lower_root in
+    unlink lower_path;
+    let$ _ = Irmin_pack_unix.Io.Unix.mkdir lower_path in
+    lower_path
+
+let create_control volume_path payload =
+  let path = Irmin_pack.Layout.V5.Volume.control ~root:volume_path in
+  Control.create_rw ~path ~overwrite:true payload
+
+let test_empty () =
+  let lower_root = create_lower_root () in
+  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  Alcotest.(check int) "0 volumes" 0 (Lower.volume_num lower);
+  let _ = Lower.close lower in
+  Lwt.return_unit
+
+let test_volume_num () =
+  let lower_root = create_lower_root () in
+  let result = Lower.v ~readonly:false ~volume_num:1 lower_root in
+  let () =
+    match result with
+    | Error (`Volume_missing _) -> ()
+    | _ -> Alcotest.fail "volume_num too high should return an error"
+  in
+  Lwt.return_unit
+
+let test_add_volume () =
+  let lower_root = create_lower_root () in
+  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let$ _ = Lower.add_volume lower in
+  Alcotest.(check int) "1 volume" 1 (Lower.volume_num lower);
+  let$ _ = Lower.reload ~volume_num:1 lower in
+  Alcotest.(check int) "1 volume after reload" 1 (Lower.volume_num lower);
+  let _ = Lower.close lower in
+  Lwt.return_unit
+
+let test_add_volume_ro () =
+  let lower_root = create_lower_root () in
+  let$ lower = Lower.v ~readonly:true ~volume_num:0 lower_root in
+  let result = Lower.add_volume lower in
+  let () =
+    match result with
+    | Error `Ro_not_allowed -> ()
+    | _ -> Alcotest.fail "cannot add volume to ro lower"
+  in
+  let _ = Lower.close lower in
+  Lwt.return_unit
+
+let test_add_multiple_empty () =
+  let lower_root = create_lower_root () in
+  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let$ _ = Lower.add_volume lower in
+  let result = Lower.add_volume lower |> Result.get_error in
+  let () =
+    match result with
+    | `Multiple_empty_volumes -> ()
+    | _ -> Alcotest.fail "cannot add multiple empty volumes"
+  in
+  let _ = Lower.close lower in
+  Lwt.return_unit
+
+let test_find_volume () =
+  let lower_root = create_lower_root () in
+  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let$ volume = Lower.add_volume lower in
+  let payload =
+    Irmin_pack_unix.Control_file.Payload.Volume.Latest.
+      {
+        start_offset = Int63.zero;
+        end_offset = Int63.of_int 42;
+        mapping_end_poff = Int63.zero;
+        data_end_poff = Int63.zero;
+        checksum = Int63.zero;
+      }
+  in
+  let _ = create_control (Lower.Volume.path volume) payload in
+  let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
+  Alcotest.(check bool)
+    "volume not found before reload" false (Option.is_some volume);
+  let$ _ = Lower.reload ~volume_num:1 lower in
+  let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
+  Alcotest.(check bool) "found volume" true (Option.is_some volume);
+  let _ = Lower.close lower in
+  Lwt.return_unit
+
+let tests =
+  Alcotest_lwt.
+    [
+      test_case "empty lower" `Quick (fun _switch () -> test_empty ());
+      test_case "volume_num too high" `Quick (fun _switch () ->
+          test_volume_num ());
+      test_case "add volume" `Quick (fun _switch () -> test_add_volume ());
+      test_case "add volume ro" `Quick (fun _switch () -> test_add_volume_ro ());
+      test_case "add multiple empty" `Quick (fun _switch () ->
+          test_add_multiple_empty ());
+      test_case "find volume" `Quick (fun _switch () -> test_find_volume ());
+    ]

--- a/test/irmin-pack/test_lower.mli
+++ b/test/irmin-pack/test_lower.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+val tests : unit Alcotest_lwt.test_case list

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -556,4 +556,5 @@ let misc =
     ("snapshot_gc", Test_gc.Snapshot.tests);
     ("async tasks", Test_async.tests);
     ("indexing strategy", Test_indexing_strategy.tests);
+    ("lower", Test_lower.tests);
   ]


### PR DESCRIPTION
This is the first PR for the new lower layer. It builds on the introduction of the volume control file in #2180 by introducing a minimal lower layer module that enables:
- loading volumes contained in a root path
- adding new empty volumes
- finding a volume that can address a global offset

I tried not to make too many assumptions about how we want to integrate this since I expect subsequent PRs that add specific functionality to shape the `Lower` and `Volume` modules quite a bit.

