### PR TITLE
irmin-pack: initial integration of lower into store api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   - Add configuration option, `lower_root`, to specify a path for archiving data
     during a GC. (#2177, @metanivek)
   - Add `is_split_allowed` to check if a store allows split. (#2175, @metanivek)
+  - Add `add_volume` to allow creating new empty volume in lower layer. (#2188,
+    @metanivek)
 
 ### Changed
 

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -73,7 +73,8 @@ type base_error =
   | `Multiple_empty_chunks
   | `Forbidden_during_gc
   | `Multiple_empty_volumes
-  | `Volume_missing of string ]
+  | `Volume_missing of string
+  | `Add_volume_forbidden_during_gc ]
 [@@deriving irmin ~pp]
 (** [base_error] is the type of most errors that can occur in a [result], except
     for errors that have associated exceptions (see below) and backend-specific

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -65,6 +65,7 @@ module type S = sig
   module Index : Pack_index.S
   module Errs : Io_errors.S with module Io = Io
   module Sparse : Sparse_file.S with module Io = Io
+  module Lower : Lower.S with module Io = Io
 
   type t
 
@@ -107,7 +108,7 @@ module type S = sig
     | `Index_failure of string
     | `Invalid_argument
     | `Invalid_layout
-    | `Io_misc of Control.Io.misc_error
+    | `Io_misc of Io.misc_error
     | `Migration_needed
     | `No_such_file_or_directory of string
     | `Not_a_directory of string
@@ -120,7 +121,8 @@ module type S = sig
     | `Unknown_major_pack_version of string
     | `Index_failure of string
     | `Sys_error of string
-    | `Inconsistent_store ]
+    | `Inconsistent_store
+    | `Volume_missing of string ]
 
   val open_rw : Irmin.Backend.Conf.t -> (t, [> open_rw_error ]) result
   (** Create a rw instance of [t] by opening existing files.
@@ -149,6 +151,7 @@ module type S = sig
     | `Migration_needed
     | `No_such_file_or_directory of string
     | `Not_a_file
+    | `Double_close
     | `Closed
     | `V3_store_from_the_future
     | `Index_failure of string
@@ -156,7 +159,8 @@ module type S = sig
     | `Inconsistent_store
     | `Invalid_argument
     | `Read_out_of_bounds
-    | `Invalid_layout ]
+    | `Invalid_layout
+    | `Volume_missing of string ]
 
   val open_ro : Irmin.Backend.Conf.t -> (t, [> open_ro_error ]) result
   (** Create a ro instance of [t] by opening existing files.

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -76,6 +76,7 @@ module type S = sig
   val suffix : t -> Suffix.t
   val index : t -> Index.t
   val prefix : t -> Sparse.t option
+  val lower : t -> Lower.t option
 
   type create_error :=
     [ Io.create_error
@@ -83,7 +84,12 @@ module type S = sig
     | Io.open_error
     | Io.mkdir_error
     | `Corrupted_mapping_file of string
+    | `Corrupted_control_file
+    | `Double_close
+    | `Unknown_major_pack_version of string
+    | `Volume_missing of string
     | `Not_a_directory of string
+    | `Multiple_empty_volumes
     | `Index_failure of string ]
 
   val create_rw :
@@ -259,6 +265,7 @@ module type S = sig
   val generation : t -> int
   val gc_allowed : t -> bool
   val split : t -> (unit, [> Errs.t ]) result
+  val add_volume : t -> (unit, [> Errs.t ]) result
 
   val create_one_commit_store :
     t ->

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -77,7 +77,8 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Multiple_empty_chunks
     | `Forbidden_during_gc
     | `Multiple_empty_volumes
-    | `Volume_missing of string ]
+    | `Volume_missing of string
+    | `Add_volume_forbidden_during_gc ]
   [@@deriving irmin]
 
   let raise_error = function

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -47,7 +47,7 @@ end
 module type S = sig
   module Io : Io.S
   module Errs : Io_errors.S
