### PR TITLE
irmin-pack: fast migration to lower by copy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
     @metanivek)
   - Add a `behaviour` function to the GC to check wether the GC will archive or
     delete data. (#2190, @Firobe)
+  - Add a migration on `open_rw` to move the data to the `lower_root` if
+    the configuration was enabled (#2205, @art-w)
 
 ### Changed
 

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -262,7 +262,6 @@ module Payload = struct
         start_offset : int63;
         end_offset : int63;
         mapping_end_poff : int63;
-        data_end_poff : int63;
         checksum : int63;
       }
       [@@deriving irmin]
@@ -275,8 +274,6 @@ module Payload = struct
           - [end_offset] is the global offset for the end of the volume's data.
             Used for routing reads.
           - [mapping_end_poff] is the end offset for the mapping file. Used when
-            writing.
-          - [data_end_poff] is the end offset for the data file. Used for
             writing. *)
     end
 

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -51,6 +51,7 @@ type base_error =
   | `Pending_flush
   | `Rw_not_allowed
   | `Migration_needed
+  | `Migration_to_lower_not_allowed
   | `Corrupted_control_file
   | `Sys_error of string
   | `V3_store_from_the_future
@@ -67,6 +68,7 @@ type base_error =
   | `Gc_forbidden_on_32bit_platforms
   | `Invalid_prefix_read of string
   | `Invalid_sparse_read of [ `After | `Before | `Hole ] * int63
+  | `Invalid_volume_read of [ `Empty | `Closed ] * int63
   | `Inconsistent_store
   | `Split_forbidden_during_batch
   | `Split_disallowed

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -116,6 +116,7 @@ module type S = sig
     | `Invalid_layout
     | `Io_misc of Io.misc_error
     | `Migration_needed
+    | `Migration_to_lower_not_allowed
     | `No_such_file_or_directory of string
     | `Not_a_directory of string
     | `Not_a_file
@@ -128,7 +129,10 @@ module type S = sig
     | `Index_failure of string
     | `Sys_error of string
     | `Inconsistent_store
-    | `Volume_missing of string ]
+    | `Volume_missing of string
+    | `Multiple_empty_volumes
+    | `Invalid_parent_directory
+    | `Pending_flush ]
 
   val open_rw : Irmin.Backend.Conf.t -> (t, [> open_rw_error ]) result
   (** Create a rw instance of [t] by opening existing files.

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -52,6 +52,7 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Pending_flush
     | `Rw_not_allowed
     | `Migration_needed
+    | `Migration_to_lower_not_allowed
     | `Corrupted_control_file
     | `Sys_error of string
     | `V3_store_from_the_future
@@ -68,6 +69,7 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Gc_forbidden_on_32bit_platforms
     | `Invalid_prefix_read of string
     | `Invalid_sparse_read of [ `After | `Before | `Hole ] * int63
+    | `Invalid_volume_read of [ `Empty | `Closed ] * int63
     | `Inconsistent_store
     | `Closed
     | `Ro_not_allowed

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -146,6 +146,19 @@ module type S = sig
     volume_identifier
   (** Same as [read_exn] but will read at least [min_len] bytes and at most
       [max_len]. *)
+
+  type create_error :=
+    [ open_error | close_error | add_error | `Sys_error of string ]
+
+  val create_from :
+    src:string ->
+    dead_header_size:int ->
+    size:Int63.t ->
+    string ->
+    (unit, [> create_error ]) result
+  (** [create_from ~src ~dead_header_size ~size lower_root] initializes the
+      first lower volume in the directory [lower_root] by moving the suffix file
+      [src] with end offset [size]. *)
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/unix/sparse_file_intf.ml
+++ b/src/irmin-pack/unix/sparse_file_intf.ml
@@ -76,6 +76,20 @@ module type S = sig
 
     val close : t -> (unit, [> Io.close_error ]) result
     (** Close the underlying files. *)
+
+    val create_from_data :
+      mapping:string ->
+      dead_header_size:int ->
+      size:Int63.t ->
+      data:string ->
+      (int63, [> Io.create_error | Io.write_error | Io.close_error ]) result
+    (** [create_from_data ~mapping ~dead_header_size ~size ~data] initializes a
+        new sparse file on disk from the existing file [data], by creating the
+        corresponding [mapping] file. The first [dead_header_size] bytes are
+        ignored and the remaining [size] bytes of [data] are made available.
+
+        On success, returns the size of the [mapping] file to be stored in the
+        control file for consistency checking on open. *)
   end
 
   module Ao : sig


### PR DESCRIPTION
(builds on top of #2204)

A draft for the fast migration when enabling lower volumes from an existing store (which only had an upper suffix file, never garbage collected or chunk splitted). I went with a file copy rather than a move when initializing the lower volume to avoid any surprise if the operation fails midway... it should be as efficient as a rename when happening on the same hard drive anyway :) But the code is still missing some way of recovering and cleaning up the drive if the migration fails!