### PR TITLE
irmin-pack: fix index integrity check for v3

### DIFF
--- a/src/irmin-pack/pack_value.ml
+++ b/src/irmin-pack/pack_value.ml
@@ -236,6 +236,6 @@ struct
     fun s off ->
       match Kind.of_magic_exn s.[off + Hash.hash_size] with
       | Commit_v1 -> of_v0_entry s off
-      | Commit_v2 -> of_v1_entry s off
+      | Commit_v2 | Dangling_parent_commit -> of_v1_entry s off
       | _ -> assert false
 end

--- a/src/irmin-pack/unix/checks_intf.ml
+++ b/src/irmin-pack/unix/checks_intf.ml
@@ -82,7 +82,8 @@ module type S = sig
   module Integrity_check_index : sig
     include
       Subcommand
-        with type run := root:string -> auto_repair:bool -> unit -> unit
+        with type run :=
+          root:string -> auto_repair:bool -> always:bool -> unit -> unit
   end
 
   (** Checks the integrity of inodes in a store *)

--- a/test/irmin-tezos/generate.ml
+++ b/test/irmin-tezos/generate.ml
@@ -17,15 +17,12 @@
 open Lwt.Syntax
 
 let rm_dir data_dir =
-  if Sys.file_exists data_dir then (
+  if Sys.file_exists data_dir then
     let cmd = Printf.sprintf "rm -rf %s" data_dir in
-    Fmt.epr "exec: %s\n%!" cmd;
     let _ = Sys.command cmd in
-    ())
+    ()
 
-module Simple = struct
-  let data_dir = "data/pack"
-
+module Generator = struct
   module Conf = struct
     include Irmin_tezos.Conf
 
@@ -40,29 +37,66 @@ module Simple = struct
     include Make (Schema)
   end
 
-  let config root = Irmin_pack.config ~readonly:false ~fresh:true root
+  let config ~indexing_strategy root =
+    Irmin_pack.config ~indexing_strategy ~readonly:false ~fresh:true root
+
   let info = Store.Info.empty
 
-  let create_store () =
-    rm_dir data_dir;
-    (* make sure the parent directory data/ exists; by default Store.Repo.v will not
-       create the containing directory *)
-    if not (Sys.file_exists "data") then Unix.mkdir "data" 0o755;
-    let* rw = Store.Repo.v (config data_dir) in
+  let create_store ?(before_closing = fun _repo _head -> Lwt.return_unit)
+      indexing_strategy path =
+    rm_dir path;
+    let large_contents = String.make 4096 'Z' in
+    let* rw = Store.Repo.v (config ~indexing_strategy path) in
     let tree = Store.Tree.singleton [ "a"; "b1"; "c1"; "d1"; "e1" ] "x1" in
     let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d2"; "e2" ] "x2" in
     let* tree = Store.Tree.add tree [ "a"; "b1"; "c1"; "d3"; "e3" ] "x2" in
     let* tree = Store.Tree.add tree [ "a"; "b2"; "c2"; "e3" ] "x2" in
     let* c1 = Store.Commit.v rw ~parents:[] ~info tree in
 
-    let* tree = Store.Tree.add tree [ "a"; "b3" ] "x3" in
+    let* tree = Store.Tree.add tree [ "a"; "b3" ] large_contents in
     let* c2 = Store.Commit.v rw ~parents:[ Store.Commit.key c1 ] ~info tree in
 
     let* tree = Store.Tree.remove tree [ "a"; "b1"; "c1" ] in
-    let* _ = Store.Commit.v rw ~parents:[ Store.Commit.key c2 ] ~info tree in
+    let* c3 = Store.Commit.v rw ~parents:[ Store.Commit.key c2 ] ~info tree in
 
-    Store.Repo.close rw
+    let* () = before_closing rw (Store.Commit.key c3) in
+
+    let* _ = Store.Repo.close rw in
+
+    Lwt.return c3
+
+  let create_gced_store path =
+    let before_closing repo head =
+      let* _ = Store.Gc.start_exn repo head in
+      let* _ = Store.Gc.wait repo in
+      Lwt.return_unit
+    in
+    create_store ~before_closing Irmin_pack.Indexing_strategy.minimal path
+
+  let create_snapshot_store ~src ~dest =
+    let before_closing repo head =
+      rm_dir dest;
+      Store.create_one_commit_store repo head dest
+    in
+    create_store ~before_closing Irmin_pack.Indexing_strategy.minimal src
 end
 
