### PR TITLE
irmin-pack: Use temp control files upon writing

### DIFF
--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -54,6 +54,7 @@ module V4 = struct
   let branch = toplevel "store.branches"
   let dict = toplevel "store.dict"
   let control = toplevel "store.control"
+  let control_tmp = toplevel "store.control.tmp"
 
   let suffix_chunk ~chunk_idx =
     toplevel ("store." ^ string_of_int chunk_idx ^ ".suffix")
@@ -81,7 +82,7 @@ module V5 = struct
     let directory ~idx = toplevel ("volume." ^ string_of_int idx)
     let control = toplevel "volume.control"
 
-    let control_tmp ~generation =
+    let control_gc_tmp ~generation =
       toplevel ("volume." ^ string_of_int generation ^ ".control")
 
     let mapping = toplevel "volume.mapping"
@@ -107,6 +108,7 @@ module Classification = struct
     type t =
       [ `Branch
       | `Control
+      | `Control_tmp
       | `Dict
       | `Gc_result of int
       | `Mapping of int
@@ -123,6 +125,7 @@ module Classification = struct
       | [ "store"; "pack" ] -> `V1_or_v2_pack
       | [ "store"; "branches" ] -> `Branch
       | [ "store"; "control" ] -> `Control
+      | [ "store"; "control"; "tmp" ] -> `Control_tmp
       | [ "store"; "dict" ] -> `Dict
       | [ "store"; g; "out" ] when is_number g -> `Gc_result (int_of_string g)
       | [ "store"; g; "reachable" ] when is_number g ->

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -80,7 +80,8 @@ type base_error =
   | `Add_volume_requires_lower
   | `Volume_history_discontinuous
   | `Lower_has_no_volume
-  | `Volume_not_found of string ]
+  | `Volume_not_found of string
+  | `No_tmp_path_provided ]
 [@@deriving irmin ~pp]
 (** [base_error] is the type of most errors that can occur in a [result], except
     for errors that have associated exceptions (see below) and backend-specific

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -90,7 +90,9 @@ module type S = sig
     | `Volume_missing of string
     | `Not_a_directory of string
     | `Multiple_empty_volumes
-    | `Index_failure of string ]
+    | `Index_failure of string
+    | `Sys_error of string
+    | `No_tmp_path_provided ]
 
   val create_rw :
     overwrite:bool -> Irmin.Backend.Conf.t -> (t, [> create_error ]) result
@@ -120,6 +122,7 @@ module type S = sig
     | `No_such_file_or_directory of string
     | `Not_a_directory of string
     | `Not_a_file
+    | `No_tmp_path_provided
     | `Read_out_of_bounds
     | `Ro_not_allowed
     | `Sys_error of string
@@ -204,7 +207,11 @@ module type S = sig
     [ `Index_failure of string
     | `Io_misc of Io.misc_error
     | `Ro_not_allowed
-    | `Closed ]
+    | `Closed
+    | `Double_close
+    | `File_exists of string
+    | `Sys_error of string
+    | `No_tmp_path_provided ]
 
   type flush_stages := [ `After_dict | `After_suffix ]
   type 'a hook := 'a -> unit

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -84,7 +84,8 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Lower_has_no_volume
     | `Add_volume_forbidden_during_gc
     | `Add_volume_requires_lower
-    | `Volume_not_found of string ]
+    | `Volume_not_found of string
+    | `No_tmp_path_provided ]
   [@@deriving irmin]
 
   let raise_error = function

--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -99,7 +99,8 @@ module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
       }
     in
     let control = Layout.control ~root in
-    Control.create_rw ~path:control ~overwrite:false payload >>= Control.close
+    Control.create_rw ~path:control ~tmp_path:None ~overwrite:false payload
+    >>= Control.close
 
   let path = function Empty { path } -> path | Nonempty { path; _ } -> path
 
@@ -198,11 +199,12 @@ module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
         { start_offset; end_offset; mapping_end_poff; checksum = Int63.zero }
     in
     (* Write into temporary file on disk *)
-    let tmp_control_path =
-      Irmin_pack.Layout.V5.Volume.control_tmp ~generation ~root
+    let control_gc_tmp =
+      Irmin_pack.Layout.V5.Volume.control_gc_tmp ~generation ~root
     in
     let* c =
-      Control.create_rw ~path:tmp_control_path ~overwrite:true new_control
+      Control.create_rw ~path:control_gc_tmp ~tmp_path:None ~overwrite:true
+        new_control
     in
     let* () = Control.close c in
     Ok root

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -32,7 +32,7 @@ module Direct_tc = struct
 
   let create_control volume_path payload =
     let path = Irmin_pack.Layout.V5.Volume.control ~root:volume_path in
-    Control.create_rw ~path ~overwrite:true payload
+    Control.create_rw ~path ~tmp_path:None ~overwrite:true payload
 
   let test_empty () =
     let lower_root = create_lower_root () in

--- a/test/irmin-pack/test_pack.ml
+++ b/test/irmin-pack/test_pack.ml
@@ -505,6 +505,7 @@ module Layout = struct
     c `V1_or_v2_pack (V1_and_v2.pack ~root:"" |> classif);
     c `Branch (V4.branch ~root:"" |> classif);
     c `Control (V4.control ~root:"" |> classif);
+    c `Control_tmp (V4.control_tmp ~root:"" |> classif);
     c `Dict (V4.dict ~root:"" |> classif);
     c (`Gc_result 0) (V4.gc_result ~generation:0 ~root:"" |> classif);
     c (`Reachable 1) (V4.reachable ~generation:1 ~root:"" |> classif);


### PR DESCRIPTION
This PR changes the writing of control files: They were currently updated while making the assumption that the file itself being smaller than a page, the writing would be atomic. However it was deemed dubious that we could use such an assumption.
This is why this PR:
- Adds the usage of temporary control file when writing a new payload (path of the cf + `.tmp`).
- Moves the temporary file in stead of the old control file.
- Then updates the `Io` file stored in the `Control_file.t` with the new
- On the RO instances side, it simply re-opens a new Io file, as the old file descriptor might point to the inode of a file replaced by the RW instance.
- Updates the errors of the related functions.

This leaves however one question in the case of RO instances:
Because we open a new `Io` each time we want to reload the payload, storing said Io has currently purpose. Maybe we could do something about that (separating RO & RW control files ? Using an option ? Remove the reload function ?)