### PR TITLE
irmin-pack-tools: Add base58 support for ppidx

### DIFF
--- a/irmin-pack-tools.opam
+++ b/irmin-pack-tools.opam
@@ -24,6 +24,7 @@ depends: [
   "cmdliner"    {>= "1.1.0"}
   "cmdliner"    {>= "1.1.0"}
   "notty"       {>= "0.2.3"}
+  "base58"      {= "0.1.0"}
   "ptime"
   "hex"
   "irmin-test"  {with-test & = version}

--- a/irmin-pack-tools.opam
+++ b/irmin-pack-tools.opam
@@ -24,7 +24,6 @@ depends: [
   "cmdliner"    {>= "1.1.0"}
   "cmdliner"    {>= "1.1.0"}
   "notty"       {>= "0.2.3"}
-  "base58"      {= "0.1.0"}
   "ptime"
   "hex"
   "irmin-test"  {with-test & = version}

--- a/src/irmin-pack-tools/README.md
+++ b/src/irmin-pack-tools/README.md
@@ -51,21 +51,19 @@ Will give:
 This tool prints the informations stored in the index of a store in a human readable manner (json), allowing to fetch important informations easily.
 It is fairly straightforward:
 ```shell
-$ dune exec -- irmin-ppidx [ -p bitcoin|ripple|flickr | -c <custom_alphabet> ] <path-to-store>
+$ dune exec -- irmin-ppidx Irmin|Tezos <path-to-store>
 ```
-The first argument is the alphabet used for the base58 encoding: It can be specified using a predefined alphabet or a custom one:
-- For a predefined alphabet, use the flag `-p` followed by `bitcoin`, `ripple` or `flickr` depending on which one you want.
-- For a custom alphabet, use the flag `-c` followed by your custom alphabet.
-- If both the `-c` and `-p` flags are used, `-p` is ignored.
-- if none are used, default is `-p bitcoin`.
+The first argument is the type of store, either:
+- Irmin, which implies that we will use the SHA256 hash, and will print it has an hexadecimal representation of the hash.
+- Tezos, which implies that we will use the default tezos hash (Blake2B) and we will print it with their encoding (base58 + a tezos specific prefix).
 
-The last argument is the path to the root of the store, not the index folder (e.g. `output/root/` where `output/root/index/` exists)
+The second one is the path to the root of the store, not the index folder (e.g. `output/root/` where `output/root/index/` exists)
 
-It will typically give the following json output, with one line per entry registered:
+It will typically give the following json output for Irmin, with one line per entry registered:
 ```
-{"hash":{"base64":"cGrDVlQkzEjlw2DA4bL5fAnDSOh4TRKtLZrAiavclsI=","base58":"8Zq5sJi8d4e63eXaDR3VEdwJUTaj6KBo3o1UemLCxnHf"},"off":13431448,"len":101,"kind":"Commit_v2"}
-{"hash":{"base64":"i2LiUbc7fPMu5ON1MLN97thf7cU0OUTcDBwNlvzAUVo=","base58":"AP78AdX8F18idUPuepac1WbhmY2xfE8U6nf46w5j9zXj"},"off":95461096,"len":103,"kind":"Commit_v2"}
-{"hash":{"base64":"cXMN2n8Re6RAvVbHbzaptzfIdFp+X/ey36S5RiWTsUw=","base58":"8drpouq8uvZj7961HkxidYPHYER37aCna5TemGsCQpe7"},"off":28541134,"len":104,"kind":"Commit_v2"}
+{"hash":"706ac3565424cc48e5c360c0e1b2f97c09c348e8784d12ad2d9ac089abdc96c2","off":13431448,"len":101,"kind":"Commit_v2"}
+{"hash":"8b62e251b73b7cf32ee4e37530b37deed85fedc5343944dc0c1c0d96fcc0515a","off":95461096,"len":103,"kind":"Commit_v2"}
+{"hash":"71730dda7f117ba440bd56c76f36a9b737c8745a7e5ff7b2dfa4b9462593b14c","off":28541134,"len":104,"kind":"Commit_v2"}
 ...
 ```
 Which can be further improved using the tool `jq`:
@@ -76,28 +74,19 @@ $ jq -s '.' -- index
 Will give:
 ```json
 {
-  "hash": {
-    "base64": "cGrDVlQkzEjlw2DA4bL5fAnDSOh4TRKtLZrAiavclsI=",
-    "base58": "8Zq5sJi8d4e63eXaDR3VEdwJUTaj6KBo3o1UemLCxnHf"
-  },
+  "hash": "706ac3565424cc48e5c360c0e1b2f97c09c348e8784d12ad2d9ac089abdc96c2",
   "off": 13431448,
   "len": 101,
   "kind": "Commit_v2"
 }
 {
-  "hash": {
-    "base64": "i2LiUbc7fPMu5ON1MLN97thf7cU0OUTcDBwNlvzAUVo=",
-    "base58": "AP78AdX8F18idUPuepac1WbhmY2xfE8U6nf46w5j9zXj"
-  },
+  "hash": "8b62e251b73b7cf32ee4e37530b37deed85fedc5343944dc0c1c0d96fcc0515a",
   "off": 95461096,
   "len": 103,
   "kind": "Commit_v2"
 }
 {
-  "hash": {
-    "base64": "cXMN2n8Re6RAvVbHbzaptzfIdFp+X/ey36S5RiWTsUw=",
-    "base58": "8drpouq8uvZj7961HkxidYPHYER37aCna5TemGsCQpe7"
-  },
+  "hash": "71730dda7f117ba440bd56c76f36a9b737c8745a7e5ff7b2dfa4b9462593b14c",
   "off": 28541134,
   "len": 104,
   "kind": "Commit_v2"

--- a/src/irmin-pack-tools/README.md
+++ b/src/irmin-pack-tools/README.md
@@ -51,15 +51,21 @@ Will give:
 This tool prints the informations stored in the index of a store in a human readable manner (json), allowing to fetch important informations easily.
 It is fairly straightforward:
 ```shell
-$ dune exec -- irmin-ppidx <path-to-store>
+$ dune exec -- irmin-ppidx [ -p bitcoin|ripple|flickr | -c <custom_alphabet> ] <path-to-store>
 ```
-The second one is the path to the root of the store, not the index folder (e.g. `output/root/` where `output/root/index/` exists)
+The first argument is the alphabet used for the base58 encoding: It can be specified using a predefined alphabet or a custom one:
+- For a predefined alphabet, use the flag `-p` followed by `bitcoin`, `ripple` or `flickr` depending on which one you want.
+- For a custom alphabet, use the flag `-c` followed by your custom alphabet.
+- If both the `-c` and `-p` flags are used, `-p` is ignored.
+- if none are used, default is `-p bitcoin`.
+
+The last argument is the path to the root of the store, not the index folder (e.g. `output/root/` where `output/root/index/` exists)
 
 It will typically give the following json output, with one line per entry registered:
 ```
-{"hash":"cGrDVlQkzEjlw2DA4bL5fAnDSOh4TRKtLZrAiavclsI=","off":13431448,"len":101,"kind":"Commit_v2"}
-{"hash":"i2LiUbc7fPMu5ON1MLN97thf7cU0OUTcDBwNlvzAUVo=","off":95461096,"len":103,"kind":"Commit_v2"}
-{"hash":"cXMN2n8Re6RAvVbHbzaptzfIdFp+X/ey36S5RiWTsUw=","off":28541134,"len":104,"kind":"Commit_v2"}
+{"hash":{"base64":"cGrDVlQkzEjlw2DA4bL5fAnDSOh4TRKtLZrAiavclsI=","base58":"8Zq5sJi8d4e63eXaDR3VEdwJUTaj6KBo3o1UemLCxnHf"},"off":13431448,"len":101,"kind":"Commit_v2"}
+{"hash":{"base64":"i2LiUbc7fPMu5ON1MLN97thf7cU0OUTcDBwNlvzAUVo=","base58":"AP78AdX8F18idUPuepac1WbhmY2xfE8U6nf46w5j9zXj"},"off":95461096,"len":103,"kind":"Commit_v2"}
+{"hash":{"base64":"cXMN2n8Re6RAvVbHbzaptzfIdFp+X/ey36S5RiWTsUw=","base58":"8drpouq8uvZj7961HkxidYPHYER37aCna5TemGsCQpe7"},"off":28541134,"len":104,"kind":"Commit_v2"}
 ...
 ```
 Which can be further improved using the tool `jq`:
@@ -70,19 +76,28 @@ $ jq -s '.' -- index
 Will give:
 ```json
 {
-  "hash": "cGrDVlQkzEjlw2DA4bL5fAnDSOh4TRKtLZrAiavclsI=",
+  "hash": {
+    "base64": "cGrDVlQkzEjlw2DA4bL5fAnDSOh4TRKtLZrAiavclsI=",
+    "base58": "8Zq5sJi8d4e63eXaDR3VEdwJUTaj6KBo3o1UemLCxnHf"
+  },
   "off": 13431448,
   "len": 101,
   "kind": "Commit_v2"
 }
 {
-  "hash": "i2LiUbc7fPMu5ON1MLN97thf7cU0OUTcDBwNlvzAUVo=",
+  "hash": {
+    "base64": "i2LiUbc7fPMu5ON1MLN97thf7cU0OUTcDBwNlvzAUVo=",
+    "base58": "AP78AdX8F18idUPuepac1WbhmY2xfE8U6nf46w5j9zXj"
+  },
   "off": 95461096,
   "len": 103,
   "kind": "Commit_v2"
 }
 {
-  "hash": "cXMN2n8Re6RAvVbHbzaptzfIdFp+X/ey36S5RiWTsUw=",
+  "hash": {
+    "base64": "cXMN2n8Re6RAvVbHbzaptzfIdFp+X/ey36S5RiWTsUw=",
+    "base58": "8drpouq8uvZj7961HkxidYPHYER37aCna5TemGsCQpe7"
+  },
   "off": 28541134,
   "len": 104,
   "kind": "Commit_v2"

--- a/src/irmin-pack-tools/ppidx/dune
+++ b/src/irmin-pack-tools/ppidx/dune
@@ -3,6 +3,6 @@
  (package irmin-pack-tools)
  (name ppidx)
  (modules ppidx)
- (libraries irmin-pack irmin-pack.unix base58 cmdliner)
+ (libraries irmin-pack irmin-pack.unix tezos-base58 irmin-tezos cmdliner)
  (preprocess
   (pps ppx_irmin.internal)))

--- a/src/irmin-pack-tools/ppidx/dune
+++ b/src/irmin-pack-tools/ppidx/dune
@@ -3,6 +3,6 @@
  (package irmin-pack-tools)
  (name ppidx)
  (modules ppidx)
- (libraries irmin-pack irmin-pack.unix cmdliner)
+ (libraries irmin-pack irmin-pack.unix base58 cmdliner)
  (preprocess
   (pps ppx_irmin.internal)))

--- a/src/irmin-pack-tools/ppidx/dune
+++ b/src/irmin-pack-tools/ppidx/dune
@@ -3,6 +3,6 @@
  (package irmin-pack-tools)
  (name ppidx)
  (modules ppidx)
- (libraries irmin-pack irmin-pack.unix tezos-base58 irmin-tezos cmdliner)
+ (libraries irmin-pack irmin-pack.unix irmin-tezos cmdliner)
  (preprocess
   (pps ppx_irmin.internal)))

