### PR TITLE
irmin-pack: archive only reachable objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
   - GC now supports stores imported V1/V2 stores, in presence of a lower layer
     only. (#2190, @art-w, @Firobe)
   - Upgrade on-disk format to version 5. (#2184, @metanivek)
+  - Archive to lower volume does not copy orphaned commits. (#2215, @art-w)
 
 ### Fixed
 - **irmin-pack**

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -78,7 +78,7 @@ type base_error =
   | `Volume_missing of string
   | `Add_volume_forbidden_during_gc
   | `Add_volume_requires_lower
-  | `Volume_history_discontinuous
+  | `Volume_history_newer_than_archived_data of int63 * int63
   | `Lower_has_no_volume
   | `Volume_not_found of string
   | `No_tmp_path_provided ]

--- a/src/irmin-pack/unix/gc_stats.ml
+++ b/src/irmin-pack/unix/gc_stats.ml
@@ -189,10 +189,8 @@ module Worker = struct
       prev_ocaml_gc = ocaml_gc;
     }
 
-  let incr_objects_traversed t =
-    let stats =
-      { t.stats with objects_traversed = Int63.succ t.stats.objects_traversed }
-    in
+  let set_objects_traversed t v =
+    let stats = { t.stats with objects_traversed = Int63.of_int v } in
     { t with stats }
 
   let add_suffix_transfer t count =

--- a/src/irmin-pack/unix/gc_stats.mli
+++ b/src/irmin-pack/unix/gc_stats.mli
@@ -43,7 +43,7 @@ module Worker : sig
   type t
 
   val create : string -> t
-  val incr_objects_traversed : t -> t
+  val set_objects_traversed : t -> int -> t
   val add_suffix_transfer : t -> int63 -> t
   val add_file_size : t -> string -> int63 -> t
   val finish_current_step : t -> string -> t

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -80,7 +80,7 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Forbidden_during_gc
     | `Multiple_empty_volumes
     | `Volume_missing of string
-    | `Volume_history_discontinuous
+    | `Volume_history_newer_than_archived_data of int63 * int63
     | `Lower_has_no_volume
     | `Add_volume_forbidden_during_gc
     | `Add_volume_requires_lower

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -123,14 +123,13 @@ module type S = sig
   val archive_seq_exn :
     upper_root:string ->
     generation:int ->
-    to_archive:string Seq.t ->
-    off:int63 ->
+    to_archive:(int63 * string Seq.t) list ->
     t ->
     volume_identifier
-  (** [archive_seq ~upper_root ~generation ~to_archive ~off t] is called by the
-      GC worker during the creation of the new [generation] to archive
-      [to_archive] at offset [off] in the lower layer and returns the identifier
-      of the volume where data was appended.
+  (** [archive_seq ~upper_root ~generation ~to_archive t] is called by the GC
+      worker during the creation of the new [generation] to archive [to_archive]
+      in the lower layer and returns the identifier of the volume where data was
+      appended.
 
       It is the only write operation allowed on the lower layer, and it makes no
       observable change as the control file is left untouched : instead new


### PR DESCRIPTION
Update the GC step "copy deleted data to lower volume" to not include the (orphaned) unreachable commits (and their tree).