### PR TITLE
irmin-cli: change --store irf to --store fs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- **irmin-cli**
+  - Changed `--store irf` to `--store fs` to align the CLI
+    with what is published on the Irmin website.
+
 ### Fixed
 
 - **irmin-pack**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 - **irmin-cli**
-  - Changed `--store irf` to `--store fs` to align the CLI
-    with what is published on the Irmin website.
+  - Changed `--store irf` to `--store fs` to align the CLI with what is
+    published on the Irmin website (@wyn, #2243)
 
 ### Fixed
 

--- a/src/irmin-cli/resolver.ml
+++ b/src/irmin-cli/resolver.ml
@@ -297,7 +297,7 @@ module Store = struct
     v spec (module S)
 
   let mem = create Irmin_mem.Conf.spec (module Irmin_mem)
-  let irf = create Irmin_fs.Conf.spec (module Irmin_fs_unix)
+  let fs = create Irmin_fs.Conf.spec (module Irmin_fs_unix)
 
   let http = function
     | T { impl = Generic_keyed _; _ } ->
@@ -341,7 +341,7 @@ module Store = struct
       [
         ("git", Fixed_hash git);
         ("git-mem", Fixed_hash git_mem);
-        ("irf", Variable_hash irf);
+        ("fs", Variable_hash fs);
         ("mem", Variable_hash mem);
         ("mem-http", Variable_hash (fun h c -> http (mem h c)));
         ("git-http", Fixed_hash (fun c -> http (git c)));
@@ -678,7 +678,7 @@ let infer_remote hash contents branch headers str =
     let r =
       if Sys.file_exists (str / ".git") then Store.git contents
       else if Sys.file_exists (str / "store.dict") then Store.pack hash contents
-      else Store.irf hash contents
+      else Store.fs hash contents
     in
     match r with
     | Store.T { impl; spec; _ } ->

--- a/src/irmin-cli/resolver.mli
+++ b/src/irmin-cli/resolver.mli
@@ -86,7 +86,7 @@ module Store : sig
     t
 
   val mem : hash -> contents -> t
-  val irf : hash -> contents -> t
+  val fs : hash -> contents -> t
   val http : t -> t
   val git : contents -> t
   val pack : hash -> contents -> t

--- a/test/irmin-cli/test_command_line.t
+++ b/test/irmin-cli/test_command_line.t
@@ -26,7 +26,7 @@ Check for foo in ./test1
   bar
 
 Try getting foo from ./test1 using the wrong store type
-  $ irmin get --root ./test1 -s irf foo
+  $ irmin get --root ./test1 -s fs foo
   <none>
   [1]
 
@@ -85,8 +85,8 @@ Check that g/h/i has been deleted after merge
   [1]
 
 Check mismatched hash function
-  $ irmin set --root ./test-hash -s irf -h sha1 abc 123
-  $ irmin snapshot --root ./test-hash -s irf -h blake2b 2> /dev/null
+  $ irmin set --root ./test-hash -s fs -h sha1 abc 123
+  $ irmin snapshot --root ./test-hash -s fs -h blake2b 2> /dev/null
   [1]
 
 Clone a local repo


### PR DESCRIPTION
The information in the Irmin website uses "fs" where-as the irmin-cli Resolver uses "irf". Changed command line and module sig to use fs and also updated cram tests.

**NOTE previous use of "irf" will now error, I wasn't sure whether backwards compatibility was expected?**

As an example, looking at the cli `--help` segment:

before
```
       -s VAL, --store=VAL
           The storage backend (one of git, git-mem, irf, mem, mem-http,
           git-http, pack or tezos). Default is `git'.
```
after
```
       -s VAL, --store=VAL
           The storage backend (one of git, git-mem, fs, mem, mem-http,
           git-http, pack or tezos). Default is `git'.
```