### PR TITLE
irmin-pack: fix GC creation of prefix from lower volume data after migration

### DIFF
--- a/src/irmin-pack/unix/chunked_suffix.ml
+++ b/src/irmin-pack/unix/chunked_suffix.ml
@@ -309,7 +309,8 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
       else if bytes_after_off > max_len then max_len
       else bytes_after_off
     in
-    read_exn t ~off ~len buf
+    read_exn t ~off ~len buf;
+    len
 
   let append_exn t s = Ao.append_exn (appendable_ao t) s
 

--- a/src/irmin-pack/unix/chunked_suffix_intf.ml
+++ b/src/irmin-pack/unix/chunked_suffix_intf.ml
@@ -115,7 +115,7 @@ module type S = sig
   val read_exn : t -> off:int63 -> len:int -> bytes -> unit
 
   val read_range_exn :
-    t -> off:int63 -> min_len:int -> max_len:int -> bytes -> unit
+    t -> off:int63 -> min_len:int -> max_len:int -> bytes -> int
 
   val append_exn : t -> string -> unit
   val readonly : t -> bool

--- a/src/irmin-pack/unix/dispatcher_intf.ml
+++ b/src/irmin-pack/unix/dispatcher_intf.ml
@@ -47,9 +47,11 @@ module type S = sig
     max_len:int ->
     ?volume_identifier:Lower.volume_identifier ->
     bytes ->
-    Lower.volume_identifier option
+    int * Lower.volume_identifier option
   (** Same as [read_exn], the amount read is [max_len] if possible or at least
-      [min_len] if reading more would step over a hole in the sparse file. *)
+      [min_len] if reading more would step over a hole in the sparse file.
+      Returns the actually read length and optionnaly the volume where the data
+      was found. *)
 
   val end_offset : t -> int63
   (** [end_offset] is the end offsets of the pack entries, counting that the

--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -328,8 +328,8 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
       | Some id -> find_volume_by_identifier_exn t ~id
     in
     set_open_volume t volume |> Errs.raise_if_error;
-    Volume.read_range_exn ~off ~min_len ~max_len b volume;
-    Volume.identifier volume
+    let len = Volume.read_range_exn ~off ~min_len ~max_len b volume in
+    (len, Volume.identifier volume)
 
   let archive_seq_exn ~upper_root ~generation ~to_archive ~off t =
     Errs.raise_if_error
@@ -349,7 +349,8 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
       Volume.archive_seq ~upper_root ~generation ~to_archive ~off ~is_first v)
 
   let read_exn ~off ~len ?volume t b =
-    read_range_exn ~off ~min_len:len ~max_len:len ?volume t b
+    let _, volume = read_range_exn ~off ~min_len:len ~max_len:len ?volume t b in
+    volume
 
   let create_from = Volume.create_from
 end

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -143,9 +143,10 @@ module type S = sig
     ?volume:volume_identifier ->
     t ->
     bytes ->
-    volume_identifier
+    int * volume_identifier
   (** Same as [read_exn] but will read at least [min_len] bytes and at most
-      [max_len]. *)
+      [max_len]. Returns the read length and the volume identifier from which
+      the data was fetched. *)
 
   type create_error :=
     [ open_error | close_error | add_error | `Sys_error of string ]

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -156,7 +156,7 @@ struct
 
   let read_and_decode_entry_prefix ~off ?volume_identifier dispatcher =
     let buf = Bytes.create Entry_prefix.max_length in
-    let (_volume : Lower.volume_identifier option) =
+    let _len, _volume =
       try
         (* We may read fewer then [Entry_prefix.max_length] bytes when reading the
            final entry in the pack file (if the data section of the entry is

--- a/src/irmin-pack/unix/sparse_file.ml
+++ b/src/irmin-pack/unix/sparse_file.ml
@@ -173,7 +173,8 @@ module Make (Io : Io.S) = struct
     if max_entry_len < min_len then
       raise (Errors.Pack_error `Read_out_of_bounds);
     let len = min max_len max_entry_len in
-    Io.read_exn t.data ~off:poff ~len buf
+    Io.read_exn t.data ~off:poff ~len buf;
+    len
 
   let next_valid_offset { mapping; _ } ~off =
     match Mapping_file.find_nearest_geq mapping off with

--- a/src/irmin-pack/unix/sparse_file_intf.ml
+++ b/src/irmin-pack/unix/sparse_file_intf.ml
@@ -35,9 +35,11 @@ module type S = sig
       [off+len]. *)
 
   val read_range_exn :
-    t -> off:int63 -> min_len:int -> max_len:int -> bytes -> unit
+    t -> off:int63 -> min_len:int -> max_len:int -> bytes -> int
   (** Same as [read_exn], the amount read is [max_len] if possible or at least
-      [min_len] if reading more would step over a hole in the sparse file. *)
+      [min_len] if reading more would step over a hole in the sparse file.
+
+      Returns the actually read length. *)
 
   val next_valid_offset : t -> off:int63 -> int63 option
   (** [next_valid_offset t ~off] returns [Some off'] such that [off'] is the

--- a/src/irmin-pack/unix/traverse_pack_file.ml
+++ b/src/irmin-pack/unix/traverse_pack_file.ml
@@ -241,7 +241,7 @@ end = struct
       min_bytes_needed_to_discover_length + Varint.max_encoded_size
     in
     let buffer = Bytes.create max_bytes_needed_to_discover_length in
-    let (_volume : Lower.volume_identifier option) =
+    let _len, _volume =
       Dispatcher.read_range_exn dispatcher ~off
         ~min_len:min_bytes_needed_to_discover_length
         ~max_len:max_bytes_needed_to_discover_length buffer


### PR DESCRIPTION
After a migration, the GC might have to read live data from the lower volume to construct the prefix (with `Dispatcher.read_seq_exn` which only supported reading from the upper store).