### PR TITLE
irmin-pack: unify LRUs and add max memory config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
     default. Add `allow_duplicate` optional argument to override. (@metanivek,
     #2252)
     
+- **irmin-pack**
+  - Add maximum memory as an alternative configuration option, `lru_max_memory`,
+    for setting LRU capacity. (@metanivek, #2254)
+
 ### Changed
 
 - **irmin**
@@ -19,7 +23,6 @@
     published on the Irmin website (@wyn, #2243)
 
 ## 3.7.1 (2023-05-24)
-
 
 ### Fixed
 

--- a/src/irmin-pack/conf.ml
+++ b/src/irmin-pack/conf.ml
@@ -30,6 +30,7 @@ end
 module Default = struct
   let fresh = false
   let lru_size = 100_000
+  let lru_max_memory = None
   let index_log_size = 2_500_000
   let readonly = false
   let merge_throttle = `Block_writes
@@ -53,8 +54,14 @@ module Key = struct
       Default.fresh
 
   let lru_size =
-    key ~spec ~doc:"Size of the LRU cache for pack entries." "lru-size"
+    key ~spec ~doc:"Maximum size of the LRU cache for pack entries." "lru-size"
       Irmin.Type.int Default.lru_size
+
+  let lru_max_memory =
+    key ~spec ~doc:"Maximum memory in bytes of the LRU cache for pack entries."
+      "lru-max-memory"
+      Irmin.Type.(option int)
+      Default.lru_max_memory
 
   let index_log_size =
     key ~spec ~doc:"Size of index logs." "index-log-size" Irmin.Type.int
@@ -109,6 +116,7 @@ end
 
 let fresh config = get config Key.fresh
 let lru_size config = get config Key.lru_size
+let lru_max_memory config = get config Key.lru_max_memory
 let readonly config = get config Key.readonly
 let index_log_size config = get config Key.index_log_size
 let merge_throttle config = get config Key.merge_throttle
@@ -132,7 +140,8 @@ let suffix_auto_flush_threshold config =
 let no_migrate config = get config Key.no_migrate
 
 let init ?(fresh = Default.fresh) ?(readonly = Default.readonly)
-    ?(lru_size = Default.lru_size) ?(index_log_size = Default.index_log_size)
+    ?(lru_size = Default.lru_size) ?(lru_max_memory = Default.lru_max_memory)
+    ?(index_log_size = Default.index_log_size)
     ?(merge_throttle = Default.merge_throttle)
     ?(indexing_strategy = Default.indexing_strategy)
     ?(use_fsync = Default.use_fsync)
@@ -144,6 +153,7 @@ let init ?(fresh = Default.fresh) ?(readonly = Default.readonly)
   let config = add config Key.lower_root lower_root in
   let config = add config Key.fresh fresh in
   let config = add config Key.lru_size lru_size in
+  let config = add config Key.lru_max_memory lru_max_memory in
   let config = add config Key.index_log_size index_log_size in
   let config = add config Key.readonly readonly in
   let config = add config Key.merge_throttle merge_throttle in

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -71,6 +71,7 @@ type merge_throttle = [ `Block_writes | `Overcommit_memory ] [@@deriving irmin]
 module Key : sig
   val fresh : bool Irmin.Backend.Conf.key
   val lru_size : int Irmin.Backend.Conf.key
+  val lru_max_memory : int option Irmin.Backend.Conf.key
   val index_log_size : int Irmin.Backend.Conf.key
   val readonly : bool Irmin.Backend.Conf.key
   val root : string Irmin.Backend.Conf.key
@@ -88,7 +89,12 @@ val fresh : Irmin.Backend.Conf.t -> bool
     setting this to [true] will delete existing data. Default is [false]. *)
 
 val lru_size : Irmin.Backend.Conf.t -> int
-(** Size, in number of entries, of LRU cache. Default [100_000]. *)
+(** Maximum size, in number of entries, of LRU cache. Default [100_000]. Unused
+    if {!lru_max_memory} is set. *)
+
+val lru_max_memory : Irmin.Backend.Conf.t -> int option
+(** Maximum memory, in bytes, for the LRU cache to use. Default [None], which
+    falls back to {!lru_size} for LRU limit. *)
 
 val index_log_size : Irmin.Backend.Conf.t -> int
 (** Size, in number of entries, of index log. Default [2_500_000]. *)
@@ -136,6 +142,7 @@ val init :
   ?fresh:bool ->
   ?readonly:bool ->
   ?lru_size:int ->
+  ?lru_max_memory:int option ->
   ?index_log_size:int ->
   ?merge_throttle:merge_throttle ->
   ?indexing_strategy:Indexing_strategy.t ->

--- a/src/irmin-pack/import.ml
+++ b/src/irmin-pack/import.ml
@@ -27,3 +27,17 @@ module Int63 = struct
 end
 
 type int63 = Int63.t [@@deriving irmin]
+
+module Mem = struct
+  let bytes_per_word = Sys.word_size / 8
+
+  let reachable_bytes o =
+    Obj.repr o |> Obj.reachable_words |> Int.mul bytes_per_word
+
+  let repr_size : type a. a Repr.t -> a -> int =
+   fun ty ->
+    match Irmin.Type.Size.of_value ty with
+    | Unknown -> Fun.const max_int
+    | Dynamic f -> fun v -> f v
+    | Static n -> Fun.const n
+end

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1776,7 +1776,10 @@ struct
     type key = Key.t
     type t = T.key Bin.t [@@deriving irmin]
     type metadata = T.metadata [@@deriving irmin]
+    type Pack_value.kinded += Node of t
 
+    let to_kinded t = Node t
+    let of_kinded = function Node n -> n | _ -> assert false
     let depth = Bin.depth
 
     exception Invalid_depth of { expected : int; got : int; v : t }

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1789,7 +1789,18 @@ struct
       if t.root then Pack_value.Kind.Inode_v2_root
       else Pack_value.Kind.Inode_v2_nonroot
 
-    let weight _ = 1
+    let repr_size = Mem.repr_size t
+
+    (** [repr_size] undercounts the size of an inode by around this factor.
+
+        A value of 4.5 was empirically observed by averaging the ratio between
+        [Mem.reachable_bytes] and [repr_size] during a few runs of a trace
+        replay. This value is rounded to 5 to prevent float-int conversion
+        during weight calculation, at the expense of letting fewer objects into
+        the LRU. *)
+    let repr_size_adjustment = 5
+
+    let weight t = repr_size_adjustment * repr_size t
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string
     let step_of_bin = T.step_of_bin_string

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -1800,7 +1800,9 @@ struct
         the LRU. *)
     let repr_size_adjustment = 5
 
-    let weight t = repr_size_adjustment * repr_size t
+    let weight t =
+      Pack_value.Deferred (fun () -> repr_size_adjustment * repr_size t)
+
     let hash t = Bin.hash t
     let step_to_bin = T.step_to_bin_string
     let step_of_bin = T.step_of_bin_string

--- a/src/irmin-pack/irmin_pack_intf.ml
+++ b/src/irmin-pack/irmin_pack_intf.ml
@@ -73,6 +73,7 @@ module type Sigs = sig
     ?fresh:bool ->
     ?readonly:bool ->
     ?lru_size:int ->
+    ?lru_max_memory:int option ->
     ?index_log_size:int ->
     ?merge_throttle:Conf.merge_throttle ->
     ?indexing_strategy:Indexing_strategy.t ->

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -139,7 +139,10 @@ struct
 
   let decode_bin_length = get_dynamic_sizer_exn value
   let kind _ = kind
-  let weight = Mem.repr_size t
+
+  let weight =
+    let size = Mem.repr_size t in
+    fun v -> Immediate (size v)
 end
 
 module Of_commit
@@ -160,7 +163,10 @@ struct
   let of_kinded = function Commit c -> c | _ -> assert false
   let hash = Hash.hash
   let kind _ = Kind.Commit_v2
-  let weight = Mem.repr_size t
+
+  let weight =
+    let size = Mem.repr_size t in
+    fun v -> Deferred (fun () -> size v)
 
   (* A commit implementation that uses integer offsets for addresses where possible. *)
   module Commit_direct = struct

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -119,7 +119,10 @@ struct
   type t = Data.t [@@deriving irmin ~size_of]
   type key = Key.t
   type hash = Hash.t
+  type kinded += Contents of t
 
+  let to_kinded t = Contents t
+  let of_kinded = function Contents c -> c | _ -> assert false
   let hash = Hash.hash
   let kind = Kind.Contents
   let length_header = Fun.const Conf.contents_length_header
@@ -162,7 +165,10 @@ struct
   type t = Commit.t [@@deriving irmin]
   type key = Key.t
   type hash = Hash.t [@@deriving irmin ~encode_bin ~decode_bin]
+  type kinded += Commit of t
 
+  let to_kinded t = Commit t
+  let of_kinded = function Commit c -> c | _ -> assert false
   let hash = Hash.hash
   let kind _ = Kind.Commit_v2
   let weight _ = 1

--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -139,18 +139,7 @@ struct
 
   let decode_bin_length = get_dynamic_sizer_exn value
   let kind _ = kind
-
-  let weight =
-    (* Normalise the weight of the blob, assuming that the 'average'
-       size for a blob is 1k bytes. *)
-    let normalise n = max 1 (n / 1_000) in
-    match Irmin.Type.Size.of_value t with
-    | Unknown ->
-        (* this should not happen unless the user has specified a very
-           weird content type. *)
-        Fun.const max_int
-    | Dynamic f -> fun v -> normalise (f v)
-    | Static n -> Fun.const (normalise n)
+  let weight = Mem.repr_size t
 end
 
 module Of_commit
@@ -171,7 +160,7 @@ struct
   let of_kinded = function Commit c -> c | _ -> assert false
   let hash = Hash.hash
   let kind _ = Kind.Commit_v2
-  let weight _ = 1
+  let weight = Mem.repr_size t
 
   (* A commit implementation that uses integer offsets for addresses where possible. *)
   module Commit_direct = struct

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -17,6 +17,7 @@
 open! Import
 
 type length_header = [ `Varint ] option
+type weight = Immediate of int | Deferred of (unit -> int)
 type kinded = ..
 
 module type S = sig
@@ -33,7 +34,7 @@ module type S = sig
   (** Describes the length header formats for the {i data} sections of pack
       entries. *)
 
-  val weight : t -> int
+  val weight : t -> weight
   (** [weight t] is the [t]'s LRU weight. *)
 
   val encode_bin :
@@ -93,6 +94,8 @@ module type Sigs = sig
     (** Raises an exception on [Contents], as the availability of a length
         header is user defined. *)
   end
+
+  type nonrec weight = weight = Immediate of int | Deferred of (unit -> int)
 
   type nonrec kinded = kinded = ..
   (** [kinded] is an extenisble variant that each {!S} extends so that it can

--- a/src/irmin-pack/pack_value_intf.ml
+++ b/src/irmin-pack/pack_value_intf.ml
@@ -17,6 +17,7 @@
 open! Import
 
 type length_header = [ `Varint ] option
+type kinded = ..
 
 module type S = sig
   include Irmin.Type.S
@@ -48,6 +49,15 @@ module type S = sig
     t Irmin.Type.decode_bin
 
   val decode_bin_length : string -> int -> int
+
+  val to_kinded : t -> kinded
+  (** [to_kinded t] returns a {!kinded} version of [t]. *)
+
+  val of_kinded : kinded -> t
+  (** [of_kinded k] is the inverse of [to_kinded t].
+
+      It is expected that an implementation only works for [k] that is returned
+      from [to_kinded t] and will raise an exception otherwise. *)
 end
 
 module type T = sig
@@ -83,6 +93,13 @@ module type Sigs = sig
     (** Raises an exception on [Contents], as the availability of a length
         header is user defined. *)
   end
+
+  type nonrec kinded = kinded = ..
+  (** [kinded] is an extenisble variant that each {!S} extends so that it can
+      define {!S.to_kinded} and {!S.of_kinded}. Its purpose is to allow
+      containers, such as {!Irmin_pack_unix.Lru}, to store and return all types
+      of {!S} and thus be usable by modules defined over {!S}, such as
+      {!Irmin_pack_unix.Pack_store}. *)
 
   module type S = S with type kind := Kind.t
   module type Config = Config

--- a/src/irmin-pack/unix/gc_args.ml
+++ b/src/irmin-pack/unix/gc_args.ml
@@ -53,6 +53,7 @@ module type S = sig
       fm:Fm.t ->
       dict:Dict.t ->
       dispatcher:Dispatcher.t ->
+      lru:Lru.t ->
       read t
 
     val unsafe_find :

--- a/src/irmin-pack/unix/gc_worker.ml
+++ b/src/irmin-pack/unix/gc_worker.ml
@@ -230,8 +230,9 @@ module Make (Args : Gc_args.S) = struct
     @@ fun () ->
     let dict = Dict.v fm |> Errs.raise_if_error in
     let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
-    let node_store = Node_store.v ~config ~fm ~dict ~dispatcher in
-    let commit_store = Commit_store.v ~config ~fm ~dict ~dispatcher in
+    let lru = Lru.create config in
+    let node_store = Node_store.v ~config ~fm ~dict ~dispatcher ~lru in
+    let commit_store = Commit_store.v ~config ~fm ~dict ~dispatcher ~lru in
 
     (* Step 2. Load commit which will make [commit_key] [Direct] if it's not
        already the case. *)

--- a/src/irmin-pack/unix/inode_intf.ml
+++ b/src/irmin-pack/unix/inode_intf.ml
@@ -29,6 +29,7 @@ module type Persistent = sig
     fm:file_manager ->
     dict:dict ->
     dispatcher:dispatcher ->
+    lru:Lru.t ->
     read t
 
   include Irmin_pack.Checkable with type 'a t := 'a t and type hash := hash

--- a/src/irmin-pack/unix/irmin_pack_unix.ml
+++ b/src/irmin-pack/unix/irmin_pack_unix.ml
@@ -60,3 +60,4 @@ module Sparse_file = Sparse_file
 module File_manager = File_manager
 module Lower = Lower
 module Utils = Utils
+module Lru = Lru

--- a/src/irmin-pack/unix/irmin_pack_unix.mli
+++ b/src/irmin-pack/unix/irmin_pack_unix.mli
@@ -65,3 +65,4 @@ module Sparse_file = Sparse_file
 module File_manager = File_manager
 module Lower = Lower
 module Utils = Utils
+module Lru = Lru

--- a/src/irmin-pack/unix/lru.ml
+++ b/src/irmin-pack/unix/lru.ml
@@ -24,14 +24,50 @@ end)
 
 type key = int63
 type value = Irmin_pack.Pack_value.kinded
-type t = value Internal.t
+type weighted_value = { v : value; weight : int }
+
+type t = {
+  lru : weighted_value Internal.t;
+  weight_limit : int option;
+  mutable total_weight : int;
+}
 
 let create config =
-  let lru_size = Irmin_pack.Conf.lru_size config in
-  Internal.create lru_size
+  let lru_max_memory = Irmin_pack.Conf.lru_max_memory config in
+  let lru_size, weight_limit =
+    match lru_max_memory with
+    | None -> (Irmin_pack.Conf.lru_size config, None)
+    | Some b -> (-42, Some b)
+  in
+  let lru = Internal.create lru_size in
+  { lru; weight_limit; total_weight = 0 }
 
-let add = Internal.add
-let find = Internal.find
-let mem = Internal.mem
-let clear = Internal.clear
-let iter = Internal.iter
+let lru_enabled t = match t.weight_limit with None -> true | Some x -> x > 0
+
+let add t k w v =
+  if lru_enabled t = false then ()
+  else
+    let add t k v w =
+      let n = { v; weight = w } in
+      t.total_weight <- t.total_weight + w;
+      Internal.add t.lru k n
+    in
+    match t.weight_limit with
+    | None -> add t k v 0
+    | Some limit ->
+        add t k v (w ());
+        while t.total_weight > limit do
+          match Internal.drop t.lru with
+          | None -> t.total_weight <- 0
+          | Some n -> t.total_weight <- t.total_weight - n.weight
+        done
+
+let v v = v.v
+let find { lru; _ } k = Internal.find lru k |> v
+let mem { lru; _ } k = Internal.mem lru k
+
+let clear t =
+  Internal.clear t.lru;
+  t.total_weight <- 0
+
+let iter { lru; _ } f = Internal.iter lru (fun k wv -> f k (v wv))

--- a/src/irmin-pack/unix/lru.ml
+++ b/src/irmin-pack/unix/lru.ml
@@ -28,7 +28,7 @@ type t = value Internal.t
 
 let create config =
   let lru_size = Irmin_pack.Conf.lru_size config in
-  Internal.create ?weight:None lru_size
+  Internal.create lru_size
 
 let add = Internal.add
 let find = Internal.find

--- a/src/irmin-pack/unix/lru.ml
+++ b/src/irmin-pack/unix/lru.ml
@@ -1,0 +1,37 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Import
+
+module Internal = Irmin.Backend.Lru.Make (struct
+  include Int63
+
+  let hash = Hashtbl.hash
+end)
+
+type key = int63
+type value = Irmin_pack.Pack_value.kinded
+type t = value Internal.t
+
+let create config =
+  let lru_size = Irmin_pack.Conf.lru_size config in
+  Internal.create ?weight:None lru_size
+
+let add = Internal.add
+let find = Internal.find
+let mem = Internal.mem
+let clear = Internal.clear
+let iter = Internal.iter

--- a/src/irmin-pack/unix/lru.mli
+++ b/src/irmin-pack/unix/lru.mli
@@ -1,0 +1,28 @@
+(*
+ * Copyright (c) 2023 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Import
+
+type t
+type key = int63
+type value = Irmin_pack.Pack_value.kinded
+
+val create : Irmin.Backend.Conf.t -> t
+val add : t -> int63 -> value -> unit
+val find : t -> key -> value
+val mem : t -> key -> bool
+val clear : t -> unit
+val iter : t -> (key -> value -> unit) -> unit

--- a/src/irmin-pack/unix/lru.mli
+++ b/src/irmin-pack/unix/lru.mli
@@ -26,8 +26,12 @@ type value = Irmin_pack.Pack_value.kinded
 
 val create : Irmin.Backend.Conf.t -> t
 
-val add : t -> int63 -> (unit -> int) -> value -> unit
-(** [add t key weight value] maps [value] with [weight] to [key] in [t]. *)
+val add : t -> int63 -> Irmin_pack.Pack_value.weight -> value -> unit
+(** [add t key weight value] maps [value] with [weight] to [key] in [t].
+
+    Note: {!Irmin_pack.Pack_value.Immediate} weights will be checked to see if
+    they exceed an entry weight limit. The current hard-coded entry weight limit
+    is 20kB. *)
 
 val find : t -> key -> value
 val mem : t -> key -> bool

--- a/src/irmin-pack/unix/lru.mli
+++ b/src/irmin-pack/unix/lru.mli
@@ -17,11 +17,18 @@
 open Import
 
 type t
+(** An LRU that support memory-bound capacity via configuration key
+    [lru_max_memory]. Falls back to entry-based capacity via [lru_size]
+    configuration key, if max memory is not configured. *)
+
 type key = int63
 type value = Irmin_pack.Pack_value.kinded
 
 val create : Irmin.Backend.Conf.t -> t
-val add : t -> int63 -> value -> unit
+
+val add : t -> int63 -> (unit -> int) -> value -> unit
+(** [add t key weight value] maps [value] with [weight] to [key] in [t]. *)
+
 val find : t -> key -> value
 val mem : t -> key -> bool
 val clear : t -> unit

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -50,7 +50,7 @@ struct
   module Lru = struct
     include Lru
 
-    let add t k v = Val.to_kinded v |> add t k (fun () -> Val.weight v)
+    let add t k v = Val.to_kinded v |> add t k (Val.weight v)
     let find t k = find t k |> Val.of_kinded
   end
 

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -50,7 +50,7 @@ struct
   module Lru = struct
     include Lru
 
-    let add t k v = Val.to_kinded v |> add t k
+    let add t k v = Val.to_kinded v |> add t k (fun () -> Val.weight v)
     let find t k = find t k |> Val.of_kinded
   end
 

--- a/src/irmin-pack/unix/pack_store_intf.ml
+++ b/src/irmin-pack/unix/pack_store_intf.ml
@@ -33,6 +33,7 @@ module type S = sig
     fm:file_manager ->
     dict:dict ->
     dispatcher:dispatcher ->
+    lru:Lru.t ->
     read t
 
   val cast : read t -> read_write t

--- a/src/irmin/lru.ml
+++ b/src/irmin/lru.ml
@@ -80,24 +80,23 @@ module Make (H : Hashtbl.HashedType) = struct
     q : (key * 'a) Q.t;
     mutable cap : int;
     mutable w : int;
-    weight : 'a -> int;
   }
 
-  let create ?(weight = function _ -> 1) cap =
-    { cap; w = 0; ht = HT.create cap; q = Q.create (); weight }
+  let weight t = t.w
+  let create cap = { cap; w = 0; ht = HT.create cap; q = Q.create () }
 
   let drop_lru t =
     match t.q.first with
     | None -> ()
-    | Some ({ Q.value = k, v; _ } as n) ->
-        t.w <- t.w - t.weight v;
+    | Some ({ Q.value = k, _; _ } as n) ->
+        t.w <- t.w - 1;
         HT.remove t.ht k;
         Q.detach t.q n
 
   let remove t k =
     try
       let n = HT.find t.ht k in
-      t.w <- t.w - t.weight (snd n.value);
+      t.w <- t.w - 1;
       HT.remove t.ht k;
       Q.detach t.q n
     with Not_found -> ()
@@ -107,16 +106,10 @@ module Make (H : Hashtbl.HashedType) = struct
     else (
       remove t k;
       let n = Q.node (k, v) in
-      let w = t.weight v in
-      if w > t.cap then
-        (* if [v] is bigger than the LRU capacity, just skip it *) ()
-      else (
-        t.w <- t.w + w;
-        while t.w > t.cap do
-          drop_lru t
-        done;
-        HT.add t.ht k n;
-        Q.append t.q n))
+      t.w <- t.w + 1;
+      if weight t > t.cap then drop_lru t;
+      HT.add t.ht k n;
+      Q.append t.q n)
 
   let promote t k =
     try

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -24,4 +24,5 @@ module Make (H : Hashtbl.HashedType) : sig
   val mem : 'a t -> H.t -> bool
   val clear : 'a t -> unit
   val iter : 'a t -> (H.t -> 'a -> unit) -> unit
+  val drop : 'a t -> 'a option
 end

--- a/src/irmin/lru.mli
+++ b/src/irmin/lru.mli
@@ -18,7 +18,7 @@
 module Make (H : Hashtbl.HashedType) : sig
   type 'a t
 
-  val create : ?weight:('a -> int) -> int -> 'a t
+  val create : int -> 'a t
   val add : 'a t -> H.t -> 'a -> unit
   val find : 'a t -> H.t -> 'a
   val mem : 'a t -> H.t -> bool

--- a/test/irmin-pack/common.ml
+++ b/test/irmin-pack/common.ml
@@ -63,7 +63,7 @@ module Contents = struct
 
   let hash = H.hash
   let magic = 'B'
-  let weight _ = 1
+  let weight _ = Irmin_pack.Pack_value.Immediate 1
   let encode_triple = Irmin.Type.(unstage (encode_bin (triple H.t char t)))
   let decode_triple = Irmin.Type.(unstage (decode_bin (triple H.t char t)))
   let length_header = Fun.const (Some `Varint)

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -144,8 +144,11 @@ struct
       let fm = get_fm config in
       let dict = Dict.v fm |> Errs.raise_if_error in
       let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
-      let store = Inode.v ~config ~fm ~dict ~dispatcher in
-      let store_contents = Contents_store.v ~config ~fm ~dict ~dispatcher in
+      let lru = Irmin_pack_unix.Lru.create config in
+      let store = Inode.v ~config ~fm ~dict ~dispatcher ~lru in
+      let store_contents =
+        Contents_store.v ~config ~fm ~dict ~dispatcher ~lru
+      in
       let+ foo, bar =
         Contents_store.batch store_contents (fun writer ->
             let* foo = Contents_store.add writer Contents.foo in

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -75,14 +75,4 @@ let test_map =
     QCheck.(list arbitrary_action)
     (fun t -> eq (run t) (run' t))
 
-let test_weight =
-  QCheck.Test.make ~name:"Weights" ~count:10_000
-    QCheck.(list arbitrary_action)
-    (fun t ->
-      let cap = 5 in
-      let tbl = run_aux (fun () -> M.create ~weight:(fun k -> k) cap) apply t in
-      let elts = M.bindings tbl in
-      let w = List.fold_left (fun acc (_, v) -> acc + v) 0 elts in
-      w <= cap)
-
-let suite = List.map QCheck_alcotest.to_alcotest [ test_map; test_weight ]
+let suite = List.map QCheck_alcotest.to_alcotest [ test_map ]


### PR DESCRIPTION
At a high-level, this PR:
1. Unifies the previous 3 LRUs in `irmin-pack` into one
2. Adds a configuration option to bound the LRU by memory used instead of entry count
3. Maintains previous cap of "large" contents objects for both entry-based cap and memory-based cap

When deciding how to count the memory usage of objects in the LRU, two paths were evaluated: using `Obj.reachable_words` or using `repr`'s size function. The former was too slow in replay benchmarks, so that latter is used. The size is used as-is for commits and contents, and a correction factor, based on benchmark observations, is applied to inode sizes.

The definition of "large" for contents objects is 20kB. This seems like a reasonable value based on [previous analysis of object size](https://github.com/tarides/tezos-hangzhou-analysis/blob/34e300b94e1dbf01ab3f04e7667bbef604ae21e4//tree_of_cycle_445.ipynb) which indicated that less than 0.1% of contents objects are larger than 512B. Note: the [previous weight based limit](https://github.com/mirage/irmin/pull/2050) would allow any object < ~500kB into the LRU (based on Octez's default configuration of 5000 entry cap), but lowering the cap allows more objects into the cache.

Conclusions based on benchmarks (to be pushed to the benchmarks repo once I finish tidying the analysis and running a final bench):

1. Entry-based cap still slightly out-performs the memory-cap. My assumption is that it is the overhead of memory usage calculation for inodes.
2. Both entry-based and memory-based can out perform 3.7.1 with only slightly more memory used.
3. Past a certain size increase, the LRU starts hurting performance of the benchmark. More could be investigated here in the future. I did not use `cachecache`'s LRU for this, but with some modifications to its code, it may provide better scaling. I ran its [benchmarks](https://github.com/pascutto/cachecache/blob/36efb3cfb66198c6aaf155334db42220f264d97a/bench/main.ml) against the modified `irmin` LRU in this PR, and it does seem to scale better.

~~The final benchmark I want to run is an 80mb, but here is some high-level analysis.~~

Snippet of benchmark stats:
```
 |                          |   3.7.1   |   entry-15k    |   entry-30k    |   40mb-optim   |   80mb-optim
 | --                       | --        | --             | --             | --             | --
 | -- main metrics --       |           |                |                |                | 
 | CPU time elapsed         |   104m07s |    99m13s  95% |    97m38s  94% |   100m07s  96% |    98m20s  94%
 | Wall time elapsed        |   104m28s |    99m33s  95% |    97m56s  94% |   100m25s  96% |    98m38s  94%
 | TZ-transactions per sec  |   736.349 |   772.810 105% |   785.217 107% |   765.767 104% |   779.649 106%
 | TZ-operations per sec    |  4809.664 |  5047.817 105% |  5128.860 107% |  5001.817 104% |  5092.489 106%
 | Context.add per sec      | 14121.692 | 14820.934 105% | 15058.886 107% | 14685.872 104% | 14952.096 106%
 | tail latency (1)         |   0.224 s |   0.222 s  99% |   0.244 s 109% |   0.245 s 109% |   0.240 s 107%
 |                          |           |                |                |                | 
 | -- resource usage --     |           |                |                |                | 
 | disk IO (total)          |           |                |                |                | 
 |   IOPS (op/sec)          |   180_572 |   142_980  79% |   119_928  66% |   145_343  80% |   122_530  68%
 |   throughput (bytes/sec) |  18.060 M |  16.541 M  92% |  15.280 M  85% |  16.609 M  92% |  15.378 M  85%
 |   total (bytes)          | 112.826 G |  98.463 G  87% |  89.517 G  79% |  99.772 G  88% |  90.737 G  80%
 | disk IO (read)           |           |                |                |                | 
 |   IOPS (op/sec)          |   180_475 |   142_878  79% |   119_825  66% |   145_242  80% |   122_427  68%
 |   throughput (bytes/sec) |  10.639 M |   8.753 M  82% |   7.367 M  69% |   8.891 M  84% |   7.521 M  71%
 |   total (bytes)          |  66.466 G |  52.103 G  78% |  43.157 G  65% |  53.412 G  80% |  44.376 G  67%
 | disk IO (write)          |           |                |                |                | 
 |   IOPS (op/sec)          |        97 |       102 105% |       103 107% |       101 104% |       103 106%
 |   throughput (bytes/sec) |   7.421 M |   7.788 M 105% |   7.913 M 107% |   7.717 M 104% |   7.857 M 106%
 |   total (bytes)          |  46.360 G |  46.360 G 100% |  46.360 G 100% |  46.360 G 100% |  46.360 G 100%
 |                          |           |                |                |                | 
 | max memory usage (bytes) |   0.394 G |   0.401 G 102% |   0.428 G 108% |   0.416 G 106% |   0.469 G 119%
 | mean CPU usage           |      100% |      100%      |      100%      |      100%      |      100%     

```

Here is memory usage comparisons. You can see:
1. `entry-100k` and `500mb` regress in performance (not shown is `entry-60k` but it also regresses in perf)
2. `entry-30k` has the best performance (but 80mb is almost the same in perf and memory)
3. `entry-15k` has almost equivalent memory usage as `3.7.1` but better performance

![mem-used](https://github.com/mirage/irmin/assets/87719817/9171652d-d6ad-4610-8281-b897769771f8)

