### PR TITLE
irmin-pack: migration to lower has unknown GC target

### DIFF
--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -556,7 +556,7 @@ struct
             {
               suffix_start_offset = end_offset;
               generation;
-              latest_gc_target_offset = end_offset;
+              latest_gc_target_offset = Int63.zero;
               suffix_dead_bytes = Int63.zero;
             };
       }

--- a/src/irmin-pack/unix/store.ml
+++ b/src/irmin-pack/unix/store.ml
@@ -340,6 +340,9 @@ module Maker (Config : Conf.S) = struct
             | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 | T11 | T12 | T13
             | T14 | T15 ->
                 assert false
+            | Gced { latest_gc_target_offset = offset; _ }
+              when offset = Int63.zero ->
+                None
             | Gced { latest_gc_target_offset = offset; _ } -> (
                 let entry =
                   Commit.CA.read_and_decode_entry_prefix ~off:offset

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -277,6 +277,9 @@ module Store_tc = struct
     let* main = Store.main repo in
     let* a = Store.get main [ "a" ] in
     Alcotest.(check string) "migrated commit" "a" a;
+    Alcotest.(check bool)
+      "no latest GC commit" true
+      (Option.is_none (Store.Gc.latest_gc_target repo));
     let* () = Store.set_exn ~info main [ "a" ] "b" in
     let* () = Store.Repo.close repo in
     (* Reopen with the same lower and check reads *)


### PR DESCRIPTION
I don't think the field `latest_gc_target_offset` is very useful atm, but at least we should make it easier to detect that a migration to the lower didn't have a GC commit.