### PR TITLE
irmin-pack: add context for corrupted control file

### DIFF
--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -309,7 +309,7 @@ module type S = sig
   (** Create a rw instance of [t] by creating a control file. *)
 
   type open_error :=
-    [ `Corrupted_control_file
+    [ `Corrupted_control_file of string
     | `Io_misc of Io.misc_error
     | `No_such_file_or_directory of string
     | `Not_a_file
@@ -350,14 +350,7 @@ module type S = sig
       [payload t] is the [payload], as it was seen during [open_] or during the
       most recent [reload]. *)
 
-  type reload_error :=
-    [ `Corrupted_control_file
-    | `Io_misc of Io.misc_error
-    | `Closed
-    | `Rw_not_allowed
-    | `Unknown_major_pack_version of string
-    | open_error
-    | Io.close_error ]
+  type reload_error := [ `Rw_not_allowed | open_error | Io.close_error ]
 
   val reload : t -> (unit, [> reload_error ]) result
   (** {3 RW mode}

--- a/src/irmin-pack/unix/errors.ml
+++ b/src/irmin-pack/unix/errors.ml
@@ -52,7 +52,7 @@ type base_error =
   | `Rw_not_allowed
   | `Migration_needed
   | `Migration_to_lower_not_allowed
-  | `Corrupted_control_file
+  | `Corrupted_control_file of string
   | `Sys_error of string
   | `V3_store_from_the_future
   | `Gc_forbidden_during_batch

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -809,7 +809,7 @@ struct
         | Error `Not_a_file -> Error `Invalid_layout
         | Error `Closed -> assert false
         | Error
-            ( `Io_misc _ | `Corrupted_control_file
+            ( `Io_misc _ | `Corrupted_control_file _
             | `Unknown_major_pack_version _ ) as e ->
             e)
 

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -84,7 +84,7 @@ module type S = sig
     | Io.open_error
     | Io.mkdir_error
     | `Corrupted_mapping_file of string
-    | `Corrupted_control_file
+    | `Corrupted_control_file of string
     | `Double_close
     | `Unknown_major_pack_version of string
     | `Volume_missing of string
@@ -108,7 +108,7 @@ module type S = sig
       undefined state and some file descriptors might not be closed. *)
 
   type open_rw_error :=
-    [ `Corrupted_control_file
+    [ `Corrupted_control_file of string
     | `Corrupted_mapping_file of string
     | `Double_close
     | `Closed
@@ -158,7 +158,7 @@ module type S = sig
       is unaffected. Anyhow, some file descriptors might not be closed. *)
 
   type open_ro_error :=
-    [ `Corrupted_control_file
+    [ `Corrupted_control_file of string
     | `Corrupted_mapping_file of string
     | `Io_misc of Io.misc_error
     | `Migration_needed
@@ -246,7 +246,7 @@ module type S = sig
   val register_suffix_consumer : t -> after_flush:(unit -> unit) -> unit
 
   type version_error :=
-    [ `Corrupted_control_file
+    [ `Corrupted_control_file of string
     | `Corrupted_legacy_file
     | `Invalid_layout
     | `Io_misc of Io.misc_error

--- a/src/irmin-pack/unix/io_errors.ml
+++ b/src/irmin-pack/unix/io_errors.ml
@@ -53,7 +53,7 @@ module Make (Io : Io.S) : S with module Io = Io = struct
     | `Rw_not_allowed
     | `Migration_needed
     | `Migration_to_lower_not_allowed
-    | `Corrupted_control_file
+    | `Corrupted_control_file of string
     | `Sys_error of string
     | `V3_store_from_the_future
     | `Gc_forbidden_during_batch

--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -37,7 +37,7 @@ module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
     [ Io.open_error
     | `Closed
     | `Double_close
-    | `Corrupted_control_file
+    | `Corrupted_control_file of string
     | `Unknown_major_pack_version of string ]
 
   let v volume_path =

--- a/src/irmin-pack/unix/lower_intf.ml
+++ b/src/irmin-pack/unix/lower_intf.ml
@@ -29,7 +29,7 @@ module type Volume = sig
     [ Io.open_error
     | `Closed
     | `Double_close
-    | `Corrupted_control_file
+    | `Corrupted_control_file of string
     | `Unknown_major_pack_version of string ]
 
   val v : string -> (t, [> open_error ]) result

--- a/test/irmin-pack/test_corrupted.ml
+++ b/test/irmin-pack/test_corrupted.ml
@@ -75,9 +75,11 @@ let test_corrupted_control_file () =
         Ok r)
       (fun exn -> Lwt.return (Error exn))
   in
-  Alcotest.(check bool)
-    "is corrupted" true
-    (error = Error (Irmin_pack_unix.Errors.Pack_error `Corrupted_control_file));
+  (match error with
+  | Error (Irmin_pack_unix.Errors.Pack_error (`Corrupted_control_file s)) ->
+      Alcotest.(check string)
+        "path is corrupted" s "_build/test-corrupted/store.control"
+  | _ -> Alcotest.fail "unexpected error");
   Lwt.return_unit
 
 let tests =


### PR DESCRIPTION
This PR adds context to the `Corrupted_control_file` error to let us distinguish the different control files: upper layer and volumes in lower layer.