### PR TITLE
irmin-pack.unix: Use asynchronous unlink when cleaning up chunks in Gc.

### DIFF
--- a/src/irmin-pack/unix/io.ml
+++ b/src/irmin-pack/unix/io.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2022-2022 Tarides <contact@tarides.com>
+ * Copyright (c) 2022-2023 Tarides <contact@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -292,4 +292,7 @@ module Unix = struct
       Sys.remove path;
       Ok ()
     with Sys_error msg -> Error (`Sys_error msg)
+
+  let unlink_dont_wait ~on_exn path =
+    Lwt.dont_wait (fun () -> Lwt_unix.unlink path) on_exn
 end

--- a/src/irmin-pack/unix/io_intf.ml
+++ b/src/irmin-pack/unix/io_intf.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2022-2022 Tarides <contact@tarides.com>
+ * Copyright (c) 2022-2023 Tarides <contact@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -85,6 +85,12 @@ module type S = sig
 
   val mkdir : string -> (unit, [> mkdir_error ]) result
   val unlink : string -> (unit, [> `Sys_error of string ]) result
+
+  val unlink_dont_wait : on_exn:(exn -> unit) -> string -> unit
+  (** [unlink_dont_wait file] attempts to unlink the named file but doesn't wait
+      for the completion of the unlink operation.
+
+      If unlink raises an exception it is passed to [on_exn]. *)
 
   (** {2 Read Functions} *)
 


### PR DESCRIPTION
First try to tackle #2220.

This adds `Io.unlink_async` which calls `Lwt_unix.unlink`.

Lwt maintains a pool of system threads where the unlinks will be called, thus not blocking the main application thread.

I'm not sure if this will provide any real benefits as Gc is still waited on by `Async.await`.