### PR TITLE
irmin-pack: clear LRU when reloading RO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- **irmin-pack**
+  - Clear LRU when calling `reload` after a GC (#2200, @metanivek)
+
 ## 3.5.1
 
 ### Fixed

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -46,6 +46,7 @@ struct
     mutable mapping : Mapping_file.t option;
     index : Index.t;
     mutable dict_consumers : after_reload_consumer list;
+    mutable prefix_consumers : after_reload_consumer list;
     mutable suffix_consumers : after_flush_consumer list;
     indexing_strategy : Irmin_pack.Indexing_strategy.t;
     use_fsync : bool;
@@ -71,6 +72,9 @@ struct
   let register_dict_consumer t ~after_reload =
     t.dict_consumers <- { after_reload } :: t.dict_consumers
 
+  let register_prefix_consumer t ~after_reload =
+    t.prefix_consumers <- { after_reload } :: t.prefix_consumers
+
   let register_suffix_consumer t ~after_flush =
     t.suffix_consumers <- { after_flush } :: t.suffix_consumers
 
@@ -83,6 +87,12 @@ struct
         (* Unreachable *)
         assert false
     | Gced x -> x.generation
+
+  let notify_reload_consumers consumers =
+    List.fold_left
+      (fun acc { after_reload } -> Result.bind acc after_reload)
+      (Ok ()) consumers
+    |> Result.map_error (fun err -> (err : Errs.t :> [> Errs.t ]))
 
   (** Flush stages *************************************************************
 
@@ -216,6 +226,7 @@ struct
     in
     let prefix0 = t.prefix in
     t.prefix <- Some prefix1;
+    let* () = notify_reload_consumers t.prefix_consumers in
     match prefix0 with None -> Ok () | Some io -> Prefix.close io
 
   let open_mapping ~root ~generation =
@@ -379,6 +390,7 @@ struct
         use_fsync;
         index;
         dict_consumers = [];
+        prefix_consumers = [];
         suffix_consumers = [];
         indexing_strategy;
         root;
@@ -435,16 +447,7 @@ struct
       (match hook with Some h -> h `After_suffix | None -> ());
       let* () = Dict.refresh_end_poff t.dict pl1.dict_end_poff in
       (* Step 5. Notify the dict consumers that they must reload *)
-      let* () =
-        let res =
-          List.fold_left
-            (fun acc { after_reload } -> Result.bind acc after_reload)
-            (Ok ()) t.dict_consumers
-        in
-        (* The following dirty trick casts the result from
-           [read_error] to [ [>read_error] ]. *)
-        match res with Ok () -> Ok () | Error (#Errs.t as e) -> Error e
-      in
+      let* () = notify_reload_consumers t.dict_consumers in
       Ok ()
 
   (* File creation ********************************************************** *)
@@ -680,6 +683,7 @@ struct
         indexing_strategy;
         index;
         dict_consumers = [];
+        prefix_consumers = [];
         suffix_consumers = [];
         root;
       }

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -220,6 +220,9 @@ module type S = sig
   val register_dict_consumer :
     t -> after_reload:(unit -> (unit, Errs.t) result) -> unit
 
+  val register_prefix_consumer :
+    t -> after_reload:(unit -> (unit, Errs.t) result) -> unit
+
   val register_suffix_consumer : t -> after_flush:(unit -> unit) -> unit
 
   type version_error :=

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -116,6 +116,7 @@ struct
     in
     let lru = Lru.create ~weight lru_size in
     Fm.register_suffix_consumer fm ~after_flush:(fun () -> Tbl.clear staging);
+    Fm.register_prefix_consumer fm ~after_reload:(fun () -> Ok (Lru.clear lru));
     { lru; staging; indexing_strategy; fm; dict; dispatcher }
 
   module Entry_prefix = struct


### PR DESCRIPTION
Currently, when a RO instance calls `reload`, the LRU is not cleared. We have seen some issues in octez that we _think_ is caused by this behavior. See #2171. 

When opening that issue, I originally made the assumption we did not have what we needed to "smartly" clear the LRU for RO instances, but I had an idea upon second consideration. During `reload`, we only reopen the prefix if the generation changes so we can use that as our signal to clear the LRU. With some refactoring, that is what this PR does.

In order to clear the LRU when `reload` is called, this is a general refactor to move clearing of the LRU to happen when the prefix is reopened. This covers both a swap after a GC and when reload is called for a RO instance.

I added some new tests to verify the LRU has cleared for both a GC and a reload (and importantly it is _not_ cleared if a GC has not occurred). They are a bit indirect by testing hits to the LRU, but get the job done. Open to other suggestions though!

---

This PR is to address #2171, but we shouldn't close that issue until this fix is merged to main. The reason this PR is targeted at 3.5 is that we will likely release this as a 3.5.2 release (for downstream octez usage), then we will forward port to `main`. It is unclear if we will also need to do a 3.6.1 release.

