### PR TITLE
irmin-pack: implement reading from lower

### DIFF
--- a/src/irmin-pack/unix/checks.ml
+++ b/src/irmin-pack/unix/checks.ml
@@ -463,7 +463,7 @@ struct
             "Not supported for stores which have entries obtained with irmin < \
              3.0. If all entries were added with irmin < 3.0, please use \
              [integrity_check] instead."
-      | Direct { offset; length; hash } -> (
+      | Direct { offset; length; hash; _ } -> (
           let result = check ~offset ~length hash in
           match result with
           | Ok () -> Lwt.return_unit

--- a/src/irmin-pack/unix/dispatcher.ml
+++ b/src/irmin-pack/unix/dispatcher.ml
@@ -25,6 +25,7 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
   module Io = Fm.Io
   module Suffix = Fm.Suffix
   module Sparse = Fm.Sparse
+  module Lower = Fm.Lower
   module Errs = Fm.Errs
   module Control = Fm.Control
 
@@ -85,11 +86,32 @@ module Make (Fm : File_manager.S with module Io = Io.Unix) :
     let open Int63.Syntax in
     if off >= suffix_start_offset t then Some (soff_of_offset t off) else None
 
-  let read_exn t ~off ~len buf =
+  let read_exn t ~off ~len ?volume_identifier buf =
     [%log.debug "read_exn ~off:%a ~len:%i" Int63.pp off len];
+    let read_lower_exn ?volume () =
+      let lower = Fm.lower t.fm in
+      match lower with
+      | None -> None
+      | Some l -> Some (Lower.read_exn l ~off ~len ?volume buf)
+    in
+    let read_sparse_then_lower_exn () =
+      match Sparse.read_exn (get_prefix t) ~off ~len buf with
+      | exception
+          (Errors.Pack_error (`Invalid_sparse_read ((`Before | `Hole), _)) as
+          exn) -> (
+          match read_lower_exn () with
+          | None -> raise exn
+          | Some _ as identifier -> identifier)
+      | () -> None
+    in
     match dispatch_suffix t ~off with
-    | Some off -> Suffix.read_exn (get_suffix t) ~off ~len buf
-    | None -> Sparse.read_exn (get_prefix t) ~off ~len buf
+    | Some off ->
+        Suffix.read_exn (get_suffix t) ~off ~len buf;
+        None
+    | None -> (
+        match volume_identifier with
+        | None -> read_sparse_then_lower_exn ()
+        | Some volume -> read_lower_exn ~volume ())
 
   let read_range_exn t ~off ~min_len ~max_len buf =
     match dispatch_suffix t ~off with

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -23,9 +23,22 @@ module type S = sig
 
   val v : Fm.t -> (t, [> Fm.Errs.t ]) result
 
-  val read_exn : t -> off:int63 -> len:int -> bytes -> unit
+  val read_exn :
+    t ->
+    off:int63 ->
+    len:int ->
+    ?volume_identifier:Lower.volume_identifier ->
+    bytes ->
+    Lower.volume_identifier option
   (** [read_exn t ~off ~len buffer] writes into [buffer] the bytes from [off] to
-      [off+len]. *)
+      [off+len]. If the read occurred, in a lower volume, its identifier is
+      returned.
+
+      If you know which volume to read from in the lower, provide
+      [volume_identifier] to skip checking the prefix.
+
+      Note: [read_exn] is the only read function that supports reading in the
+      lower. *)
 
   val read_range_exn :
     t -> off:int63 -> min_len:int -> max_len:int -> bytes -> unit

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -66,7 +66,7 @@ type base_error =
   | `Gc_process_died_without_result_file of string
   | `Gc_forbidden_on_32bit_platforms
   | `Invalid_prefix_read of string
-  | `Invalid_sparse_read of string
+  | `Invalid_sparse_read of [ `After | `Before | `Hole ] * int63
   | `Inconsistent_store
   | `Split_forbidden_during_batch
   | `Split_disallowed

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -75,7 +75,8 @@ type base_error =
   | `Multiple_empty_volumes
   | `Volume_missing of string
   | `Add_volume_forbidden_during_gc
-  | `Add_volume_requires_lower ]
+  | `Add_volume_requires_lower
+  | `Volume_not_found of string ]
 [@@deriving irmin ~pp]
 (** [base_error] is the type of most errors that can occur in a [result], except
     for errors that have associated exceptions (see below) and backend-specific

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -905,7 +905,7 @@ struct
     (* Step 5. Add the commit to the index, close the index. *)
     let () =
       match Pack_key.inspect commit_key with
-      | Pack_key.Direct { hash; offset; length } ->
+      | Pack_key.Direct { hash; offset; length; _ } ->
           Index.add index hash (offset, length, Pack_value.Kind.Commit_v2)
       | Indexed _ -> assert false
     in

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -67,7 +67,7 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Gc_process_died_without_result_file of string
     | `Gc_forbidden_on_32bit_platforms
     | `Invalid_prefix_read of string
-    | `Invalid_sparse_read of string
+    | `Invalid_sparse_read of [ `After | `Before | `Hole ] * int63
     | `Inconsistent_store
     | `Closed
     | `Ro_not_allowed

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -79,7 +79,8 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Multiple_empty_volumes
     | `Volume_missing of string
     | `Add_volume_forbidden_during_gc
-    | `Add_volume_requires_lower ]
+    | `Add_volume_requires_lower
+    | `Volume_not_found of string ]
   [@@deriving irmin]
 
   let raise_error = function

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -95,6 +95,13 @@ module type S = sig
 
   val find_volume : offset:int63 -> t -> Volume.t option
   (** [find_volume ~offset t] returns the {!Volume} that contains [offset]. *)
+
+  val read_exn : off:int63 -> len:int -> ?volume:Volume.t -> t -> bytes -> unit
+  (** [read_exn ~off ~len ~volume t b] will read [len] bytes from a global
+      [offset] located in [volume].
+
+      If [volume] is not provided, {!find_volume} will be used to attempt to
+      locate the correct volume for the read. *)
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -16,6 +16,8 @@
 
 open! Import
 
+type volume_identifier = string
+
 module type Volume = sig
   module Io : Io.S
   module Errs : Io_errors.S
@@ -42,6 +44,9 @@ module type Volume = sig
 
   val control : t -> Control_file.Payload.Volume.Latest.t option
   (** [control t] returns the control file payload for the volume. *)
+
+  val identifier : t -> volume_identifier
+  (** [identifier t] is a unique idendifier for the volume. *)
 end
 
 module type S = sig
@@ -93,12 +98,19 @@ module type S = sig
 
       If [t] is read-only, [Error `Ro_not_allowed] is returned. *)
 
-  val find_volume : offset:int63 -> t -> Volume.t option
-  (** [find_volume ~offset t] returns the {!Volume} that contains [offset]. *)
+  val find_volume : off:int63 -> t -> Volume.t option
+  (** [find_volume ~off t] returns the {!Volume} that contains [off]. *)
 
-  val read_exn : off:int63 -> len:int -> ?volume:Volume.t -> t -> bytes -> unit
-  (** [read_exn ~off ~len ~volume t b] will read [len] bytes from a global
-      [offset] located in [volume].
+  val read_exn :
+    off:int63 ->
+    len:int ->
+    ?volume:volume_identifier ->
+    t ->
+    bytes ->
+    volume_identifier
+  (** [read_exn ~off ~len ~volume t b] will read [len] bytes from a global [off]
+      located in the volume with identifier [volume]. The volume identifier of
+      the volume where the read occurs is returned.
 
       If [volume] is not provided, {!find_volume} will be used to attempt to
       locate the correct volume for the read. *)
@@ -106,6 +118,8 @@ end
 
 module type Sigs = sig
   module type S = S
+
+  type nonrec volume_identifier = volume_identifier
 
   module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) :
     Volume with module Io = Io and module Errs = Errs

--- a/src/irmin-pack/unix/pack_key_intf.ml
+++ b/src/irmin-pack/unix/pack_key_intf.ml
@@ -33,6 +33,7 @@ module type Sigs = sig
         hash : 'hash;
         offset : int63;
         length : int;
+        volume_identifier : Lower.volume_identifier option;
       }
         -> ('hash, safe) unsafe_state
         (** A "direct" pointer to a value stored at [offset] in the pack-file
@@ -83,10 +84,24 @@ module type Sigs = sig
         repository may not be dereferenced with respect to another by design. *)
 
   val inspect : 'hash t -> 'hash state
-  val v_direct : hash:'h -> offset:int63 -> length:int -> 'h t
+
+  val v_direct :
+    offset:int63 ->
+    length:int ->
+    ?volume_identifier:Lower.volume_identifier ->
+    'h ->
+    'h t
+
   val v_indexed : 'h -> 'h t
   val v_offset : int63 -> 'h t
-  val promote_exn : 'h t -> offset:int63 -> length:int -> unit
+
+  val promote_exn :
+    offset:int63 ->
+    length:int ->
+    ?volume_identifier:Lower.volume_identifier ->
+    'h t ->
+    unit
+
   val to_offset : 'h t -> int63 option
   val to_hash : 'h t -> 'h
   val to_length : 'h t -> int option

--- a/src/irmin-pack/unix/store.ml
+++ b/src/irmin-pack/unix/store.ml
@@ -350,9 +350,7 @@ module Maker (Config : Conf.S) = struct
                        length in their header. *)
                     assert false
                 | Some length ->
-                    let key =
-                      Pack_key.v_direct ~offset ~length ~hash:entry.hash
-                    in
+                    let key = Pack_key.v_direct ~offset ~length entry.hash in
                     Some key)
 
           let create_one_commit_store t commit_key path =

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -274,7 +274,7 @@ end = struct
     let buffer = Bytes.create initial_buffer_size in
     let on_entry missing_hash off =
       let len = guess_entry_len dispatcher ~off in
-      Dispatcher.read_exn dispatcher ~off ~len buffer;
+      let _ = Dispatcher.read_exn dispatcher ~off ~len buffer in
       let { key; data } =
         decode_entry_exn ~off
           ~buffer:(Bytes.unsafe_to_string buffer)

--- a/src/irmin-tezos-utils/files.ml
+++ b/src/irmin-tezos-utils/files.ml
@@ -84,9 +84,9 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
       ~min_len:min_bytes_needed_to_discover_length
       ~max_len:max_bytes_needed_to_discover_length buffer;
     let kind, len = decode_entry_header buffer in
-    Dispatcher.read_exn dispatcher ~off ~len:Hash.hash_size buffer;
+    let _ = Dispatcher.read_exn dispatcher ~off ~len:Hash.hash_size buffer in
     let hash = Bytes.sub_string buffer 0 Hash.hash_size in
-    Dispatcher.read_exn dispatcher ~off ~len buffer;
+    let _ = Dispatcher.read_exn dispatcher ~off ~len buffer in
     let content = Bytes.sub_string buffer 0 len in
     (hash, kind, len, content)
 
@@ -105,7 +105,7 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
     let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
     let buffer = Bytes.create (4096 * 4096) in
     let on_entry ~off ~len =
-      Dispatcher.read_exn dispatcher ~off ~len buffer;
+      let _ = Dispatcher.read_exn dispatcher ~off ~len buffer in
       let kind = decode_entry_kind buffer in
       let entry =
         match kind with

--- a/test/irmin-pack/test_dispatcher.ml
+++ b/test/irmin-pack/test_dispatcher.ml
@@ -82,14 +82,15 @@ let test_read () =
   let _ =
     Alcotest.check_raises "cannot read node_1"
       (Irmin_pack_unix.Errors.Pack_error
-         (`Invalid_sparse_read "offset 30 is in a sparse hole"))
+         (`Invalid_sparse_read (`Before, Int63.of_int 30)))
       (fun () ->
         let buf = Bytes.create node_1.len in
-        Dispatcher.read_exn dsp ~off:node_1.off ~len:node_1.len buf)
+        let _ = Dispatcher.read_exn dsp ~off:node_1.off ~len:node_1.len buf in
+        ())
   in
   let test_accessor msg obj =
     let buf = Bytes.create obj.len in
-    Dispatcher.read_exn dsp ~off:obj.off ~len:obj.len buf;
+    let _ = Dispatcher.read_exn dsp ~off:obj.off ~len:obj.len buf in
     check_hex msg buf obj.hex
   in
   test_accessor "node_2" node_2;

--- a/test/irmin-pack/test_indexing_strategy.ml
+++ b/test/irmin-pack/test_indexing_strategy.ml
@@ -41,7 +41,7 @@ let test_unique_when_switched () =
   in
   let get_direct_key key =
     match Irmin_pack_unix.Pack_key.inspect key with
-    | Direct { offset; hash; length } -> (offset, hash, length)
+    | Direct { offset; hash; length; _ } -> (offset, hash, length)
     | _ -> assert false
   in
   let get_key_offset key =

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -101,11 +101,11 @@ module Direct_tc = struct
         }
     in
     let _ = create_control (Lower.Volume.path volume) payload in
-    let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
+    let volume = Lower.find_volume ~off:(Int63.of_int 21) lower in
     Alcotest.(check bool)
       "volume not found before reload" false (Option.is_some volume);
     let$ _ = Lower.reload ~volume_num:1 lower in
-    let volume = Lower.find_volume ~offset:(Int63.of_int 21) lower in
+    let volume = Lower.find_volume ~off:(Int63.of_int 21) lower in
     Alcotest.(check bool) "found volume" true (Option.is_some volume);
     let _ = Lower.close lower in
     Lwt.return_unit

--- a/test/irmin-pack/test_upgrade.ml
+++ b/test/irmin-pack/test_upgrade.ml
@@ -85,7 +85,7 @@ let index_entries =
   List.map (fun e -> (e.h, e.o)) pack_entries |> List.to_seq |> Hashtbl.of_seq
 
 let key_of_entry x =
-  Irmin_pack_unix.Pack_key.v_direct ~hash:x.h ~offset:x.o ~length:x.l
+  Irmin_pack_unix.Pack_key.v_direct ~offset:x.o ~length:x.l x.h
 
 type start_mode = From_v2 | From_v3 | From_scratch | From_v3_c0_gced
 [@@deriving irmin]


### PR DESCRIPTION
This PR:
- adds a `read_exn` function to `Lower`
- limits "open" volumes to one at a time for a simple management of open file descriptors
- adds `volume_identifier` to direct keys to allow tracking the context of a read so that subsequent reads can skip looking in the upper
- handles dangling parent commits by not propagating the volume identifier to them, thereby forcing a fresh lookup
