### PR TITLE
irmin-pack: test data locality for volumes

### DIFF
--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -311,6 +311,9 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
     | Some v -> v
 
   let read_range_exn ~off ~min_len ~max_len ?volume t b =
+    [%log.debug
+      "read_range_exn ~off:%a ~min_len:%i ~max_len:%i" Int63.pp off min_len
+        max_len];
     let set_open_volume t v =
       (* Maintain one open volume at a time. *)
       let open Result_syntax in

--- a/src/irmin-pack/unix/pack_key.ml
+++ b/src/irmin-pack/unix/pack_key.ml
@@ -65,6 +65,15 @@ let promote_exn ~offset ~length ?volume_identifier (State t) =
   | Indexed hash ->
       t.state <- Direct { hash; offset; length; volume_identifier }
 
+let set_volume_identifier_exn ~volume_identifier (State t) =
+  match t.state with
+  | Indexed _ ->
+      failwith "Attempted to set volume identifier to a key that is Indexed"
+  | Offset _ ->
+      failwith "Attempted to set volume identifier to an offset without hash"
+  | Direct { hash; offset; length; _ } ->
+      t.state <- Direct { hash; offset; length; volume_identifier }
+
 let t : type h. h Irmin.Type.t -> h t Irmin.Type.t =
  fun hash_t ->
   let open Irmin.Type in

--- a/src/irmin-pack/unix/pack_key_intf.ml
+++ b/src/irmin-pack/unix/pack_key_intf.ml
@@ -102,6 +102,9 @@ module type Sigs = sig
     'h t ->
     unit
 
+  val set_volume_identifier_exn :
+    volume_identifier:Lower.volume_identifier option -> 'h t -> unit
+
   val to_offset : 'h t -> int63 option
   val to_hash : 'h t -> 'h
   val to_length : 'h t -> int option

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -314,6 +314,7 @@ struct
     in
     if gced t buf then None
     else
+      let () = Pack_key.set_volume_identifier_exn ~volume_identifier key in
       let key_of_offset = key_of_offset ?volume_identifier t in
       let key_of_hash = Pack_key.v_indexed in
       let dict = Dict.find t.dict in

--- a/src/irmin-pack/unix/sparse_file.ml
+++ b/src/irmin-pack/unix/sparse_file.ml
@@ -169,6 +169,9 @@ module Make (Io : Io.S) = struct
     Io.read_exn t.data ~off:poff ~len buf
 
   let read_range_exn t ~off ~min_len ~max_len buf =
+    [%log.debug
+      "read_range_exn ~off:%a ~min_len:%i ~max_len:%i" Int63.pp off min_len
+        max_len];
     let poff, max_entry_len = get_poff t ~off in
     if max_entry_len < min_len then
       raise (Errors.Pack_error `Read_out_of_bounds);

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -294,6 +294,69 @@ module Store_tc = struct
     let* _ = Store.Gc.start_exn repo (Store.Commit.key b_commit) in
     let* _ = Store.Gc.finalise_exn ~wait:true repo in
     Store.Repo.close repo
+
+  let test_volume_data_locality () =
+    let root, lower_root = fresh_roots () in
+    let* repo = Store.Repo.v (config ~fresh:true ~lower_root root) in
+    let* main = Store.main repo in
+    let info () = Store.Info.v ~author:"test" Int64.zero in
+    [%log.debug "add c1"];
+    let* () = Store.set_exn ~info main [ "c1" ] "a" in
+    let* c1 = Store.Head.get main in
+    [%log.debug "GC c1"];
+    let* _ = Store.Gc.start_exn repo (Store.Commit.key c1) in
+    let* _ = Store.Gc.finalise_exn ~wait:true repo in
+    let () = Store.add_volume repo in
+    [%log.debug "add c2, c3, c4"];
+    let* () = Store.set_exn ~info main [ "c2" ] "b" in
+    let* () = Store.set_exn ~info main [ "c3" ] "c" in
+    let* c3 = Store.Head.get main in
+    let* () = Store.set_exn ~info main [ "c4" ] "d" in
+    let* () = Store.set_exn ~info main [ "c5" ] "e" in
+    let* c5 = Store.Head.get main in
+    [%log.debug "GC c5"];
+    let* _ = Store.Gc.start_exn repo (Store.Commit.key c5) in
+    let* _ = Store.Gc.finalise_exn ~wait:true repo in
+    let get_direct_key key =
+      match Irmin_pack_unix.Pack_key.inspect key with
+      | Direct { offset; hash; length; volume_identifier } ->
+          (offset, hash, length, volume_identifier)
+      | _ -> assert false
+    in
+    (* NOTE: we need to lookup c3 again so that its volume
+       identifier is on its key *)
+    let _, hash, _, _ = get_direct_key (Store.Commit.key c3) in
+    let* c3 = Store.Commit.of_hash repo hash in
+    let c3 = Option.get c3 in
+    let _, _, _, identifier = get_direct_key (Store.Commit.key c3) in
+    let identifier = Option.get identifier in
+    [%log.debug "Check c3 tree items are in volume %s" identifier];
+    let* c3 = Store.Commit.of_key repo (Store.Commit.key c3) in
+    let tree = Store.Commit.tree (Option.get c3) in
+    let* () =
+      let get_volume_identifier key =
+        let _, _, _, identifier = get_direct_key key in
+        match identifier with
+        | None -> Alcotest.fail "expected volume identifier"
+        | Some v -> v
+      in
+      (* Check every item of c3's tree to ensure it is in the first volume. *)
+      Store.Tree.fold
+        ~tree:(fun _p t a ->
+          let kinded_key = Store.Tree.key t in
+          let key_identifier =
+            match kinded_key with
+            | None -> assert false
+            | Some (`Contents (k, _)) -> get_volume_identifier k
+            | Some (`Node k) -> get_volume_identifier k
+          in
+          [%log.debug "identifier: %s" key_identifier];
+          Alcotest.(check string)
+            "key is in expected volume" identifier key_identifier;
+          Lwt.return a)
+        tree ()
+    in
+    Store.Repo.close repo
 end
 
 module Store = struct
@@ -309,6 +372,7 @@ module Store = struct
         quick_tc "add volume and reopen" test_add_volume_reopen;
         quick_tc "create without lower then migrate" test_migrate;
         quick_tc "migrate then gc" test_migrate_then_gc;
+        quick_tc "test data locality" test_volume_data_locality;
       ]
 end
 


### PR DESCRIPTION
This PR adds a test to confirm the reading a commit and its data in a volume only reads data from that volume.

I discovered that commit keys did not have a volume identifier after read, so this PR also fixes that. The previous behavior didn't break anything, but it's nice to be able to inspect a commit after you read it to know which volume (if any) it came from.