-  module Volume : Volume
+  module Volume : Volume with module Io = Io
 
   type t
   type open_error = [ Volume.open_error | `Volume_missing of string ]

--- a/src/irmin-pack/unix/store.ml
+++ b/src/irmin-pack/unix/store.ml
@@ -401,6 +401,15 @@ module Maker (Config : Conf.S) = struct
 
         let split_exn repo = split repo |> Errs.raise_if_error
 
+        let add_volume_exn t =
+          let () =
+            if Irmin_pack.Conf.readonly t.config then
+              Errs.raise_error `Ro_not_allowed;
+            if Gc.is_finished t = false then
+              Errs.raise_error `Add_volume_forbidden_during_gc
+          in
+          File_manager.add_volume t.fm |> Errs.raise_if_error
+
         let batch t f =
           [%log.debug "[pack] batch start"];
           let readonly = Irmin_pack.Conf.readonly t.config in
@@ -586,6 +595,7 @@ module Maker (Config : Conf.S) = struct
     let fsync = X.Repo.fsync
     let is_split_allowed = X.Repo.is_split_allowed
     let split = X.Repo.split_exn
+    let add_volume = X.Repo.add_volume_exn
     let create_one_commit_store = X.Repo.Gc.create_one_commit_store
 
     module Gc = struct

--- a/src/irmin-pack/unix/store.ml
+++ b/src/irmin-pack/unix/store.ml
@@ -169,17 +169,14 @@ module Maker (Config : Conf.S) = struct
 
         let v config =
           let root = Irmin_pack.Conf.root config in
-          let _lower_path =
-            (* Validate lower layer root directory.
-
-               TODO: The value is a placeholder which will be used
-               in subsequent chagnes. *)
+          let () =
+            (* Validate lower layer root directory. *)
             let lower_root = Irmin_pack.Conf.lower_root config in
             match lower_root with
-            | None -> None
+            | None -> ()
             | Some path -> (
                 match Io.classify_path path with
-                | `Directory -> Some path
+                | `Directory -> ()
                 | `No_such_file_or_directory ->
                     Errs.raise_error (`No_such_file_or_directory path)
                 | `File | `Other -> Errs.raise_error (`Not_a_directory path))

--- a/src/irmin-pack/unix/store_intf.ml
+++ b/src/irmin-pack/unix/store_intf.ml
@@ -81,6 +81,17 @@ module type S = sig
   (** [is_split_allowed repo] returns if split is supported. Currently returns
       the same value as {!Gc.is_allowed}. *)
 
+  (** {1 Lower layer} *)
+
+  val add_volume : repo -> unit
+  (** [add_volume t] creates a new empty volume in the lower layer.
+
+      Raises [RO_Not_Allowed] if called by a readonly instance.
+
+      Raises [Add_volume_forbidden_during_gc] if called while a GC is running.
+
+      Raises [Multiple_empty_volumes] if there is already an empty volume. *)
+
   (** {1 On-disk} *)
 
   val reload : repo -> unit

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -217,6 +217,12 @@ module Alcotest = struct
   let hash = testable_repr Schema.Hash.t
 end
 
+module Alcotest_lwt = struct
+  include Alcotest_lwt
+
+  let quick_tc name f = test_case name `Quick (fun _switch () -> f ())
+end
+
 module Filename = struct
   include Filename
 

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -73,6 +73,14 @@ module Alcotest : sig
   val testable_repr : 'a Irmin.Type.t -> 'a Alcotest.testable
 end
 
+module Alcotest_lwt : sig
+  include module type of Alcotest_lwt
+
+  val quick_tc : string -> (unit -> unit Lwt.t) -> unit test_case
+  (** Convenience to create a `Quick test_case that doesn't need to use a
+      switch. *)
+end
+
 module Index : module type of Irmin_pack_unix.Index.Make (Schema.Hash)
 module Key : Irmin_pack_unix.Pack_key.S with type hash = Schema.Hash.t
 

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -16,10 +16,11 @@
 
 open! Import
 open Common
+
+let src = Logs.Src.create "tests.lower" ~doc:"Test lower"
+
+module Log = (val Logs.src_log src : Logs.LOG)
 module Io = Irmin_pack_unix.Io.Unix
-module Control = Irmin_pack_unix.Control_file.Volume (Io)
-module Errs = Irmin_pack_unix.Io_errors.Make (Io)
-module Lower = Irmin_pack_unix.Lower.Make (Io) (Errs)
 
 let ( let$ ) res f = f @@ Result.get_ok res
 
