### PR TITLE
irmin-pack: fix snapshot export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- **irmin-pack**
+  - Fix snapshot export when using lower layer (#2257, @metanivek)
+
 ## 3.7.1 
 
 ### Fixed

--- a/src/irmin-pack/unix/gc.mli
+++ b/src/irmin-pack/unix/gc.mli
@@ -26,7 +26,7 @@ module Make (Args : Gc_args.S) : sig
   val v :
     root:string ->
     lower_root:string option ->
-    new_files_path:string ->
+    output:[ `External of string | `Root ] ->
     generation:int ->
     unlink:bool ->
     dispatcher:Args.Dispatcher.t ->

--- a/test/irmin-pack/test_gc.ml
+++ b/test/irmin-pack/test_gc.ml
@@ -1470,10 +1470,32 @@ module Snapshot = struct
     let* () = check_2 t c2 in
     S.Repo.close t.repo
 
+  (* Test creating a snapshot in an archive store for a commit that is before
+     the last gc target commit (ie it is in the lower) *)
+  let snapshot_gced_commit () =
+    let lower_root = create_lower_root ~mkdir:false () in
+    let* t = init ~lower_root:(Some lower_root) () in
+    let* t, c1 = commit_1 t in
+    let* t = checkout_exn t c1 in
+    let* t, c2 = commit_2 t in
+    let* () = start_gc t c2 in
+    let* () = finalise_gc t in
+    let root_snap = Filename.concat t.root "snap" in
+    let* () = export t c1 root_snap in
+    let* () = S.Repo.close t.repo in
+    [%log.debug "open store from snapshot"];
+    let* t = init ~readonly:false ~fresh:false ~root:root_snap () in
+    let* t = checkout_exn t c1 in
+    let* t, c2 = commit_2 t in
+    let* () = check_1 t c1 in
+    let* () = check_2 t c2 in
+    S.Repo.close t.repo
+
   let tests =
     [
       tc "Import/export in rw" snapshot_rw;
       tc "Import in ro" snapshot_import_in_ro;
       tc "Export in ro" snapshot_export_in_ro;
+      tc "Snapshot gced commit" snapshot_gced_commit;
     ]
 end


### PR DESCRIPTION
GC-based snapshot export did not work if called with a commit that is older than the latest GC commit.