### PR TITLE
irmin-pack: add V5 version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
     the need for temporary files. (#2085, @art-w)
   - Split now raises an exception if it is not allowed. It is not allowed on
     stores that do not allow GC. (#2175, @metanivek)
+  - Upgrade on-disk format to version 5. (#2184, @metanivek)
 
 ### Fixed
 - **irmin-pack**

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -192,11 +192,67 @@ module Payload = struct
           - [suffix_end_poff] is replaced by [appendable_chunk_poff] *)
     end
 
-    module Latest = V4
+    module V5 = struct
+      type gced = V4.gced = {
+        suffix_start_offset : int63;
+        generation : int;
+        latest_gc_target_offset : int63;
+        suffix_dead_bytes : int63;
+      }
+      [@@deriving irmin]
+
+      type status = V4.status =
+        | From_v1_v2_post_upgrade of V3.from_v1_v2_post_upgrade
+        | No_gc_yet
+        | Used_non_minimal_indexing_strategy
+        | Gced of gced
+        | T1
+        | T2
+        | T3
+        | T4
+        | T5
+        | T6
+        | T7
+        | T8
+        | T9
+        | T10
+        | T11
+        | T12
+        | T13
+        | T14
+        | T15
+      [@@deriving irmin]
+
+      type t = {
+        dict_end_poff : int63;
+        appendable_chunk_poff : int63;
+        upgraded_from : int option;
+        checksum : int63;
+        chunk_start_idx : int;
+        chunk_num : int;
+        volume_num : int;
+        status : status; (* must be last to allow extensions *)
+      }
+      [@@deriving irmin]
+      (** The same as {!V4.t}, with the following modifications:
+
+          New fields
+
+          - [volume_num] stores the number of volumes in the lower layer.
+
+          Changed fields
+
+          - Replaced [upgraded_from_v3_to_v4] with generic field [upgraded_from]
+            to track version upgrades. Note, it is an [int option] since
+            [Version.t option] has a bug somewhere in repr that needs further
+            investigation. *)
+    end
+
+    module Latest = V5
   end
 
   module Volume = struct
-    module V4 = struct
+    module V5 = struct
       type t = {
         start_offset : int63;
         end_offset : int63;
@@ -219,7 +275,7 @@ module Payload = struct
             writing. *)
     end
 
-    module Latest = V4
+    module Latest = V5
   end
 end
 

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -443,9 +443,10 @@ struct
           appendable_chunk_poff = z;
           checksum = z;
           status;
-          upgraded_from_v3_to_v4 = false;
+          upgraded_from = None;
           chunk_start_idx = 0;
           chunk_num = 1;
+          volume_num = 0;
         }
       in
       create_control_file ~overwrite config pl
@@ -548,9 +549,10 @@ struct
           appendable_chunk_poff = suffix_end_poff;
           checksum = Int63.zero;
           status;
-          upgraded_from_v3_to_v4 = false;
+          upgraded_from = None;
           chunk_start_idx;
           chunk_num = 1;
+          volume_num = 0;
         }
       in
       create_control_file ~overwrite:false config pl
@@ -825,9 +827,10 @@ struct
         appendable_chunk_poff = Int63.zero;
         checksum = Int63.zero;
         status;
-        upgraded_from_v3_to_v4 = false;
+        upgraded_from = None;
         chunk_num = 1;
         chunk_start_idx = 1;
+        volume_num = 0;
       }
     in
     let path = Layout.control ~root:dst_root in

--- a/src/irmin-pack/version.ml
+++ b/src/irmin-pack/version.ml
@@ -17,22 +17,29 @@
 (* For every new version, update the [version] type and [versions]
    headers. *)
 
-type t = [ `V1 | `V2 | `V3 | `V4 ] [@@deriving irmin]
+type t = [ `V1 | `V2 | `V3 | `V4 | `V5 ] [@@deriving irmin]
 
-let latest = `V4
+let latest = `V5
 
 let enum =
-  [ (`V1, "00000001"); (`V2, "00000002"); (`V3, "00000003"); (`V4, "00000004") ]
+  [
+    (`V1, "00000001");
+    (`V2, "00000002");
+    (`V3, "00000003");
+    (`V4, "00000004");
+    (`V5, "00000005");
+  ]
 
 let pp =
   Fmt.of_to_string (function
     | `V1 -> "v1"
     | `V2 -> "v2"
     | `V3 -> "v3"
-    | `V4 -> "v4")
+    | `V4 -> "v4"
+    | `V5 -> "v5")
 
 let to_bin v = List.assoc v enum
-let to_int = function `V1 -> 1 | `V2 -> 2 | `V3 -> 3 | `V4 -> 4
+let to_int = function `V1 -> 1 | `V2 -> 2 | `V3 -> 3 | `V4 -> 4 | `V5 -> 5
 let compare a b = Int.compare (to_int a) (to_int b)
 let encode_bin t f = to_bin t |> f
 
@@ -44,6 +51,7 @@ let decode_bin s offref =
     | "00000002" -> `V2
     | "00000003" -> `V3
     | "00000004" -> `V4
+    | "00000005" -> `V5
     | _ -> failwith "Couldn't decode pack version"
   in
   offref := !offref + 8;

--- a/src/irmin-pack/version.mli
+++ b/src/irmin-pack/version.mli
@@ -27,11 +27,15 @@
     store in rw mode.
 
     [`V4] introduced the chunked suffix. Upgrade from [`V3] happened on first
-    write to the control file. *)
+    write to the control file.
 
-type t = [ `V1 | `V2 | `V3 | `V4 ] [@@deriving irmin]
+    [`V5] introduced the lower layer. Upgrade happened on first write to the
+    control file. *)
+
+type t = [ `V1 | `V2 | `V3 | `V4 | `V5 ] [@@deriving irmin]
 (** The type for version numbers. *)
 
+val to_int : t -> int
 val compare : t -> t -> int
 val latest : t
 

--- a/test/irmin-pack/test_pack_version_bump.ml
+++ b/test/irmin-pack/test_pack_version_bump.ml
@@ -91,7 +91,7 @@ module Util = struct
 
   (** Get the version of the underlying file; file is assumed to exist; file is
       assumed to be an Irmin_pack.IO.Unix file *)
-  let io_get_version ~root : [ `V1 | `V2 | `V3 | `V4 ] =
+  let io_get_version ~root : [ `V1 | `V2 | `V3 | `V4 | `V5 ] =
     File_manager.version ~root |> Errs.raise_if_error
 
   let alco_check_version ~pos ~expected ~actual =


### PR DESCRIPTION
This PR makes changes for the upper control file needed for the lower layer and bumps the irmin-pack version to V5.

- Add `volume_num` to upper control file.
- Change version of volume control file to V5. 
- Refactor checksum code to model valid and invalid payloads and allow checking checksums when upgrading.

I ran into one small issue where I wanted to use `Version.t option` as a type in the control file (for tracking upgrades) but ran into an error in the tests that seems to be coming out of repr (or maybe the `version.ml` code -- my brief investigation didn't shed light on what was going on). To get around this, I changed the type to `int option` and am using `Version.to_int V4` when setting the value during an upgrade. It's not the most ideal but not the worst thing either. If anybody wants to try to dig further... :angel: 