### PR TITLE
irmin-pack: Update deprecated call

### DIFF
--- a/src/irmin-pack/unix/async.ml
+++ b/src/irmin-pack/unix/async.ml
@@ -61,7 +61,7 @@ module Unix = struct
     match Lwt_unix.fork () with
     | 0 ->
         Lwt_main.Exit_hooks.remove_all ();
-        Lwt_main.abandon_yielded_and_paused ();
+        Lwt.abandon_paused ();
         let exit_code =
           match f () with
           | () -> Exit_code.success


### PR DESCRIPTION
Lwt's latest update [5.7.0](https://github.com/ocsigen/lwt/releases/tag/5.7.0) deprecated the function `Lwt_main.abandon_yielded_and_paused` in favor of `Lwt.abandon_paused`
(see this [commit](https://github.com/ocsigen/lwt/commit/322cc45db73aaf1f77041db91e53d9ab78d773d2)).
This PR fixes that issue.