### PR TITLE
irmin-pack: remove append-only external flush callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
 - **irmin-mirage-git**
   - Lower bound for `mirage-kv` is now `6.0.0` (#2256, @metanivek)
 
+- **irmin-pack**
+  - Removed `dict_auto_flush_threshold` and `suffix_auto_flush_threshold` configuration. (#2235, @art-w)
+
 ### Fixed
 
 - **irmin-cli**

--- a/examples/irmin-pack/gc.ml
+++ b/examples/irmin-pack/gc.ml
@@ -60,12 +60,6 @@ module Repo_config = struct
   (** Must use minimal indexing strategy to use GC *)
   let indexing_strategy = Irmin_pack.Indexing_strategy.minimal
 
-  (** Buffer size that triggers auto flushing to disk *)
-  let dict_auto_flush_threshold = 1_000_000
-
-  (** Buffer size that triggers auto flushing to disk *)
-  let suffix_auto_flush_threshold = 1_000_000
-
   (** Location on disk to save the repository
 
       Note: irmin-pack will not create the entire path, only the final directory *)
@@ -81,7 +75,7 @@ module Repo_config = struct
   (** Create config for our repository *)
   let config =
     Irmin_pack.config ~fresh ~index_log_size ~merge_throttle ~indexing_strategy
-      ~dict_auto_flush_threshold ~suffix_auto_flush_threshold root
+      root
 
   (** We can add an optional lower layer to our repository. Data discarded by
       the GC will be stored there and still be accessible instead of being
@@ -91,7 +85,7 @@ module Repo_config = struct
   (** Create a copy of the previous configuration, now with a lower layer *)
   let config_with_lower =
     Irmin_pack.config ~fresh ~index_log_size ~merge_throttle ~indexing_strategy
-      ~dict_auto_flush_threshold ~suffix_auto_flush_threshold ~lower_root root
+      ~lower_root root
 end
 
 (** Utility for creating commit info *)

--- a/examples/irmin-pack/kv.ml
+++ b/examples/irmin-pack/kv.ml
@@ -50,12 +50,6 @@ module Repo_config = struct
   (** Must use minimal indexing strategy to use GC *)
   let indexing_strategy = Irmin_pack.Indexing_strategy.minimal
 
-  (** Buffer size that triggers auto flushing to disk *)
-  let dict_auto_flush_threshold = 1_000_000
-
-  (** Buffer size that triggers auto flushing to disk *)
-  let suffix_auto_flush_threshold = 1_000_000
-
   (** Location on disk to save the repository
 
       Note: irmin-pack will not create the entire path, only the final directory *)
@@ -71,7 +65,7 @@ module Repo_config = struct
   (** Create config for our repository *)
   let config =
     Irmin_pack.config ~fresh ~index_log_size ~merge_throttle ~indexing_strategy
-      ~dict_auto_flush_threshold ~suffix_auto_flush_threshold root
+      root
 end
 
 module StoreMaker = Irmin_pack_unix.KV (Conf)

--- a/src/irmin-pack-tools/tezos_explorer/files.ml
+++ b/src/irmin-pack-tools/tezos_explorer/files.ml
@@ -130,22 +130,4 @@ module Make (Conf : Irmin_pack.Conf.S) (Schema : Irmin.Schema.Extended) = struct
           traverse next_off
     in
     traverse Int63.zero
-
-  let rec traverse_dict dict size buffer off acc =
-    if off < size then (
-      File_manager.Dict.read_exn dict buffer ~off ~len:4;
-      let len = Int32.to_int @@ Bytes.get_int32_be buffer 0 in
-      let off = Int63.(add off (of_int 4)) in
-      File_manager.Dict.read_exn dict buffer ~off ~len;
-      let str = Bytes.sub_string buffer 0 len in
-      let acc = str :: acc in
-      let off = Int63.(add off (of_int len)) in
-      traverse_dict dict size buffer off acc)
-    else acc
-
-  let load_dict (dict : File_manager.Dict.t) buffer =
-    let max_offset = File_manager.Dict.end_poff dict in
-    let off = Int63.zero in
-    let dict = traverse_dict dict max_offset buffer off [] in
-    List.rev dict
 end

--- a/src/irmin-pack-tools/tezos_explorer/show.ml
+++ b/src/irmin-pack-tools/tezos_explorer/show.ml
@@ -26,7 +26,7 @@ type context = {
   idxs : idxs list;
   fm : Files.File_manager.t;
   dispatcher : Files.Dispatcher.t;
-  dict : string list;
+  dict : Files.File_manager.Dict.t;
   max_entry : int;
   max_offset : Int63.t;
   history : history Ring.t;
@@ -546,7 +546,7 @@ let show_inode c (inode : Files.Inode.compress) =
   let name (n : Files.Inode.Compress.name) =
     match n with
     | Indirect dict_key ->
-        let key = List.nth_opt c.dict dict_key in
+        let key = Files.File_manager.Dict.find c.dict dict_key in
         strf
           ~attr:A.(fg lightwhite ++ st bold)
           "Indirect key: \'%a\' (%#d)" (Fmt.option Fmt.string) key dict_key
@@ -860,7 +860,6 @@ let main store_path info_last_path info_next_path index_path =
   let dispatcher = Files.Dispatcher.v fm |> Files.Errs.raise_if_error in
   let max_offset = Files.Dispatcher.end_offset dispatcher in
   let dict = Files.File_manager.dict fm in
-  let dict = Files.load_dict dict buffer in
   let info_last_fd =
     Unix.openfile info_last_path Unix.[ O_RDONLY; O_CLOEXEC ] 0o644
   in

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -36,8 +36,6 @@ module Default = struct
   let merge_throttle = `Block_writes
   let indexing_strategy = Indexing_strategy.default
   let use_fsync = false
-  let dict_auto_flush_threshold = 1_000_000
-  let suffix_auto_flush_threshold = 1_000_000
   let no_migrate = false
   let lower_root = None
 end
@@ -99,16 +97,6 @@ module Key = struct
       ~doc:"Whether fsync should be used to ensure persistence order of files"
       "use-fsync" Irmin.Type.bool Default.use_fsync
 
-  let dict_auto_flush_threshold =
-    key ~spec ~doc:"Buffer size of the dict at which automatic flushes occur"
-      "dict-auto-flush-threshold" Irmin.Type.int
-      Default.dict_auto_flush_threshold
-
-  let suffix_auto_flush_threshold =
-    key ~spec ~doc:"Buffer size of the suffix at which automatic flushes occur"
-      "suffix-auto-flush-threshold" Irmin.Type.int
-      Default.suffix_auto_flush_threshold
-
   let no_migrate =
     key ~spec ~doc:"Prevent migration of V1 and V2 stores" "no-migrate"
       Irmin.Type.bool Default.no_migrate
@@ -132,11 +120,6 @@ let root config =
 let lower_root config = get config Key.lower_root
 let indexing_strategy config = get config Key.indexing_strategy
 let use_fsync config = get config Key.use_fsync
-let dict_auto_flush_threshold config = get config Key.dict_auto_flush_threshold
-
-let suffix_auto_flush_threshold config =
-  get config Key.suffix_auto_flush_threshold
-
 let no_migrate config = get config Key.no_migrate
 
 let init ?(fresh = Default.fresh) ?(readonly = Default.readonly)
@@ -144,10 +127,8 @@ let init ?(fresh = Default.fresh) ?(readonly = Default.readonly)
     ?(index_log_size = Default.index_log_size)
     ?(merge_throttle = Default.merge_throttle)
     ?(indexing_strategy = Default.indexing_strategy)
-    ?(use_fsync = Default.use_fsync)
-    ?(dict_auto_flush_threshold = Default.dict_auto_flush_threshold)
-    ?(suffix_auto_flush_threshold = Default.suffix_auto_flush_threshold)
-    ?(no_migrate = Default.no_migrate) ?(lower_root = Default.lower_root) root =
+    ?(use_fsync = Default.use_fsync) ?(no_migrate = Default.no_migrate)
+    ?(lower_root = Default.lower_root) root =
   let config = empty spec in
   let config = add config Key.root root in
   let config = add config Key.lower_root lower_root in
@@ -159,11 +140,5 @@ let init ?(fresh = Default.fresh) ?(readonly = Default.readonly)
   let config = add config Key.merge_throttle merge_throttle in
   let config = add config Key.indexing_strategy indexing_strategy in
   let config = add config Key.use_fsync use_fsync in
-  let config =
-    add config Key.dict_auto_flush_threshold dict_auto_flush_threshold
-  in
-  let config =
-    add config Key.suffix_auto_flush_threshold suffix_auto_flush_threshold
-  in
   let config = add config Key.no_migrate no_migrate in
   verify config

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -79,8 +79,6 @@ module Key : sig
   val merge_throttle : merge_throttle Irmin.Backend.Conf.key
   val indexing_strategy : Indexing_strategy.t Irmin.Backend.Conf.key
   val use_fsync : bool Irmin.Backend.Conf.key
-  val dict_auto_flush_threshold : int Irmin.Backend.Conf.key
-  val suffix_auto_flush_threshold : int Irmin.Backend.Conf.key
   val no_migrate : bool Irmin.Backend.Conf.key
 end
 
@@ -127,14 +125,6 @@ val use_fsync : Irmin.Backend.Conf.t -> bool
 (** Flag to indicate that fsync should be used to enforce durability when
     flushing data to disk. Default [false]. *)
 
-val dict_auto_flush_threshold : Irmin.Backend.Conf.t -> int
-(** Size, in bytes, when automatic flushing of dict file to disk. Default
-    [1_000_000]. *)
-
-val suffix_auto_flush_threshold : Irmin.Backend.Conf.t -> int
-(** Size, in bytes, when automatic flushing of suffix file to disk. Default
-    [1_000_000]. *)
-
 val no_migrate : Irmin.Backend.Conf.t -> bool
 (** Flag to prevent migration of data. Default [false]. *)
 
@@ -147,8 +137,6 @@ val init :
   ?merge_throttle:merge_throttle ->
   ?indexing_strategy:Indexing_strategy.t ->
   ?use_fsync:bool ->
-  ?dict_auto_flush_threshold:int ->
-  ?suffix_auto_flush_threshold:int ->
   ?no_migrate:bool ->
   ?lower_root:string option ->
   string ->

--- a/src/irmin-pack/irmin_pack_intf.ml
+++ b/src/irmin-pack/irmin_pack_intf.ml
@@ -78,8 +78,6 @@ module type Sigs = sig
     ?merge_throttle:Conf.merge_throttle ->
     ?indexing_strategy:Indexing_strategy.t ->
     ?use_fsync:bool ->
-    ?dict_auto_flush_threshold:int ->
-    ?suffix_auto_flush_threshold:int ->
     ?no_migrate:bool ->
     ?lower_root:string option ->
     string ->

--- a/src/irmin-pack/unix/append_only_file_intf.ml
+++ b/src/irmin-pack/unix/append_only_file_intf.ml
@@ -30,29 +30,14 @@ module type S = sig
 
   type t
 
-  type auto_flush_procedure = [ `Internal | `External of t -> unit ]
-  (** [auto_flush_procedure] defines behavior when the flush threshold is
-      reached.
-
-      - Use [`Internal] to have the buffer automatically flushed.
-      - Use [`External f] to have [f] called when the flush threshold is
-        reached. It is the responsibility of [f] to call flush, in addition to
-        any other processing it does. *)
-
   val create_rw :
-    path:string ->
-    overwrite:bool ->
-    auto_flush_threshold:int ->
-    auto_flush_procedure:auto_flush_procedure ->
-    (t, [> Io.create_error ]) result
+    path:string -> overwrite:bool -> (t, [> Io.create_error ]) result
   (** Create a rw instance of [t] by creating the file at [path]. *)
 
   val open_rw :
     path:string ->
     end_poff:int63 ->
     dead_header_size:int ->
-    auto_flush_threshold:int ->
-    auto_flush_procedure:auto_flush_procedure ->
     ( t,
       [> Io.open_error
       | `Closed
@@ -79,16 +64,7 @@ module type S = sig
       The actual persisted size of a file is [end_poff + dead_header_size].
 
       This concept exists in order to keep supporting [`V1] and [`V2] pack
-      stores with [`V3].
-
-      {3 Auto Flushes}
-
-      One of the goals of the [Append_only_file] abstraction is to provide
-      buffered appends. [auto_flush_threshold] is the soft cap after which the
-      buffer should be flushed. When a call to [append_exn] fills the buffer,
-      either the buffer will be flushed automatically, if
-      [auto_flush_procedure = `Internal], or the supplied external function [f]
-      will be called, if [auto_flush_procedure = `External f]. *)
+      stores with [`V3]. *)
 
   val open_ro :
     path:string ->
@@ -179,7 +155,6 @@ module type S = sig
       Always returns [Error `Rw_not_allowed]. *)
 
   val readonly : t -> bool
-  val auto_flush_threshold : t -> int option
   val empty_buffer : t -> bool
   val path : t -> string
 end

--- a/src/irmin-pack/unix/chunked_suffix_intf.ml
+++ b/src/irmin-pack/unix/chunked_suffix_intf.ml
@@ -50,8 +50,6 @@ module type S = sig
     root:string ->
     start_idx:int ->
     overwrite:bool ->
-    auto_flush_threshold:int ->
-    auto_flush_procedure:Ao.auto_flush_procedure ->
     (t, [> create_error ]) result
 
   val open_rw :
@@ -60,8 +58,6 @@ module type S = sig
     start_idx:int ->
     chunk_num:int ->
     dead_header_size:int ->
-    auto_flush_threshold:int ->
-    auto_flush_procedure:Ao.auto_flush_procedure ->
     (t, [> open_error ]) result
 
   val open_ro :
@@ -72,12 +68,7 @@ module type S = sig
     chunk_num:int ->
     (t, [> open_error ]) result
 
-  val add_chunk :
-    auto_flush_threshold:int ->
-    auto_flush_procedure:Ao.auto_flush_procedure ->
-    t ->
-    (unit, [> add_new_error ]) result
-
+  val add_chunk : t -> (unit, [> add_new_error ]) result
   val start_idx : t -> int
   val chunk_num : t -> int
   val close : t -> (unit, [> Io.close_error | `Pending_flush ]) result
@@ -119,7 +110,6 @@ module type S = sig
 
   val append_exn : t -> string -> unit
   val readonly : t -> bool
-  val auto_flush_threshold : t -> int option
 
   val fold_chunks :
     (acc:'a ->

--- a/src/irmin-pack/unix/dict_intf.ml
+++ b/src/irmin-pack/unix/dict_intf.ml
@@ -14,19 +14,43 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open! Import
+
 module type S = sig
-  module Fm : File_manager.S
+  module Io : Io.S
 
   type t
 
   val find : t -> int -> string option
   val index : t -> string -> int option
-  val v : Fm.t -> (t, [> Fm.Io.read_error ]) result
-  val close : t -> unit
+
+  val create_rw :
+    overwrite:bool -> path:string -> (t, [> Io.create_error ]) result
+
+  val open_rw :
+    size:int63 ->
+    dead_header_size:int ->
+    string ->
+    (t, [> Io.open_error | Io.read_error | `Inconsistent_store ]) result
+
+  val open_ro :
+    size:int63 ->
+    dead_header_size:int ->
+    string ->
+    (t, [> Io.open_error | Io.read_error | `Inconsistent_store ]) result
+
+  val refresh_end_poff :
+    t -> int63 -> (unit, [> Io.read_error | `Rw_not_allowed ]) result
+
+  val empty_buffer : t -> bool
+  val end_poff : t -> int63
+  val close : t -> (unit, [> Io.close_error | `Pending_flush ]) result
+  val fsync : t -> (unit, [> Io.write_error ]) result
+  val flush : t -> (unit, [> Io.write_error ]) result
 end
 
 module type Sigs = sig
   module type S = S
 
-  module Make (Fm : File_manager.S) : S with module Fm = Fm
+  module Make (Io : Io.S) : S with module Io = Io
 end

--- a/src/irmin-pack/unix/file_manager.ml
+++ b/src/irmin-pack/unix/file_manager.ml
@@ -28,8 +28,9 @@ struct
   module Io = Errs.Io
   module Index = Index
   module Errs = Io_errors.Make (Io)
+  module Ao = Append_only_file.Make (Io) (Errs)
   module Control = Control_file.Upper (Io)
-  module Dict = Append_only_file.Make (Io) (Errs)
+  module Dict = Dict.Make (Io)
   module Suffix = Chunked_suffix.Make (Io) (Errs)
   module Sparse = Sparse_file.Make (Io)
   module Lower = Lower.Make (Io) (Errs)
@@ -370,6 +371,7 @@ struct
       }
     in
     instance := Some t;
+    register_dict_consumer t ~after_reload:(fun () -> Dict.refill dict);
     Ok t
 
   let create_control_file ~overwrite config pl =
@@ -630,7 +632,9 @@ struct
       | T15 ->
           Error `V3_store_from_the_future
     in
-    let make_dict = Dict.open_rw ~end_poff:dict_end_poff ~dead_header_size in
+    let make_dict ~path =
+      Dict.open_rw ~size:dict_end_poff ~dead_header_size path
+    in
     let make_suffix () =
       Suffix.open_rw ~root ~appendable_chunk_poff ~start_idx ~chunk_num
         ~dead_header_size
@@ -775,8 +779,8 @@ struct
       open_prefix ~root ~generation ~mapping_size:(mapping_size status)
     in
     let* dict =
-      let path = Layout.dict ~root in
-      Dict.open_ro ~path ~end_poff:dict_end_poff ~dead_header_size
+      let filename = Layout.dict ~root in
+      Dict.open_ro ~size:dict_end_poff ~dead_header_size filename
     in
     let* index =
       let log_size = Conf.index_log_size config in

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -60,7 +60,7 @@ module type S = sig
 
   module Io : Io.S
   module Control : Control_file.Upper with module Io = Io
-  module Dict : Append_only_file.S with module Io = Io
+  module Dict : Dict.S with module Io = Io
   module Suffix : Chunked_suffix.S with module Io = Io
   module Index : Pack_index.S
   module Errs : Io_errors.S with module Io = Io

--- a/src/irmin-pack/unix/file_manager_intf.ml
+++ b/src/irmin-pack/unix/file_manager_intf.ml
@@ -237,9 +237,6 @@ module type S = sig
 
       Is a no-op if the control file did not change. *)
 
-  val register_dict_consumer :
-    t -> after_reload:(unit -> (unit, Errs.t) result) -> unit
-
   val register_prefix_consumer :
     t -> after_reload:(unit -> (unit, Errs.t) result) -> unit
 

--- a/src/irmin-pack/unix/gc_args.ml
+++ b/src/irmin-pack/unix/gc_args.ml
@@ -19,7 +19,6 @@ open! Import
 module type S = sig
   module Fm : File_manager.S with module Io = Io.Unix
   module Async : Async.S
-  module Dict : Dict.S with module Fm = Fm
   module Errs : Io_errors.S with module Io = Fm.Io
   module Dispatcher : Dispatcher.S with module Fm = Fm
 
@@ -51,7 +50,7 @@ module type S = sig
     val v :
       config:Irmin.Backend.Conf.t ->
       fm:Fm.t ->
-      dict:Dict.t ->
+      dict:Fm.Dict.t ->
       dispatcher:Dispatcher.t ->
       lru:Lru.t ->
       read t
@@ -78,7 +77,7 @@ module type S = sig
       with type value = Commit_value.t
        and type key = key
        and type file_manager = Fm.t
-       and type dict = Dict.t
+       and type dict = Fm.Dict.t
        and type dispatcher = Dispatcher.t
        and type hash = hash
 end

--- a/src/irmin-pack/unix/gc_worker.ml
+++ b/src/irmin-pack/unix/gc_worker.ml
@@ -23,7 +23,8 @@ module Make (Args : Gc_args.S) = struct
   open Args
   module Io = Fm.Io
   module Lower = Fm.Lower
-  module Sparse = Dispatcher.Fm.Sparse
+  module Dict = Fm.Dict
+  module Sparse = Fm.Sparse
   module Ao = Append_only_file.Make (Fm.Io) (Errs)
 
   let string_of_key = Irmin.Type.to_string key_t
@@ -228,7 +229,7 @@ module Make (Args : Gc_args.S) = struct
     Errors.finalise_exn (fun _outcome ->
         Fm.close fm |> Errs.log_if_error "GC: Close File_manager")
     @@ fun () ->
-    let dict = Dict.v fm |> Errs.raise_if_error in
+    let dict = Fm.dict fm in
     let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
     let lru = Lru.create config in
     let node_store = Node_store.v ~config ~fm ~dict ~dispatcher ~lru in

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -33,7 +33,6 @@ end)
 
 module Make_without_close_checks
     (Fm : File_manager.S)
-    (Dict : Dict.S)
     (Dispatcher : Dispatcher.S with module Fm = Fm)
     (Hash : Irmin.Hash.S with type t = Fm.Index.key)
     (Val : Pack_value.Persistent
@@ -43,6 +42,7 @@ module Make_without_close_checks
 struct
   module Tbl = Table (Hash)
   module Control = Fm.Control
+  module Dict = Fm.Dict
   module Suffix = Fm.Suffix
   module Index = Fm.Index
   module Key = Pack_key.Make (Hash)
@@ -510,7 +510,6 @@ end
 
 module Make
     (Fm : File_manager.S)
-    (Dict : Dict.S)
     (Dispatcher : Dispatcher.S with module Fm = Fm)
     (Hash : Irmin.Hash.S with type t = Fm.Index.key)
     (Val : Pack_value.Persistent
@@ -518,9 +517,7 @@ module Make
               and type key := Hash.t Pack_key.t)
     (Errs : Io_errors.S with module Io = Fm.Io) =
 struct
-  module Inner =
-    Make_without_close_checks (Fm) (Dict) (Dispatcher) (Hash) (Val) (Errs)
-
+  module Inner = Make_without_close_checks (Fm) (Dispatcher) (Hash) (Val) (Errs)
   include Inner
   include Indexable.Closeable (Inner)
 

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -470,8 +470,6 @@ struct
       let dict = Dict.index t.dict in
       let off = Dispatcher.end_offset t.dispatcher in
 
-      (* [encode_bin] will most likely call [append] several time. One of these
-         call may trigger an auto flush. *)
       let append = Suffix.append_exn (Fm.suffix t.fm) in
       Val.encode_bin ~offset_of_key ~dict hash v append;
 

--- a/src/irmin-pack/unix/pack_store_intf.ml
+++ b/src/irmin-pack/unix/pack_store_intf.ml
@@ -91,7 +91,6 @@ module type Sigs = sig
 
   module Make
       (Fm : File_manager.S)
-      (Dict : Dict.S with module Fm = Fm)
       (Dispatcher : Dispatcher.S with module Fm = Fm)
       (Hash : Irmin.Hash.S with type t = Fm.Index.key)
       (Val : Pack_value.Persistent
@@ -104,5 +103,5 @@ module type Sigs = sig
        and type value = Val.t
        and type file_manager = Fm.t
        and type dispatcher = Dispatcher.t
-       and type dict = Dict.t
+       and type dict = Fm.Dict.t
 end

--- a/src/irmin-pack/unix/sparse_file.ml
+++ b/src/irmin-pack/unix/sparse_file.ml
@@ -234,10 +234,7 @@ module Make (Io : Io.S) = struct
 
     let create ~mapping ~data =
       let open Result_syntax in
-      let ao_create path =
-        Ao.create_rw ~path ~overwrite:false ~auto_flush_threshold:1_000_000
-          ~auto_flush_procedure:`Internal
-      in
+      let ao_create path = Ao.create_rw ~path ~overwrite:false in
       let* mapping = ao_create mapping in
       let+ data = ao_create data in
       { mapping; data; end_off = Int63.zero }
@@ -246,7 +243,6 @@ module Make (Io : Io.S) = struct
       let open Result_syntax in
       let ao_open ~end_poff path =
         Ao.open_rw ~path ~end_poff ~dead_header_size:0
-          ~auto_flush_threshold:1_000_000 ~auto_flush_procedure:`Internal
       in
       let* ao_mapping = ao_open ~end_poff:mapping_size mapping in
       let* end_off, end_poff =

--- a/test/irmin-pack/test_flush_reload.ml
+++ b/test/irmin-pack/test_flush_reload.ml
@@ -84,8 +84,10 @@ let reload_ro t current_phase =
       let () =
         match current_phase with
         | S1_before_flush -> ()
-        | S2_after_flush_dict -> write1_dict model
-        | S3_after_flush_suffix -> write1_suffix model
+        | S2_after_flush_dict -> ()
+        | S3_after_flush_suffix ->
+            write1_dict model;
+            write1_suffix model
         | S4_after_flush -> write1_index model
       in
       Store.reload repo

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -59,18 +59,16 @@ struct
   module Io = Irmin_pack_unix.Io.Unix
   module Errs = Irmin_pack_unix.Io_errors.Make (Io)
   module File_manager = Irmin_pack_unix.File_manager.Make (Io) (Index) (Errs)
-  module Dict = Irmin_pack_unix.Dict.Make (File_manager)
+  module Dict = File_manager.Dict
   module Dispatcher = Irmin_pack_unix.Dispatcher.Make (File_manager)
 
   module Pack =
-    Irmin_pack_unix.Pack_store.Make (File_manager) (Dict) (Dispatcher)
-      (Schema.Hash)
+    Irmin_pack_unix.Pack_store.Make (File_manager) (Dispatcher) (Schema.Hash)
       (Inter.Raw)
       (Errs)
 
   module Pack_mock =
-    Irmin_pack_unix.Pack_store.Make (File_manager) (Dict) (Dispatcher)
-      (Schema.Hash)
+    Irmin_pack_unix.Pack_store.Make (File_manager) (Dispatcher) (Schema.Hash)
       (Inter_mock.Raw)
       (Errs)
 
@@ -86,8 +84,7 @@ struct
       (Schema.Contents)
 
   module Contents_store =
-    Irmin_pack_unix.Pack_store.Make (File_manager) (Dict) (Dispatcher)
-      (Schema.Hash)
+    Irmin_pack_unix.Pack_store.Make (File_manager) (Dispatcher) (Schema.Hash)
       (Contents_value)
       (Errs)
 
@@ -142,7 +139,7 @@ struct
       rm_dir root;
       let config = config ~indexing_strategy ~readonly:false ~fresh:true root in
       let fm = get_fm config in
-      let dict = Dict.v fm |> Errs.raise_if_error in
+      let dict = File_manager.dict fm in
       let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
       let lru = Irmin_pack_unix.Lru.create config in
       let store = Inode.v ~config ~fm ~dict ~dispatcher ~lru in


### PR DESCRIPTION
I was trying to simplify the logic to update the control file in the file manager. The `Append_only_file` was using an external callback to signify the need to flush when its buffer was full, which would in turn update the control file (to make that portion of the file visible)... but then we could end up with a visible partially written commit, which isn't an issue in itself, but isn't how we think about the control file payload. As the flush threshold was fairly high, I don't think this "partial flush" was really stress tested either (?)

Anyway it's gone, as it should be fine to just write to the append-only files when their memory buffer is full, we only need to update the control file at the end to publish the writes.

While testing I discovered that I broke the `Dict` flushing its `end_poff` to the control file, so I refactored that a bit to match with the chunks/sparse file abstractions (inverting the `File_manager` dependency). A few breaking changes here:
- Previously the dict updates would become visible "in the middle" of the store flushing, now it's at the same time as the rest (... this should be fine since dict updates are only useful to interpret that rest)
- Removed the dict consumers callback, as it looked unused (?)