### PR TITLE
irmin-pack: fix read object headers from lower volumes

### DIFF
--- a/src/irmin-pack-tools/tezos_explorer/files.ml
+++ b/src/irmin-pack-tools/tezos_explorer/files.ml
@@ -80,9 +80,11 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
     Hash.hash_size + 1 + length_length + suffix_length
 
   let decode_entry dispatcher buffer off =
-    Dispatcher.read_range_exn dispatcher ~off
-      ~min_len:min_bytes_needed_to_discover_length
-      ~max_len:max_bytes_needed_to_discover_length buffer;
+    let (_ : string option) =
+      Dispatcher.read_range_exn dispatcher ~off
+        ~min_len:min_bytes_needed_to_discover_length
+        ~max_len:max_bytes_needed_to_discover_length buffer
+    in
     let kind, len = decode_entry_header buffer in
     let _ = Dispatcher.read_exn dispatcher ~off ~len:Hash.hash_size buffer in
     let hash = Bytes.sub_string buffer 0 Hash.hash_size in
@@ -96,9 +98,11 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
       min_bytes_needed_to_discover_length + Varint.max_encoded_size
     in
     let buffer = Bytes.create max_bytes_needed_to_discover_length in
-    Dispatcher.read_range_exn dispatcher ~off
-      ~min_len:min_bytes_needed_to_discover_length
-      ~max_len:max_bytes_needed_to_discover_length buffer;
+    let (_ : string option) =
+      Dispatcher.read_range_exn dispatcher ~off
+        ~min_len:min_bytes_needed_to_discover_length
+        ~max_len:max_bytes_needed_to_discover_length buffer
+    in
     decode_entry_len buffer
 
   let iter_store fm ~on_entry =

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -41,7 +41,13 @@ module type S = sig
       lower. *)
 
   val read_range_exn :
-    t -> off:int63 -> min_len:int -> max_len:int -> bytes -> unit
+    t ->
+    off:int63 ->
+    min_len:int ->
+    max_len:int ->
+    ?volume_identifier:Lower.volume_identifier ->
+    bytes ->
+    Lower.volume_identifier option
   (** Same as [read_exn], the amount read is [max_len] if possible or at least
       [min_len] if reading more would step over a hole in the sparse file. *)
 

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -114,6 +114,17 @@ module type S = sig
 
       If [volume] is not provided, {!find_volume} will be used to attempt to
       locate the correct volume for the read. *)
+
+  val read_range_exn :
+    off:int63 ->
+    min_len:int ->
+    max_len:int ->
+    ?volume:volume_identifier ->
+    t ->
+    bytes ->
+    volume_identifier
+  (** Same as [read_exn] but will read at least [min_len] bytes and at most
+      [max_len]. *)
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/sparse_file.ml
+++ b/src/irmin-pack/unix/sparse_file.ml
@@ -68,7 +68,7 @@ module Make (Io : Io.S) = struct
           let mmap = Int64_mmap.open_ro ~fn:path ~sz:(-1) in
           let arr = mmap.arr in
           let len = BigArr1.dim arr in
-          match len > 0 && len mod 3 = 0 with
+          match len mod 3 = 0 with
           | true ->
               Int64_mmap.close mmap;
               Ok { path; arr }

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -241,9 +241,11 @@ end = struct
       min_bytes_needed_to_discover_length + Varint.max_encoded_size
     in
     let buffer = Bytes.create max_bytes_needed_to_discover_length in
-    Dispatcher.read_range_exn dispatcher ~off
-      ~min_len:min_bytes_needed_to_discover_length
-      ~max_len:max_bytes_needed_to_discover_length buffer;
+    let (_volume : Lower.volume_identifier option) =
+      Dispatcher.read_range_exn dispatcher ~off
+        ~min_len:min_bytes_needed_to_discover_length
+        ~max_len:max_bytes_needed_to_discover_length buffer
+    in
     decode_entry_len buffer
 
   (* Read at most [len], by checking that [(off, len)] don't go out of bounds of

--- a/src/irmin-pack/unix/utils.ml
+++ b/src/irmin-pack/unix/utils.ml
@@ -70,20 +70,22 @@ end
     in the sorted [arr] that is [>=] the given key. Routine is based on binary
     search. *)
 let nearest_geq ~arr ~get ~lo ~hi ~key =
-  match Stdlib.compare key (get arr hi) with
-  | 0 -> Some hi
-  | c when c > 0 -> None
-  | _ when get arr lo >= key -> Some lo
-  | _ ->
-      let rec search lo hi =
-        assert (lo < hi);
-        assert (get arr lo < key && key < get arr hi);
-        if lo + 1 = hi then Some hi
-        else
-          let mid = (lo + hi) / 2 in
-          match Stdlib.compare key (get arr mid) with
-          | 0 -> Some mid
-          | c when c < 0 -> search lo mid
-          | _ -> search mid hi
-      in
-      search lo hi
+  if lo > hi then None
+  else
+    match Stdlib.compare key (get arr hi) with
+    | 0 -> Some hi
+    | c when c > 0 -> None
+    | _ when get arr lo >= key -> Some lo
+    | _ ->
+        let rec search lo hi =
+          assert (lo < hi);
+          assert (get arr lo < key && key < get arr hi);
+          if lo + 1 = hi then Some hi
+          else
+            let mid = (lo + hi) / 2 in
+            match Stdlib.compare key (get arr mid) with
+            | 0 -> Some mid
+            | c when c < 0 -> search lo mid
+            | _ -> search mid hi
+        in
+        search lo hi


### PR DESCRIPTION
I ran into this edge-case when testing the fast migration to a lower volume. The children objects' headers are read with `read_range_exn` which only supported reading from the upper store. (cc @Firobe as this should also be useful for #2202)