--- a/src/irmin-pack-tools/ppidx/ppidx.ml
+++ b/src/irmin-pack-tools/ppidx/ppidx.ml
@@ -11,8 +11,8 @@ type t = { hash : string; off : Optint.Int63.t; len : int; kind : string }
 let main store_type root_folder =
   let module Index =
     (val match store_type with
-    | Irmin -> (module Irmin_pack_unix.Index.Make (Sha256) : Type)
-    | Tezos -> (module Irmin_pack_unix.Index.Make (Blake2B) : Type))
+         | Irmin -> (module Irmin_pack_unix.Index.Make (Sha256) : Type)
+         | Tezos -> (module Irmin_pack_unix.Index.Make (Blake2B) : Type))
   in
   let v = Index.v_exn ~readonly:true ~log_size:500_000 root_folder in
   let dump_json k v =
@@ -32,8 +32,7 @@ let store_type =
   Arg.(
     required
     & pos 0 (some (enum [ ("Tezos", Tezos); ("Irmin", Irmin) ])) None
-    & info [] ~docv:"store type"
-        ~doc:"the type of store, either Irmin or Tezos")
+    & info [] ~docv:"store type" ~doc:"the type of store, either Irmin or Tezos")
 
 let root_folder =
   Arg.(

--- a/src/irmin-pack-tools/ppidx/ppidx.ml
+++ b/src/irmin-pack-tools/ppidx/ppidx.ml
@@ -1,19 +1,34 @@
 module Hash = Irmin.Hash.SHA256
 module Index = Irmin_pack_unix.Index.Make (Hash)
 
-type t = { hash : string; off : Optint.Int63.t; len : int; kind : string }
+type hash = { base64 : string; base58 : string }
 [@@deriving irmin]
 
-let dump_json k v =
-  let hash = Base64.encode_exn (Index.Key.encode k) in
+type t = { hash : hash; off : Optint.Int63.t; len : int; kind : string }
+[@@deriving irmin]
+
+type alphabet = Bitcoin | Ripple | Flickr
+
+let make_alphabet p c =
+  match p, c with
+  | _, Some s -> B58.make_alphabet s
+  | Bitcoin, _ -> B58.make_alphabet "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+  | Ripple, _ -> B58.make_alphabet "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"
+  | Flickr, _ -> B58.make_alphabet "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
+
+let dump_json alphabet k v =
+  let key = Index.Key.encode k in
+  let base64 = Base64.encode_exn key in
+  let base58 = Bytes.to_string @@ B58.encode alphabet (Bytes.of_string key) in
+  let hash = { base64; base58 } in
   let off, len, kind = v in
   let kind = Fmt.str "%a" Irmin_pack.Pack_value.Kind.pp kind in
   let a = { hash; off; len; kind } in
   Fmt.pr "%a@." (Irmin.Type.pp_json t) a
 
-let main root_folder =
+let main root_folder alphabet =
   let v = Index.v_exn ~readonly:true ~log_size:500_000 root_folder in
-  Index.iter dump_json v
+  Index.iter (dump_json alphabet) v
 
 (** Cmdliner **)
 
@@ -23,11 +38,27 @@ let root_folder =
   Arg.(
     required
     & pos 0 (some string) None
-    & info [] ~docv:"root folder" ~doc:"the path to the store")
+    & info [] ~docv:"root_folder" ~doc:"the path to the store")
+
+let predefined_alphabet =
+  Arg.(
+    value
+    & opt (enum [ ("bitcoin", Bitcoin); ("ripple", Ripple); ("flickr", Flickr) ]) Bitcoin
+    & info [ "p" ] ~docv:"pre-defined_base58_alphabet"
+        ~doc:"the pre-defined alphabet used for the base58 encoding, default to Bitcoin, ignored if '-c' is set")
+
+let custom_alphabet =
+  Arg.(
+    value
+    & opt (some string) None
+    & info [ "c" ]
+        ~doc:
+          "the path to the info file generated for next entries data, default \
+           to `store.info.next`")
 
 let main_cmd =
   let doc = "a json printer for the informations stored in the index folder" in
   let info = Cmd.info "irmin-ppidx" ~doc in
-  Cmd.v info Term.(const main $ root_folder)
+  Cmd.v info Term.(const main $ root_folder $ (const make_alphabet $ predefined_alphabet $ custom_alphabet))
 
 let () = exit (Cmd.eval ~catch:false main_cmd)


### PR DESCRIPTION
Adds the dump of the hashes in base58 alongside the base64 as asked by @art-w 