### PR TITLE
irmin-pack 3.6: fix mmap keeps a file descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## 3.6.0
 
+### Fixed
+
+- **irmin-pack**
+  - Close the mapping file descriptor. (#2196, @art-w)
+
+## 3.6.0
+
 ### Changed
 
 - **irmin-pack**

--- a/src/irmin-pack/unix/bigarray_munmap.c
+++ b/src/irmin-pack/unix/bigarray_munmap.c
@@ -1,0 +1,36 @@
+/* Adapted from https://github.com/ocaml/ocaml/pull/389
+ * and https://github.com/janestreet/core/blob/4b6635d206f7adcfac8324820d246299d6f572fe/core/src/bigstring_stubs.c#L114
+ */
+
+#include <caml/bigarray.h>
+#include <caml/custom.h>
+
+CAMLextern void caml_ba_finalize(value v);
+
+CAMLprim void bigarray_munmap(value v)
+{
+  struct caml_ba_array * b = Caml_ba_array_val(v);
+  struct custom_operations *ops = Custom_ops_val(v);
+  int i;
+  switch (b->flags & CAML_BA_MANAGED_MASK) {
+  case CAML_BA_MAPPED_FILE:
+    if (ops->finalize != NULL) {
+      /* This call to finalize is actually a call to caml_ba_mapped_finalize
+         (the finalize function for *mapped* bigarrays), which will unmap the
+         array. (note: this is compatible with OCaml 4.06+) */
+      ops->finalize(v);
+    }
+    break;
+  default:
+    /* Not used by the Mapping_file, so untested. */
+    caml_ba_finalize(v);
+  }
+
+  /* Prevent later GC or free from doing anything more */
+  b->flags = CAML_BA_EXTERNAL;
+  /* Disallow all access via this bigarray */
+  for (i = 0; i < b->num_dims; i++) b->dim[i] = Long_val(0);
+  /* Tidy up (and let C users know that the data is gone). */
+  b->data = NULL;
+  b->proxy = NULL;
+}

--- a/src/irmin-pack/unix/dune
+++ b/src/irmin-pack/unix/dune
@@ -16,6 +16,9 @@
   checkseum
   checkseum.ocaml
   rusage)
+ (foreign_stubs
+  (language c)
+  (names bigarray_munmap))
  (preprocess
   (pps ppx_irmin.internal))
  (instrumentation

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -64,6 +64,7 @@ struct
     let* () = Dict.close t.dict in
     let* () = Control.close t.control in
     let* () = Suffix.close t.suffix in
+    Option.iter Mapping_file.close t.mapping;
     let* () = Option.might Prefix.close t.prefix in
     let+ () = Index.close t.index in
     ()
@@ -228,7 +229,9 @@ struct
   let reopen_mapping t ~generation =
     let open Result_syntax in
     let root = t.root in
+    let mapping0 = t.mapping in
     let* mapping = open_mapping ~root ~generation in
+    Option.iter Mapping_file.close mapping0;
     [%log.debug "reload: opening %s" root];
     t.mapping <- mapping;
     Ok ()

--- a/src/irmin-pack/unix/mapping_file.ml
+++ b/src/irmin-pack/unix/mapping_file.ml
@@ -141,7 +141,9 @@ module Make (Io : Io.S) = struct
   module Errs = Io_errors.Make (Io)
   module Ao = Append_only_file.Make (Io) (Errs)
 
-  type t = { arr : int64_bigarray; root : string; generation : int }
+  type t = { mutable arr : int64_bigarray; root : string; generation : int }
+
+  let close t = t.arr <- Bigarray.(Array1.create Int64 c_layout 0)
 
   let open_map ~root ~generation =
     let path = Irmin_pack.Layout.V4.mapping ~generation ~root in

--- a/src/irmin-pack/unix/mapping_file_intf.ml
+++ b/src/irmin-pack/unix/mapping_file_intf.ml
@@ -51,6 +51,8 @@ module type S = sig
   val open_map : root:string -> generation:int -> (t, [> open_error ]) result
   (** [open_map ~root ~generation] opens a mapping file. *)
 
+  val close : t -> unit
+
   val iter : t -> (off:int63 -> len:int -> unit) -> (unit, Errs.t) result
   (** [iter mapping f] calls [f] on each [(off,len)] pair in [mapping].
 

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -1205,8 +1205,6 @@ module Snapshot = struct
     let* t = checkout_exn t c1 in
     let* () = check_1 t c1 in
     let* () = S.Repo.close t.repo in
-    (* [Gc.full_major] forces the release of the mmaped file *)
-    Stdlib.Gc.full_major ();
     let+ count_after = lsof_count pid_self in
     Alcotest.(check bool)
       "open file descriptors" true


### PR DESCRIPTION
I'm not too happy about this quickfix. The mapping file uses `mmap` to lazy load its content, but this keeps the underlying file descriptor alive (until the OCaml GC calls the finalizer and releases it, but later than Irmin `close`)

I've included two commits:
- The first one shows that calling `Stdlib.Gc.full_major ()` after `close` is good enough to release the file descriptor
- The second steals C stubs from https://github.com/ocaml/ocaml/pull/389 and `munmap` specific update from https://github.com/janestreet/core/blob/4b6635d206f7adcfac8324820d246299d6f572fe/core/src/bigstring_stubs.c#L114 to release the file descriptor early, without `full_major`. The linked PR explains why this is considered unsafe, but it's very easy to confirm that we are in the "no use after free".

While the updated C stub seems to work, it would be nice if someone knowledgeable could take a look at the changes (cc @talex5 ? for some reason `caml_ba_finalize` isn't calling `munmap` anymore https://github.com/ocaml/ocaml/blob/0e09dc477c131a404f28be373effc3508c99ff6f/runtime/bigarray.c#L164)

With the sparse file refactoring, our use of `mmap` has significantly dropped to the point that we could implement `mmap` in userland (since the file is never updated, we only need lazy reading.) This would allow removing the C stubs and I would feel a lot better.