### PR TITLE
irmin-pack: adding a volume w/o lower is an error

### DIFF
--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -74,7 +74,8 @@ type base_error =
   | `Forbidden_during_gc
   | `Multiple_empty_volumes
   | `Volume_missing of string
-  | `Add_volume_forbidden_during_gc ]
+  | `Add_volume_forbidden_during_gc
+  | `Add_volume_requires_lower ]
 [@@deriving irmin ~pp]
 (** [base_error] is the type of most errors that can occur in a [result], except
     for errors that have associated exceptions (see below) and backend-specific

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -844,7 +844,7 @@ struct
 
   let add_volume t =
     match t.lower with
-    | None -> Ok () (* TODO: throw exception? *)
+    | None -> Error `Add_volume_requires_lower
     | Some lower -> add_volume_and_update_control lower t.control
 
   let cleanup t =

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -78,7 +78,8 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Forbidden_during_gc
     | `Multiple_empty_volumes
     | `Volume_missing of string
-    | `Add_volume_forbidden_during_gc ]
+    | `Add_volume_forbidden_during_gc
+    | `Add_volume_requires_lower ]
   [@@deriving irmin]
 
   let raise_error = function


### PR DESCRIPTION
Follow up from #2188 to return an error when calling `add_volume` and there is no lower configured.