### PR TITLE
bench: update tree replay to support lower layer

### DIFF
--- a/bench/irmin-pack/trace_replay_intf.ml
+++ b/bench/irmin-pack/trace_replay_intf.ml
@@ -33,6 +33,7 @@ module Config = struct
     gc_every : int;
     gc_distance_in_the_past : int;
     gc_wait_after : int;
+    add_volume_every : int;
   }
   (** Replay configuration
 
@@ -102,6 +103,7 @@ module type Store = sig
     root:string -> store_config -> (Repo.t * on_commit * on_end) Lwt.t
 
   val split : repo -> unit
+  val add_volume : repo -> unit
   val gc_wait : repo -> unit Lwt.t
 
   type stats := Irmin_pack_unix.Stats.Latest_gc.stats

--- a/test/irmin-bench/replay.ml
+++ b/test/irmin-bench/replay.ml
@@ -95,6 +95,7 @@ let replay_1_commit () =
       gc_every = 0;
       gc_distance_in_the_past = 0;
       gc_wait_after = 0;
+      add_volume_every = 0;
     }
   in
   let+ summary = Replay.run () replay_config in
@@ -141,6 +142,7 @@ module Store_mem = struct
     Lwt.return (repo, on_commit, on_end)
 
   let split _repo = ()
+  let add_volume _repo = ()
   let gc_wait _repo = Lwt.return_unit
   let gc_run ?finished:_ _repo _key = Lwt.return_unit
 end
@@ -164,6 +166,7 @@ let replay_1_commit_mem () =
       gc_every = 0;
       gc_distance_in_the_past = 0;
       gc_wait_after = 0;
+      add_volume_every = 0;
     }
   in
   let+ summary = Replay_mem.run () replay_config in


### PR DESCRIPTION
This PR updates the `bench/irmin-pack/tree.ml` and related files to support a lower layer and adding volumes during replay.

One flag is added to the tree exec, `add-volume-every`. It defaults to 0. Setting it to a number greater than 0 will create a lower layer and add a new volume every N GCs.