### PR TITLE
irmin-pack: use supplied ppf for integrity check

### DIFF
--- a/src/irmin-pack/unix/checks_intf.ml
+++ b/src/irmin-pack/unix/checks_intf.ml
@@ -70,6 +70,7 @@ module type S = sig
           unit Lwt.t
 
     val handle_result :
+      ?ppf:Format.formatter ->
       ?name:string ->
       ( [< `Fixed of int | `No_error ],
         [< `Cannot_fix of string | `Corrupted of int ] )


### PR DESCRIPTION
Fix integrity check command to use supplied ppf when printing successful results. Errors are still printed to stderr.

Closes #2211 