-let generate () = Simple.create_store ()
+let ensure_data_dir () =
+  if not (Sys.file_exists "data") then Unix.mkdir "data" 0o755
+
+let generate () =
+  ensure_data_dir ();
+  let* _ =
+    Generator.create_store Irmin_pack.Indexing_strategy.minimal "data/minimal"
+  in
+  let* _ =
+    Generator.create_store Irmin_pack.Indexing_strategy.always "data/always"
+  in
+  let* _ = Generator.create_gced_store "data/gced" in
+  let* _ =
+    Generator.create_snapshot_store ~src:"data/snapshot_src"
+      ~dest:"data/snapshot"
+  in
+  Lwt.return_unit
+
 let () = Lwt_main.run (generate ())

--- a/test/irmin-tezos/stat.t/run.t
+++ b/test/irmin-tezos/stat.t/run.t
@@ -1,5 +1,5 @@
-Running stat on a v3 store
-  $ STORE=PACK ../irmin_fsck.exe stat ../data/pack 2>&1 | cat -e | tail -n 10
+Running stat on a v3 store always
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/always 2>&1 | cat -e | tail -n 10
     "hash_size": {$
       "Bytes": 64$
     },$
@@ -11,8 +11,47 @@ Running stat on a v3 store
     }$
   }
 
-Running index-integrity-check on a v3 store minimal
-  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/pack 2>&1 | cat -e | tail -n 10
+Running stat on a v3 store minimal
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/minimal 2>&1 | cat -e | tail -n 10
+    "hash_size": {$
+      "Bytes": 64$
+    },$
+    "log_size": 2500000,$
+    "objects": {$
+      "nb_commits": 3,$
+      "nb_nodes": 0,$
+      "nb_contents": 0$
+    }$
+  }
+
+Running stat on a v3 store GCed
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/gced 2>&1 | cat -e | tail -n 10
+    "hash_size": {$
+      "Bytes": 64$
+    },$
+    "log_size": 2500000,$
+    "objects": {$
+      "nb_commits": 3,$
+      "nb_nodes": 0,$
+      "nb_contents": 0$
+    }$
+  }
+
+Running stat on a v3 store snapshot
+  $ STORE=PACK ../irmin_fsck.exe stat ../data/snapshot 2>&1 | cat -e | tail -n 10
+    "hash_size": {$
+      "Bytes": 64$
+    },$
+    "log_size": 2500000,$
+    "objects": {$
+      "nb_commits": 1,$
+      "nb_nodes": 0,$
+      "nb_contents": 0$
+    }$
+  }
+
+Running index-integrity-check on a v3 store always
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index --always ../data/always 2>&1 | cat -e | tail -n 10
     { "Commit_v1" = 0;$
       "Commit_v2" = 3;$
       "Contents" = 3;$
@@ -21,5 +60,44 @@ Running index-integrity-check on a v3 store minimal
       "Inode_v2_root" = 12;$
       "Inode_v2_nonroot" = 4;$
       "Dangling_parent_commit" = 0;$
+      "Duplicated entries" = 0;$
+      "Missing entries" = 0 }$
+
+Running index-integrity-check on a v3 store minimal
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/minimal 2>&1 | cat -e | tail -n 10
+    { "Commit_v1" = 0;$
+      "Commit_v2" = 3;$
+      "Contents" = 5;$
+      "Inode_v1_unstable" = 0;$
+      "Inode_v1_stable" = 0;$
+      "Inode_v2_root" = 13;$
+      "Inode_v2_nonroot" = 4;$
+      "Dangling_parent_commit" = 0;$
+      "Duplicated entries" = 0;$
+      "Missing entries" = 0 }$
+
+Running index-integrity-check on a v3 store GCed
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/gced 2>&1 | cat -e | tail -n 10
+    { "Commit_v1" = 0;$
+      "Commit_v2" = 1;$
+      "Contents" = 2;$
+      "Inode_v1_unstable" = 0;$
+      "Inode_v1_stable" = 0;$
+      "Inode_v2_root" = 4;$
+      "Inode_v2_nonroot" = 0;$
+      "Dangling_parent_commit" = 1;$
+      "Duplicated entries" = 0;$
+      "Missing entries" = 0 }$
+
+Running index-integrity-check on a v3 store snapshot
+  $ STORE=PACK ../irmin_fsck.exe integrity-check-index ../data/snapshot 2>&1 | cat -e | tail -n 10
+    { "Commit_v1" = 0;$
+      "Commit_v2" = 1;$
+      "Contents" = 2;$
+      "Inode_v1_unstable" = 0;$
+      "Inode_v1_stable" = 0;$
+      "Inode_v2_root" = 4;$
+      "Inode_v2_nonroot" = 0;$
+      "Dangling_parent_commit" = 1;$
       "Duplicated entries" = 0;$
       "Missing entries" = 0 }$


### PR DESCRIPTION
A few issues existed for running the index integrity check for v3 stores:
- Buffer for reading data never resized
- Dangling parent commits not able to decode length and considered "indexable"
- Store always used non-minimal indexing strategy

I've added more stores to our cram test so that we cover all of these issues.

Fixes #2264