### PR TITLE
irmin: expose info type equality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 
 ### Changed
 
+- **irmin**
+  - Expose type equality for `Schema.Info` to avoid defining the `info` function
+    multiple times when using similar stores (#2189, @samoht)
 - **irmin-pack**
   - Improve GC reachability traversal to optimize memory, speed and remove
     the need for temporary files. (#2085, @art-w)

--- a/src/irmin-fs/irmin_fs.mli
+++ b/src/irmin-fs/irmin_fs.mli
@@ -78,7 +78,7 @@ end
 module Append_only (IO : IO) : Irmin.Append_only.Maker
 module Atomic_write (IO : IO) : Irmin.Atomic_write.Maker
 module Maker (IO : IO) : Irmin.Maker
-module KV (IO : IO) : Irmin.KV_maker
+module KV (IO : IO) : Irmin.KV_maker with type info = Irmin.Info.default
 
 (** {2 Advanced configuration} *)
 

--- a/src/irmin-fs/unix/irmin_fs_unix.mli
+++ b/src/irmin-fs/unix/irmin_fs_unix.mli
@@ -17,7 +17,7 @@
 module Append_only : Irmin.Append_only.Maker
 module Atomic_write : Irmin.Atomic_write.Maker
 include Irmin.Maker
-module KV : Irmin.KV_maker
+module KV : Irmin.KV_maker with type info = Irmin.Info.default
 
 (** {1 Extended Stores} *)
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -190,6 +190,7 @@ struct
   type metadata = Metadata.t
   type branch = Branch.t
   type hash = G.hash
+  type info = Irmin.Info.default
 
   module Make (C : Irmin.Contents.S) = Maker.Make (Schema.Make (G) (C) (Branch))
 end
@@ -218,6 +219,7 @@ struct
   type endpoint = unit
   type metadata = Metadata.t
   type hash = G.hash
+  type info = Irmin.Info.default
 
   include Irmin.Key.Store_spec.Hash_keyed
 

--- a/src/irmin/irmin.ml
+++ b/src/irmin/irmin.ml
@@ -173,6 +173,7 @@ module KV_maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) =
 struct
   type metadata = unit
   type hash = Schema.default_hash
+  type info = Info.default
 
   module Maker = Maker (CA) (AW)
   include Maker

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -201,7 +201,10 @@ module Maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
 (** [KV_maker] is like {!module-Maker} but uses sensible default implementations
     for everything except the contents type. *)
 module KV_maker (CA : Content_addressable.Maker) (AW : Atomic_write.Maker) :
-  KV_maker with type endpoint = unit and type metadata = unit
+  KV_maker
+    with type endpoint = unit
+     and type metadata = unit
+     and type info = Info.default
 
 (** {2 Backend} *)
 

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -1173,6 +1173,7 @@ module type KV_maker_generic_key = sig
   type endpoint
   type metadata
   type hash
+  type info
 
   include Key.Store_spec.S
 
@@ -1185,6 +1186,7 @@ module type KV_maker_generic_key = sig
        and type contents_key = (hash, C.t) contents_key
        and type node_key = hash node_key
        and type commit_key = hash commit_key
+       and type Schema.Info.t = info
 end
 
 module type KV_maker =


### PR DESCRIPTION
That allows to re-use the same info function in various store - in practice backend are either using Irmin.Info.default or Imin_unix.info so it's a bit odd to hide that equality.