@@ -33,105 +34,201 @@ let rec unlink path =
       Unix.rmdir path
   | _ -> Unix.unlink path
 
-let create_lower_root =
-  let counter = ref 0 in
-  fun () ->
-    let lower_root = "test_lower_" ^ string_of_int !counter in
-    incr counter;
-    let lower_path = Filename.concat "_build" lower_root in
-    unlink lower_path;
-    let$ _ = Irmin_pack_unix.Io.Unix.mkdir lower_path in
-    lower_path
+module Direct_tc = struct
+  module Control = Irmin_pack_unix.Control_file.Volume (Io)
+  module Errs = Irmin_pack_unix.Io_errors.Make (Io)
+  module Lower = Irmin_pack_unix.Lower.Make (Io) (Errs)
 
-let create_control volume_path payload =
-  let path = Irmin_pack.Layout.V5.Volume.control ~root:volume_path in
-  Control.create_rw ~path ~overwrite:true payload
+  let create_lower_root =
+    let counter = ref 0 in
+    fun () ->
+      let lower_root = "test_lower_" ^ string_of_int !counter in
+      incr counter;
+      let lower_path = Filename.concat "_build" lower_root in
+      unlink lower_path;
+      let$ _ = Irmin_pack_unix.Io.Unix.mkdir lower_path in
+      lower_path
 
-let test_empty () =
-  let lower_root = create_lower_root () in
-  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
-  Alcotest.(check int) "0 volumes" 0 (Lower.volume_num lower);
-  let _ = Lower.close lower in
-  Lwt.return_unit
+  let create_control volume_path payload =
+    let path = Irmin_pack.Layout.V5.Volume.control ~root:volume_path in
+    Control.create_rw ~path ~overwrite:true payload
 
-let test_volume_num () =
-  let lower_root = create_lower_root () in
-  let result = Lower.v ~readonly:false ~volume_num:1 lower_root in
-  let () =
-    match result with
-    | Error (`Volume_missing _) -> ()
-    | _ -> Alcotest.fail "volume_num too high should return an error"
-  in
-  Lwt.return_unit
+  let test_empty () =
+    let lower_root = create_lower_root () in
+    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+    Alcotest.(check int) "0 volumes" 0 (Lower.volume_num lower);
+    let _ = Lower.close lower in
+    Lwt.return_unit
 
-let test_add_volume () =
-  let lower_root = create_lower_root () in
-  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
-  let$ _ = Lower.add_volume lower in
-  Alcotest.(check int) "1 volume" 1 (Lower.volume_num lower);
-  let$ _ = Lower.reload ~volume_num:1 lower in
-  Alcotest.(check int) "1 volume after reload" 1 (Lower.volume_num lower);
-  let _ = Lower.close lower in
-  Lwt.return_unit
+  let test_volume_num () =
+    let lower_root = create_lower_root () in
+    let result = Lower.v ~readonly:false ~volume_num:1 lower_root in
+    let () =
+      match result with
+      | Error (`Volume_missing _) -> ()
+      | _ -> Alcotest.fail "volume_num too high should return an error"
+    in
+    Lwt.return_unit
 
