### PR TITLE
irmin-pack: no mmap syscall

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
   - Unhandled exceptions in GC worker process are now reported as a failure
     (#2163, @metanivek)
   - Fix the silent mode for the integrity checks. (#2179, @icristescu)
+  - Fix file descriptor leak caused by `mmap`. (#2232, @art-w)
 
 ## 3.6.1 (2023-03-15)
 

--- a/src/irmin-pack/unix/control_file_intf.ml
+++ b/src/irmin-pack/unix/control_file_intf.ml
@@ -193,15 +193,16 @@ module Payload = struct
     end
 
     module V5 = struct
-      type gced = V4.gced = {
+      type gced = {
         suffix_start_offset : int63;
         generation : int;
         latest_gc_target_offset : int63;
         suffix_dead_bytes : int63;
+        mapping_end_poff : int63 option;
       }
       [@@deriving irmin]
 
-      type status = V4.status =
+      type status =
         | From_v1_v2_post_upgrade of V3.from_v1_v2_post_upgrade
         | No_gc_yet
         | Used_non_minimal_indexing_strategy
@@ -239,6 +240,8 @@ module Payload = struct
           New fields
 
           - [volume_num] stores the number of volumes in the lower layer.
+          - [mapping_end_poff] stores the mapping file size (optional if missing
+            or unknown after a migration from V4).
 
           Changed fields
 

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -221,7 +221,9 @@ struct
     else
       let mapping = Layout.mapping ~generation ~root in
       let data = Layout.prefix ~root ~generation in
-      let+ prefix = Sparse.open_ro ~mapping ~data in
+      let* mapping_size = Io.size_of_path mapping in
+      let mapping_size = Int63.to_int mapping_size in
+      let+ prefix = Sparse.open_ro ~mapping_size ~mapping ~data in
       Some prefix
 
   let reopen_prefix t ~generation =

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -263,6 +263,7 @@ module type S = sig
   val swap :
     t ->
     generation:int ->
+    mapping_size:int63 ->
     suffix_start_offset:int63 ->
     chunk_start_idx:int ->
     chunk_num:int ->
@@ -292,9 +293,7 @@ module type S = sig
   val create_one_commit_store :
     t ->
     Irmin.Backend.Conf.t ->
-    generation:int ->
-    latest_gc_target_offset:int63 ->
-    suffix_start_offset:int63 ->
+    Control_file.Payload.Upper.Latest.gced ->
     Index.key Pack_key.t ->
     (unit, [> open_rw_error | close_error ]) result
   (** [create_one_commit_store t conf generation new_store_root key] is called

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -282,9 +282,14 @@ module Make (Args : Gc_args.S) = struct
     match (status, gc_output) with
     | `Success, Ok gc_results ->
         Lwt.return
-          ( t.latest_gc_target_offset,
-            t.new_suffix_start_offset,
-            gc_results.mapping_size )
+          {
+            Control_file_intf.Payload.Upper.Latest.generation =
+              Fm.generation t.fm + 1;
+            latest_gc_target_offset = t.latest_gc_target_offset;
+            suffix_start_offset = t.new_suffix_start_offset;
+            suffix_dead_bytes = Int63.zero;
+            mapping_end_poff = Some gc_results.mapping_size;
+          }
     | _ ->
         let r = gc_errors status gc_output |> Errs.raise_if_error in
         Lwt.return r

--- a/src/irmin-pack/unix/gc.ml
+++ b/src/irmin-pack/unix/gc.ml
@@ -107,7 +107,8 @@ module Make (Args : Gc_args.S) = struct
       latest_gc_target_offset;
     }
 
-  let swap_and_purge t removable_chunk_num modified_volume suffix_params =
+  let swap_and_purge t (gc_results : Worker.gc_results) =
+    let removable_chunk_num = List.length gc_results.removable_chunk_idxs in
     let { generation; latest_gc_target_offset; _ } = t in
     let Worker.
           {
@@ -115,7 +116,7 @@ module Make (Args : Gc_args.S) = struct
             chunk_start_idx;
             dead_bytes = suffix_dead_bytes;
           } =
-      suffix_params
+      gc_results.suffix_params
     in
     (* Calculate chunk num in main process since more chunks could have been
        added while GC was running. GC process only tells us how many chunks are
@@ -126,8 +127,9 @@ module Make (Args : Gc_args.S) = struct
        is guaranteed by the GC process. *)
     assert (chunk_num >= 1);
 
-    Fm.swap t.fm ~generation ~suffix_start_offset ~chunk_start_idx ~chunk_num
-      ~suffix_dead_bytes ~latest_gc_target_offset ~volume:modified_volume
+    Fm.swap t.fm ~generation ~mapping_size:gc_results.mapping_size
+      ~suffix_start_offset ~chunk_start_idx ~chunk_num ~suffix_dead_bytes
+      ~latest_gc_target_offset ~volume:gc_results.modified_volume
 
   let unlink_all { root; generation; _ } removable_chunk_idxs =
     (* Unlink suffix chunks *)
@@ -231,33 +233,22 @@ module Make (Args : Gc_args.S) = struct
           let result =
             let open Result_syntax in
             match (status, gc_output) with
-            | ( `Success,
-                Ok
-                  {
-                    suffix_params;
-                    removable_chunk_idxs;
-                    stats = worker_stats;
-                    modified_volume;
-                  } ) ->
+            | `Success, Ok gc_results ->
                 let partial_stats =
                   Gc_stats.Main.finish_current_step partial_stats
                     "swap and purge"
                 in
-                let* () =
-                  swap_and_purge t
-                    (List.length removable_chunk_idxs)
-                    modified_volume suffix_params
-                in
+                let* () = swap_and_purge t gc_results in
                 let partial_stats =
                   Gc_stats.Main.finish_current_step partial_stats "unlink"
                 in
-                if t.unlink then unlink_all t removable_chunk_idxs;
+                if t.unlink then unlink_all t gc_results.removable_chunk_idxs;
 
                 let stats =
                   let after_suffix_end_offset =
                     Dispatcher.end_offset t.dispatcher
                   in
-                  Gc_stats.Main.finalise partial_stats worker_stats
+                  Gc_stats.Main.finalise partial_stats gc_results.stats
                     ~after_suffix_end_offset
                 in
                 Stats.report_latest_gc stats;
@@ -289,8 +280,11 @@ module Make (Args : Gc_args.S) = struct
     let* status = Async.await t.task in
     let gc_output = read_gc_output ~root:t.root ~generation:t.generation in
     match (status, gc_output) with
-    | `Success, Ok _ ->
-        Lwt.return (t.latest_gc_target_offset, t.new_suffix_start_offset)
+    | `Success, Ok gc_results ->
+        Lwt.return
+          ( t.latest_gc_target_offset,
+            t.new_suffix_start_offset,
+            gc_results.mapping_size )
     | _ ->
         let r = gc_errors status gc_output |> Errs.raise_if_error in
         Lwt.return r

--- a/src/irmin-pack/unix/gc.mli
+++ b/src/irmin-pack/unix/gc.mli
@@ -54,11 +54,10 @@ module Make (Args : Gc_args.S) : sig
 
   val cancel : t -> bool
 
-  val finalise_without_swap : t -> (int63 * int63) Lwt.t
+  val finalise_without_swap :
+    t -> Control_file_intf.Payload.Upper.Latest.gced Lwt.t
   (** Waits for the current gc to finish and returns immediately without
       swapping the files and doing the other finalisation steps from [finalise].
-
-      It returns the [latest_gc_target_offset] and the
-      [new_suffix_start_offset]. *)
+      Returns the [gced] status to create a fresh control file for the snapshot. *)
 end
 with module Args = Args

--- a/src/irmin-pack/unix/gc_worker.mli
+++ b/src/irmin-pack/unix/gc_worker.mli
@@ -40,6 +40,7 @@ module Make (Args : Gc_args.S) : sig
 
   type gc_results = {
     suffix_params : suffix_params;
+    mapping_size : int63;
     removable_chunk_idxs : int list;
     modified_volume : Lower.volume_identifier option;
     stats : Stats.Latest_gc.worker;

--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -118,14 +118,15 @@ module Make_volume (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
 
   let open_ = function
     | Empty _ -> Ok () (* Opening an empty volume is a no-op *)
-    | Nonempty ({ path = root; sparse; _ } as t) -> (
+    | Nonempty ({ path = root; sparse; control; _ } as t) -> (
         match sparse with
         | Some _ -> Ok () (* Sparse file is already open *)
         | None ->
             let open Result_syntax in
             let mapping = Layout.mapping ~root in
             let data = Layout.data ~root in
-            let+ sparse = Sparse.open_ro ~mapping ~data in
+            let mapping_size = Int63.to_int control.Payload.mapping_end_poff in
+            let+ sparse = Sparse.open_ro ~mapping_size ~mapping ~data in
             t.sparse <- Some sparse)
 
   let close = function

--- a/src/irmin-pack/unix/sparse_file_intf.ml
+++ b/src/irmin-pack/unix/sparse_file_intf.ml
@@ -23,9 +23,15 @@ module type S = sig
   type t
   type open_error := [ Io.open_error | `Corrupted_mapping_file of string ]
 
-  val open_ro : mapping:string -> data:string -> (t, [> open_error ]) result
-  (** [open_ro ~mapping ~data] returns a new read-only view of the sparse file,
-      represented on disk by two files named [mapping] and [data]. *)
+  val open_ro :
+    mapping_size:int ->
+    mapping:string ->
+    data:string ->
+    (t, [> open_error ]) result
+  (** [open_ro ~mapping_size ~mapping ~data] returns a new read-only view of the
+      sparse file, represented on disk by two files named [mapping] and [data].
+      The mapping file is expected to have size at least [mapping_size] (and the
+      rest is ignored if the file is larger). *)
 
   val close : t -> (unit, [> Io.close_error ]) result
   (** Close the underlying files. *)
@@ -60,9 +66,13 @@ module type S = sig
   module Wo : sig
     type t
 
-    val open_wo : mapping:string -> data:string -> (t, [> open_error ]) result
-    (** [open_wo ~mapping ~data] returns a write-only instance of the sparse
-        file.
+    val open_wo :
+      mapping_size:int ->
+      mapping:string ->
+      data:string ->
+      (t, [> open_error ]) result
+    (** [open_wo ~mapping_size ~mapping ~data] returns a write-only instance of
+        the sparse file.
 
         Note: This is unsafe and is only used by the GC to mark the parent
         commits as dangling. One must ensure that no read-only instance is

--- a/src/irmin-pack/unix/store.ml
+++ b/src/irmin-pack/unix/store.ml
@@ -357,16 +357,14 @@ module Maker (Config : Conf.S) = struct
             let () =
               if not launched then Errs.raise_error `Forbidden_during_gc
             in
-            let* latest_gc_target_offset, suffix_start_offset =
+            let* gced =
               match t.running_gc with
               | None -> assert false
               | Some { gc; _ } -> Gc.finalise_without_swap gc
             in
-            let generation = File_manager.generation t.fm + 1 in
             let config = Irmin.Backend.Conf.add t.config Conf.Key.root path in
             let () =
-              File_manager.create_one_commit_store t.fm config ~generation
-                ~latest_gc_target_offset ~suffix_start_offset commit_key
+              File_manager.create_one_commit_store t.fm config gced commit_key
               |> Errs.raise_if_error
             in
             let branch_path = Irmin_pack.Layout.V4.branch ~root:path in

--- a/test/irmin-pack/test_mapping.ml
+++ b/test/irmin-pack/test_mapping.ml
@@ -42,9 +42,12 @@ let process_on_disk pairs =
       let off = Int63.of_int off in
       Sparse_file.Ao.append_seq_exn sparse ~off str)
     (List.rev pairs);
+  let mapping_size = Int63.to_int (Sparse_file.Ao.mapping_size sparse) in
   Sparse_file.Ao.flush sparse |> Errs.raise_if_error;
   Sparse_file.Ao.close sparse |> Errs.raise_if_error;
-  let sparse = Sparse_file.open_ro ~mapping ~data |> Errs.raise_if_error in
+  let sparse =
+    Sparse_file.open_ro ~mapping_size ~mapping ~data |> Errs.raise_if_error
+  in
   let l = ref [] in
   let f ~off ~len = l := (Int63.to_int off, len) :: !l in
   Sparse_file.iter sparse f |> Errs.raise_if_error;


### PR DESCRIPTION
Since the mapping file is read-only, we can simulate the mmap in userland by lazily reading chunks on demand (and avoid the [file descriptor leak](https://github.com/mirage/irmin/pull/2196) from mmaped bigarrays..) There are a bunch of optimizations that we could try here, but I'm curious how the benchmarks are impacted by this change before going too deep into this rabbit hole :)

(also added the expected `mapping_size` in the control file as a consistency check to detect a partially written mapping, after a gc or a snapshot)