### PR TITLE
irmin-git: fix decoding contents in the middle of a buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,11 @@
     the maintenance of that part of the code, as ensuring the correct order of
     cached IO operations was tricky for stream proofs (#2275, @samoht)
 
+### Changed
+
+- **irmin-git**
+  - Moved lower bounds to `git.3.14.0` to use new function (#2277, @metanivek)
+
 ## 3.8.0 (2023-07-06)
 
 ### Added

--- a/examples/server/config.ml
+++ b/examples/server/config.ml
@@ -14,6 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
+module Store = struct
+  module Git_impl = Irmin_git.Mem
+  module Sync = Git.Mem.Sync (Git_impl)
+  module Maker = Irmin_git.KV (Git_impl) (Sync)
+  include Maker.Make (Irmin.Contents.String)
+end
 
 let uri = Uri.of_string "tcp://localhost:4242"

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -19,8 +19,8 @@ depends: [
   "dune"       {>= "2.9.0"}
   "irmin"      {= version}
   "ppx_irmin"  {= version}
-  "git"        {>= "3.7.0"}
-  "git-unix"   {>= "3.7.0"}
+  "git"        {>= "3.14.0"}
+  "git-unix"   {>= "3.14.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/src/irmin-git/contents.ml
+++ b/src/irmin-git/contents.ml
@@ -52,9 +52,10 @@ module Make (G : Git.S) (C : Irmin.Contents.S) = struct
       match Raw.of_raw_with_header ~off buf with
       | Ok g -> (
           match V.of_git g with
-          | Some g ->
-              pos_ref := String.length buf;
-              g
+          | Some v ->
+              let len = Raw.length_with_header g |> Int64.to_int in
+              pos_ref := off + len;
+              v
           | None -> failwith "wrong object kind")
       | Error (`Msg _) -> failwith "wrong object"
 


### PR DESCRIPTION
This code previously assumed that it could read to the end of the buffer, but this is not always the case. This issue was discovered while testing the new batch API in `irmin-client`.

This PR updates `irmin-git` to use `ocaml-git` 3.14.0 or newer. This release of `ocaml-git` fixes the discovered bug and also exposes a function (`length_with_header`) that can be used to know the length of buffer read. I also updated the client/server example to use an in-memory git store, which can be used to manually verify this fix.