-let test_add_volume_ro () =
-  let lower_root = create_lower_root () in
-  let$ lower = Lower.v ~readonly:true ~volume_num:0 lower_root in
-  let result = Lower.add_volume lower in
-  let () =
-    match result with
-    | Error `Ro_not_allowed -> ()
-    | _ -> Alcotest.fail "cannot add volume to ro lower"
-  in
-  let _ = Lower.close lower in
-  Lwt.return_unit
+  let test_add_volume () =
+    let lower_root = create_lower_root () in
+    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+    let$ _ = Lower.add_volume lower in
+    Alcotest.(check int) "1 volume" 1 (Lower.volume_num lower);
+    let$ _ = Lower.reload ~volume_num:1 lower in
+    Alcotest.(check int) "1 volume after reload" 1 (Lower.volume_num lower);
+    let _ = Lower.close lower in
+    Lwt.return_unit
 
-let test_add_multiple_empty () =
-  let lower_root = create_lower_root () in
-  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
-  let$ _ = Lower.add_volume lower in
-  let result = Lower.add_volume lower |> Result.get_error in
-  let () =
-    match result with
-    | `Multiple_empty_volumes -> ()
-    | _ -> Alcotest.fail "cannot add multiple empty volumes"
-  in
-  let _ = Lower.close lower in
-  Lwt.return_unit
+  let test_add_volume_ro () =
+    let lower_root = create_lower_root () in
+    let$ lower = Lower.v ~readonly:true ~volume_num:0 lower_root in
+    let result = Lower.add_volume lower in
+    let () =
+      match result with
+      | Error `Ro_not_allowed -> ()
+      | _ -> Alcotest.fail "cannot add volume to ro lower"
+    in
+    let _ = Lower.close lower in
+    Lwt.return_unit
 
-let test_find_volume () =
-  let lower_root = create_lower_root () in
-  let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
-  let$ volume = Lower.add_volume lower in
-  let payload =
-    Irmin_pack_unix.Control_file.Payload.Volume.Latest.
-      {
-        start_offset = Int63.zero;
-        end_offset = Int63.of_int 42;
-        mapping_end_poff = Int63.zero;
-        data_end_poff = Int63.zero;
-        checksum = Int63.zero;
-      }
-  in
-  let _ = create_control (Lower.Volume.path volume) payload in
-  let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
-  Alcotest.(check bool)
-    "volume not found before reload" false (Option.is_some volume);
-  let$ _ = Lower.reload ~volume_num:1 lower in
-  let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
-  Alcotest.(check bool) "found volume" true (Option.is_some volume);
-  let _ = Lower.close lower in
-  Lwt.return_unit
+  let test_add_multiple_empty () =
+    let lower_root = create_lower_root () in
+    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+    let$ _ = Lower.add_volume lower in
+    let result = Lower.add_volume lower |> Result.get_error in
+    let () =
+      match result with
+      | `Multiple_empty_volumes -> ()
+      | _ -> Alcotest.fail "cannot add multiple empty volumes"
+    in
+    let _ = Lower.close lower in
+    Lwt.return_unit
 
