### PR TITLE
irmin: raise exception on duplicate Conf key name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,17 @@
 ## Unreleased
 
+### Added
+
+- **irmin**
+  - Change behavior of `Irmin.Conf.key` to disallow duplicate key names by
+    default. Add `allow_duplicate` optional argument to override. (@metanivek,
+    #2252)
+
+### Fixed
+
 - **irmin-cli**
   - Changed `--store irf` to `--store fs` to align the CLI with what is
     published on the Irmin website (@wyn, #2243)
-
-### Fixed
 
 - **irmin-pack**
   - Fix issue when migrating v2 stores to use lower layer (@metanivek, #2241)

--- a/src/irmin/conf.ml
+++ b/src/irmin/conf.ml
@@ -115,17 +115,17 @@ let singleton spec k v = (spec, M.singleton (K k) (k.to_univ v))
 let is_empty (_, t) = M.is_empty t
 let mem (_, d) k = M.mem (K k) d
 
+let validate_key spec k =
+  match Spec.find_key spec k.name with
+  | None -> Fmt.invalid_arg "invalid config key: %s" k.name
+  | Some _ -> ()
+
 let add (spec, d) k v =
-  if Spec.find_key spec k.name |> Option.is_none then
-    Fmt.invalid_arg "invalid config key: %s" k.name
-  else (spec, M.add (K k) (k.to_univ v) d)
+  validate_key spec k;
+  (spec, M.add (K k) (k.to_univ v) d)
 
 let verify (spec, d) =
-  M.iter
-    (fun (K k) _ ->
-      if Spec.find_key spec k.name |> Option.is_none then
-        Fmt.invalid_arg "invalid config key: %s" k.name)
-    d;
+  M.iter (fun (K k) _ -> validate_key spec k) d;
   (spec, d)
 
 let union (rs, r) (ss, s) =

--- a/src/irmin/conf.mli
+++ b/src/irmin/conf.mli
@@ -59,6 +59,7 @@ val key :
   ?docs:string ->
   ?docv:string ->
   ?doc:string ->
+  ?allow_duplicate:bool ->
   spec:Spec.t ->
   string ->
   'a Type.t ->
@@ -78,9 +79,9 @@ val key :
     @raise Invalid_argument
       if the key name is not made of a sequence of ASCII lowercase letter,
       digit, dash or underscore.
-
-      {b Warning.} No two keys should share the same [name] as this may lead to
-      difficulties in the UI. *)
+    @raise Invalid_argument
+      if [allow_duplicate] is [false] (the default) and [name] has already been
+      used to create a key *)
 
 val name : 'a key -> string
 (** The key name. *)

--- a/test/irmin/test_conf.ml
+++ b/test/irmin/test_conf.ml
@@ -43,4 +43,16 @@ let test_conf () =
   let () = Alcotest.(check (list string)) "Key list" [ "x"; "y" ] keys in
   ()
 
-let suite = [ Alcotest_lwt.test_case_sync "conf" `Quick test_conf ]
+let test_duplicate_key_names () =
+  let spec = Spec.v "test" in
+  let name = "name" in
+  let _ = key ~spec name Irmin.Type.char 'Z' in
+  Alcotest.check_raises "Duplicate key" (Invalid_argument "duplicate key: name")
+    (fun () -> ignore (key ~spec name Irmin.Type.bool false))
+
+let suite =
+  [
+    Alcotest_lwt.test_case_sync "conf" `Quick test_conf;
+    Alcotest_lwt.test_case_sync "duplicate key names" `Quick
+      test_duplicate_key_names;
+  ]


### PR DESCRIPTION
This bit me while working on the memory-bounded LRU (no, I obviously did not copy-pasta an existing key 🫣).

I don't think there is a valid use case for calling `key` twice with the same name but different types, and it can result in annoying to debug runtime behavior since it will silently return the default value for the overwritten key.