### PR TITLE
Upgrade to ocamlformat 0.26.0

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Upgrade to OCamlformat 0.26.0
+faab08a7dd9c275111cae51651a78fd62ac3e031

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.24.1
+version = 0.26.0
 profile = conventional
 
 ocaml-version = 4.08.0

--- a/src/irmin-chunk/irmin_chunk.ml
+++ b/src/irmin-chunk/irmin_chunk.ml
@@ -192,8 +192,8 @@ struct
     in
     let chunking = Conf.get config Conf.Key.chunking in
     (if max_children <= 1 then
-     let min = Chunk.size_of_index_header + (H.hash_size * 2) in
-     err_too_small ~min chunk_size);
+       let min = Chunk.size_of_index_header + (H.hash_size * 2) in
+       err_too_small ~min chunk_size);
     [%log.debug
       "config: chunk-size=%d digest-size=%d max-data=%d max-children=%d"
         chunk_size H.hash_size max_data max_children];

--- a/src/irmin-graphql/unix/irmin_graphql_unix.ml
+++ b/src/irmin-graphql/unix/irmin_graphql_unix.ml
@@ -25,7 +25,8 @@ module Server = struct
   end
 
   module Make_ext
-      (S : Irmin.Generic_key.S) (Remote : sig
+      (S : Irmin.Generic_key.S)
+      (Remote : sig
         val remote : remote_fn option
       end)
       (T : Irmin_graphql.Server.CUSTOM_TYPES
@@ -55,7 +56,8 @@ module Server = struct
       (T)
 
   module Make
-      (S : Irmin.Generic_key.S) (Remote : sig
+      (S : Irmin.Generic_key.S)
+      (Remote : sig
         val remote : remote_fn option
       end) =
     Irmin_graphql.Server.Make

--- a/src/irmin-graphql/unix/irmin_graphql_unix.mli
+++ b/src/irmin-graphql/unix/irmin_graphql_unix.mli
@@ -25,7 +25,8 @@ module Server : sig
   end
 
   module Make
-      (S : Irmin.Generic_key.S) (Remote : sig
+      (S : Irmin.Generic_key.S)
+      (Remote : sig
         val remote : remote_fn option
       end) :
     Irmin_graphql.Server.S
@@ -34,7 +35,8 @@ module Server : sig
        and module IO = Cohttp_lwt_unix.IO
 
   module Make_ext
-      (S : Irmin.Generic_key.S) (Remote : sig
+      (S : Irmin.Generic_key.S)
+      (Remote : sig
         val remote : remote_fn option
       end)
       (T : Irmin_graphql.Server.CUSTOM_TYPES

--- a/src/irmin-http/irmin_http_server.ml
+++ b/src/irmin-http/irmin_http_server.ml
@@ -62,13 +62,14 @@ module Make (HTTP : Cohttp_lwt.S.Server) (S : Irmin.S) = struct
     let err = Fmt.str "Parse error %S: %s" str e in
     Wm.respond ~body:(`String err) 400 rd
 
-  module Content_addressable (S : sig
-    include Irmin.Content_addressable.S
+  module Content_addressable
+      (S : sig
+        include Irmin.Content_addressable.S
 
-    val batch : B.Repo.t -> (read_write t -> 'a Lwt.t) -> 'a Lwt.t
-  end)
-  (K : Irmin.Type.S with type t = S.key)
-  (V : Irmin.Type.S with type t = S.value) =
+        val batch : B.Repo.t -> (read_write t -> 'a Lwt.t) -> 'a Lwt.t
+      end)
+      (K : Irmin.Type.S with type t = S.key)
+      (V : Irmin.Type.S with type t = S.value) =
   struct
     let with_key rd f =
       match Irmin.Type.of_string K.t (Wm.Rd.lookup_path_info_exn "id" rd) with

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -21,7 +21,8 @@ exception Max_depth of int
 
 module Make_internal
     (Conf : Conf.S)
-    (H : Irmin.Hash.S) (Key : sig
+    (H : Irmin.Hash.S)
+    (Key : sig
       include Irmin.Key.S with type hash = H.t
 
       val unfindable_of_hash : hash -> t

--- a/src/irmin-pack/inode_intf.ml
+++ b/src/irmin-pack/inode_intf.ml
@@ -256,7 +256,8 @@ module type Sigs = sig
 
   module Make_internal
       (Conf : Conf.S)
-      (H : Irmin.Hash.S) (Key : sig
+      (H : Irmin.Hash.S)
+      (Key : sig
         include Irmin.Key.S with type hash = H.t
 
         val unfindable_of_hash : hash -> t

--- a/src/irmin-pack/unix/gc.mli
+++ b/src/irmin-pack/unix/gc.mli
@@ -17,7 +17,8 @@
 open! Import
 
 (** [Make] returns a module that can manage GC processes. *)
-module Make (Args : Gc_args.S) : sig
+module Make
+    (Args : Gc_args.S) : sig
   module Args : Gc_args.S
 
   type t

--- a/src/irmin-pack/unix/gc_worker.mli
+++ b/src/irmin-pack/unix/gc_worker.mli
@@ -19,7 +19,8 @@
 open! Import
 module Payload = Control_file.Payload.Upper.Latest
 
-module Make (Args : Gc_args.S) : sig
+module Make
+    (Args : Gc_args.S) : sig
   module Args : Gc_args.S
 
   val run_and_output_result :

--- a/src/irmin-pack/unix/lower.ml
+++ b/src/irmin-pack/unix/lower.ml
@@ -385,19 +385,19 @@ module Make (Io : Io.S) (Errs : Io_errors.S with module Io = Io) = struct
   let archive_seq_exn ~upper_root ~generation ~to_archive t =
     Errs.raise_if_error
       (let open Result_syntax in
-      let* () = if t.readonly then Error `Ro_not_allowed else Ok () in
-      let* v =
-        match appendable_volume t with
-        | None -> Error `Lower_has_no_volume
-        | Some v -> Ok v
-      in
-      let* () =
-        match t.open_volume with
-        | None -> Ok ()
-        | Some v0 -> if Volume.eq v0 v then close_open_volume t else Ok ()
-      in
-      let is_first = volume_num t = 1 in
-      Volume.archive_seq ~upper_root ~generation ~to_archive ~is_first v)
+       let* () = if t.readonly then Error `Ro_not_allowed else Ok () in
+       let* v =
+         match appendable_volume t with
+         | None -> Error `Lower_has_no_volume
+         | Some v -> Ok v
+       in
+       let* () =
+         match t.open_volume with
+         | None -> Ok ()
+         | Some v0 -> if Volume.eq v0 v then close_open_volume t else Ok ()
+       in
+       let is_first = volume_num t = 1 in
+       Volume.archive_seq ~upper_root ~generation ~to_archive ~is_first v)
 
   let read_exn ~off ~len ?volume t b =
     let _, volume = read_range_exn ~off ~min_len:len ~max_len:len ?volume t b in

--- a/src/irmin-pack/unix/pack_store.ml
+++ b/src/irmin-pack/unix/pack_store.ml
@@ -232,9 +232,9 @@ struct
            become valid on [reload]; otherwise we know that this key wasn't
            constructed for this store. *)
         (if not (Control.readonly (Fm.control t.fm)) then
-         let io_offset = Dispatcher.end_offset t.dispatcher in
-         invalid_read "invalid key %a checked for membership (IO offset = %a)"
-           pp_key k Int63.pp io_offset);
+           let io_offset = Dispatcher.end_offset t.dispatcher in
+           invalid_read "invalid key %a checked for membership (IO offset = %a)"
+             pp_key k Int63.pp io_offset);
         false
     | Errors.Pack_error (`Invalid_sparse_read _) -> false
     | Errors.Pack_error (`Invalid_prefix_read _) -> false

--- a/src/irmin-test/irmin_bench.mli
+++ b/src/irmin-test/irmin_bench.mli
@@ -15,7 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (S : Irmin.Generic_key.KV with type Schema.Contents.t = string) : sig
+module Make
+    (S : Irmin.Generic_key.KV with type Schema.Contents.t = string) : sig
   val run :
     config:(root:string -> Irmin.config) -> size:(root:string -> int) -> unit
 end

--- a/src/irmin/commit_intf.ml
+++ b/src/irmin/commit_intf.ml
@@ -259,7 +259,9 @@ module type Sigs = sig
     module Info : Info.S with type t = Info.Default.t
     (** Serialisation format for V1 info. *)
 
-    module Make (Hash : Hash.S) (C : Generic_key.S with module Info := Info) : sig
+    module Make
+        (Hash : Hash.S)
+        (C : Generic_key.S with module Info := Info) : sig
       include
         Generic_key.S
           with module Info = Info

--- a/src/irmin/dot.ml
+++ b/src/irmin/dot.ml
@@ -90,8 +90,8 @@ module Make (S : Store.Generic_key.S) = struct
     let label_of_node k _ =
       let s =
         (if html then
-         sprintf "<div class='node'><div class='sha1'>%s</div></div>"
-        else fun x -> x)
+           sprintf "<div class='node'><div class='sha1'>%s</div></div>"
+         else fun x -> x)
           (string_of_hash Node.Hash.t k)
       in
       `Label s

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -54,9 +54,9 @@ end
 module Type = Repr
 (** Dynamic types for Irmin values, supplied by
     {{:https://github.com/mirage/repr} [Repr]}. These values can be derived from
-    type definitions via [\[@@deriving irmin\]] (see the
+    type definitions via [[@@deriving irmin]] (see the
     {{:https://github.com/mirage/irmin/blob/main/README_PPX.md} documentation
-    for [ppx_irmin]})*)
+      for [ppx_irmin]})*)
 
 module Hash = Hash
 (** Hashing functions.

--- a/src/irmin/node.ml
+++ b/src/irmin/node.ml
@@ -78,7 +78,8 @@ module Irmin_hash = Hash
 (* A [Make] implementation providing the subset of [S] that can be implemented
    over abstract [key] types. *)
 module Make_core
-    (Hash : Hash.S) (Path : sig
+    (Hash : Hash.S)
+    (Path : sig
       type step [@@deriving irmin]
     end)
     (Metadata : Metadata.S)
@@ -335,7 +336,8 @@ module Portable = struct
 end
 
 module Make_generic_key
-    (Hash : Hash.S) (Path : sig
+    (Hash : Hash.S)
+    (Path : sig
       type step [@@deriving irmin]
     end)
     (Metadata : Metadata.S)
@@ -403,7 +405,8 @@ struct
 end
 
 module Make_generic_key_v2
-    (Hash : Hash.S) (Path : sig
+    (Hash : Hash.S)
+    (Path : sig
       type step [@@deriving irmin]
     end)
     (Metadata : Metadata.S)
@@ -422,7 +425,8 @@ struct
 end
 
 module Make
-    (Hash : Hash.S) (Path : sig
+    (Hash : Hash.S)
+    (Path : sig
       type step [@@deriving irmin]
     end)
     (Metadata : Metadata.S) =

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -351,7 +351,8 @@ module type Sigs = sig
       and metadata implementations. The contents and node values are addressed
       directly by their hash. *)
   module Make
-      (Hash : Hash.S) (Path : sig
+      (Hash : Hash.S)
+      (Path : sig
         type step [@@deriving irmin]
       end)
       (Metadata : Metadata.S) :

--- a/src/irmin/proof.ml
+++ b/src/irmin/proof.ml
@@ -19,7 +19,8 @@ include Proof_intf
 
 module Make
     (C : Type.S)
-    (H : Type.S) (S : sig
+    (H : Type.S)
+    (S : sig
       type step [@@deriving irmin]
     end)
     (M : Type.S) =

--- a/src/irmin/proof_intf.ml
+++ b/src/irmin/proof_intf.ml
@@ -71,10 +71,10 @@ module type S = sig
       concrete proof or a hash of that proof.
 
       If an inode proof contains singleton children [i_0, ..., i_n] such as:
-      [{length=l; proofs = \[ (i_0, {proofs = ... { proofs = \[ (i_n, p) \] }})\]}],
+      [{length=l; proofs = [ (i_0, {proofs = ... { proofs = [ (i_n, p) ] }})]}],
       then it is compressed into the inode extender
-      [{length=l; segment = \[i_0;..;i_n\]; proof=p}] sharing the same length
-      [l] and final proof [p]. *)
+      [{length=l; segment = [i_0;..;i_n]; proof=p}] sharing the same length [l]
+      and final proof [p]. *)
 
   (** The type for compressed and partial Merkle tree proofs.
 
@@ -329,7 +329,8 @@ module type Proof = sig
 
   module Make
       (C : Type.S)
-      (H : Hash.S) (P : sig
+      (H : Hash.S)
+      (P : sig
         type step [@@deriving irmin]
       end)
       (M : Type.S) : sig

--- a/src/irmin/store_intf.ml
+++ b/src/irmin/store_intf.ml
@@ -1130,7 +1130,7 @@ module type S_generic_key = sig
   (** {Deprecated} *)
 
   val master : repo -> t Lwt.t
-    [@@ocaml.deprecated "Use `main` instead."]
+  [@@ocaml.deprecated "Use `main` instead."]
   (** @deprecated Use {!main} instead *)
 end
 

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -921,7 +921,7 @@ module Make (P : Backend.S) = struct
       let rec aux acc = function
         | [] ->
             (if cache then
-             match acc with Node n -> t.info.value <- Some n | Pnode _ -> ());
+               match acc with Node n -> t.info.value <- Some n | Pnode _ -> ());
             k acc
         | (k, Add e) :: rest ->
             hash_preimage_value_of_elt ~cache e (fun e ->
@@ -2420,7 +2420,7 @@ module Make (P : Backend.S) = struct
       | [] ->
           k
             (if StepMap.is_empty map then Empty
-            else Non_empty (Node.of_map ~env:(Env.empty ()) map))
+             else Non_empty (Node.of_map ~env:(Env.empty ()) map))
       | (s, n) :: t ->
           (concrete [@tailcall]) n (fun v ->
               (tree [@tailcall])

--- a/src/irmin/tree_intf.ml
+++ b/src/irmin/tree_intf.ml
@@ -307,8 +307,9 @@ module type S = sig
         [post path steps].
       - If [n] is any kind, call [tree path t'] where [t'] is the tree of [n].
 
-      See {{:https://github.com/mirage/irmin/blob/main/examples/fold.ml}
-      examples/fold.ml} for a demo of the different {!folder}s.
+      See
+      {{:https://github.com/mirage/irmin/blob/main/examples/fold.ml}
+        examples/fold.ml} for a demo of the different {!folder}s.
 
       See {!force} for details about the [force] parameters. By default it is
       [`True].

--- a/src/libirmin/commit.ml
+++ b/src/libirmin/commit.ml
@@ -49,8 +49,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> hash @-> returning commit)
       (fun (type repo) repo hash ->
         with_repo' repo commit
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let hash = Root.get_hash (module Store) hash in
             let c = run (Store.Commit.of_hash repo hash) in
             match c with
@@ -62,8 +62,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> commit_key @-> returning commit)
       (fun (type repo) repo hash ->
         with_repo' repo commit
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let hash = Root.get_commit_key (module Store) hash in
             let c = run (Store.Commit.of_key repo hash) in
             match c with
@@ -75,8 +75,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> ptr commit @-> uint64_t @-> tree @-> info @-> returning commit)
       (fun (type repo) repo parents n tree info ->
         with_repo' repo commit
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let n = UInt64.to_int n in
             let parents =
               if is_null parents || n = 0 then []
@@ -97,8 +97,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> commit @-> returning commit_array)
       (fun (type repo) repo commit ->
         with_repo' repo commit_array
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let commit = Root.get_commit (module Store) commit in
             let parents = Store.Commit.parents commit in
             let parents =
@@ -117,8 +117,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> commit @-> commit @-> returning bool)
       (fun (type repo) repo a b ->
         with_repo repo false
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let a = Root.get_commit (module Store) a in
             let b = Root.get_commit (module Store) b in
             Irmin.Type.(unstage (equal (Store.commit_t repo))) a b))

--- a/src/libirmin/repo.ml
+++ b/src/libirmin/repo.ml
@@ -40,8 +40,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> returning branch_array)
       (fun (type repo) repo ->
         with_repo' repo branch_array
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let b = run (Store.Repo.branches repo) in
             Root.create_branch_array (module Store) b))
 
@@ -91,8 +91,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> hash @-> returning contents)
       (fun (type repo) repo a ->
         with_repo' repo contents
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let a = Root.get_hash (module Store) a in
             let c = run @@ Store.Contents.of_hash repo a in
             match c with
@@ -104,8 +104,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> kinded_key @-> returning contents)
       (fun (type repo) repo a ->
         with_repo' repo contents
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let a = Root.get_kinded_key (module Store) a in
             match a with
             | `Contents (a, _) -> (

--- a/src/libirmin/store.ml
+++ b/src/libirmin/store.ml
@@ -23,8 +23,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun (type repo) repo' ->
         let r = Root.to_voidp repo repo' in
         with_repo' repo' store
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             Root.create_store
               (module Store)
               {
@@ -40,8 +40,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (fun (type repo) repo' name ->
         let r = Root.to_voidp repo repo' in
         with_repo' repo' store
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             match Irmin.Type.of_string Store.Branch.t name with
             | Error (`Msg err) -> failwith err
             | Ok branch ->

--- a/src/libirmin/tree.ml
+++ b/src/libirmin/tree.ml
@@ -64,8 +64,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> hash @-> returning tree)
       (fun (type repo) repo k ->
         with_repo' repo tree
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let k = Root.get_hash (module Store) k in
             let t = run (Store.Tree.of_hash repo (`Node k)) in
             match t with
@@ -89,8 +89,8 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> kinded_key @-> returning tree)
       (fun (type repo) repo k ->
         with_repo' repo tree
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          ->
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
             let k = Root.get_kinded_key (module Store) k in
             let t = run (Store.Tree.of_key repo k) in
             match t with

--- a/src/libirmin/type.ml
+++ b/src/libirmin/type.ml
@@ -91,8 +91,9 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
       (repo @-> returning ty)
       (fun (type repo) repo ->
         with_repo' repo ty
-          (fun (module Store : Irmin.Generic_key.S with type repo = repo) repo
-          -> Root.create_ty (Store.commit_t repo)))
+          (fun
+            (module Store : Irmin.Generic_key.S with type repo = repo) repo ->
+            Root.create_ty (Store.commit_t repo)))
 
   let () =
     fn "type_metadata"

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -61,21 +61,21 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
     let get_repo (type a) (x : Struct.repo ptr) : a repo =
       Root.get (to_voidp repo x)
-      [@@inline]
+    [@@inline]
 
     let create_repo (type a) (module S : Irmin.Generic_key.S with type repo = a)
         (r : a repo) : Struct.repo ptr =
       Root.create r |> of_voidp repo
-      [@@inline]
+    [@@inline]
 
     let get_store (type a) (x : Struct.store ptr) : a store =
       Root.get (to_voidp store x)
-      [@@inline]
+    [@@inline]
 
     let create_store (type a) (module S : Irmin.Generic_key.S with type t = a)
         (r : a store) : Struct.store ptr =
       Root.create r |> of_voidp store
-      [@@inline]
+    [@@inline]
 
     let get_config (x : Struct.config ptr) : config =
       Root.get (to_voidp config x)
@@ -259,7 +259,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     | exn ->
         repo.error <- Some (Printexc.to_string exn);
         return
-    [@@inline]
+  [@@inline]
 
   let null t = Ctypes.coerce (ptr void) t null
 
@@ -279,7 +279,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     | exn ->
         ctx.error <- Some (Printexc.to_string exn);
         return
-    [@@inline]
+  [@@inline]
 
   (* Similar to [with_store] but returns a null pointer *)
   let with_store' (store : Struct.store ptr) t f = with_store store (null t) f

--- a/test/irmin-chunk/test.ml
+++ b/test/irmin-chunk/test.ml
@@ -37,8 +37,8 @@ let test_add_read ?(stable = false) (module AO : Test_chunk.S) () =
     let v = String.make size 'x' in
     let* k = AO.batch t (fun t -> AO.add t v) in
     (if stable then
-     let str = value_to_bin v in
-     Alcotest.(check key_t) (name ^ " is stable") k (hash_contents str));
+       let str = value_to_bin v in
+       Alcotest.(check key_t) (name ^ " is stable") k (hash_contents str));
     let+ v' = AO.find t k in
     Alcotest.(check @@ option value_t) name (Some v) v'
   in

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -29,7 +29,8 @@ let wrong_depth = 100
 
 module Inode_modules
     (Conf : Irmin_pack.Conf.S)
-    (Schema : Irmin.Schema.S) (Contents : sig
+    (Schema : Irmin.Schema.S)
+    (Contents : sig
       val foo : Schema.Contents.t
       val bar : Schema.Contents.t
     end) =
@@ -242,8 +243,8 @@ module Inode_permutations_generator = struct
     let max_brute_force_iterations = 100 in
     let letters_per_step = (max_brute_force_iterations + 25) / 26 in
     fun inter indices ->
-      let module Inter = (val inter : Irmin_pack.Inode.Internal
-                            with type Val.step = Path.step)
+      let module Inter =
+        (val inter : Irmin_pack.Inode.Internal with type Val.step = Path.step)
       in
       let rec aux i =
         if i > max_brute_force_iterations then


### PR DESCRIPTION
The formatting of module arguments changed and this cause large diffs on Irmin.

The aim of this commit is to gather feedback.

Changelog can be found here: https://github.com/ocaml-ppx/ocamlformat/blob/main/CHANGES.md