-let tests =
-  Alcotest_lwt.
-    [
-      test_case "empty lower" `Quick (fun _switch () -> test_empty ());
-      test_case "volume_num too high" `Quick (fun _switch () ->
-          test_volume_num ());
-      test_case "add volume" `Quick (fun _switch () -> test_add_volume ());
-      test_case "add volume ro" `Quick (fun _switch () -> test_add_volume_ro ());
-      test_case "add multiple empty" `Quick (fun _switch () ->
-          test_add_multiple_empty ());
-      test_case "find volume" `Quick (fun _switch () -> test_find_volume ());
-    ]
+  let test_find_volume () =
+    let lower_root = create_lower_root () in
+    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+    let$ volume = Lower.add_volume lower in
+    let payload =
+      Irmin_pack_unix.Control_file.Payload.Volume.Latest.
+        {
+          start_offset = Int63.zero;
+          end_offset = Int63.of_int 42;
+          mapping_end_poff = Int63.zero;
+          data_end_poff = Int63.zero;
+          checksum = Int63.zero;
+        }
+    in
+    let _ = create_control (Lower.Volume.path volume) payload in
+    let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
+    Alcotest.(check bool)
+      "volume not found before reload" false (Option.is_some volume);
+    let$ _ = Lower.reload ~volume_num:1 lower in
+    let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
+    Alcotest.(check bool) "found volume" true (Option.is_some volume);
+    let _ = Lower.close lower in
+    Lwt.return_unit
+end
+
+module Store_tc = struct
+  module Store = struct
+    module Maker = Irmin_pack_unix.Maker (Conf)
+    include Maker.Make (Schema)
+  end
+
+  let test_dir = "_build"
+
+  let mkdir_if_needed path =
+    match Io.mkdir path with
+    | Error (`File_exists _) | Ok () -> Ok ()
+    | _ as r -> r
+
+  let fresh_roots =
+    let c = ref 0 in
+    fun () ->
+      incr c;
+      let name =
+        Filename.concat test_dir ("test_lower_store_" ^ string_of_int !c)
+      in
+      let$ _ = mkdir_if_needed name in
+      let lower = Filename.concat name "lower" in
+      let$ _ = mkdir_if_needed lower in
+      (name, lower)
+
+  let init ?(readonly = false) ?(fresh = true) ?(unlink_lower = true) ?config ()
+      =
+    (* [unlink_lower] defaults to true to make dir clean for multiple test runs. *)
+    let config =
+      match config with
+      | None ->
+          let root, lower_root = fresh_roots () in
+          if unlink_lower then unlink lower_root;
+          Irmin_pack.(
+            config ~readonly ~indexing_strategy:Indexing_strategy.minimal ~fresh
+              ~lower_root:(Some lower_root) root)
+      | Some c -> c
+    in
+    Store.Repo.v config
+
+  let test_create () =
+    let* repo = init () in
+    (* A newly created store with a lower should have an empty volume. *)
+    let volume_num =
+      Store.Internal.(
+        file_manager repo
+        |> File_manager.lower
+        |> Option.map File_manager.Lower.volume_num
+        |> Option.value ~default:0)
+    in
+    Alcotest.(check int) "volume_num is 1" 1 volume_num;
+    Store.Repo.close repo
+
+  let test_add_volume_during_gc () =
+    let* repo = init () in
+    let* main = Store.main repo in
+    let* () =
+      Store.set_exn
+        ~info:(fun () -> Store.Info.v ~author:"tester" Int64.zero)
+        main [ "a" ] "a"
+    in
+    let* c = Store.Head.get main in
+    let* _ = Store.Gc.start_exn repo (Store.Commit.key c) in
+    let* () =
+      Alcotest.check_raises_lwt "add volume during gc"
+        (Irmin_pack_unix.Errors.Pack_error `Add_volume_forbidden_during_gc)
+        (fun () -> Store.add_volume repo |> Lwt.return)
+    in
+    Store.Repo.close repo
+
+  let test_add_volume_reopen () =
+    (* TODO: test adding a volume and reopning store to
+       ensure conrol file is updated correclty. *)
+    Lwt.return_unit
+end
+
+module Store = struct
+  include Store_tc
+
+  let tests =
+    Alcotest_lwt.
+      [
+        quick_tc "create store" test_create;
+        quick_tc "add volume during gc" test_add_volume_during_gc;
+        quick_tc "control file updated after add" test_add_volume_reopen;
+      ]
+end
+
+module Direct = struct
+  include Direct_tc
+
+  let tests =
+    Alcotest_lwt.
+      [
+        quick_tc "empty lower" test_empty;
+        quick_tc "volume_num too high" test_volume_num;
+        quick_tc "add volume" test_add_volume;
+        quick_tc "add volume ro" test_add_volume_ro;
+        quick_tc "add multiple empty" test_add_multiple_empty;
+        quick_tc "find volume" test_find_volume;
+      ]
+end

--- a/test/irmin-pack/test_lower.mli
+++ b/test/irmin-pack/test_lower.mli
@@ -14,4 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest_lwt.test_case list
+module Store : sig
+  val tests : unit Alcotest_lwt.test_case list
+end
+
+module Direct : sig
+  val tests : unit Alcotest_lwt.test_case list
+end

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -556,5 +556,6 @@ let misc =
     ("snapshot_gc", Test_gc.Snapshot.tests);
     ("async tasks", Test_async.tests);
     ("indexing strategy", Test_indexing_strategy.tests);
-    ("lower", Test_lower.tests);
+    ("lower: direct", Test_lower.Direct.tests);
+    ("lower: store", Test_lower.Store.tests);
   ]


### PR DESCRIPTION
This PR does a few things to integrate the lower module into the higher level store code:
- creates the lower root path if needed
- loads the lower when opening/creating a store, if a lower is configured
- creates an empty volume when creating a store, if a lower is configured
- adds an `add_volume` function to the store api
- adds a few tests to exercise the above

There are some TODOs for subsequent PRs:
- [ ] to properly support `fresh`, we need to recursively delete the lower root's volumes
- [ ] should we return an error when `add_volume` is called and no lower exists?
- [ ] there is a placeholder for a future test when we have proper control file writing for volumes

~~(Note: this PR is based on #2184 so skip the first couple of commits if reviewing before it is merged)~~