### PR TITLE
irmin-pack: fix v2 lower migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- **irmin-pack**
+  - Fix issue when migrating v2 stores to use lower layer (@metanivek, #2241)
+
 ## 3.7.0 (2023-04-26)
 
 ### Added

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -210,6 +210,28 @@ module Store_tc = struct
     | Gced { generation; _ } -> generation
     | _ -> Alcotest.fail "expected gced status"
 
+  (* Reads all objects from the repo by iterating its index and folding its commit trees. *)
+  let read_everything repo =
+    let fm = Store.Internal.file_manager repo in
+    let index = Store.Internal.File_manager.index fm in
+    let commits = ref [] in
+    let () =
+      Store.Internal.Index.iter
+        (fun hash (_offset, _len, kind) ->
+          match kind with
+          | Irmin_pack.Pack_value.Kind.Commit_v2 -> commits := hash :: !commits
+          | _ -> ())
+        index
+    in
+    Lwt_list.map_s
+      (fun hash ->
+        [%log.debug "read %a" Irmin.Type.(pp Store.Hash.t) hash];
+        let* commit = Store.Commit.of_hash repo hash in
+        match commit with
+        | None -> Alcotest.fail "failed to read commit"
+        | Some commit -> Store.Tree.fold (Store.Commit.tree commit) ())
+      !commits
+
   let test_create () =
     let* repo = init () in
     (* A newly created store with a lower should have an empty volume. *)
@@ -307,6 +329,21 @@ module Store_tc = struct
     let previous_tree = Store.Commit.tree @@ Option.get parent in
     let* a_opt = Store.Tree.find previous_tree [ "a" ] in
     Alcotest.(check (option string)) "upper to lower" (Some "a") a_opt;
+
+  (* Tests that dead header is handled appropriately *)
+  let test_migrate_v2 () =
+    let ( / ) = Filename.concat in
+    let root_archive =
+      "test" / "irmin-pack" / "data" / "version_2_to_3_always"
+    in
+    let root = "_build" / "test_lower_migrate_v2" in
+    setup_test_env ~root_archive ~root_local_build:root;
+    let lower_root = root / "lower" in
+    (* Open store and trigger migration. This should succeed. *)
+    let* repo = Store.Repo.v (config ~fresh:false ~lower_root root) in
+    let* _ = read_everything repo in
+    Store.Repo.close repo
+
     Store.Repo.close repo
 
   let test_migrate_then_gc () =
@@ -444,6 +481,7 @@ module Store = struct
         quick_tc "control file updated after add" test_add_volume_reopen;
         quick_tc "add volume and reopen" test_add_volume_reopen;
         quick_tc "create without lower then migrate" test_migrate;
+        quick_tc "migrate v2" test_migrate_v2;
         quick_tc "migrate then gc" test_migrate_then_gc;
         quick_tc "test data locality" test_volume_data_locality;
         quick_tc "test cleanup" test_cleanup;


### PR DESCRIPTION
Previously we did not take the dead header of the dict into account when performing a lower layer migration for older stores. This commit fixes this issue by removing the dead header from the dict during the migration.

I also added some tests for v3 stores and updated migration tests to ensuring reading contents after a migration works. These tests all passed anyway, but thought it didn't hurt for completeness against potential future changes.