### PR TITLE
irmin-pack.unix: Expose dispatcher in the `Internal` module.

### DIFF
--- a/src/irmin-pack/unix/store.ml
+++ b/src/irmin-pack/unix/store.ml
@@ -752,6 +752,10 @@ module Maker (Config : Conf.S) = struct
 
       let dict (repo : X.Repo.t) = repo.dict
 
+      module Dispatcher = Dispatcher
+
+      let dispatcher (repo : X.Repo.t) = repo.dispatcher
+
       module XKey = XKey
 
       let suffix_commit_mem repo key =

--- a/src/irmin-pack/unix/store_intf.ml
+++ b/src/irmin-pack/unix/store_intf.ml
@@ -311,6 +311,10 @@ module type S = sig
 
     val dict : repo -> Dict.t
 
+    module Dispatcher : Dispatcher.S
+
+    val dispatcher : repo -> Dispatcher.t
+
     module XKey : Pack_key.S with type hash = Schema.Hash.t
 
     val suffix_commit_mem : repo -> XKey.t -> bool


### PR DESCRIPTION
This is useful for traversing the store with external tooling.

Exposing this migh reduce the number of functors that need to be manually created in tools such as the [tezos-explorer](https://github.com/mirage/irmin/tree/main/src/irmin-pack-tools). cc @clecat