### PR TITLE
libirmin: reuse a single eio scheduler across calls

### DIFF
--- a/bench/irmin-pack/bench_common.ml
+++ b/bench/irmin-pack/bench_common.ml
@@ -60,20 +60,11 @@ let random_string n = String.init n (fun _i -> random_char ())
 let random_blob () = random_string 10 |> Bytes.of_string
 let random_key () = random_string 5
 
-let default_artefacts_dir =
-  let ( / ) = Filename.concat in
-  Unix.getcwd () / "_artefacts" / Uuidm.to_string (Uuidm.v `V4)
+let default_artefacts_dir cwd =
+  Eio.Path.(cwd / "_artefacts" / Uuidm.to_string (Uuidm.v `V4))
 
 let prepare_artefacts_dir path =
-  let rec mkdir_p path =
-    if Sys.file_exists path then ()
-    else
-      let path' = Filename.dirname path in
-      if path' = path then failwith "Failed to prepare result dir";
-      mkdir_p path';
-      Unix.mkdir path 0o755
-  in
-  mkdir_p path
+  Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 path
 
 let with_timer f =
   let t0 = Sys.time () in
@@ -121,27 +112,26 @@ end
 
 module FSHelper = struct
   let file f =
-    try (Unix.stat f).st_size with Unix.Unix_error (Unix.ENOENT, _, _) -> 0
+    (* in MiB *)
+    try
+      Eio.Switch.run @@ fun sw ->
+      let f = Eio.Path.open_in ~sw f in
+      Optint.Int63.to_int (Eio.File.size f)
+    with Eio.Exn.Io (Eio.Fs.E (Not_found _), _) -> 0
 
   let dict root = file (Irmin_pack.Layout.V1_and_v2.dict ~root) / 1024 / 1024
   let pack root = file (Irmin_pack.Layout.V1_and_v2.pack ~root) / 1024 / 1024
 
   let index root =
-    let index_dir = Filename.concat root "index" in
-    let a = file (Filename.concat index_dir "data") in
-    let b = file (Filename.concat index_dir "log") in
-    let c = file (Filename.concat index_dir "log_async") in
+    let index_dir = Eio.Path.(root / "index") in
+    let a = file Eio.Path.(index_dir / "data") in
+    let b = file Eio.Path.(index_dir / "log") in
+    let c = file Eio.Path.(index_dir / "log_async") in
     (a + b + c) / 1024 / 1024
 
   let size root = dict root + pack root + index root
   let get_size root = size root
-
-  let rm_dir root =
-    if Sys.file_exists root then (
-      let cmd = Printf.sprintf "rm -rf %s" root in
-      [%logs.info "exec: %s" cmd];
-      let _ = Sys.command cmd in
-      ())
+  let rm_dir root = Eio.Path.rmtree ~missing_ok:true root
 end
 
 module Generate_trees

--- a/bench/irmin-pack/bench_common.mli
+++ b/bench/irmin-pack/bench_common.mli
@@ -16,8 +16,8 @@
 
 module Mtime : module type of Import.Mtime
 
-val default_artefacts_dir : string
-val prepare_artefacts_dir : string -> unit
+val default_artefacts_dir : Eio.Fs.dir_ty Eio.Path.t -> Eio.Fs.dir_ty Eio.Path.t
+val prepare_artefacts_dir : Eio.Fs.dir_ty Eio.Path.t -> unit
 val reporter : ?prefix:string -> unit -> Logs.reporter
 val setup_log : Fmt.style_renderer option -> Logs.level option -> unit
 val reset_stats : unit -> unit
@@ -36,8 +36,8 @@ module Conf : Irmin_pack.Conf.S
 module Schema : Irmin.Schema.S
 
 module FSHelper : sig
-  val rm_dir : string -> unit
-  val get_size : string -> int
+  val rm_dir : Eio.Fs.dir_ty Eio.Path.t -> unit
+  val get_size : Eio.Fs.dir_ty Eio.Path.t -> int
 end
 
 module Generate_trees

--- a/bench/irmin-pack/dune
+++ b/bench/irmin-pack/dune
@@ -80,7 +80,7 @@
 (executable
  (name trace_stats)
  (modules trace_stats)
- (libraries cmdliner irmin_traces))
+ (libraries cmdliner irmin_traces eio_main))
 
 ;; Require the executables to compile during tests
 

--- a/bench/irmin-pack/main.ml
+++ b/bench/irmin-pack/main.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let config ~root = Irmin_pack.config ~fresh:false root
-
 module Config = struct
   let entries = 2
   let stable_hash = 3
@@ -33,15 +31,19 @@ module Bench = Irmin_bench.Make (KV)
 
 let file f =
   (* in MiB *)
-  try (Unix.stat f).st_size / 1024 / 1024
-  with Unix.Unix_error (Unix.ENOENT, _, _) -> 0
+  try
+    Eio.Switch.run @@ fun sw ->
+    let open Optint.Int63 in
+    let f = Eio.Path.open_in ~sw f in
+    Infix.(to_int @@ (Eio.File.size f / of_int 1024 / of_int 1024))
+  with Eio.Exn.Io (Eio.Fs.E (Not_found _), _) -> 0
 
 let index root =
   let rec aux acc i =
     if i = 256 then acc
     else
       let filename = Format.sprintf "store.index.%d" i in
-      let s = file (Filename.concat root filename) in
+      let s = file Eio.Path.(root / filename) in
       aux (acc + s) (i + 1)
   in
   aux 0 0
@@ -52,4 +54,12 @@ let size ~root =
   |> List.map file
   |> List.fold_left ( + ) index_size
 
-let () = Bench.run ~config ~size
+let () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let fs = Eio.Stdenv.cwd env in
+  let config ~root =
+    Irmin_pack.config ~sw ~fs ~fresh:false Eio.Path.(fs / root)
+  in
+  let size ~root = size ~root:Eio.Path.(fs / root) in
+  Bench.run ~config ~size

--- a/bench/irmin-pack/trace_collection.ml
+++ b/bench/irmin-pack/trace_collection.ml
@@ -167,7 +167,7 @@ module Make_stat (Store : Irmin.Generic_key.KV) = struct
         }
   end
 
-  let create_file : string -> Def.config -> string -> t =
+  let create_file : Eio.Fs.dir_ty Eio.Path.t -> Def.config -> string -> t =
    fun path config store_path ->
     let header =
       Def.

--- a/bench/irmin-pack/trace_common.ml
+++ b/bench/irmin-pack/trace_common.ml
@@ -228,8 +228,10 @@ module Io (Ff : File_format) = struct
     in
     Seq.unfold produce_row ()
 
-  let open_reader : string -> Ff.Latest.header * Ff.Latest.row Seq.t =
+  let open_reader :
+      Eio.Fs.dir_ty Eio.Path.t -> Ff.Latest.header * Ff.Latest.row Seq.t =
    fun path ->
+    let path = Eio.Path.native_exn path in
     let chan = open_in_bin path in
     let len = LargeFile.in_channel_length chan in
     if len < 12L then
@@ -260,6 +262,7 @@ module Io (Ff : File_format) = struct
   type writer = { path : string; channel : out_channel; buffer : Buffer.t }
 
   let create_file path header =
+    let path = Eio.Path.native_exn path in
     let channel = open_out path in
     let buffer = Buffer.create 0 in
     output_string channel (Magic.to_string Ff.magic);

--- a/bench/irmin-pack/trace_stat_summary.ml
+++ b/bench/irmin-pack/trace_stat_summary.ml
@@ -1098,6 +1098,7 @@ let summarise ?block_count trace_stat_path =
 (* Section 4/4 - Conversion from summary to json file *)
 
 let save_to_json v path =
+  let path = Eio.Path.native_exn path in
   let j = Fmt.str "%a\n" (Irmin.Type.pp_json t) v in
   let chan = open_out path in
   output_string chan j;

--- a/bench/irmin-pack/trace_stats.ml
+++ b/bench/irmin-pack/trace_stats.ml
@@ -29,9 +29,10 @@ let summarise path =
   Summary.(summarise path |> Fmt.pr "%a\n" (Irmin.Type.pp_json t))
 
 let class_of_path p =
-  let chan = open_in_bin p in
+  let path = Eio.Path.native_exn p in
+  let chan = open_in_bin path in
   if in_channel_length chan < 8 then
-    Fmt.invalid_arg "File \"%s\" should be a stat trace or a json." p;
+    Fmt.invalid_arg "File \"%s\" should be a stat trace or a json." path;
   let magic = really_input_string chan 8 in
   close_in chan;
   if is_trace_magic magic then
@@ -44,13 +45,13 @@ let class_of_path p =
     in
     `Trace block_count
   else
-    let chan = open_in_bin p in
+    let chan = open_in_bin path in
     let raw = really_input_string chan (in_channel_length chan) in
     close_in chan;
     match Irmin.Type.of_json_string Summary.t raw with
     | Error (`Msg msg) ->
         Fmt.invalid_arg
-          "File \"%s\" should be a stat trace or a json.\nError: %s" p msg
+          "File \"%s\" should be a stat trace or a json.\nError: %s" path msg
     | Ok s -> `Summary s
 
 let pp name_per_path paths cols_opt =
@@ -120,23 +121,41 @@ let summary_to_cb path =
 
 open Cmdliner
 
-let term_summarise =
+let eio_path fs =
+  let parse s = Ok Eio.Path.(fs / s) in
+  let print = Eio.Path.pp in
+  Arg.conv ~docv:"PATH" (parse, print)
+
+let term_summarise fs =
   let stat_trace_file =
     let doc = Arg.info ~docv:"PATH" ~doc:"A stat trace file" [] in
-    Arg.(required @@ pos 0 (some string) None doc)
+    Arg.(required @@ pos 0 (some (eio_path fs)) None doc)
   in
   Term.(const summarise $ stat_trace_file)
 
-let term_pp =
+let eio_file fs =
+  let parse s =
+    let path = Eio.Path.(fs / s) in
+    match Eio.Path.kind ~follow:true path with
+    | `Regular_file -> Ok path
+    | `Not_found -> Error (`Msg (Format.sprintf "no file %s" s))
+    | _ -> Error (`Msg (Format.sprintf "%s is a directory" s))
+  in
+  let print = Eio.Path.pp in
+  Arg.conv ~docv:"PATH" (parse, print)
+
+let term_pp fs =
   let arg_indexed_files =
     let open Arg in
-    let a = pos_all non_dir_file [] (info [] ~docv:"FILE") in
+    let a = pos_all (eio_file fs) [] (info [] ~docv:"FILE") in
     value a
   in
   let arg_named_files =
     let open Arg in
     let a =
-      opt_all (pair string non_dir_file) []
+      opt_all
+        (pair string (eio_file fs))
+        []
         (info [ "f"; "named-file" ]
            ~doc:
              "A comma-separated pair of short name / path to trace or summary. \
@@ -208,6 +227,9 @@ let () =
   let l =
     deprecated_info ~man ~doc:"Summary JSON to Continous Benchmarks JSON" "cb"
   in
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
   deprecated_exit
-  @@ deprecated_eval_choice (term_summarise, i)
-       [ (term_summarise, j); (term_pp, k); (term_cb, l) ]
+  @@ deprecated_eval_choice
+       (term_summarise fs, i)
+       [ (term_summarise fs, j); (term_pp fs, k); (term_cb, l) ]

--- a/bench/irmin-pack/tree.ml
+++ b/bench/irmin-pack/tree.ml
@@ -25,12 +25,12 @@ type config = {
   nchain_trees : int;
   width : int;
   nlarge_trees : int;
-  store_dir : string;
+  store_dir : Eio.Fs.dir_ty Eio.Path.t;
   path_conversion : [ `None | `V1 | `V0_and_v1 | `V0 ];
   inode_config : int * int;
   store_type : [ `Pack | `Pack_mem ];
-  replay_trace_path : string;
-  artefacts_path : string;
+  replay_trace_path : Eio.Fs.dir_ty Eio.Path.t;
+  artefacts_path : Eio.Fs.dir_ty Eio.Path.t;
   keep_store : bool;
   keep_stat_trace : bool;
   no_summary : bool;
@@ -55,7 +55,12 @@ module type Store = sig
   type on_commit := int -> Hash.t -> unit
   type on_end := unit -> unit
 
-  val create_repo : root:string -> store_config -> Repo.t * on_commit * on_end
+  val create_repo :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
+    store_config ->
+    Repo.t * on_commit * on_end
 
   type stats := Irmin_pack_unix.Stats.Latest_gc.stats
 
@@ -63,7 +68,12 @@ module type Store = sig
   val add_volume : repo -> unit
 
   val gc_run :
-    ?finished:((stats, string) result -> unit) -> repo -> commit_key -> unit
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    ?finished:((stats, string) result -> unit) ->
+    repo ->
+    commit_key ->
+    unit
 
   val gc_wait : repo -> unit
 end
@@ -121,10 +131,11 @@ module Bench_suite (Store : Store) = struct
     in
     aux None 0
 
-  let run_large config =
+  let run_large ~fs config =
     reset_stats ();
+    Eio.Switch.run @@ fun sw ->
     let root = config.store_dir in
-    let repo, on_commit, on_end = Store.create_repo ~root config in
+    let repo, on_commit, on_end = Store.create_repo ~sw ~fs ~root config in
     let result, () =
       Trees.add_large_trees config.width config.nlarge_trees
       |> add_commits ~message:"Playing large mode" repo config.ncommits
@@ -141,10 +152,11 @@ module Bench_suite (Store : Store) = struct
         config.ncommits config.nlarge_trees config.width Benchmark.pp_results
         result
 
-  let run_chains config =
+  let run_chains ~fs config =
     reset_stats ();
+    Eio.Switch.run @@ fun sw ->
     let root = config.store_dir in
-    let repo, on_commit, on_end = Store.create_repo ~root config in
+    let repo, on_commit, on_end = Store.create_repo ~sw ~fs ~root config in
     let result, () =
       Trees.add_chain_trees config.depth config.nchain_trees
       |> add_commits ~message:"Playing chain mode" repo config.ncommits
@@ -161,7 +173,7 @@ module Bench_suite (Store : Store) = struct
         config.ncommits config.nchain_trees config.depth Benchmark.pp_results
         result
 
-  let run_read_trace config =
+  let run_read_trace ~fs ~domain_mgr config =
     let replay_config : _ Irmin_traces.Trace_replay.config =
       {
         number_of_commits_to_replay = config.number_of_commits_to_replay;
@@ -183,14 +195,15 @@ module Bench_suite (Store : Store) = struct
     in
     if config.no_summary then
       let () =
-        Trace_replay.run config { replay_config with return_type = Unit }
+        Trace_replay.run ~fs ~domain_mgr config
+          { replay_config with return_type = Unit }
       in
       fun _ppf -> ()
     else
-      let summary = Trace_replay.run config replay_config in
+      let summary = Trace_replay.run ~fs ~domain_mgr config replay_config in
       fun ppf ->
         if not config.no_summary then (
-          let p = Filename.concat config.artefacts_path "stat_summary.json" in
+          let p = Eio.Path.(config.artefacts_path / "stat_summary.json") in
           Trace_stat_summary.save_to_json summary p;
           Format.fprintf ppf "%a"
             (Trace_stat_summary_pp.pp 5)
@@ -211,9 +224,10 @@ module Make_store_mem (Conf : Irmin_pack.Conf.S) = struct
 
   let indexing_strategy = Irmin_pack.Indexing_strategy.minimal
 
-  let create_repo ~root _config =
+  let create_repo ~sw ~fs ~root _config =
     let conf =
-      Irmin_pack.config ~readonly:false ~fresh:true ~indexing_strategy root
+      Irmin_pack.config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy
+        root
     in
     prepare_artefacts_dir root;
     let repo = Store.Repo.v conf in
@@ -224,7 +238,7 @@ module Make_store_mem (Conf : Irmin_pack.Conf.S) = struct
   let split _repo = ()
   let add_volume _repo = ()
   let gc_wait _repo = ()
-  let gc_run ?finished:_ _repo _key = ()
+  let gc_run ~fs:_ ~domain_mgr:_ ?finished:_ _repo _key = ()
 end
 
 module Make_store_pack (Conf : Irmin_pack.Conf.S) = struct
@@ -241,13 +255,13 @@ module Make_store_pack (Conf : Irmin_pack.Conf.S) = struct
 
   let indexing_strategy = Irmin_pack.Indexing_strategy.minimal
 
-  let create_repo ~root (config : store_config) =
+  let create_repo ~sw ~fs ~root (config : store_config) =
     let lower_root =
-      if config.add_volume_every > 0 then Some (Filename.concat root "lower")
+      if config.add_volume_every > 0 then Some Eio.Path.(root / "lower")
       else None
     in
     let conf =
-      Irmin_pack.config ~readonly:false ~fresh:true ~indexing_strategy
+      Irmin_pack.config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy
         ~lower_root root
     in
     prepare_artefacts_dir root;
@@ -263,13 +277,13 @@ module Make_store_pack (Conf : Irmin_pack.Conf.S) = struct
     let r = Store.Gc.wait repo in
     match r with Ok _ -> () | Error (`Msg err) -> failwith err
 
-  let gc_run ?(finished = fun _ -> ()) repo key =
+  let gc_run ~fs ~domain_mgr ?(finished = fun _ -> ()) repo key =
     let f (result : (_, Store.Gc.msg) result) =
       match result with
       | Error (`Msg err) -> finished @@ Error err
       | Ok stats -> finished @@ Ok stats
     in
-    let launched = Store.Gc.run ~finished:f repo key in
+    let launched = Store.Gc.run ~fs ~domain_mgr ~finished:f repo key in
     match launched with
     | Ok true -> ()
     | Ok false -> [%logs.app "GC skipped"]
@@ -277,9 +291,18 @@ module Make_store_pack (Conf : Irmin_pack.Conf.S) = struct
 end
 
 module type B = sig
-  val run_large : config -> Format.formatter -> unit
-  val run_chains : config -> Format.formatter -> unit
-  val run_read_trace : config -> Format.formatter -> unit
+  val run_large :
+    fs:Eio.Fs.dir_ty Eio.Path.t -> config -> Format.formatter -> unit
+
+  val run_chains :
+    fs:Eio.Fs.dir_ty Eio.Path.t -> config -> Format.formatter -> unit
+
+  val run_read_trace :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    config ->
+    Format.formatter ->
+    unit
 end
 
 let store_of_config config =
@@ -300,7 +323,7 @@ type suite_elt = {
   run : config -> Format.formatter -> unit;
 }
 
-let suite : suite_elt list =
+let suite ~fs ~domain_mgr : suite_elt list =
   List.rev
     [
       {
@@ -312,7 +335,7 @@ let suite : suite_elt list =
               { config with inode_config = (32, 256); store_type = `Pack }
             in
             let (module Store) = store_of_config config in
-            Store.run_read_trace config);
+            Store.run_read_trace ~fs ~domain_mgr config);
       };
       {
         mode = `Read_trace;
@@ -323,7 +346,7 @@ let suite : suite_elt list =
               { config with inode_config = (32, 256); store_type = `Pack }
             in
             let (module Store) = store_of_config config in
-            Store.run_read_trace config);
+            Store.run_read_trace ~fs ~domain_mgr config);
       };
       {
         mode = `Chains;
@@ -334,7 +357,7 @@ let suite : suite_elt list =
               { config with inode_config = (32, 256); store_type = `Pack }
             in
             let (module Store) = store_of_config config in
-            Store.run_chains config);
+            Store.run_chains ~fs config);
       };
       {
         mode = `Chains;
@@ -345,7 +368,7 @@ let suite : suite_elt list =
               { config with inode_config = (2, 5); store_type = `Pack }
             in
             let (module Store) = store_of_config config in
-            Store.run_chains config);
+            Store.run_chains ~fs config);
       };
       {
         mode = `Large;
@@ -356,7 +379,7 @@ let suite : suite_elt list =
               { config with inode_config = (32, 256); store_type = `Pack }
             in
             let (module Store) = store_of_config config in
-            Store.run_large config);
+            Store.run_large ~fs config);
       };
       {
         mode = `Large;
@@ -367,7 +390,7 @@ let suite : suite_elt list =
               { config with inode_config = (2, 5); store_type = `Pack }
             in
             let (module Store) = store_of_config config in
-            Store.run_large config);
+            Store.run_large ~fs config);
       };
       {
         mode = `Read_trace;
@@ -375,11 +398,11 @@ let suite : suite_elt list =
         run =
           (fun config ->
             let (module Store) = store_of_config config in
-            Store.run_read_trace config);
+            Store.run_read_trace ~fs ~domain_mgr config);
       };
     ]
 
-let get_suite suite_filter =
+let get_suite ~fs ~domain_mgr suite_filter =
   List.filter
     (fun { mode; speed; _ } ->
       match (suite_filter, speed, mode) with
@@ -396,9 +419,9 @@ let get_suite suite_filter =
       | (`Slow | `Quick | `Custom_trace | `Custom_chains | `Custom_large), _, _
         ->
           false)
-    suite
+    (suite ~fs ~domain_mgr)
 
-let main () ncommits number_of_commits_to_replay suite_filter inode_config
+let main ~fs () ncommits number_of_commits_to_replay suite_filter inode_config
     store_type _freeze_commit path_conversion depth width nchain_trees
     nlarge_trees replay_trace_path artefacts_path keep_store keep_stat_trace
     no_summary empty_blobs gc_every gc_distance_in_the_past gc_wait_after
@@ -411,7 +434,7 @@ let main () ncommits number_of_commits_to_replay suite_filter inode_config
     {
       ncommits;
       number_of_commits_to_replay;
-      store_dir = Filename.concat artefacts_path "store";
+      store_dir = Eio.Path.(artefacts_path / "store");
       path_conversion;
       depth;
       width;
@@ -437,21 +460,21 @@ let main () ncommits number_of_commits_to_replay suite_filter inode_config
      results. *)
   Gc.set { (Gc.get ()) with Gc.allocation_policy = 0 };
   FSHelper.rm_dir config.store_dir;
-  let suite = get_suite suite_filter in
+  Eio_main.run @@ fun env ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  let suite = get_suite ~fs ~domain_mgr suite_filter in
   let run_benchmarks () = List.map (fun b -> b.run config) suite in
   let results =
-    Eio_main.run @@ fun _env ->
     Fun.protect run_benchmarks ~finally:(fun () ->
         if keep_store then (
-          [%logs.app "Store kept at %s" config.store_dir];
-          let ( / ) = Filename.concat in
+          [%logs.app "Store kept at %s" (Eio.Path.native_exn config.store_dir)];
           let ro p = if Sys.file_exists p then Unix.chmod p 0o444 in
-          ro (config.store_dir / "store.branches");
-          ro (config.store_dir / "store.dict");
-          ro (config.store_dir / "store.pack");
-          ro (config.store_dir / "index" / "data");
-          ro (config.store_dir / "index" / "log");
-          ro (config.store_dir / "index" / "log_async"))
+          ro Eio.Path.(native_exn @@ (config.store_dir / "store.branches"));
+          ro Eio.Path.(native_exn @@ (config.store_dir / "store.dict"));
+          ro Eio.Path.(native_exn @@ (config.store_dir / "store.pack"));
+          ro Eio.Path.(native_exn @@ (config.store_dir / "index" / "data"));
+          ro Eio.Path.(native_exn @@ (config.store_dir / "index" / "log"));
+          ro Eio.Path.(native_exn @@ (config.store_dir / "index" / "log_async")))
         else FSHelper.rm_dir config.store_dir)
   in
   [%logs.app "%a@." Fmt.(list ~sep:(any "@\n@\n") (fun ppf f -> f ppf)) results]
@@ -571,18 +594,23 @@ let nlarge_trees =
   in
   Arg.(value @@ opt int 1 doc)
 
-let replay_trace_path =
+let eio_path fs =
+  let parse s = Ok Eio.Path.(fs / s) in
+  let print = Eio.Path.pp in
+  Arg.conv ~docv:"PATH" (parse, print)
+
+let replay_trace_path fs =
   let doc =
     Arg.info ~docv:"PATH" ~doc:"Trace of Tezos operations to be replayed." []
   in
-  Arg.(required @@ pos 0 (some string) None doc)
+  Arg.(required @@ pos 0 (some (eio_path fs)) None doc)
 
-let artefacts_path =
+let artefacts_path fs cwd =
   let doc =
     Arg.info ~docv:"PATH" ~doc:"Destination of the bench artefacts."
       [ "artefacts" ]
   in
-  Arg.(value @@ opt string default_artefacts_dir doc)
+  Arg.(value @@ opt (eio_path fs) (default_artefacts_dir cwd) doc)
 
 let setup_log =
   Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
@@ -612,9 +640,9 @@ let add_volume_every =
   let doc = Arg.info ~doc:"Add volume ever N GCs" [ "add-volume-every" ] in
   Arg.(value @@ opt int 0 doc)
 
-let main_term =
+let main_term fs cwd =
   Term.(
-    const main
+    const (main ~fs)
     $ setup_log
     $ ncommits
     $ number_of_commits_to_replay
@@ -627,8 +655,8 @@ let main_term =
     $ width
     $ nchain_trees
     $ nlarge_trees
-    $ replay_trace_path
-    $ artefacts_path
+    $ replay_trace_path fs
+    $ artefacts_path fs cwd
     $ keep_store
     $ keep_stat_trace
     $ no_summary
@@ -663,4 +691,7 @@ let () =
   let info =
     deprecated_info ~man ~doc:"Benchmarks for tree operations" "tree"
   in
-  deprecated_exit @@ deprecated_eval (main_term, info)
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let cwd = Eio.Stdenv.cwd env in
+  deprecated_exit @@ deprecated_eval (main_term fs cwd, info)

--- a/examples/irmin-pack/gc.ml
+++ b/examples/irmin-pack/gc.ml
@@ -61,7 +61,7 @@ module Repo_config = struct
   (** Location on disk to save the repository
 
       Note: irmin-pack will not create the entire path, only the final directory *)
-  let root = "./irmin-pack-example"
+  let root fs = Eio.Path.(fs / "./irmin-pack-example")
 
   (** See {!Irmin_pack.Conf} for more keys that can be used when initialising
       the repository config *)
@@ -71,19 +71,19 @@ module Repo_config = struct
   let fresh = true
 
   (** Create config for our repository *)
-  let config =
-    Irmin_pack.config ~fresh ~index_log_size ~merge_throttle ~indexing_strategy
-      root
+  let config ~sw fs =
+    Irmin_pack.config ~sw ~fs ~fresh ~index_log_size ~merge_throttle
+      ~indexing_strategy (root fs)
 
   (** We can add an optional lower layer to our repository. Data discarded by
       the GC will be stored there and still be accessible instead of being
       deleted. *)
-  let lower_root = Some "./irmin-pack-example-lower"
+  let lower_root fs = Some Eio.Path.(fs / "./irmin-pack-example-lower")
 
   (** Create a copy of the previous configuration, now with a lower layer *)
-  let config_with_lower =
-    Irmin_pack.config ~fresh ~index_log_size ~merge_throttle ~indexing_strategy
-      ~lower_root root
+  let config_with_lower ~sw fs =
+    Irmin_pack.config ~sw ~fs ~fresh ~index_log_size ~merge_throttle
+      ~indexing_strategy ~lower_root:(lower_root fs) (root fs)
 end
 
 (** Utility for creating commit info *)
@@ -121,7 +121,7 @@ end
 
 (** Demonstrate running GC on a previous commit aligned to the end of a chunk
     for ideal GC space reclamation. *)
-let run_gc config repo tracker =
+let run_gc fs domain_mgr config repo tracker =
   let () =
     match Tracker.(tracker.next_gc_commit) with
     | None -> ()
@@ -148,7 +148,7 @@ let run_gc config repo tracker =
         in
         (* Launch GC *)
         let commit_key = Store.Commit.key commit in
-        let launched = Store.Gc.run ~finished repo commit_key in
+        let launched = Store.Gc.run ~fs ~domain_mgr ~finished repo commit_key in
         match launched with
         | Ok false -> ()
         | Ok true ->
@@ -160,7 +160,9 @@ let run_gc config repo tracker =
   let () = Store.split repo in
   Tracker.mark_next_gc_commit tracker
 
-let run_experiment config =
+let run_experiment env config =
+  let fs = Eio.Stdenv.fs env in
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
   let num_of_commits = 200_000 in
   let gc_every = 1_000 in
   let repo = Store.Repo.v config in
@@ -176,7 +178,9 @@ let run_experiment config =
         Store.Commit.v repo ~info:(info "add %s = %s" key value) ~parents tree
       in
       Tracker.update_latest_commit tracker commit;
-      let _ = if i mod gc_every = 0 then run_gc config repo tracker in
+      let _ =
+        if i mod gc_every = 0 then run_gc fs domain_mgr config repo tracker
+      in
       if i >= n then () else loop (i + 1) n
     in
     loop 1 num_of_commits
@@ -186,8 +190,10 @@ let run_experiment config =
   ()
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
   Printf.printf "== RUN 1: deleting discarded data ==\n";
-  run_experiment Repo_config.config;
+  run_experiment env (Repo_config.config ~sw fs);
   Printf.printf "== RUN 2: archiving discarded data ==\n";
-  run_experiment Repo_config.config_with_lower
+  run_experiment env (Repo_config.config_with_lower ~sw fs)

--- a/examples/irmin-pack/kv.ml
+++ b/examples/irmin-pack/kv.ml
@@ -50,7 +50,7 @@ module Repo_config = struct
   (** Location on disk to save the repository
 
       Note: irmin-pack will not create the entire path, only the final directory *)
-  let root = "./irmin-pack-example"
+  let root fs = Eio.Path.(fs / "./irmin-pack-example")
 
   (** See {!Irmin_pack.Conf} for more keys that can be used when initialising
       the repository config *)
@@ -60,17 +60,20 @@ module Repo_config = struct
   let fresh = true
 
   (** Create config for our repository *)
-  let config =
+  let config fs =
     Irmin_pack.config ~fresh ~index_log_size ~merge_throttle ~indexing_strategy
-      root
+      (root fs)
 end
 
 module StoreMaker = Irmin_pack_unix.KV (Conf)
 module Store = StoreMaker.Make (Irmin.Contents.String)
 
-let main () =
+let main env =
+  (* Create a switch *)
+  Eio.Switch.run @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
   (* Instantiate a repository *)
-  let repo = Store.Repo.v Repo_config.config in
+  let repo = Store.Repo.v (Repo_config.config ~sw ~fs fs) in
 
   (* Get the store from the main branch. *)
   let store = Store.main repo in
@@ -93,6 +96,6 @@ let setup_logs () =
   Logs.(set_level @@ Some Debug)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   setup_logs ();
-  main ()
+  main env

--- a/src/irmin-cli/cli.ml
+++ b/src/irmin-cli/cli.ml
@@ -19,6 +19,8 @@ open Cmdliner
 open Resolver
 module Graphql = Irmin_graphql_unix
 
+type eio = Import.eio
+
 let deprecated_info = (Term.info [@alert "-deprecated"])
 let deprecated_man_format = (Term.man_format [@alert "-deprecated"])
 let deprecated_eval_choice = (Term.eval_choice [@alert "-deprecated"])
@@ -53,7 +55,7 @@ let term_info title ~doc ~man =
   deprecated_info ~sdocs:global_option_section ~docs:global_option_section ~doc
     ~man title
 
-type command = (unit Term.t * Term.info[@alert "-deprecated"])
+type command = env:eio -> (unit Term.t * Term.info[@alert "-deprecated"])
 
 type sub = {
   name : string;
@@ -62,7 +64,8 @@ type sub = {
   term : unit Term.t;
 }
 
-let create_command c =
+let create_command c ~env =
+  let c = c ~env in
   let man = [ `S "DESCRIPTION"; `P c.doc ] @ c.man in
   (c.term, term_info c.name ~doc:c.doc ~man)
 
@@ -113,14 +116,14 @@ let run t = try t () with err -> print_exc err
 let mk (fn : 'a) : 'a Term.t = Term.(const (fun () -> fn) $ setup_log)
 
 (* INIT *)
-let init =
+let init ~env =
   {
     name = "init";
     doc = "Initialize a store.";
     man = [];
     term =
       (let init (S (_, _store, _)) = () in
-       Term.(mk init $ store ()));
+       Term.(mk init $ store ~env));
   }
 
 let print fmt = Fmt.kstr print_endline fmt
@@ -136,7 +139,7 @@ let branch f x = get "branch" f x
 let commit f x = get "commit" f x
 
 (* GET *)
-let get =
+let get ~env =
   {
     name = "get";
     doc = "Read the value associated with a key.";
@@ -152,11 +155,11 @@ let get =
              exit 1
          | Some v -> print "%a" (Irmin.Type.pp S.Contents.t) v
        in
-       Term.(mk get $ store () $ path));
+       Term.(mk get $ store ~env $ path));
   }
 
 (* LIST *)
-let list =
+let list ~env =
   {
     name = "list";
     doc = "List subdirectories.";
@@ -180,11 +183,11 @@ let list =
          in
          List.iter (print "%a" pp) paths
        in
-       Term.(mk list $ store () $ path_or_empty));
+       Term.(mk list $ store ~env $ path_or_empty));
   }
 
 (* TREE *)
-let tree =
+let tree ~env =
   {
     name = "tree";
     doc = "List the store contents.";
@@ -236,7 +239,7 @@ let tree =
              print "%s%s%s" k dots v)
            all
        in
-       Term.(mk tree $ store ()));
+       Term.(mk tree $ store ~env));
   }
 
 let author =
@@ -248,7 +251,7 @@ let message =
   Arg.(value & opt (some string) None & doc)
 
 (* SET *)
-let set =
+let set ~env =
   {
     name = "set";
     doc = "Update the value associated with a key.";
@@ -267,11 +270,11 @@ let set =
          let value = value S.Contents.t v in
          S.set_exn t ~info:(info (module S) ?author "%s" message) path value
        in
-       Term.(mk set $ store () $ author $ message $ path $ v));
+       Term.(mk set $ store ~env $ author $ message $ path $ v));
   }
 
 (* REMOVE *)
-let remove =
+let remove ~env =
   {
     name = "remove";
     doc = "Delete a key.";
@@ -288,7 +291,7 @@ let remove =
            ~info:(info (module S) ?author "%s" message)
            (key S.Path.t path)
        in
-       Term.(mk remove $ store () $ author $ message $ path));
+       Term.(mk remove $ store ~env $ author $ message $ path));
   }
 
 let apply e f =
@@ -298,7 +301,7 @@ let apply e f =
   | r, _ -> r
 
 (* CLONE *)
-let clone =
+let clone ~env =
   {
     name = "clone";
     doc = "Copy a remote respository to a local store";
@@ -316,11 +319,11 @@ let clone =
          | Ok `Empty -> ()
          | Error (`Msg e) -> failwith e
        in
-       Term.(mk clone $ Resolver.remote () $ depth));
+       Term.(mk clone $ Resolver.remote ~env $ depth));
   }
 
 (* FETCH *)
-let fetch =
+let fetch ~env =
   {
     name = "fetch";
     doc = "Download objects and refs from another repository.";
@@ -338,11 +341,11 @@ let fetch =
          let _ = Sync.pull_exn t x `Set in
          ()
        in
-       Term.(mk fetch $ Resolver.remote ()));
+       Term.(mk fetch $ Resolver.remote ~env));
   }
 
 (* MERGE *)
-let merge =
+let merge ~env =
   {
     name = "merge";
     doc = "Merge branches.";
@@ -371,11 +374,11 @@ let merge =
          let doc = Arg.info ~docv:"BRANCH" ~doc:"Branch to merge from." [] in
          Arg.(required & pos 0 (some string) None & doc)
        in
-       Term.(mk merge $ store () $ author $ message $ branch_name));
+       Term.(mk merge $ store ~env $ author $ message $ branch_name));
   }
 
 (* PULL *)
-let pull =
+let pull ~env =
   {
     name = "pull";
     doc = "Fetch and merge with another repository.";
@@ -394,11 +397,11 @@ let pull =
          in
          ()
        in
-       Term.(mk pull $ remote () $ author $ message));
+       Term.(mk pull $ remote ~env $ author $ message));
   }
 
 (* PUSH *)
-let push =
+let push ~env =
   {
     name = "push";
     doc = "Update remote references along with associated objects.";
@@ -414,11 +417,11 @@ let push =
          let _ = Sync.push_exn t x in
          ()
        in
-       Term.(mk push $ remote ()));
+       Term.(mk push $ remote ~env));
   }
 
 (* SNAPSHOT *)
-let snapshot =
+let snapshot ~env =
   {
     name = "snapshot";
     doc = "Return a snapshot for the current state of the database.";
@@ -432,11 +435,11 @@ let snapshot =
          print "%a" S.Commit.pp_hash k;
          ()
        in
-       Term.(mk snapshot $ store ()));
+       Term.(mk snapshot $ store ~env));
   }
 
 (* REVERT *)
-let revert =
+let revert ~env =
   {
     name = "revert";
     doc = "Revert the contents of the store to a previous state.";
@@ -457,7 +460,7 @@ let revert =
          | Some s -> S.Head.set t s
          | None -> failwith "invalid commit"
        in
-       Term.(mk revert $ store () $ snapshot));
+       Term.(mk revert $ store ~env $ snapshot));
   }
 
 (* WATCH *)
@@ -543,7 +546,7 @@ let handle_diff (type a b)
        and type Schema.Metadata.t = S.metadata)
     diff command proc
 
-let watch =
+let watch ~env =
   {
     name = "watch";
     doc = "Get notifications when values change.";
@@ -573,11 +576,11 @@ let watch =
          let doc = Arg.info ~docv:"COMMAND" ~doc:"Command to execute" [] in
          Arg.(value & pos_right 0 string [] & doc)
        in
-       Term.(mk watch $ store () $ path $ command));
+       Term.(mk watch $ store ~env $ path $ command));
   }
 
 (* DOT *)
-let dot =
+let dot ~env =
   {
     name = "dot";
     doc = "Dump the contents of the store as a Graphviz file.";
@@ -639,7 +642,7 @@ let dot =
            in
            if i <> 0 then [%logs.err "The %s.dot is corrupted" basename])
        in
-       Term.(mk dot $ store () $ basename $ depth $ no_dot_call $ full));
+       Term.(mk dot $ store ~env $ basename $ depth $ no_dot_call $ full));
   }
 
 let config_man =
@@ -676,7 +679,7 @@ let config_man =
     @ help_sections )
 
 (* HELP *)
-let help =
+let help ~env:_ =
   {
     name = "help";
     doc = "Display help about Irmin and Irmin commands.";
@@ -710,7 +713,7 @@ let help =
   }
 
 (* GRAPHQL *)
-let graphql =
+let graphql ~env =
   {
     name = "graphql";
     doc = "Run a graphql server.";
@@ -748,19 +751,19 @@ let graphql =
            ~mode:(`TCP (`Port port))
            server
        in
-       Term.(mk graphql $ store () $ port $ addr));
+       Term.(mk graphql $ store ~env $ port $ addr));
   }
 
 (* SERVER *)
-let server =
+let server ~env =
   {
     name = "server";
     doc = "Run irmin-server.";
     man = [];
-    term = Server.main_term;
+    term = Server.main_term ~env;
   }
 
-let options =
+let options ~env =
   {
     name = "options";
     doc = "Get information about backend specific configuration options.";
@@ -768,26 +771,22 @@ let options =
     term =
       (let options (store, hash, contents) =
          let module Conf = Irmin.Backend.Conf in
-         let store, _ = Resolver.load_config ?store ?hash ?contents () in
+         let store, _ = Resolver.load_config ~env ?store ?hash ?contents () in
          let spec = Store.spec store in
          Seq.iter
            (fun (Conf.K k) ->
              let name = Conf.name k in
              if name = "root" || name = "uri" then ()
              else
-               let ty = Conf.ty k in
+               let ty = Conf.typename k in
                let doc = Conf.doc k |> Option.value ~default:"" in
-               let ty =
-                 Fmt.str "%a" Irmin.Type.pp_ty ty
-                 |> Astring.String.filter (fun c -> c <> '\n')
-               in
                Fmt.pr "%s: %s\n\t%s\n" name ty doc)
            (Conf.Spec.keys spec)
        in
        Term.(mk options $ Store.term ()));
   }
 
-let branches =
+let branches ~env =
   {
     name = "branches";
     doc = "List branches";
@@ -800,7 +799,7 @@ let branches =
          let branches = S.Branch.list (S.repo t) in
          List.iter (Fmt.pr "%a\n" (Irmin.Type.pp S.branch_t)) branches
        in
-       Term.(mk branches $ store ()));
+       Term.(mk branches $ store ~env));
   }
 
 let weekday Unix.{ tm_wday; _ } =
@@ -830,7 +829,7 @@ let month Unix.{ tm_mon; _ } =
   | 11 -> "Dec"
   | _ -> assert false
 
-let log =
+let log ~env =
   {
     name = "log";
     doc = "List commits";
@@ -911,10 +910,36 @@ let log =
              ()
            with Sys_error s when String.equal s "Broken pipe" -> ()
        in
-       Term.(mk commits $ store () $ plain $ pager $ num $ skip $ reverse));
+       Term.(mk commits $ store ~env $ plain $ pager $ num $ skip $ reverse));
   }
 
-let default =
+let common_commands =
+  [
+    init;
+    get;
+    set;
+    remove;
+    list;
+    tree;
+    clone;
+    fetch;
+    merge;
+    pull;
+    push;
+    snapshot;
+    revert;
+    watch;
+    dot;
+    graphql;
+    server;
+    options;
+    branches;
+    log;
+  ]
+
+let commands = help :: common_commands
+
+let default ~env =
   let doc = "Irmin, the database that never forgets." in
   let man =
     [
@@ -933,66 +958,28 @@ let default =
       "usage: irmin [--version]\n\
       \             [--help]\n\
       \             <command> [<args>]\n\n\
-       The most commonly used subcommands are:\n\
-      \    init        %s\n\
-      \    get         %s\n\
-      \    set         %s\n\
-      \    remove      %s\n\
-      \    list        %s\n\
-      \    tree        %s\n\
-      \    clone       %s\n\
-      \    fetch       %s\n\
-      \    merge       %s\n\
-      \    pull        %s\n\
-      \    push        %s\n\
-      \    snapshot    %s\n\
-      \    revert      %s\n\
-      \    watch       %s\n\
-      \    dot         %s\n\
-      \    graphql     %s\n\
-      \    server      %s\n\
-      \    options     %s\n\
-      \    branches    %s\n\
-      \    log         %s\n\n\
-       See `irmin help <command>` for more information on a specific command.\n\
-       %!"
-      init.doc get.doc set.doc remove.doc list.doc tree.doc clone.doc fetch.doc
-      merge.doc pull.doc push.doc snapshot.doc revert.doc watch.doc dot.doc
-      graphql.doc server.doc options.doc branches.doc log.doc
+       The most commonly used subcommands are:\n";
+    List.iter
+      (fun cmd ->
+        let cmd = cmd ~env in
+        Fmt.pr "    %-11s %s\n" cmd.name cmd.doc)
+      common_commands;
+    Fmt.pr
+      "\n\
+       See `irmin help <command>` for more information on a specific command.@."
   in
   ( Term.(mk usage $ const ()),
     deprecated_info "irmin" ~version:Irmin.version ~sdocs:global_option_section
       ~doc ~man )
 
-let commands =
-  List.map create_command
-    [
-      help;
-      init;
-      get;
-      set;
-      remove;
-      list;
-      tree;
-      clone;
-      fetch;
-      merge;
-      pull;
-      push;
-      snapshot;
-      revert;
-      watch;
-      dot;
-      graphql;
-      server;
-      options;
-      branches;
-      log;
-    ]
+let commands = List.map create_command commands
 
 let run ~default:x y =
   Eio_main.run @@ fun env ->
-  Irmin_fs.run env#fs @@ fun () ->
   Lwt_eio.with_event_loop ~clock:env#clock @@ fun _ ->
   Irmin.Backend.Watch.set_listen_dir_hook Irmin_watcher.hook;
-  match deprecated_eval_choice x y with `Error _ -> exit 1 | _ -> ()
+  let env = (env :> eio) in
+  let run cmd = cmd ~env in
+  match deprecated_eval_choice (run x) (List.map run y) with
+  | `Error _ -> exit 1
+  | _ -> ()

--- a/src/irmin-cli/cli.mli
+++ b/src/irmin-cli/cli.mli
@@ -16,7 +16,10 @@
 
 (** CLI commands. *)
 
-type command = (unit Cmdliner.Term.t * Cmdliner.Term.info[@alert "-deprecated"])
+type eio = Import.eio
+
+type command =
+  env:eio -> (unit Cmdliner.Term.t * Cmdliner.Term.info[@alert "-deprecated"])
 (** [Cmdliner] commands. *)
 
 val default : command
@@ -38,5 +41,5 @@ type sub = {
 }
 (** Subcommand. *)
 
-val create_command : sub -> command
+val create_command : (env:eio -> sub) -> command
 (** Build a subcommand. *)

--- a/src/irmin-cli/dune
+++ b/src/irmin-cli/dune
@@ -19,6 +19,7 @@
   cohttp-lwt-unix
   unix
   yaml
+  eio
   eio_main
   lwt_eio)
  (preprocess

--- a/src/irmin-cli/import.ml
+++ b/src/irmin-cli/import.ml
@@ -15,3 +15,7 @@
  *)
 
 include Irmin.Export_for_backends
+
+type eio =
+  < cwd : Eio.Fs.dir_ty Eio.Path.t
+  ; clock : float Eio.Time.clock_ty Eio.Time.clock >

--- a/src/irmin-cli/import.ml
+++ b/src/irmin-cli/import.ml
@@ -18,4 +18,5 @@ include Irmin.Export_for_backends
 
 type eio =
   < cwd : Eio.Fs.dir_ty Eio.Path.t
-  ; clock : float Eio.Time.clock_ty Eio.Time.clock >
+  ; clock : float Eio.Time.clock_ty Eio.Time.clock
+  ; sw : Eio.Switch.t >

--- a/src/irmin-cli/resolver.ml
+++ b/src/irmin-cli/resolver.ml
@@ -23,21 +23,23 @@ let global_option_section = "COMMON OPTIONS"
 
 module Conf = Irmin.Backend.Conf
 
-let try_parse ty v =
-  match Irmin.Type.of_string ty v with
+let try_parse of_string v =
+  match of_string v with
   | Error e -> (
       let x = Format.sprintf "{\"some\": %s}" v in
-      match Irmin.Type.of_string ty x with
+      match of_string x with
       | Error _ ->
           let y = Format.sprintf "{\"some\": \"%s\"}" v in
-          Irmin.Type.of_string ty y |> Result.map_error (fun _ -> e)
+          of_string y |> Result.map_error (fun _ -> e)
       | v -> v)
   | v -> v
 
 let pconv t =
   let pp = Irmin.Type.pp t in
   let parse s =
-    match try_parse t s with Ok x -> `Ok x | Error (`Msg e) -> `Error e
+    match try_parse (Irmin.Type.of_string t) s with
+    | Ok x -> `Ok x
+    | Error (`Msg e) -> `Error e
   in
   (parse, pp)
 
@@ -296,7 +298,14 @@ module Store = struct
     v spec (module S)
 
   let mem = create Irmin_mem.Conf.spec (module Irmin_mem)
-  let fs = create Irmin_fs.Conf.spec (module Irmin_fs_unix)
+
+  let fs env =
+    let spec =
+      Irmin_fs_unix.spec ~path:(Eio.Stdenv.cwd env)
+        ~clock:(Eio.Stdenv.clock env)
+    in
+    create spec (module Irmin_fs_unix)
+
   let git (module C : Irmin.Contents.S) = v_git (module Xgit.FS.KV (C))
   let git_mem (module C : Irmin.Contents.S) = v_git (module Xgit.Mem.KV (C))
 
@@ -324,23 +333,24 @@ module Store = struct
   let all =
     ref
       [
-        ("git", Fixed_hash git);
-        ("git-mem", Fixed_hash git_mem);
-        ("fs", Variable_hash fs);
-        ("mem", Variable_hash mem);
-        ("pack", Variable_hash pack);
-        ("tezos", Fixed tezos);
+        ("git", fun _ -> Fixed_hash git);
+        ("git-mem", fun _ -> Fixed_hash git_mem);
+        ("fs", fun env -> Variable_hash (fs env));
+        ("mem", fun _ -> Variable_hash mem);
+        ("pack", fun _ -> Variable_hash pack);
+        ("tezos", fun _ -> Fixed tezos);
       ]
 
   let default = "git" |> fun n -> ref (n, List.assoc n !all)
 
   let add name ?default:(x = false) m =
+    let m (_ : eio) = m in
     all := (name, m) :: !all;
     if x then default := (name, m)
 
-  let find name =
+  let find name env =
     match List.assoc_opt (String.Ascii.lowercase name) !all with
-    | Some s -> s
+    | Some s -> s env
     | None ->
         let valid = String.concat ~sep:", " (List.split !all |> fst) in
         let msg =
@@ -456,10 +466,10 @@ let parse_config ?root y spec =
         | Some (Irmin.Backend.Conf.K k), Some v ->
             let v = json_of_yaml v |> Yojson.Basic.to_string in
             let v =
-              match Irmin.Type.of_json_string (Conf.ty k) v with
+              match Conf.of_json_string k v with
               | Error _ ->
                   let v = Format.sprintf "{\"some\": %s}" v in
-                  Irmin.Type.of_json_string (Conf.ty k) v |> Result.get_ok
+                  Conf.of_json_string k v |> Result.get_ok
               | Ok v -> v
             in
             Conf.add config k v
@@ -475,7 +485,7 @@ let parse_config ?root y spec =
   let config =
     match (root, Conf.Spec.find_key spec "root") with
     | Some root, Some (K r) ->
-        let v = Irmin.Type.of_string (Conf.ty r) root |> Result.get_ok in
+        let v = Conf.of_string r root |> Result.get_ok in
         Conf.add config r v
     | _ -> config
   in
@@ -489,7 +499,7 @@ let load_plugin ?plugin config =
       | Ok (Some v) -> Dynlink.loadfile_private (Yaml.Util.to_string_exn v)
       | _ -> ())
 
-let get_store ?plugin config (store, hash, contents) =
+let get_store ~env ?plugin config (store, hash, contents) =
   let () = load_plugin ?plugin config in
   let store =
     match store with
@@ -500,6 +510,7 @@ let get_store ?plugin config (store, hash, contents) =
             match store with Some s -> Store.find s | None -> Store.find s)
         | _ -> snd !Store.default)
   in
+  let store = store env in
   let contents =
     match contents with
     | Some s -> Contents.find s
@@ -532,9 +543,9 @@ let get_store ?plugin config (store, hash, contents) =
       | _ ->
           Fmt.failwith "Cannot customize the hash function for the given store")
 
-let load_config ?plugin ?root ?config_path ?store ?hash ?contents () =
+let load_config ~env ?plugin ?root ?config_path ?store ?hash ?contents () =
   let y = read_config_file config_path in
-  let store = get_store ?plugin y (store, hash, contents) in
+  let store = get_store ~env ?plugin y (store, hash, contents) in
   let spec = Store.spec store in
   let config = parse_config ?root y spec in
   (store, config)
@@ -564,10 +575,10 @@ let get_commit (type a b)
   | None -> of_string (find_key config "commit")
   | Some t -> of_string (Some t)
 
-let build_irmin_config config root opts (store, hash, contents) branch commit
-    plugin : store =
+let build_irmin_config ~env config root opts (store, hash, contents) branch
+    commit plugin : store =
   let (T { impl; spec; remote }) =
-    get_store ?plugin config (store, hash, contents)
+    get_store ~env ?plugin config (store, hash, contents)
   in
   let (module S) = Store.Impl.generic_keyed impl in
   let branch = get_branch (module S) config branch in
@@ -586,8 +597,7 @@ let build_irmin_config config root opts (store, hash, contents) branch commit
             | Some x -> x
             | None -> invalid_arg ("opt: " ^ k)
         in
-        let ty = Conf.ty key in
-        let v = try_parse ty v |> Result.get_ok in
+        let v = try_parse (Conf.of_string key) v |> Result.get_ok in
         let config = Conf.add config key v in
         config)
       config (List.flatten opts)
@@ -626,10 +636,10 @@ let plugin =
   let doc = "Register new contents, store or hash types" in
   Arg.(value & opt (some string) None & info ~doc [ "plugin" ])
 
-let store () =
+let store ~env =
   let create plugin store (root, config_path, opts) branch commit =
     let y = read_config_file config_path in
-    build_irmin_config y root opts store branch commit plugin
+    build_irmin_config ~env y root opts store branch commit plugin
   in
   Term.(const create $ plugin $ Store.term () $ config_term $ branch $ commit)
 
@@ -653,7 +663,7 @@ type Irmin.remote += R of Cohttp.Header.t option * string
 (* FIXME: this is a very crude heuristic to choose the remote
    kind. Would be better to read the config file and look for remote
    alias. *)
-let infer_remote hash contents branch headers str =
+let infer_remote ~env hash contents branch headers str =
   let hash = match hash with None -> snd !Hash.default | Some c -> c in
   let contents =
     match contents with
@@ -664,7 +674,7 @@ let infer_remote hash contents branch headers str =
     let r =
       if Sys.file_exists (str / ".git") then Store.git contents
       else if Sys.file_exists (str / "store.dict") then Store.pack hash contents
-      else Store.fs hash contents
+      else Store.fs env hash contents
     in
     match r with
     | Store.T { impl; spec; _ } ->
@@ -673,7 +683,7 @@ let infer_remote hash contents branch headers str =
         let config =
           match Conf.Spec.find_key spec "root" with
           | Some (K r) ->
-              let v = Irmin.Type.of_string (Conf.ty r) str |> Result.get_ok in
+              let v = Conf.of_string r str |> Result.get_ok in
               Conf.add config r v
           | _ -> config
         in
@@ -691,7 +701,7 @@ let infer_remote hash contents branch headers str =
     in
     R (headers, str)
 
-let remote () =
+let remote ~env =
   let repo =
     let doc =
       Arg.info ~docv:"REMOTE"
@@ -703,9 +713,10 @@ let remote () =
       headers str =
     let y = read_config_file config_path in
     let store =
-      build_irmin_config y root opts (store, hash, contents) branch commit None
+      build_irmin_config ~env y root opts (store, hash, contents) branch commit
+        None
     in
-    let remote () = infer_remote hash contents branch headers str in
+    let remote () = infer_remote ~env hash contents branch headers str in
     (store, remote)
   in
   Term.(

--- a/src/irmin-cli/resolver.ml
+++ b/src/irmin-cli/resolver.ml
@@ -320,15 +320,20 @@ module Store = struct
     end)
   end
 
-  let pack : hash -> contents -> t =
-   fun (module H) (module C) ->
+  let pack : eio -> hash -> contents -> t =
+   fun env (module H) (module C) ->
     let module Schema = struct
       include Irmin.Schema.KV (C)
       module Hash = H
     end in
-    v_generic Irmin_pack.Conf.spec (module Irmin_pack_maker.Make (Schema))
+    v_generic
+      (Irmin_pack.Conf.spec ~sw:env#sw ~fs:env#cwd)
+      (module Irmin_pack_maker.Make (Schema))
 
-  let tezos = v_generic Irmin_pack.Conf.spec (module Irmin_tezos.Store)
+  let tezos env =
+    v_generic
+      (Irmin_pack.Conf.spec ~sw:env#sw ~fs:env#cwd)
+      (module Irmin_tezos.Store)
 
   let all =
     ref
@@ -337,8 +342,8 @@ module Store = struct
         ("git-mem", fun _ -> Fixed_hash git_mem);
         ("fs", fun env -> Variable_hash (fs env));
         ("mem", fun _ -> Variable_hash mem);
-        ("pack", fun _ -> Variable_hash pack);
-        ("tezos", fun _ -> Fixed tezos);
+        ("pack", fun env -> Variable_hash (pack env));
+        ("tezos", fun env -> Fixed (tezos env));
       ]
 
   let default = "git" |> fun n -> ref (n, List.assoc n !all)
@@ -673,7 +678,8 @@ let infer_remote ~env hash contents branch headers str =
   if Sys.file_exists str then
     let r =
       if Sys.file_exists (str / ".git") then Store.git contents
-      else if Sys.file_exists (str / "store.dict") then Store.pack hash contents
+      else if Sys.file_exists (str / "store.dict") then
+        Store.pack env hash contents
       else Store.fs env hash contents
     in
     match r with

--- a/src/irmin-cli/resolver.mli
+++ b/src/irmin-cli/resolver.mli
@@ -90,7 +90,7 @@ module Store : sig
   val mem : hash -> contents -> t
   val fs : eio -> hash -> contents -> t
   val git : contents -> t
-  val pack : hash -> contents -> t
+  val pack : eio -> hash -> contents -> t
   val find : string -> eio -> store_functor
   val add : string -> ?default:bool -> store_functor -> unit
   val spec : t -> Irmin.Backend.Conf.Spec.t

--- a/src/irmin-cli/resolver.mli
+++ b/src/irmin-cli/resolver.mli
@@ -43,6 +43,8 @@ type contents = Contents.t
 
 (** {1 Global Configuration} *)
 
+type eio := Import.eio
+
 module Store : sig
   module Impl : sig
     (** The type of {i implementations} of an Irmin store.
@@ -86,10 +88,10 @@ module Store : sig
     t
 
   val mem : hash -> contents -> t
-  val fs : hash -> contents -> t
+  val fs : eio -> hash -> contents -> t
   val git : contents -> t
   val pack : hash -> contents -> t
-  val find : string -> store_functor
+  val find : string -> eio -> store_functor
   val add : string -> ?default:bool -> store_functor -> unit
   val spec : t -> Irmin.Backend.Conf.Spec.t
   val generic_keyed : t -> (module Irmin.Generic_key.S)
@@ -103,6 +105,7 @@ end
 (** {1 Stores} *)
 
 val load_config :
+  env:eio ->
   ?plugin:string ->
   ?root:string ->
   ?config_path:string ->
@@ -126,10 +129,10 @@ val load_config :
 type store =
   | S : 'a Store.Impl.t * (unit -> 'a) * Store.remote_fn option -> store
 
-val store : unit -> store Cmdliner.Term.t
+val store : env:eio -> store Cmdliner.Term.t
 (** Parse the command-line arguments and then the config file. *)
 
 type Irmin.remote += R of Cohttp.Header.t option * string
 
-val remote : unit -> (store * (unit -> Irmin.remote)) Cmdliner.Term.t
+val remote : env:eio -> (store * (unit -> Irmin.remote)) Cmdliner.Term.t
 (** Parse a remote store location. *)

--- a/src/irmin-cli/server.ml
+++ b/src/irmin-cli/server.ml
@@ -29,10 +29,11 @@ let setup_log =
   Cmdliner.Term.(
     const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
 
-let main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~dashboard
+let main ~env ~readonly ~root ~uri ~tls ~store ~contents ~hash ~dashboard
     ~config_path (module Codec : Conn.Codec.S) fingerprint =
+  Lwt_eio.run_lwt @@ fun () ->
   let store, config =
-    Resolver.load_config ?root ?config_path ?store ?hash ?contents ()
+    Resolver.load_config ~env ?root ?config_path ?store ?hash ?contents ()
   in
   let config = Irmin_server.Cli.Conf.v config uri in
   let (module Store : Irmin.Generic_key.S) =
@@ -61,16 +62,15 @@ let main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~dashboard
     Logs.app (fun l -> l "Listening on %a, store: %s" Uri.pp_hum uri root);
     Server.serve server
 
-let main readonly root uri tls (store, hash, contents) codec config_path
+let main ~env readonly root uri tls (store, hash, contents) codec config_path
     dashboard fingerprint () =
   let codec =
     match codec with
     | `Bin -> (module Conn.Codec.Bin : Conn.Codec.S)
     | `Json -> (module Conn.Codec.Json)
   in
-  Lwt_main.run
-  @@ main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~config_path
-       ~dashboard codec fingerprint
+  main ~env ~readonly ~root ~uri ~tls ~store ~contents ~hash ~config_path
+    ~dashboard codec fingerprint
 
 open Cmdliner
 
@@ -107,9 +107,9 @@ let dashboard =
   in
   Arg.(value @@ opt (some int) None doc)
 
-let main_term =
+let main_term ~env =
   Term.(
-    const main
+    const (main ~env)
     $ readonly
     $ root
     $ Irmin_server.Cli.uri

--- a/src/irmin-client/unix/bin/client.ml
+++ b/src/irmin-client/unix/bin/client.ml
@@ -260,7 +260,7 @@ let iterations =
   in
   Arg.(value @@ opt int 1 doc)
 
-let config =
+let config ~env =
   let create uri (branch : string option) tls (store, hash, contents) codec
       config_path () =
     let codec =
@@ -270,7 +270,7 @@ let config =
     in
     let (module Codec) = codec in
     let store, config =
-      Irmin_cli.Resolver.load_config ?config_path ?store ?hash ?contents ()
+      Irmin_cli.Resolver.load_config ~env ?config_path ?store ?hash ?contents ()
     in
     let config = Irmin_server.Cli.Conf.v config uri in
     let (module Store : Irmin.Generic_key.S) =
@@ -298,6 +298,8 @@ let help =
     (Term.info "irmin-client" [@alert "-deprecated"]) )
 
 let[@alert "-deprecated"] () =
+  Eio_main.run @@ fun env ->
+  let config = config ~env:(env :> Irmin_cli.eio) in
   Term.exit
   @@ Term.eval_choice help
        [

--- a/src/irmin-client/unix/bin/client.ml
+++ b/src/irmin-client/unix/bin/client.ml
@@ -299,6 +299,14 @@ let help =
 
 let[@alert "-deprecated"] () =
   Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let env =
+    object
+      method cwd = Eio.Stdenv.cwd env
+      method clock = Eio.Stdenv.clock env
+      method sw = sw
+    end
+  in
   let config = config ~env:(env :> Irmin_cli.eio) in
   Term.exit
   @@ Term.eval_choice help

--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -15,43 +15,49 @@
  *)
 
 open! Import
-open Eio
 open Astring
 
 let src = Logs.Src.create "irmin.fs" ~doc:"Irmin disk persistence"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let ( / ) = Path.( / )
+let ( / ) = Filename.concat
 
 module type Config = sig
-  val dir : Fs.dir_ty Path.t -> Fs.dir_ty Path.t
+  val dir : string -> string
   val file_of_key : string -> string
   val key_of_file : string -> string
 end
 
 module type IO = sig
-  type path = Fs.dir_ty Path.t
+  type io
 
-  val rec_files : path -> path list
-  val file_exists : path -> bool
-  val read_file : path -> string option
-  val mkdir : path -> unit
+  val io_of_config : Irmin.config -> io
+
+  type path = string
+
+  val rec_files : io:io -> path -> path list
+  val file_exists : io:io -> path -> bool
+  val read_file : io:io -> path -> string option
+  val mkdir : io:io -> path -> unit
 
   type lock
 
-  val lock_file : path -> lock
-  val write_file : ?temp_dir:path -> ?lock:lock -> path -> string -> unit
+  val lock_file : io:io -> path -> lock
+
+  val write_file :
+    io:io -> temp_dir:path -> ?lock:lock -> path -> string -> unit
 
   val test_and_set_file :
-    ?temp_dir:path ->
+    io:io ->
+    temp_dir:path ->
     lock:lock ->
     path ->
     test:string option ->
     set:string option ->
     bool
 
-  val remove_file : ?lock:lock -> path -> unit
+  val remove_file : io:io -> ?lock:lock -> path -> unit
 end
 
 (* ~path *)
@@ -76,15 +82,15 @@ module Read_only_ext
 struct
   type key = K.t
   type value = V.t
-  type 'a t = { path : Fs.dir_ty Path.t }
+  type 'a t = { path : string; io : IO.io }
 
   let get_path config = Option.value Conf.(find_root config) ~default:"."
 
   let v config =
-    let fs = Irmin.Backend.Conf.Env.fs () in
-    let path = Path.(fs / get_path config) in
-    IO.mkdir path;
-    { path }
+    let io = IO.io_of_config config in
+    let path = get_path config in
+    IO.mkdir ~io path;
+    { path; io }
 
   let close _ = ()
   let cast t = (t :> read_write t)
@@ -93,12 +99,13 @@ struct
   let file_of_key { path; _ } key =
     path / S.file_of_key (Irmin.Type.to_string K.t key)
 
-  let lock_of_key { path; _ } key =
-    IO.lock_file (path / "lock" / S.file_of_key (Irmin.Type.to_string K.t key))
+  let lock_of_key { io; path } key =
+    IO.lock_file ~io
+      (path / "lock" / S.file_of_key (Irmin.Type.to_string K.t key))
 
   let mem t key =
     let file = file_of_key t key in
-    IO.file_exists file
+    IO.file_exists ~io:t.io file
 
   let of_bin_string = Irmin.Type.(unstage (of_bin_string V.t))
 
@@ -113,17 +120,17 @@ struct
 
   let find t key =
     [%log.debug "find %a" pp_key key];
-    match IO.read_file (file_of_key t key) with
+    match IO.read_file ~io:t.io (file_of_key t key) with
     | None -> None
     | Some x -> value x
 
-  let list t =
+  let list { path; io } =
     [%log.debug "list"];
-    let files = IO.rec_files (S.dir t.path) in
+    let files = IO.rec_files ~io (S.dir path) in
     let files =
-      let p = String.length (snd t.path) in
+      let p = String.length path in
       List.fold_left
-        (fun acc (_, file) ->
+        (fun acc file ->
           let n = String.length file in
           if n <= p + 1 then acc
           else
@@ -156,11 +163,11 @@ struct
     [%log.debug "add %a" pp_key key];
     let file = file_of_key t key in
     let temp_dir = temp_dir t in
-    match IO.file_exists file with
+    match IO.file_exists ~io:t.io file with
     | true -> ()
     | false ->
         let str = to_bin_string value in
-        IO.write_file ~temp_dir file str
+        IO.write_file ~io:t.io ~temp_dir file str
 end
 
 module Atomic_write_ext
@@ -217,7 +224,7 @@ struct
           [%log.err "listen_dir: %s" e];
           None
     in
-    W.listen_dir t.w (snd dir) ~key ~value:(RO.find t.t)
+    W.listen_dir t.w dir ~key ~value:(RO.find t.t)
 
   let watch_key t key ?init f =
     let stop = listen_dir t in
@@ -240,14 +247,14 @@ struct
     let temp_dir = temp_dir t in
     let file = RO.file_of_key t.t key in
     let lock = RO.lock_of_key t.t key in
-    IO.write_file ~temp_dir file ~lock (raw_value value);
+    IO.write_file ~io:t.t.io ~temp_dir file ~lock (raw_value value);
     W.notify t.w key (Some value)
 
   let remove t key =
     [%log.debug "remove %a" RO.pp_key key];
     let file = RO.file_of_key t.t key in
     let lock = RO.lock_of_key t.t key in
-    let () = IO.remove_file ~lock file in
+    let () = IO.remove_file ~io:t.t.io ~lock file in
     W.notify t.w key None
 
   let test_and_set t key ~test ~set =
@@ -257,8 +264,8 @@ struct
     let lock = RO.lock_of_key t.t key in
     let raw_value = function None -> None | Some v -> Some (raw_value v) in
     let b =
-      IO.test_and_set_file file ~temp_dir ~lock ~test:(raw_value test)
-        ~set:(raw_value set)
+      IO.test_and_set_file ~io:t.t.io file ~temp_dir ~lock
+        ~test:(raw_value test) ~set:(raw_value set)
     in
     let () = if b then W.notify t.w key set in
     b
@@ -266,7 +273,8 @@ struct
   let clear t =
     [%log.debug "clear"];
     let remove_file key () =
-      IO.remove_file ~lock:(RO.lock_of_key t.t key) (RO.file_of_key t.t key)
+      IO.remove_file ~io:t.t.io ~lock:(RO.lock_of_key t.t key)
+        (RO.file_of_key t.t key)
     in
     list t |> fun keys -> Eio.Fiber.all (List.map remove_file keys)
 end
@@ -330,26 +338,31 @@ module KV (IO : IO) = struct
 end
 
 module IO_mem = struct
+  type io = unit
+
+  let io_of_config _ = ()
+
+  type path = string
+
   type t = {
     watches : (string, string -> unit) Hashtbl.t;
-    files : (Fs.dir_ty Path.t, string) Hashtbl.t;
+    files : (path, string) Hashtbl.t;
   }
 
   let t = { watches = Hashtbl.create 3; files = Hashtbl.create 13 }
 
-  type path = Fs.dir_ty Path.t
   type lock = Eio.Mutex.t
 
   let locks = Hashtbl.create 10
 
-  let lock_file (_, file) =
+  let lock_file ~io:() file =
     try Hashtbl.find locks file
     with Not_found ->
       let l = Eio.Mutex.create () in
       Hashtbl.add locks file l;
       l
 
-  let with_lock l f =
+  let with_lock ~io:() l f =
     match l with None -> f () | Some l -> Eio.Mutex.use_rw ~protect:false l f
 
   let set_listen_hook () =
@@ -363,29 +376,28 @@ module IO_mem = struct
     Hashtbl.iter
       (fun dir f -> if String.is_prefix ~affix:dir file then f file)
       t.watches
-  (* |> Eio.Fiber.all *)
 
-  let mkdir _ = ()
+  let mkdir ~io:() _ = ()
 
-  let remove_file ?lock file =
-    with_lock lock (fun () -> Hashtbl.remove t.files file)
+  let remove_file ~io ?lock file =
+    with_lock ~io lock (fun () -> Hashtbl.remove t.files file)
 
-  let rec_files (_, dir) =
+  let rec_files ~io:() dir =
     Hashtbl.fold
-      (fun ((_, k) as v) _ acc ->
-        if String.is_prefix ~affix:dir k then v :: acc else acc)
+      (fun file _ acc ->
+        if String.is_prefix ~affix:dir file then file :: acc else acc)
       t.files []
 
-  let file_exists file = Hashtbl.mem t.files file
+  let file_exists ~io:() file = Hashtbl.mem t.files file
 
-  let read_file file =
+  let read_file ~io:() file =
     try
       let buf = Hashtbl.find t.files file in
       Some buf
     with Not_found -> None
 
-  let write_file ?temp_dir:_ ?lock ((_, file) as f) v =
-    let () = with_lock lock (fun () -> Hashtbl.replace t.files f v) in
+  let write_file ~io ~temp_dir:_ ?(lock : lock option) file v =
+    let () = with_lock ~io lock (fun () -> Hashtbl.replace t.files file v) in
     notify file
 
   let equal x y =
@@ -394,7 +406,7 @@ module IO_mem = struct
     | Some x, Some y -> String.equal x y
     | _ -> false
 
-  let test_and_set_file ?temp_dir:_ ~lock file ~test ~set =
+  let test_and_set_file ~io ~temp_dir:_ ~lock file ~test ~set =
     let f () =
       let old = try Some (Hashtbl.find t.files file) with Not_found -> None in
       let b =
@@ -408,10 +420,10 @@ module IO_mem = struct
               Hashtbl.replace t.files file v;
               true
       in
-      let () = if b then notify (snd file) in
+      let () = if b then notify file in
       b
     in
-    with_lock (Some lock) f
+    with_lock ~io (Some lock) f
 
   let clear () =
     Hashtbl.clear t.files;
@@ -423,17 +435,3 @@ module Maker_is_a_maker : Irmin.Maker = Maker (IO_mem)
 
 (* Enforce that {!KV} is a sub-type of {!Irmin.KV_maker}. *)
 module KV_is_a_KV : Irmin.KV_maker = KV (IO_mem)
-
-let run (fs : Fs.dir_ty Path.t) fn =
-  Switch.run @@ fun sw ->
-  Irmin.Backend.Watch.set_watch_switch sw;
-  let open Effect.Deep in
-  try_with fn ()
-    {
-      effc =
-        (fun (type a) (e : a Effect.t) ->
-          match e with
-          | Irmin.Backend.Conf.Env.Fs ->
-              Some (fun (k : (a, _) continuation) -> continue k fs)
-          | _ -> None);
-    }

--- a/src/irmin-fs/unix/dune
+++ b/src/irmin-fs/unix/dune
@@ -1,7 +1,7 @@
 (library
  (public_name irmin-fs.unix)
  (name irmin_fs_unix)
- (libraries irmin-fs irmin.unix lwt eio eio.unix)
+ (libraries irmin-fs irmin.unix eio eio.unix)
  (preprocess
   (pps ppx_irmin.internal))
  (instrumentation

--- a/src/irmin-fs/unix/eio_pool.ml
+++ b/src/irmin-fs/unix/eio_pool.ml
@@ -103,8 +103,7 @@ let acquire p =
       (* Limit reached: wait for a free one. *)
       let promise, resolver = Promise.create () in
       Stream.add p.waiters resolver;
-      validate_and_return p (Promise.await_exn promise)
-      (* (Lwt.add_task_r [@ocaml.warning "-3"]) p.waiters >>= validate_and_return p *))
+      validate_and_return p (Promise.await_exn promise))
   else
     (* Take the first free member and validate it. *)
     let c = Queue.take p.list in

--- a/src/irmin-fs/unix/irmin_fs_unix.mli
+++ b/src/irmin-fs/unix/irmin_fs_unix.mli
@@ -28,3 +28,10 @@ module Maker_ext (Obj : Irmin_fs.Config) (Ref : Irmin_fs.Config) : Irmin.Maker
 (** {1 Common Unix utilities} *)
 
 include module type of Irmin_unix
+
+(** {1 Backend-specific config} *)
+
+val spec :
+  path:_ Eio.Path.t -> clock:_ Eio.Time.clock -> Irmin.Backend.Conf.Spec.t
+
+val conf : path:_ Eio.Path.t -> clock:_ Eio.Time.clock -> Irmin.Backend.Conf.t

--- a/src/irmin-pack-tools/ppcf/dune
+++ b/src/irmin-pack-tools/ppcf/dune
@@ -3,6 +3,6 @@
  (package irmin-pack-tools)
  (name ppcf)
  (modules ppcf)
- (libraries irmin-pack irmin-pack.unix cmdliner)
+ (libraries irmin-pack irmin-pack.unix cmdliner eio_main)
  (preprocess
   (pps ppx_repr)))

--- a/src/irmin-pack-tools/ppcf/ppcf.ml
+++ b/src/irmin-pack-tools/ppcf/ppcf.ml
@@ -5,8 +5,8 @@ module Volume_control = Irmin_pack_unix.Control_file.Volume (Io)
 
 type store_type = Upper | Volume
 
-let print_cf read print control_file =
-  let r = read ~path:control_file in
+let print_cf ~sw ~fs read print control_file =
+  let r = read ~sw ~path:Eio.Path.(fs / control_file) in
   match r with
   | Error err -> Io_errors.raise_error err
   | Ok payload -> Fmt.pr "%a\n" (Irmin.Type.pp_json print) payload
@@ -36,9 +36,13 @@ let control_file =
     & pos 1 (some string) None
     & info [] ~docv:"control file" ~doc:"the path to the control file")
 
-let main_cmd =
+let main_cmd ~sw ~fs =
   let doc = "a json printer for irmin pack control files" in
   let info = Cmd.info "irmin-ppcf" ~doc in
-  Cmd.v info Term.(const main $ store_type $ control_file)
+  Cmd.v info Term.(const (main ~sw ~fs) $ store_type $ control_file)
 
-let () = exit (Cmd.eval ~catch:false main_cmd)
+let () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
+  exit (Cmd.eval ~catch:false (main_cmd ~sw ~fs))

--- a/src/irmin-pack-tools/tezos_explorer/dune
+++ b/src/irmin-pack-tools/tezos_explorer/dune
@@ -12,6 +12,7 @@
   index.unix
   hex
   ptime
-  cmdliner)
+  cmdliner
+  eio_main)
  (preprocess
   (pps ppx_repr)))

--- a/src/irmin-pack-tools/tezos_explorer/main.ml
+++ b/src/irmin-pack-tools/tezos_explorer/main.ml
@@ -34,36 +34,40 @@ let index_path =
         ~doc:"the path to the index file generated, default to `store.index`")
 
 (* Command parse *)
-let parse_cmd =
+let parse_cmd ~sw ~fs =
   let doc =
     "parses a pack file and generates the associated .info & .idx files"
   in
   let info = Cmd.info "parse" ~doc in
   Cmd.v info
     Term.(
-      const Parse.main
+      const (Parse.main ~sw ~fs)
       $ store_path
       $ info_last_path
       $ info_next_path
       $ index_path)
 
 (* Command show *)
-let show_cmd =
+let show_cmd ~sw ~fs =
   let doc = "graphical user interface for pack files inspection" in
   let info = Cmd.info "show" ~doc in
   Cmd.v info
     Term.(
-      const Show.main
+      const (Show.main ~sw ~fs)
       $ store_path
       $ info_last_path
       $ info_next_path
       $ index_path)
 
 (* Main command *)
-let main_cmd =
+let main_cmd ~sw ~fs =
   let doc = "a visual tool for irmin pack files inspection" in
   let info = Cmd.info "irmin-pack-inspect" ~version:"%%VERSION%%" ~doc in
   let default = Term.(ret (const (`Help (`Pager, None)))) in
-  Cmd.group info ~default [ parse_cmd; show_cmd ]
+  Cmd.group info ~default [ parse_cmd ~sw ~fs; show_cmd ~sw ~fs ]
 
-let () = exit (Cmd.eval ~catch:false main_cmd)
+let () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
+  exit (Cmd.eval ~catch:false (main_cmd ~sw ~fs))

--- a/src/irmin-pack-tools/tezos_explorer/parse.ml
+++ b/src/irmin-pack-tools/tezos_explorer/parse.ml
@@ -68,9 +68,9 @@ let dump_idxs fd n is is2 =
 
 let get_values r = List.filter_map (Ring.get r) [ 1; 10; 1000 ]
 
-let main store_path info_last_path info_next_path idx_path =
-  let conf = Irmin_pack.Conf.init store_path in
-  match Files.File_manager.open_ro conf with
+let main ~sw ~fs store_path info_last_path info_next_path idx_path =
+  let conf = Irmin_pack.Conf.init ~sw ~fs Eio.Path.(fs / store_path) in
+  match Files.File_manager.open_ro ~sw ~fs conf with
   | Error exn -> Fmt.pr "%a\n%!" (Irmin.Type.pp Files.Errs.t) exn
   | Ok fm ->
       let info_fd =
@@ -136,6 +136,3 @@ let main store_path info_last_path info_next_path idx_path =
       in
       dump_idxs idx_fd entries (List.rev !idxs) !idxs2;
       Unix.close idx_fd
-
-let main store_path info_last_path info_next_path index_path =
-  main store_path info_last_path info_next_path index_path

--- a/src/irmin-pack-tools/tezos_explorer/show.ml
+++ b/src/irmin-pack-tools/tezos_explorer/show.ml
@@ -854,9 +854,11 @@ let rec loop t c =
       loop t c
   | _ -> loop t c
 
-let main store_path info_last_path info_next_path index_path =
-  let conf = Irmin_pack.Conf.init store_path in
-  let fm = Files.File_manager.open_ro conf |> Files.Errs.raise_if_error in
+let main ~sw ~fs store_path info_last_path info_next_path index_path =
+  let conf = Irmin_pack.Conf.init ~sw ~fs Eio.Path.(fs / store_path) in
+  let fm =
+    Files.File_manager.open_ro ~sw ~fs conf |> Files.Errs.raise_if_error
+  in
   let dispatcher = Files.Dispatcher.v fm |> Files.Errs.raise_if_error in
   let max_offset = Files.Dispatcher.end_offset dispatcher in
   let dict = Files.File_manager.dict fm in

--- a/src/irmin-pack/atomic_write_intf.ml
+++ b/src/irmin-pack/atomic_write_intf.ml
@@ -23,7 +23,12 @@ end
 module type Persistent = sig
   include S
 
-  val v : ?fresh:bool -> ?readonly:bool -> string -> t
+  val v :
+    sw:Eio.Switch.t ->
+    ?fresh:bool ->
+    ?readonly:bool ->
+    Eio.Fs.dir_ty Eio.Path.t ->
+    t
 end
 
 module type Value = sig

--- a/src/irmin-pack/conf.mli
+++ b/src/irmin-pack/conf.mli
@@ -58,7 +58,7 @@ module type S = sig
       See https://github.com/mirage/irmin/issues/1304 *)
 end
 
-val spec : Irmin.Backend.Conf.Spec.t
+val spec : sw:Eio.Switch.t -> fs:_ Eio.Path.t -> Irmin.Backend.Conf.Spec.t
 
 type merge_throttle = [ `Block_writes | `Overcommit_memory ] [@@deriving irmin]
 (** Strategy for when attempting to write when the index log is full and waiting
@@ -128,7 +128,15 @@ val use_fsync : Irmin.Backend.Conf.t -> bool
 val no_migrate : Irmin.Backend.Conf.t -> bool
 (** Flag to prevent migration of data. Default [false]. *)
 
+val switch : Irmin.Backend.Conf.t -> Eio.Switch.t
+(** Eio switch *)
+
+val fs : Irmin.Backend.Conf.t -> Eio.Fs.dir_ty Eio.Path.t
+(** Eio filesystem *)
+
 val init :
+  sw:Eio.Switch.t ->
+  fs:_ Eio.Path.t ->
   ?fresh:bool ->
   ?readonly:bool ->
   ?lru_size:int ->
@@ -138,8 +146,8 @@ val init :
   ?indexing_strategy:Indexing_strategy.t ->
   ?use_fsync:bool ->
   ?no_migrate:bool ->
-  ?lower_root:string option ->
-  string ->
+  ?lower_root:Eio.Fs.dir_ty Eio.Path.t option ->
+  Eio.Fs.dir_ty Eio.Path.t ->
   Irmin.config
 (** [init root] creates a backend configuration for storing data with default
     configuration parameters and stored at [root]. Flags are documented above. *)

--- a/src/irmin-pack/io/append_only_file_intf.ml
+++ b/src/irmin-pack/io/append_only_file_intf.ml
@@ -31,11 +31,15 @@ module type S = sig
   type t
 
   val create_rw :
-    path:string -> overwrite:bool -> (t, [> Io.create_error ]) result
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    overwrite:bool ->
+    (t, [> Io.create_error ]) result
   (** Create a rw instance of [t] by creating the file at [path]. *)
 
   val open_rw :
-    path:string ->
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
     end_poff:int63 ->
     dead_header_size:int ->
     ( t,
@@ -67,7 +71,8 @@ module type S = sig
       stores with [`V3]. *)
 
   val open_ro :
-    path:string ->
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
     end_poff:int63 ->
     dead_header_size:int ->
     ( t,
@@ -156,7 +161,7 @@ module type S = sig
 
   val readonly : t -> bool
   val empty_buffer : t -> bool
-  val path : t -> string
+  val path : t -> Eio.Fs.dir_ty Eio.Path.t
 end
 
 module type Sigs = sig

--- a/src/irmin-pack/io/async_intf.ml
+++ b/src/irmin-pack/io/async_intf.ml
@@ -25,7 +25,8 @@ module type S = sig
 
   type status = [ outcome | `Running ] [@@deriving irmin]
 
-  val async : (unit -> unit) -> t
+  val async :
+    sw:Eio.Switch.t -> domain_mgr:_ Eio.Domain_manager.t -> (unit -> unit) -> t
   (** Start a task. *)
 
   val await : t -> [> outcome ]

--- a/src/irmin-pack/io/chunked_suffix_intf.ml
+++ b/src/irmin-pack/io/chunked_suffix_intf.ml
@@ -47,13 +47,15 @@ module type S = sig
     | `Multiple_empty_chunks ]
 
   val create_rw :
-    root:string ->
+    sw:Eio.Switch.t ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
     start_idx:int ->
     overwrite:bool ->
     (t, [> create_error ]) result
 
   val open_rw :
-    root:string ->
+    sw:Eio.Switch.t ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
     appendable_chunk_poff:int63 ->
     start_idx:int ->
     chunk_num:int ->
@@ -61,7 +63,8 @@ module type S = sig
     (t, [> open_error ]) result
 
   val open_ro :
-    root:string ->
+    sw:Eio.Switch.t ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
     appendable_chunk_poff:int63 ->
     dead_header_size:int ->
     start_idx:int ->

--- a/src/irmin-pack/io/control_file.ml
+++ b/src/irmin-pack/io/control_file.ml
@@ -239,7 +239,7 @@ module Serde = struct
       | Valid (V4 payload) -> Ok (upgrade_from_v4 payload)
       | Valid (V5 payload) -> Ok payload
 
-    (* Similar yo [of_bin_string] but skips version upgrade *)
+    (* Similar to [of_bin_string] but skips version upgrade *)
     let raw_of_bin_string = Data.of_bin_string
     let to_bin_string payload = Data.(to_bin_string (Valid (V5 payload)))
   end
@@ -323,8 +323,8 @@ module Make (Serde : Serde.S) (Io : Io_intf.S) = struct
   type t = {
     mutable io : Io.t;
     payload : payload Atomic.t;
-    path : string;
-    tmp_path : string option;
+    path : Eio.Fs.dir_ty Eio.Path.t;
+    tmp_path : Eio.Fs.dir_ty Eio.Path.t option;
     lock : Eio.Mutex.t;
   }
 
@@ -332,7 +332,7 @@ module Make (Serde : Serde.S) (Io : Io_intf.S) = struct
     let s = Serde.to_bin_string payload in
     Io.write_string io ~off:Int63.zero s
 
-  let set_payload t payload =
+  let set_payload ~sw t payload =
     let open Result_syntax in
     Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
     if Io.readonly t.io then Error `Ro_not_allowed
@@ -341,7 +341,7 @@ module Make (Serde : Serde.S) (Io : Io_intf.S) = struct
       | None -> Error `No_tmp_path_provided
       | Some tmp_path ->
           let* () = Io.close t.io in
-          let* io_tmp = Io.create ~path:tmp_path ~overwrite:true in
+          let* io_tmp = Io.create ~sw ~path:tmp_path ~overwrite:true in
           t.io <- io_tmp;
           let* () = write io_tmp payload in
           let+ () = Io.move_file ~src:tmp_path ~dst:t.path in
@@ -350,19 +350,19 @@ module Make (Serde : Serde.S) (Io : Io_intf.S) = struct
   let read io =
     let open Result_syntax in
     let* string = Io.read_all_to_string io in
-    Serde.of_bin_string (Io.path io) string
+    Serde.of_bin_string (Eio.Path.native_exn @@ Io.path io) string
 
-  let create_rw ~path ~tmp_path ~overwrite (payload : payload) =
+  let create_rw ~sw ~path ~tmp_path ~overwrite (payload : payload) =
     let open Result_syntax in
     let lock = Eio.Mutex.create () in
-    let* io = Io.create ~path ~overwrite in
+    let* io = Io.create ~sw ~path ~overwrite in
     let+ () = write io payload in
     { io; payload = Atomic.make payload; path; tmp_path; lock }
 
-  let open_ ~path ~tmp_path ~readonly =
+  let open_ ~sw ~path ~tmp_path ~readonly =
     let open Result_syntax in
     let lock = Eio.Mutex.create () in
-    let* io = Io.open_ ~path ~readonly in
+    let* io = Io.open_ ~sw ~path ~readonly in
     let+ payload = read io in
     { io; payload = Atomic.make payload; path; tmp_path; lock }
 
@@ -373,29 +373,29 @@ module Make (Serde : Serde.S) (Io : Io_intf.S) = struct
 
   let payload t = Atomic.get t.payload
 
-  let reload t =
+  let reload ~sw t =
     let open Result_syntax in
     Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
     if not @@ Io.readonly t.io then Error `Rw_not_allowed
     else
       let* () = Io.close t.io in
-      let* io = Io.open_ ~path:t.path ~readonly:true in
+      let* io = Io.open_ ~sw ~path:t.path ~readonly:true in
       t.io <- io;
       let+ payload = read io in
       Atomic.set t.payload payload
 
-  let read_payload ~path =
+  let read_payload ~sw ~path =
     let open Result_syntax in
-    let* io = Io.open_ ~path ~readonly:true in
+    let* io = Io.open_ ~sw ~path ~readonly:true in
     let* payload = read io in
     let+ () = Io.close io in
     payload
 
-  let read_raw_payload ~path =
+  let read_raw_payload ~sw ~path =
     let open Result_syntax in
-    let* io = Io.open_ ~path ~readonly:true in
+    let* io = Io.open_ ~sw ~path ~readonly:true in
     let* string = Io.read_all_to_string io in
-    let* payload = Serde.raw_of_bin_string path string in
+    let* payload = Serde.raw_of_bin_string (Eio.Path.native_exn path) string in
     let+ () = Io.close io in
     payload
 

--- a/src/irmin-pack/io/control_file_intf.ml
+++ b/src/irmin-pack/io/control_file_intf.ml
@@ -304,8 +304,9 @@ module type S = sig
   type t
 
   val create_rw :
-    path:string ->
-    tmp_path:string option ->
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    tmp_path:Eio.Fs.dir_ty Eio.Path.t option ->
     overwrite:bool ->
     payload ->
     (t, [> Io.create_error | Io.write_error ]) result
@@ -320,8 +321,9 @@ module type S = sig
     | `Unknown_major_pack_version of string ]
 
   val open_ :
-    path:string ->
-    tmp_path:string option ->
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    tmp_path:Eio.Fs.dir_ty Eio.Path.t option ->
     readonly:bool ->
     (t, [> open_error ]) result
   (** Create a rw instance of [t] by reading an existing file at [path].
@@ -331,13 +333,17 @@ module type S = sig
   val close : t -> (unit, [> Io.close_error ]) result
 
   val read_payload :
-    path:string -> (payload, [> open_error | Io.close_error ]) result
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    (payload, [> open_error | Io.close_error ]) result
   (** [read_payload ~path] reads the payload at [path]. It is a convenient way
       to read the payload without needing to call {!open_}, {!payload},
       {!close}. *)
 
   val read_raw_payload :
-    path:string -> (raw_payload, [> open_error | Io.close_error ]) result
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    (raw_payload, [> open_error | Io.close_error ]) result
 
   val payload : t -> payload
   (** [payload t] is the payload in [t].
@@ -355,7 +361,7 @@ module type S = sig
 
   type reload_error := [ `Rw_not_allowed | open_error | Io.close_error ]
 
-  val reload : t -> (unit, [> reload_error ]) result
+  val reload : sw:Eio.Switch.t -> t -> (unit, [> reload_error ]) result
   (** {3 RW mode}
 
       Always returns an error.
@@ -376,7 +382,8 @@ module type S = sig
     | move_error
     | Io.close_error ]
 
-  val set_payload : t -> payload -> (unit, [> set_error ]) result
+  val set_payload :
+    sw:Eio.Switch.t -> t -> payload -> (unit, [> set_error ]) result
   (** {3 RW mode}
 
       Write a new payload on disk.

--- a/src/irmin-pack/io/dict.ml
+++ b/src/irmin-pack/io/dict.ml
@@ -90,9 +90,9 @@ module Make (Io : Io_intf.S) = struct
     let last_refill_offset = Int63.zero in
     { capacity = default_capacity; index; cache; ao; last_refill_offset }
 
-  let create_rw ~overwrite ~path:filename =
+  let create_rw ~sw ~overwrite ~path:filename =
     let open Result_syntax in
-    let* ao = Ao.create_rw ~overwrite ~path:filename in
+    let* ao = Ao.create_rw ~sw ~overwrite ~path:filename in
     Ok (v_empty ao)
 
   let v_filled ao =
@@ -101,14 +101,14 @@ module Make (Io : Io_intf.S) = struct
     let* () = refill t in
     Ok t
 
-  let open_rw ~size ~dead_header_size filename =
+  let open_rw ~sw ~size ~dead_header_size filename =
     let open Result_syntax in
-    let* ao = Ao.open_rw ~path:filename ~end_poff:size ~dead_header_size in
+    let* ao = Ao.open_rw ~sw ~path:filename ~end_poff:size ~dead_header_size in
     v_filled ao
 
-  let open_ro ~size ~dead_header_size filename =
+  let open_ro ~sw ~size ~dead_header_size filename =
     let open Result_syntax in
-    let* ao = Ao.open_ro ~path:filename ~end_poff:size ~dead_header_size in
+    let* ao = Ao.open_ro ~sw ~path:filename ~end_poff:size ~dead_header_size in
     v_filled ao
 
   let end_poff t = Ao.end_poff t.ao

--- a/src/irmin-pack/io/dict_intf.ml
+++ b/src/irmin-pack/io/dict_intf.ml
@@ -25,18 +25,23 @@ module type S = sig
   val index : t -> string -> int option
 
   val create_rw :
-    overwrite:bool -> path:string -> (t, [> Io.create_error ]) result
+    sw:Eio.Switch.t ->
+    overwrite:bool ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    (t, [> Io.create_error ]) result
 
   val open_rw :
+    sw:Eio.Switch.t ->
     size:int63 ->
     dead_header_size:int ->
-    string ->
+    Eio.Fs.dir_ty Eio.Path.t ->
     (t, [> Io.open_error | Io.read_error | `Inconsistent_store ]) result
 
   val open_ro :
+    sw:Eio.Switch.t ->
     size:int63 ->
     dead_header_size:int ->
-    string ->
+    Eio.Fs.dir_ty Eio.Path.t ->
     (t, [> Io.open_error | Io.read_error | `Inconsistent_store ]) result
 
   val refresh_end_poff :

--- a/src/irmin-pack/io/file_manager.ml
+++ b/src/irmin-pack/io/file_manager.ml
@@ -49,7 +49,8 @@ struct
     mutable suffix_consumers : after_flush_consumer list;
     indexing_strategy : Irmin_pack.Indexing_strategy.t;
     use_fsync : bool;
-    root : string;
+    root : Eio.Fs.dir_ty Eio.Path.t;
+    sw : Eio.Switch.t;
   }
 
   let control t = t.control
@@ -149,7 +150,7 @@ struct
     if new_pl = pl then Ok ()
     else
       let open Result_syntax in
-      let* () = Control.set_payload t.control new_pl in
+      let* () = Control.set_payload ~sw:t.sw t.control new_pl in
       if t.use_fsync then Control.fsync t.control else Ok ()
 
   (** Flush stage 2 *)
@@ -201,7 +202,7 @@ struct
 
   module Layout = Irmin_pack.Layout.V5
 
-  let open_prefix ~root ~generation ~mapping_size =
+  let open_prefix ~sw ~root ~generation ~mapping_size =
     let open Result_syntax in
     if generation = 0 then Ok None
     else
@@ -213,12 +214,14 @@ struct
         | None -> Io.size_of_path mapping
       in
       let mapping_size = Int63.to_int mapping_size in
-      let+ prefix = Sparse.open_ro ~mapping_size ~mapping ~data in
+      let+ prefix = Sparse.open_ro ~sw ~mapping_size ~mapping ~data in
       Some prefix
 
   let reopen_prefix t ~generation ~mapping_size =
     let open Result_syntax in
-    let* some_prefix = open_prefix ~root:t.root ~generation ~mapping_size in
+    let* some_prefix =
+      open_prefix ~sw:t.sw ~root:t.root ~generation ~mapping_size
+    in
     match some_prefix with
     | None -> Ok ()
     | Some _ ->
@@ -240,13 +243,14 @@ struct
     let* suffix1 =
       let root = t.root in
       let start_idx = chunk_start_idx in
+      let sw = t.sw in
       [%log.debug "reload: generation changed, opening suffix"];
       if readonly then
-        Suffix.open_ro ~root ~appendable_chunk_poff ~dead_header_size ~start_idx
-          ~chunk_num
+        Suffix.open_ro ~sw ~root ~appendable_chunk_poff ~dead_header_size
+          ~start_idx ~chunk_num
       else
-        Suffix.open_rw ~root ~appendable_chunk_poff ~dead_header_size ~start_idx
-          ~chunk_num
+        Suffix.open_rw ~sw ~root ~appendable_chunk_poff ~dead_header_size
+          ~start_idx ~chunk_num
     in
     let suffix0 = t.suffix in
     t.suffix <- suffix1;
@@ -266,19 +270,24 @@ struct
              | `Prefix g | `Mapping g -> g <> generation
              | `Suffix idx ->
                  idx < chunk_start_idx || idx > chunk_start_idx + chunk_num
-             | `Reachable _ | `Sorted _ | `Gc_result _ | `Control_tmp -> true)
+             | `Reachable _ | `Sorted _ | `Gc_result _ | `Control_tmp
+             | `Dict_tmp ->
+                 true)
       |> List.iter (fun residual ->
-             let filename = Filename.concat root residual in
-             [%log.debug "Remove residual file %s" filename];
+             let filename = Eio.Path.(root / residual) in
+             [%log.debug
+               "Remove residual file %s" (Eio.Path.native_exn filename)];
              match Io.unlink filename with
              | Ok () -> ()
              | Error (`Sys_error error) ->
                  [%log.warn
-                   "Could not remove residual file %s: %s" filename error])
+                   "Could not remove residual file %s: %s"
+                     (Eio.Path.native_exn filename)
+                     error])
     in
     Option.might (Lower.cleanup ~generation) lower
 
-  let add_volume_and_update_control lower control =
+  let add_volume_and_update_control ~sw lower control =
     let open Result_syntax in
     (* Step 1. Add volume *)
     let* _ = Lower.add_volume lower in
@@ -286,12 +295,12 @@ struct
     let pl = Control.payload control in
     let pl = { pl with volume_num = Lower.volume_num lower } in
     [%log.debug "add_volume: update control_file volume_num:%d" pl.volume_num];
-    Control.set_payload control pl
+    Control.set_payload ~sw control pl
 
-  let finish_constructing_rw config control ~make_dict ~make_suffix ~make_index
-      ~make_lower =
+  let finish_constructing_rw ~sw ~fs config control ~make_dict ~make_suffix
+      ~make_index ~make_lower =
     let open Result_syntax in
-    let root = Irmin_pack.Conf.root config in
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let use_fsync = Irmin_pack.Conf.use_fsync config in
     let indexing_strategy = Conf.indexing_strategy config in
     let pl : Payload.t = Control.payload control in
@@ -327,7 +336,7 @@ struct
     in
     (* 2. Open the other files *)
     let* suffix = make_suffix () in
-    let* prefix = open_prefix ~root ~generation ~mapping_size in
+    let* prefix = open_prefix ~sw ~root ~generation ~mapping_size in
     let* dict =
       let path = Layout.dict ~root in
       make_dict ~path
@@ -365,13 +374,14 @@ struct
         suffix_consumers = [];
         indexing_strategy;
         root;
+        sw;
       }
     in
     instance := Some t;
     Ok t
 
-  let create_control_file ~overwrite config pl =
-    let root = Irmin_pack.Conf.root config in
+  let create_control_file ~fs ~overwrite config pl =
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let path = Layout.control ~root in
     let tmp_path = Layout.control_tmp ~root in
     Control.create_rw ~path ~tmp_path:(Some tmp_path) ~overwrite pl
@@ -385,7 +395,7 @@ struct
     (match hook with Some h -> h `After_index | None -> ());
     let pl0 = Control.payload t.control in
     (* Step 2. Reread control file *)
-    let* () = Control.reload t.control in
+    let* () = Control.reload ~sw:t.sw t.control in
     (match hook with Some h -> h `After_control | None -> ());
     let pl1 : Payload.t = Control.payload t.control in
     if pl0 = pl1 then Ok ()
@@ -428,10 +438,11 @@ struct
 
   (* File creation ********************************************************** *)
 
-  let create_lower_if_needed ~lower_root ~overwrite =
+  let create_lower_if_needed ~fs ~lower_root ~overwrite =
     match lower_root with
     | None -> Ok ()
     | Some path -> (
+        let path = Eio.Path.(fs / path) in
         match (Io.classify_path path, overwrite) with
         | `Directory, false -> Ok ()
         | `Directory, true ->
@@ -439,23 +450,25 @@ struct
             failwith
               (Fmt.str
                  "Lower root already exists but fresh = true in configuration. \
-                  Please manually remove %s."
-                 path)
+                  Please manually remove %a."
+                 Eio.Path.pp path)
         | `No_such_file_or_directory, _ -> Io.mkdir path
-        | (`File | `Other), _ -> Errs.raise_error (`Not_a_directory path))
+        | (`File | `Other), _ ->
+            Errs.raise_error (`Not_a_directory (Eio.Path.native_exn path)))
 
-  let create_rw ~overwrite config =
+  let create_rw ~sw ~fs ~overwrite config =
     let open Result_syntax in
-    let root = Irmin_pack.Conf.root config in
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let lower_root = Irmin_pack.Conf.lower_root config in
     let* () =
       match (overwrite, Io.classify_path root) with
-      | _, (`File | `Other) -> Error (`Not_a_directory root)
-      | false, `Directory -> Error (`File_exists root)
+      | _, (`File | `Other) ->
+          Error (`Not_a_directory (Eio.Path.native_exn root))
+      | false, `Directory -> Error (`File_exists (Eio.Path.native_exn root))
       | true, `Directory -> Ok ()
       | _, `No_such_file_or_directory -> Io.mkdir root
     in
-    let* () = create_lower_if_needed ~lower_root ~overwrite in
+    let* () = create_lower_if_needed ~fs ~lower_root ~overwrite in
     let* control =
       let open Payload in
       let status = No_gc_yet in
@@ -472,24 +485,27 @@ struct
           volume_num = 0;
         }
       in
-      create_control_file ~overwrite config pl
+      create_control_file ~sw ~fs ~overwrite config pl
     in
-    let make_dict = Dict.create_rw ~overwrite in
-    let make_suffix () = Suffix.create_rw ~root ~overwrite ~start_idx:0 in
+    let make_dict = Dict.create_rw ~sw ~overwrite in
+    let make_suffix () = Suffix.create_rw ~sw ~root ~overwrite ~start_idx:0 in
     let make_index ~flush_callback ~readonly ~throttle ~log_size root =
       (* [overwrite] is ignored for index *)
-      Index.v ~fresh:true ~flush_callback ~readonly ~throttle ~log_size root
+      Index.v ~fresh:true ~flush_callback ~readonly ~throttle ~log_size
+        (Eio.Path.native_exn root)
     in
     let make_lower () =
       match lower_root with
       | None -> Ok None
       | Some path ->
-          let* l = Lower.v ~readonly:false ~volume_num:0 path in
-          let+ _ = add_volume_and_update_control l control in
+          let* l =
+            Lower.v ~sw ~readonly:false ~volume_num:0 Eio.Path.(fs / path)
+          in
+          let+ _ = add_volume_and_update_control ~sw l control in
           Some l
     in
-    finish_constructing_rw config control ~make_dict ~make_suffix ~make_index
-      ~make_lower
+    finish_constructing_rw ~sw ~fs config control ~make_dict ~make_suffix
+      ~make_index ~make_lower
 
   (* Open rw **************************************************************** *)
 
@@ -510,7 +526,7 @@ struct
     | T15 ->
         failwith "invalid status: T1..T15"
 
-  let migrate_to_lower ~root ~lower_root ~control (payload : Payload.t) =
+  let migrate_to_lower ~sw ~root ~lower_root ~control (payload : Payload.t) =
     let open Result_syntax in
     (* Step 1. Create a lower by moving the suffix file. *)
     let suffix_file =
@@ -519,13 +535,13 @@ struct
     let dead_header_size = dead_header_size_of_status payload.status in
     let end_offset = payload.appendable_chunk_poff in
     let* () =
-      Lower.create_from ~src:suffix_file ~dead_header_size ~size:end_offset
+      Lower.create_from ~sw ~src:suffix_file ~dead_header_size ~size:end_offset
         lower_root
     in
     (* Step 2. Create a new empty suffix for the upper. *)
     let chunk_start_idx = payload.chunk_start_idx + 1 in
     let* () =
-      Suffix.create_rw ~root ~overwrite:false ~start_idx:chunk_start_idx
+      Suffix.create_rw ~sw ~root ~overwrite:false ~start_idx:chunk_start_idx
       >>= Suffix.close
     in
     (* Step 3. Create a new empty prefix for the upper. *)
@@ -533,16 +549,18 @@ struct
     let* () =
       let mapping = Layout.mapping ~generation ~root in
       let data = Layout.prefix ~root ~generation in
-      Sparse.Ao.create ~mapping ~data >>= Sparse.Ao.close
+      Sparse.Ao.create ~sw ~mapping ~data >>= Sparse.Ao.close
     in
     (* Step 4. Remove dead header from dict (if needed) *)
     let* dict_end_poff, after_payload_write =
       if dead_header_size > 0 then (
         let dict_path = Layout.dict ~root in
-        let tmp_dict_path = Filename.temp_file ~temp_dir:root "store" "dict" in
-        let* dict_file = Io.open_ ~path:dict_path ~readonly:false in
+        let tmp_dict_path = Layout.dict_tmp ~root in
+        let* dict_file = Io.open_ ~sw ~path:dict_path ~readonly:false in
         let* len = Io.read_size dict_file in
-        let* tmp_dict_file = Io.open_ ~path:tmp_dict_path ~readonly:false in
+        let* tmp_dict_file =
+          Io.create ~sw ~path:tmp_dict_path ~overwrite:true
+        in
         let contents_len = Int63.to_int len - dead_header_size in
         let* contents =
           Io.read_to_string dict_file
@@ -578,29 +596,31 @@ struct
             };
       }
     in
-    let* () = Control.set_payload control payload in
+    let* () = Control.set_payload ~sw control payload in
     let* () = after_payload_write () in
     Ok payload
 
-  let load_payload ~config ~root ~lower_root ~control =
+  let load_payload ~sw ~fs ~config ~root ~lower_root ~control =
     let payload = Control.payload control in
     match lower_root with
     | Some lower_root when payload.volume_num = 0 ->
         if Irmin_pack.Conf.no_migrate config then Error `Migration_needed
         else if not (can_migrate_to_lower payload) then
           Error `Migration_to_lower_not_allowed
-        else migrate_to_lower ~root ~lower_root ~control payload
+        else
+          let lower_root = Eio.Path.(fs / lower_root) in
+          migrate_to_lower ~sw ~root ~lower_root ~control payload
     | _ -> Ok payload
 
-  let open_rw_with_control_file config =
+  let open_rw_with_control_file ~sw ~fs config =
     let open Result_syntax in
-    let root = Irmin_pack.Conf.root config in
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let lower_root = Irmin_pack.Conf.lower_root config in
-    let* () = create_lower_if_needed ~lower_root ~overwrite:false in
+    let* () = create_lower_if_needed ~fs ~lower_root ~overwrite:false in
     let* control =
       let path = Layout.control ~root in
       let tmp_path = Layout.control_tmp ~root in
-      Control.open_ ~readonly:false ~path ~tmp_path:(Some tmp_path)
+      Control.open_ ~sw ~readonly:false ~path ~tmp_path:(Some tmp_path)
     in
     let* Payload.
            {
@@ -612,7 +632,7 @@ struct
              volume_num;
              _;
            } =
-      load_payload ~config ~root ~lower_root ~control
+      load_payload ~sw ~fs ~config ~root ~lower_root ~control
     in
     let* dead_header_size =
       match status with
@@ -627,30 +647,32 @@ struct
           Error `V3_store_from_the_future
     in
     let make_dict ~path =
-      Dict.open_rw ~size:dict_end_poff ~dead_header_size path
+      Dict.open_rw ~sw ~size:dict_end_poff ~dead_header_size path
     in
     let make_suffix () =
-      Suffix.open_rw ~root ~appendable_chunk_poff ~start_idx ~chunk_num
+      Suffix.open_rw ~sw ~root ~appendable_chunk_poff ~start_idx ~chunk_num
         ~dead_header_size
     in
     let make_index ~flush_callback ~readonly ~throttle ~log_size root =
-      Index.v ~fresh:false ~flush_callback ~readonly ~throttle ~log_size root
+      Index.v ~fresh:false ~flush_callback ~readonly ~throttle ~log_size
+        (Eio.Path.native_exn root)
     in
     let make_lower () =
       match lower_root with
       | None -> Ok None
       | Some lower_root ->
           assert (volume_num > 0);
-          let+ l = Lower.v ~readonly:false ~volume_num lower_root in
+          let lower_root = Eio.Path.(fs / lower_root) in
+          let+ l = Lower.v ~sw ~readonly:false ~volume_num lower_root in
           Some l
     in
-    finish_constructing_rw config control ~make_dict ~make_suffix ~make_index
-      ~make_lower
+    finish_constructing_rw ~sw ~fs config control ~make_dict ~make_suffix
+      ~make_index ~make_lower
 
-  let read_offset_from_legacy_file path =
+  let read_offset_from_legacy_file ~sw path =
     let open Result_syntax in
     (* Bytes 0-7 contains the offset. Bytes 8-15 contain the version. *)
-    let* io = Io.open_ ~path ~readonly:true in
+    let* io = Io.open_ ~sw ~path ~readonly:true in
     Errors.finalise (fun _ ->
         Io.close io |> Errs.log_if_error "FM: read_offset_from_legacy_file")
     @@ fun () ->
@@ -658,10 +680,10 @@ struct
     let x = Int63.decode ~off:0 s in
     Ok x
 
-  let read_version_from_legacy_file path =
+  let read_version_from_legacy_file ~sw path =
     let open Result_syntax in
     (* Bytes 0-7 contains the offset. Bytes 8-15 contain the version. *)
-    let* io = Io.open_ ~path ~readonly:true in
+    let* io = Io.open_ ~sw ~path ~readonly:true in
     Errors.finalise (fun _ ->
         Io.close io |> Errs.log_if_error "FM: read_version_from_legacy_file")
     @@ fun () ->
@@ -671,16 +693,16 @@ struct
     | Some x -> Ok x
     | None -> Error `Corrupted_legacy_file
 
-  let open_rw_migrate_from_v1_v2 config =
+  let open_rw_migrate_from_v1_v2 ~sw ~fs config =
     let open Result_syntax in
-    let root = Irmin_pack.Conf.root config in
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let src = Irmin_pack.Layout.V1_and_v2.pack ~root in
     let chunk_start_idx = 0 in
     let dst = Layout.suffix_chunk ~root ~chunk_idx:chunk_start_idx in
-    let* suffix_end_poff = read_offset_from_legacy_file src in
+    let* suffix_end_poff = read_offset_from_legacy_file ~sw src in
     let* dict_end_poff =
       let path = Layout.dict ~root in
-      read_offset_from_legacy_file path
+      read_offset_from_legacy_file ~sw path
     in
     let* () = Io.move_file ~src ~dst in
     let* control =
@@ -701,52 +723,54 @@ struct
           volume_num = 0;
         }
       in
-      create_control_file ~overwrite:false config pl
+      create_control_file ~sw ~fs ~overwrite:false config pl
     in
     let* () = Control.close control in
-    open_rw_with_control_file config
+    open_rw_with_control_file ~sw ~fs config
 
-  let open_rw_no_control_file config =
-    let root = Irmin_pack.Conf.root config in
+  let open_rw_no_control_file ~sw ~fs config =
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let suffix_path = Irmin_pack.Layout.V1_and_v2.pack ~root in
     match Io.classify_path suffix_path with
     | `Directory | `No_such_file_or_directory | `Other -> Error `Invalid_layout
-    | `File -> open_rw_migrate_from_v1_v2 config
+    | `File -> open_rw_migrate_from_v1_v2 ~sw ~fs config
 
-  let open_rw config =
-    let root = Irmin_pack.Conf.root config in
+  let open_rw ~sw ~fs config =
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let no_migrate = Irmin_pack.Conf.no_migrate config in
     match Io.classify_path root with
-    | `File | `Other -> Error (`Not_a_directory root)
-    | `No_such_file_or_directory -> Error (`No_such_file_or_directory root)
+    | `File | `Other -> Error (`Not_a_directory (Eio.Path.native_exn root))
+    | `No_such_file_or_directory ->
+        Error (`No_such_file_or_directory (Eio.Path.native_exn root))
     | `Directory -> (
         let path = Layout.control ~root in
         match Io.classify_path path with
-        | `File -> open_rw_with_control_file config
+        | `File -> open_rw_with_control_file ~sw ~fs config
         | `No_such_file_or_directory ->
             if no_migrate then Error `Migration_needed
-            else open_rw_no_control_file config
+            else open_rw_no_control_file ~sw ~fs config
         | `Directory | `Other -> Error `Invalid_layout)
 
   (* Open ro **************************************************************** *)
 
-  let open_ro config =
+  let open_ro ~sw ~fs config =
     let open Result_syntax in
     let indexing_strategy = Conf.indexing_strategy config in
-    let root = Irmin_pack.Conf.root config in
+    let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     let lower_root = Irmin_pack.Conf.lower_root config in
     let use_fsync = Irmin_pack.Conf.use_fsync config in
     (* 1. Open the control file *)
     let* control =
       let path = Layout.control ~root in
-      Control.open_ ~readonly:true ~path ~tmp_path:None
+      Control.open_ ~sw ~readonly:true ~path ~tmp_path:None
       (* If no control file, then check whether the store is in v1 or v2. *)
       |> Result.map_error (function
            | `No_such_file_or_directory _ -> (
                let pack = Irmin_pack.Layout.V1_and_v2.pack ~root in
                match Io.classify_path pack with
                | `File -> `Migration_needed
-               | `No_such_file_or_directory -> `No_such_file_or_directory pack
+               | `No_such_file_or_directory ->
+                   `No_such_file_or_directory (Eio.Path.native_exn pack)
                | `Directory | `Other -> `Invalid_layout)
            | error -> error)
     in
@@ -766,27 +790,29 @@ struct
     let generation = generation status in
     (* 2. Open the other files *)
     let* suffix =
-      Suffix.open_ro ~root ~appendable_chunk_poff ~start_idx ~chunk_num
+      Suffix.open_ro ~sw ~root ~appendable_chunk_poff ~start_idx ~chunk_num
         ~dead_header_size
     in
     let* prefix =
-      open_prefix ~root ~generation ~mapping_size:(mapping_size status)
+      open_prefix ~sw ~root ~generation ~mapping_size:(mapping_size status)
     in
     let* dict =
       let filename = Layout.dict ~root in
-      Dict.open_ro ~size:dict_end_poff ~dead_header_size filename
+      Dict.open_ro ~sw ~size:dict_end_poff ~dead_header_size filename
     in
     let* index =
       let log_size = Conf.index_log_size config in
       let throttle = Conf.merge_throttle config in
-      Index.v ~fresh:false ~readonly:true ~throttle ~log_size root
+      Index.v ~fresh:false ~readonly:true ~throttle ~log_size
+        (Eio.Path.native_exn root)
     in
     (* 3. Open lower layer *)
     let* lower =
       match lower_root with
       | None -> Ok None
       | Some path ->
-          let+ l = Lower.v ~readonly:true ~volume_num path in
+          let path = Eio.Path.(fs / path) in
+          let+ l = Lower.v ~sw ~readonly:true ~volume_num path in
           Some l
     in
     (* 4. return with success *)
@@ -803,14 +829,15 @@ struct
         prefix_consumers = [];
         suffix_consumers = [];
         root;
+        sw;
       }
 
   (* MISC. ****************************************************************** *)
 
-  let version ~root =
+  let version ~sw ~root =
     let v2_or_v1 () =
       let path = Irmin_pack.Layout.V1_and_v2.pack ~root in
-      match read_version_from_legacy_file path with
+      match read_version_from_legacy_file ~sw path with
       | Ok v -> Ok v
       | Error `Double_close | Error `Invalid_argument | Error `Closed ->
           assert false
@@ -821,11 +848,12 @@ struct
       | Error (`Io_misc _) as e -> e
     in
     match Io.classify_path root with
-    | `No_such_file_or_directory -> Error (`No_such_file_or_directory root)
-    | `File | `Other -> Error (`Not_a_directory root)
+    | `No_such_file_or_directory ->
+        Error (`No_such_file_or_directory (Eio.Path.native_exn root))
+    | `File | `Other -> Error (`Not_a_directory (Eio.Path.native_exn root))
     | `Directory -> (
         let path = Layout.control ~root in
-        match Control.open_ ~path ~tmp_path:None ~readonly:true with
+        match Control.open_ ~sw ~path ~tmp_path:None ~readonly:true with
         | Ok _ -> Ok `V3
         | Error (`No_such_file_or_directory _) -> v2_or_v1 ()
         | Error `Not_a_file -> Error `Invalid_layout
@@ -880,7 +908,7 @@ struct
         { pl with status; chunk_start_idx; chunk_num }
       in
       [%log.debug "GC: writing new control_file"];
-      Control.set_payload t.control pl
+      Control.set_payload ~sw:t.sw t.control pl
     in
 
     (* Step 3. Swap volume and reload lower if needed *)
@@ -954,12 +982,12 @@ struct
     [%log.debug
       "split: update control_file chunk_start_idx:%d chunk_num:%d"
         pl.chunk_start_idx pl.chunk_num];
-    Control.set_payload t.control pl
+    Control.set_payload ~sw:t.sw t.control pl
 
   let add_volume t =
     match t.lower with
     | None -> Error `Add_volume_requires_lower
-    | Some lower -> add_volume_and_update_control lower t.control
+    | Some lower -> add_volume_and_update_control ~sw:t.sw lower t.control
 
   let cleanup t =
     let root = t.root in
@@ -970,17 +998,17 @@ struct
     let lower = t.lower in
     cleanup ~root ~generation ~chunk_start_idx ~chunk_num ~lower
 
-  let create_one_commit_store t config gced commit_key =
+  let create_one_commit_store ~fs t config gced commit_key =
     let open Result_syntax in
     let src_root = t.root in
-    let dst_root = Irmin_pack.Conf.root config in
+    let dst_root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
     (* Step 1. Copy the dict *)
     let src_dict = Layout.dict ~root:src_root in
     let dst_dict = Layout.dict ~root:dst_root in
     let* () = Io.copy_file ~src:src_dict ~dst:dst_dict in
     (* Step 2. Create an empty suffix and close it. *)
     let* suffix =
-      Suffix.create_rw ~root:dst_root ~overwrite:false ~start_idx:1
+      Suffix.create_rw ~sw:t.sw ~root:dst_root ~overwrite:false ~start_idx:1
     in
     let* () = Suffix.close suffix in
     (* Step 3. Create the control file and close it. *)
@@ -999,14 +1027,17 @@ struct
       }
     in
     let path = Layout.control ~root:dst_root in
-    let* control = Control.create_rw ~path ~tmp_path:None ~overwrite:false pl in
+    let* control =
+      Control.create_rw ~sw:t.sw ~path ~tmp_path:None ~overwrite:false pl
+    in
     let* () = Control.close control in
     (* Step 4. Create the index. *)
     let* index =
       let log_size = Conf.index_log_size config in
       let throttle = Conf.merge_throttle config in
       Index.v ~fresh:true ~flush_callback:Fun.id ~readonly:false ~throttle
-        ~log_size dst_root
+        ~log_size
+        (Eio.Path.native_exn dst_root)
     in
     (* Step 5. Add the commit to the index, close the index. *)
     let () =

--- a/src/irmin-pack/io/file_manager_intf.ml
+++ b/src/irmin-pack/io/file_manager_intf.ml
@@ -95,7 +95,11 @@ module type S = sig
     | `No_tmp_path_provided ]
 
   val create_rw :
-    overwrite:bool -> Irmin.Backend.Conf.t -> (t, [> create_error ]) result
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    overwrite:bool ->
+    Irmin.Backend.Conf.t ->
+    (t, [> create_error ]) result
   (** Create a rw instance of [t] by creating the files.
 
       Note on SWMR consistency: It is undefined for a reader to attempt an
@@ -137,7 +141,11 @@ module type S = sig
     | `Invalid_parent_directory
     | `Pending_flush ]
 
-  val open_rw : Irmin.Backend.Conf.t -> (t, [> open_rw_error ]) result
+  val open_rw :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    Irmin.Backend.Conf.t ->
+    (t, [> open_rw_error ]) result
   (** Create a rw instance of [t] by opening existing files.
 
       If the pack store has already been garbage collected, opening with a
@@ -175,7 +183,11 @@ module type S = sig
     | `Invalid_layout
     | `Volume_missing of string ]
 
-  val open_ro : Irmin.Backend.Conf.t -> (t, [> open_ro_error ]) result
+  val open_ro :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    Irmin.Backend.Conf.t ->
+    (t, [> open_ro_error ]) result
   (** Create a ro instance of [t] by opening existing files.
 
       Note on SWMR consistency: [open_ro] is supposed to work whichever the
@@ -251,7 +263,10 @@ module type S = sig
     | `Not_a_directory of string
     | `Unknown_major_pack_version of string ]
 
-  val version : root:string -> (Import.Version.t, [> version_error ]) result
+  val version :
+    sw:Eio.Switch.t ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
+    (Import.Version.t, [> version_error ]) result
   (** [version ~root] is the version of the pack stores at [root]. *)
 
   val cleanup : t -> (unit, [> `Sys_error of string ]) result
@@ -288,6 +303,7 @@ module type S = sig
   (** Returns where data discarded by the GC will end up. (see {!gc_behaviour}). *)
 
   val create_one_commit_store :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
     t ->
     Irmin.Backend.Conf.t ->
     Control_file.Payload.Upper.Latest.gced ->

--- a/src/irmin-pack/io/gc.mli
+++ b/src/irmin-pack/io/gc.mli
@@ -25,9 +25,12 @@ module Make
   (** A running GC process. *)
 
   val v :
-    root:string ->
-    lower_root:string option ->
-    output:[ `External of string | `Root ] ->
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
+    lower_root:Eio.Fs.dir_ty Eio.Path.t option ->
+    output:[ `External of Eio.Fs.dir_ty Eio.Path.t | `Root ] ->
     generation:int ->
     unlink:bool ->
     dispatcher:Args.Dispatcher.t ->
@@ -40,6 +43,7 @@ module Make
   (** Creates and starts a new GC process. *)
 
   val finalise :
+    sw:Eio.Switch.t ->
     wait:bool ->
     t ->
     ([> `Running | `Finalised of Stats.Latest_gc.stats ], Args.Errs.t) result

--- a/src/irmin-pack/io/gc_worker.mli
+++ b/src/irmin-pack/io/gc_worker.mli
@@ -24,10 +24,11 @@ module Make
   module Args : Gc_args.S
 
   val run_and_output_result :
-    lower_root:string option ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    lower_root:Eio.Fs.dir_ty Eio.Path.t option ->
     generation:int ->
-    new_files_path:string ->
-    string ->
+    new_files_path:Eio.Fs.dir_ty Eio.Path.t ->
+    Eio.Fs.dir_ty Eio.Path.t ->
     Args.key ->
     int63 ->
     unit

--- a/src/irmin-pack/io/io_intf.ml
+++ b/src/irmin-pack/io/io_intf.ml
@@ -64,8 +64,18 @@ module type S = sig
 
       {2 Life Cycle} *)
 
-  val create : path:string -> overwrite:bool -> (t, [> create_error ]) result
-  val open_ : path:string -> readonly:bool -> (t, [> open_error ]) result
+  val create :
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    overwrite:bool ->
+    (t, [> create_error ]) result
+
+  val open_ :
+    sw:Eio.Switch.t ->
+    path:Eio.Fs.dir_ty Eio.Path.t ->
+    readonly:bool ->
+    (t, [> open_error ]) result
+
   val close : t -> (unit, [> close_error ]) result
 
   (** {2 Write Functions} *)
@@ -78,16 +88,23 @@ module type S = sig
       write. *)
 
   val move_file :
-    src:string -> dst:string -> (unit, [> `Sys_error of string ]) result
+    src:Eio.Fs.dir_ty Eio.Path.t ->
+    dst:Eio.Fs.dir_ty Eio.Path.t ->
+    (unit, [> `Sys_error of string ]) result
 
   val copy_file :
-    src:string -> dst:string -> (unit, [> `Sys_error of string ]) result
+    src:Eio.Fs.dir_ty Eio.Path.t ->
+    dst:Eio.Fs.dir_ty Eio.Path.t ->
+    (unit, [> `Sys_error of string ]) result
 
-  val mkdir : string -> (unit, [> mkdir_error ]) result
-  val rmdir : string -> unit
-  val unlink : string -> (unit, [> `Sys_error of string ]) result
+  val mkdir : Eio.Fs.dir_ty Eio.Path.t -> (unit, [> mkdir_error ]) result
+  val rmdir : Eio.Fs.dir_ty Eio.Path.t -> unit
 
-  val unlink_dont_wait : on_exn:(exn -> unit) -> string -> unit
+  val unlink :
+    Eio.Fs.dir_ty Eio.Path.t -> (unit, [> `Sys_error of string ]) result
+
+  val unlink_dont_wait :
+    on_exn:(exn -> unit) -> sw:Eio.Switch.t -> Eio.Fs.dir_ty Eio.Path.t -> unit
   (** [unlink_dont_wait file] attempts to unlink the named file but doesn't wait
       for the completion of the unlink operation.
 
@@ -112,7 +129,7 @@ module type S = sig
       syscalls. *)
 
   val size_of_path :
-    string ->
+    Eio.Fs.dir_ty Eio.Path.t ->
     ( int63,
       [> `Io_misc of misc_error
       | `No_such_file_or_directory of string
@@ -120,14 +137,15 @@ module type S = sig
     result
 
   val classify_path :
-    string -> [> `File | `Directory | `No_such_file_or_directory | `Other ]
+    Eio.Fs.dir_ty Eio.Path.t ->
+    [> `File | `Directory | `No_such_file_or_directory | `Other ]
 
-  val readdir : string -> string list
+  val readdir : Eio.Fs.dir_ty Eio.Path.t -> string list
 
   (** {1 MISC.} *)
 
   val readonly : t -> bool
-  val path : t -> string
+  val path : t -> Eio.Fs.dir_ty Eio.Path.t
   val page_size : int
 
   (** {1 Unsafe Functions}

--- a/src/irmin-pack/io/lower_intf.ml
+++ b/src/irmin-pack/io/lower_intf.ml
@@ -32,10 +32,11 @@ module type Volume = sig
     | `Corrupted_control_file of string
     | `Unknown_major_pack_version of string ]
 
-  val v : string -> (t, [> open_error ]) result
+  val v :
+    sw:Eio.Switch.t -> Eio.Fs.dir_ty Eio.Path.t -> (t, [> open_error ]) result
   (** [v path] loads the volume at [path] in read-only. *)
 
-  val path : t -> string
+  val path : t -> Eio.Fs.dir_ty Eio.Path.t
   (** [path t] is the directory that contains the volume. *)
 
   val is_empty : t -> bool
@@ -66,7 +67,11 @@ module type S = sig
     | `Invalid_parent_directory ]
 
   val v :
-    readonly:bool -> volume_num:int -> string -> (t, [> open_error ]) result
+    sw:Eio.Switch.t ->
+    readonly:bool ->
+    volume_num:int ->
+    Eio.Fs.dir_ty Eio.Path.t ->
+    (t, [> open_error ]) result
   (** [v ~readonly ~volume_num lower_root] loads all volumes located in the
       directory [lower_root].
 
@@ -121,7 +126,7 @@ module type S = sig
       to temporarily allow RW before calling {!archive_seq_exn}. *)
 
   val archive_seq_exn :
-    upper_root:string ->
+    upper_root:Eio.Fs.dir_ty Eio.Path.t ->
     generation:int ->
     to_archive:(int63 * string Seq.t) list ->
     t ->
@@ -152,10 +157,11 @@ module type S = sig
     [ open_error | close_error | add_error | `Sys_error of string ]
 
   val create_from :
-    src:string ->
+    sw:Eio.Switch.t ->
+    src:Eio.Fs.dir_ty Eio.Path.t ->
     dead_header_size:int ->
     size:Int63.t ->
-    string ->
+    Eio.Fs.dir_ty Eio.Path.t ->
     (unit, [> create_error ]) result
   (** [create_from ~src ~dead_header_size ~size lower_root] initializes the
       first lower volume in the directory [lower_root] by moving the suffix file

--- a/src/irmin-pack/io/snapshot_intf.ml
+++ b/src/irmin-pack/io/snapshot_intf.ml
@@ -44,10 +44,16 @@ module type Sigs = sig
     module Export : sig
       type t
 
-      val v : Irmin.config -> read Contents_pack.t -> read Inode.Pack.t -> t
+      val v :
+        sw:Eio.Switch.t ->
+        fs:Eio.Fs.dir_ty Eio.Path.t ->
+        Irmin.config ->
+        read Contents_pack.t ->
+        read Inode.Pack.t ->
+        t
 
       val run :
-        ?on_disk:[ `Path of string ] ->
+        ?on_disk:[ `Path of Eio.Fs.dir_ty Eio.Path.t ] ->
         t ->
         (Contents_pack.value -> unit) ->
         (Inode.Snapshot.inode -> unit) ->
@@ -69,7 +75,7 @@ module type Sigs = sig
       type t
 
       val v :
-        ?on_disk:[ `Path of string | `Reuse ] ->
+        ?on_disk:[ `Path of Eio.Fs.dir_ty Eio.Path.t | `Reuse ] ->
         int ->
         read Contents_pack.t ->
         read Inode.Pack.t ->

--- a/src/irmin-pack/io/sparse_file.ml
+++ b/src/irmin-pack/io/sparse_file.ml
@@ -23,7 +23,12 @@ type int64_bigarray = (int64, Bigarray.int64_elt, Bigarray.c_layout) BigArr1.t
 module Int64_mmap (Io : Io_intf.S) : sig
   type t
 
-  val open_ro : fn:string -> sz:int -> (t, [> Io.open_error ]) result
+  val open_ro :
+    sw:Eio.Switch.t ->
+    fn:Eio.Fs.dir_ty Eio.Path.t ->
+    sz:int ->
+    (t, [> Io.open_error ]) result
+
   val length : t -> int
   val get : t -> int -> Int64.t
   val close : t -> (unit, [> Io.close_error ]) result
@@ -33,10 +38,10 @@ end = struct
   let sector_size = 512
   let length t = BigArr1.dim t.arr
 
-  let open_ro ~fn ~sz =
+  let open_ro ~sw ~fn ~sz =
     let open Result_syntax in
     assert (Io.classify_path fn = `File);
-    let+ fd = Io.open_ ~path:fn ~readonly:true in
+    let+ fd = Io.open_ ~sw ~path:fn ~readonly:true in
     let size = sz / 8 in
     let arr = BigArr1.create Bigarray.Int64 Bigarray.c_layout size in
     let loaded = Array.make (1 + (sz / sector_size)) false in
@@ -76,17 +81,17 @@ module Make (Io : Io_intf.S) = struct
 
     type t = Int64_mmap.t
 
-    let open_map ~path ~size =
+    let open_map ~sw ~path ~size =
       match Io.classify_path path with
       | `File ->
           let open Result_syntax in
-          let* mmap = Int64_mmap.open_ro ~fn:path ~sz:size in
+          let* mmap = Int64_mmap.open_ro ~sw ~fn:path ~sz:size in
           if Int64_mmap.length mmap mod 3 = 0 then Ok mmap
           else
             Error
               (`Corrupted_mapping_file
                 (__FILE__ ^ ": mapping mmap size did not meet size requirements"))
-      | _ -> Error (`No_such_file_or_directory path)
+      | _ -> Error (`No_such_file_or_directory (Eio.Path.native_exn path))
 
     let close = Int64_mmap.close
     let entry_count t = Int64_mmap.length t / 3
@@ -129,14 +134,14 @@ module Make (Io : Io_intf.S) = struct
 
   type t = { mapping : Mapping_file.t; data : Io.t }
 
-  let open_ ~readonly ~mapping_size ~mapping ~data =
+  let open_ ~sw ~readonly ~mapping_size ~mapping ~data =
     let open Result_syntax in
-    let* mapping = Mapping_file.open_map ~path:mapping ~size:mapping_size in
-    let+ data = Io.open_ ~path:data ~readonly in
+    let* mapping = Mapping_file.open_map ~sw ~path:mapping ~size:mapping_size in
+    let+ data = Io.open_ ~sw ~path:data ~readonly in
     { mapping; data }
 
-  let open_ro ~mapping_size ~mapping ~data =
-    open_ ~readonly:true ~mapping_size ~mapping ~data
+  let open_ro ~sw ~mapping_size ~mapping ~data =
+    open_ ~sw ~readonly:true ~mapping_size ~mapping ~data
 
   let close t =
     let open Result_syntax in
@@ -195,8 +200,8 @@ module Make (Io : Io_intf.S) = struct
   module Wo = struct
     type nonrec t = t
 
-    let open_wo ~mapping_size ~mapping ~data =
-      open_ ~readonly:false ~mapping_size ~mapping ~data
+    let open_wo ~sw ~mapping_size ~mapping ~data =
+      open_ ~sw ~readonly:false ~mapping_size ~mapping ~data
 
     let write_exn t ~off ~len str =
       let poff, max_entry_len = get_poff t ~off in
@@ -206,14 +211,14 @@ module Make (Io : Io_intf.S) = struct
     let fsync t = Io.fsync t.data
     let close = close
 
-    let create_from_data ~mapping ~dead_header_size ~size ~data:_ =
+    let create_from_data ~sw ~mapping ~dead_header_size ~size ~data:_ =
       let open Result_syntax in
       let entry =
         make_entry ~off:Int64.zero
           ~poff:(Int64.of_int dead_header_size)
           ~len:(Int63.to_int64 size)
       in
-      let* mapping = Io.create ~path:mapping ~overwrite:false in
+      let* mapping = Io.create ~sw ~path:mapping ~overwrite:false in
       let* () = Io.write_string mapping ~off:Int63.zero entry in
       let+ () = Io.close mapping in
       Int63.of_int (String.length entry)
@@ -227,19 +232,19 @@ module Make (Io : Io_intf.S) = struct
     let end_off t = t.end_off
     let mapping_size t = Ao.end_poff t.mapping
 
-    let create ~mapping ~data =
+    let create ~sw ~mapping ~data =
       let open Result_syntax in
       let ao_create path = Ao.create_rw ~path ~overwrite:false in
-      let* mapping = ao_create mapping in
-      let+ data = ao_create data in
+      let* mapping = ao_create ~sw mapping in
+      let+ data = ao_create ~sw data in
       { mapping; data; end_off = Int63.zero }
 
-    let open_ao ~mapping_size ~mapping ~data =
+    let open_ao ~sw ~mapping_size ~mapping ~data =
       let open Result_syntax in
       let ao_open ~end_poff path =
         Ao.open_rw ~path ~end_poff ~dead_header_size:0
       in
-      let* ao_mapping = ao_open ~end_poff:mapping_size mapping in
+      let* ao_mapping = ao_open ~sw ~end_poff:mapping_size mapping in
       let* end_off, end_poff =
         if mapping_size <= Int63.zero then Ok (Int63.zero, Int63.zero)
         else
@@ -256,7 +261,7 @@ module Make (Io : Io_intf.S) = struct
           let open Int63.Syntax in
           (end_off + len, end_poff + len)
       in
-      let+ ao_data = ao_open ~end_poff data in
+      let+ ao_data = ao_open ~sw ~end_poff data in
       { mapping = ao_mapping; data = ao_data; end_off }
 
     let check_offset_exn { end_off; _ } ~off =

--- a/src/irmin-pack/io/sparse_file_intf.ml
+++ b/src/irmin-pack/io/sparse_file_intf.ml
@@ -24,9 +24,10 @@ module type S = sig
   type open_error := [ Io.open_error | `Corrupted_mapping_file of string ]
 
   val open_ro :
+    sw:Eio.Switch.t ->
     mapping_size:int ->
-    mapping:string ->
-    data:string ->
+    mapping:Eio.Fs.dir_ty Eio.Path.t ->
+    data:Eio.Fs.dir_ty Eio.Path.t ->
     (t, [> open_error ]) result
   (** [open_ro ~mapping_size ~mapping ~data] returns a new read-only view of the
       sparse file, represented on disk by two files named [mapping] and [data].
@@ -67,9 +68,10 @@ module type S = sig
     type t
 
     val open_wo :
+      sw:Eio.Switch.t ->
       mapping_size:int ->
-      mapping:string ->
-      data:string ->
+      mapping:Eio.Fs.dir_ty Eio.Path.t ->
+      data:Eio.Fs.dir_ty Eio.Path.t ->
       (t, [> open_error ]) result
     (** [open_wo ~mapping_size ~mapping ~data] returns a write-only instance of
         the sparse file.
@@ -90,10 +92,11 @@ module type S = sig
     (** Close the underlying files. *)
 
     val create_from_data :
-      mapping:string ->
+      sw:Eio.Switch.t ->
+      mapping:Eio.Fs.dir_ty Eio.Path.t ->
       dead_header_size:int ->
       size:Int63.t ->
-      data:string ->
+      data:Eio.Fs.dir_ty Eio.Path.t ->
       (int63, [> Io.create_error | Io.write_error | Io.close_error ]) result
     (** [create_from_data ~mapping ~dead_header_size ~size ~data] initializes a
         new sparse file on disk from the existing file [data], by creating the
@@ -119,14 +122,18 @@ module type S = sig
         the file again. *)
 
     val create :
-      mapping:string -> data:string -> (t, [> Io.create_error ]) result
+      sw:Eio.Switch.t ->
+      mapping:Eio.Fs.dir_ty Eio.Path.t ->
+      data:Eio.Fs.dir_ty Eio.Path.t ->
+      (t, [> Io.create_error ]) result
     (** [create ~mapping ~data] initializes a new empty sparse file, represented
         on disk by two files named [mapping] and [data]. *)
 
     val open_ao :
+      sw:Eio.Switch.t ->
       mapping_size:Int63.t ->
-      mapping:string ->
-      data:string ->
+      mapping:Eio.Fs.dir_ty Eio.Path.t ->
+      data:Eio.Fs.dir_ty Eio.Path.t ->
       ( t,
         [> Io.open_error
         | `Closed

--- a/src/irmin-pack/io/store.ml
+++ b/src/irmin-pack/io/store.ml
@@ -121,8 +121,8 @@ struct
         module AW = Atomic_write.Make_persistent (Io) (Key) (Val)
         include Atomic_write.Closeable (AW)
 
-        let v ?fresh ?readonly path =
-          AW.v ?fresh ?readonly path |> make_closeable
+        let v ~sw ?fresh ?readonly path =
+          AW.v ~sw ?fresh ?readonly path |> make_closeable
       end
 
       module Slice = Irmin.Backend.Slice.Make (Contents) (Node) (Commit)
@@ -160,6 +160,8 @@ struct
           during_batch : bool Atomic.t;
           running_gc : running_gc option Atomic.t;
           lock : Eio.Mutex.t;
+          fs : Eio.Fs.dir_ty Eio.Path.t;
+          sw : Eio.Switch.t;
         }
 
         let pp_key = Irmin.Type.pp XKey.t
@@ -170,22 +172,26 @@ struct
         let config t = t.config
 
         let v config =
-          let root = Irmin_pack.Conf.root config in
+          let sw = Conf.switch config in
+          let fs = Conf.fs config in
+          let root = Eio.Path.(fs / Irmin_pack.Conf.root config) in
           let fresh = Irmin_pack.Conf.fresh config in
           let fm =
             let readonly = Irmin_pack.Conf.readonly config in
-            if readonly then File_manager.open_ro config |> Errs.raise_if_error
+            if readonly then
+              File_manager.open_ro ~sw ~fs config |> Errs.raise_if_error
             else
               match (Io.classify_path root, fresh) with
               | `No_such_file_or_directory, _ ->
-                  File_manager.create_rw ~overwrite:false config
+                  File_manager.create_rw ~sw ~fs ~overwrite:false config
                   |> Errs.raise_if_error
               | `Directory, true ->
-                  File_manager.create_rw ~overwrite:true config
+                  File_manager.create_rw ~sw ~fs ~overwrite:true config
                   |> Errs.raise_if_error
               | `Directory, false ->
-                  File_manager.open_rw config |> Errs.raise_if_error
-              | (`File | `Other), _ -> Errs.raise_error (`Not_a_directory root)
+                  File_manager.open_rw ~sw ~fs config |> Errs.raise_if_error
+              | (`File | `Other), _ ->
+                  Errs.raise_error (`Not_a_directory (Eio.Path.native_exn root))
           in
           let dict = File_manager.dict fm in
           let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
@@ -194,11 +200,11 @@ struct
           let node = Node.CA.v ~config ~fm ~dict ~dispatcher ~lru in
           let commit = Commit.CA.v ~config ~fm ~dict ~dispatcher ~lru in
           let branch =
-            let root = Conf.root config in
+            let root = Eio.Path.(fs / Conf.root config) in
             let fresh = Conf.fresh config in
             let readonly = Conf.readonly config in
             let path = Irmin_pack.Layout.V4.branch ~root in
-            Branch.v ~fresh ~readonly path
+            Branch.v ~sw ~fresh ~readonly path
           in
           let during_batch = Atomic.make false in
           let running_gc = Atomic.make None in
@@ -215,6 +221,8 @@ struct
             running_gc;
             dispatcher;
             lock;
+            fs;
+            sw;
           }
 
         let flush t = File_manager.flush ?hook:None t.fm |> Errs.raise_if_error
@@ -248,7 +256,8 @@ struct
                         (Irmin.Type.to_string XKey.t key))
                 | Some (k, _kind) -> Ok k)
 
-          let start ~unlink ~use_auto_finalisation ~output t commit_key =
+          let start ~fs ~domain_mgr ~unlink ~use_auto_finalisation ~output t
+              commit_key =
             let open Result_syntax in
             [%log.info "GC: Starting on %a" pp_key commit_key];
             let* () =
@@ -256,7 +265,7 @@ struct
               else Ok ()
             in
             let* commit_key = direct_commit_key t commit_key in
-            let root = Conf.root t.config in
+            let root = Eio.Path.(t.fs / Conf.root t.config) in
             let* () =
               if not (is_allowed t) then
                 Error (`Gc_disallowed "Store does not support GC")
@@ -265,16 +274,21 @@ struct
             Eio.Mutex.use_rw ~protect:false t.lock @@ fun () ->
             let current_generation = File_manager.generation t.fm in
             let next_generation = current_generation + 1 in
-            let lower_root = Conf.lower_root t.config in
+            let lower_root =
+              Option.map
+                (fun path -> Eio.Path.(t.fs / path))
+                (Conf.lower_root t.config)
+            in
             let* gc =
-              Gc.v ~root ~lower_root ~generation:next_generation ~unlink
-                ~dispatcher:t.dispatcher ~fm:t.fm ~contents:t.contents
-                ~node:t.node ~commit:t.commit ~output commit_key
+              Gc.v ~sw:t.sw ~fs ~domain_mgr ~root ~lower_root
+                ~generation:next_generation ~unlink ~dispatcher:t.dispatcher
+                ~fm:t.fm ~contents:t.contents ~node:t.node ~commit:t.commit
+                ~output commit_key
             in
             Atomic.set t.running_gc (Some { gc; use_auto_finalisation });
             Ok ()
 
-          let start_exn ?(unlink = true) ?(output = `Root)
+          let start_exn ~fs ~domain_mgr ?(unlink = true) ?(output = `Root)
               ~use_auto_finalisation t commit_key =
             match Atomic.get t.running_gc with
             | Some _ ->
@@ -282,7 +296,8 @@ struct
                 false
             | None -> (
                 let result =
-                  start ~unlink ~use_auto_finalisation ~output t commit_key
+                  start ~fs ~domain_mgr ~unlink ~use_auto_finalisation ~output t
+                    commit_key
                 in
                 match result with Ok _ -> true | Error e -> Errs.raise_error e)
 
@@ -293,7 +308,7 @@ struct
               | Some { gc; _ } ->
                   if Atomic.get t.during_batch then
                     Error `Gc_forbidden_during_batch
-                  else Gc.finalise ~wait gc
+                  else Gc.finalise ~sw:t.sw ~wait gc
             in
             match result with
             | Ok (`Finalised _ as x) ->
@@ -346,7 +361,7 @@ struct
                     let key = Pack_key.v_direct ~offset ~length entry.hash in
                     Some key)
 
-          let create_one_commit_store t commit_key path =
+          let create_one_commit_store ~fs ~domain_mgr t commit_key path =
             let () =
               match Io.classify_path path with
               | `Directory -> ()
@@ -360,8 +375,8 @@ struct
             (* The GC action here does not matter, since we'll not fully
                finalise it *)
             let launched =
-              start_exn ~use_auto_finalisation:false ~output:(`External path) t
-                commit_key
+              start_exn ~fs ~domain_mgr ~use_auto_finalisation:false
+                ~output:(`External path) t commit_key
             in
             let () =
               if not launched then Errs.raise_error `Forbidden_during_gc
@@ -373,14 +388,19 @@ struct
                   Eio.Mutex.use_rw ~protect:false t.lock @@ fun () ->
                   Gc.finalise_without_swap gc
             in
-            let config = Irmin.Backend.Conf.add t.config Conf.Key.root path in
+            let config =
+              (* TODO: why native_exn? *)
+              Irmin.Backend.Conf.add t.config Conf.Key.root
+                (Eio.Path.native_exn path)
+            in
             let () =
-              File_manager.create_one_commit_store t.fm config gced commit_key
+              File_manager.create_one_commit_store ~fs t.fm config gced
+                commit_key
               |> Errs.raise_if_error
             in
             let branch_path = Irmin_pack.Layout.V4.branch ~root:path in
             let branch_store =
-              Branch.v ~fresh:true ~readonly:false branch_path
+              Branch.v ~sw:t.sw ~fresh:true ~readonly:false branch_path
             in
             Branch.close branch_store
         end
@@ -630,14 +650,15 @@ struct
 
       let finalise_exn = X.Repo.Gc.finalise_exn
 
-      let start_exn ?unlink t =
-        X.Repo.Gc.start_exn ?unlink ~use_auto_finalisation:false t
+      let start_exn ~fs ~domain_mgr ?unlink t =
+        X.Repo.Gc.start_exn ~fs ~domain_mgr ?unlink ~use_auto_finalisation:false
+          t
 
-      let start repo commit_key =
+      let start ~fs ~domain_mgr repo commit_key =
         try
           let started =
-            X.Repo.Gc.start_exn ~unlink:true ~use_auto_finalisation:true repo
-              commit_key
+            X.Repo.Gc.start_exn ~fs ~domain_mgr ~unlink:true
+              ~use_auto_finalisation:true repo commit_key
           in
           Ok started
         with exn -> catch_errors "Start GC" exn
@@ -655,8 +676,8 @@ struct
           | `Finalised stats -> Ok (Some stats)
         with exn -> catch_errors "Wait for GC" exn
 
-      let run ?(finished = fun _ -> ()) repo commit_key =
-        let started = start repo commit_key in
+      let run ~fs ~domain_mgr ?(finished = fun _ -> ()) repo commit_key =
+        let started = start ~fs ~domain_mgr repo commit_key in
         match started with
         | Ok r ->
             if r then
@@ -710,7 +731,9 @@ struct
           [%log.debug "Iterate over a tree"];
           let contents = X.Repo.contents_t repo in
           let nodes = X.Repo.node_t repo |> snd in
-          let export = S.Export.v repo.config contents nodes in
+          let export =
+            S.Export.v ~sw:repo.sw ~fs:repo.fs repo.config contents nodes
+          in
           let f_contents x = f (Blob x) in
           let f_nodes x = f (Inode x) in
           match root_key with

--- a/src/irmin-pack/io/store_intf.ml
+++ b/src/irmin-pack/io/store_intf.ml
@@ -46,6 +46,8 @@ module type S = sig
     ([> `No_error ], [> `Cannot_fix of string ]) result
 
   val traverse_pack_file :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
     [ `Reconstruct_index of [ `In_place | `Output of string ]
     | `Check_index
     | `Check_and_fix_index ] ->
@@ -53,6 +55,8 @@ module type S = sig
     unit
 
   val test_traverse_pack_file :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
     [ `Reconstruct_index of [ `In_place | `Output of string ]
     | `Check_index
     | `Check_and_fix_index ] ->
@@ -101,7 +105,13 @@ module type S = sig
   (** [flush t] flush read-write pack on disk. Raises [RO_Not_Allowed] if called
       by a readonly instance.*)
 
-  val create_one_commit_store : repo -> commit_key -> string -> unit
+  val create_one_commit_store :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    repo ->
+    commit_key ->
+    Eio.Fs.dir_ty Eio.Path.t ->
+    unit
   (** [create_one_commit_store t key path] creates a new store at [path] from
       the existing one, containing only one commit, specified by the [key]. Note
       that this operation is blocking.
@@ -119,7 +129,13 @@ module type S = sig
 
     (** {1 Low-level API} *)
 
-    val start_exn : ?unlink:bool -> repo -> commit_key -> bool
+    val start_exn :
+      fs:Eio.Fs.dir_ty Eio.Path.t ->
+      domain_mgr:_ Eio.Domain_manager.t ->
+      ?unlink:bool ->
+      repo ->
+      commit_key ->
+      bool
     (** [start_exn] tries to start the GC process and returns true if the GC is
         launched. If a GC is already running, a new one is not started.
 
@@ -157,6 +173,8 @@ module type S = sig
         logging *)
 
     val run :
+      fs:Eio.Fs.dir_ty Eio.Path.t ->
+      domain_mgr:_ Eio.Domain_manager.t ->
       ?finished:((Stats.Latest_gc.stats, msg) result -> unit) ->
       repo ->
       commit_key ->
@@ -237,7 +255,7 @@ module type S = sig
     [@@deriving irmin]
 
     val export :
-      ?on_disk:[ `Path of string ] ->
+      ?on_disk:[ `Path of Eio.Fs.dir_ty Eio.Path.t ] ->
       repo ->
       (t -> unit) ->
       root_key:Tree.kinded_key ->
@@ -267,7 +285,10 @@ module type S = sig
     module Import : sig
       type process
 
-      val v : ?on_disk:[ `Path of string | `Reuse ] -> repo -> process
+      val v :
+        ?on_disk:[ `Path of Eio.Fs.dir_ty Eio.Path.t | `Reuse ] ->
+        repo ->
+        process
       (** [v ?on_disk repo] create a [snaphot] instance. The traversal requires
           an index to keep track of visited elements.
 

--- a/src/irmin-pack/io/traverse_pack_file.ml
+++ b/src/irmin-pack/io/traverse_pack_file.ml
@@ -70,6 +70,8 @@ end
 
 module Make (Args : Args) : sig
   val run :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
     [ `Reconstruct_index of [ `In_place | `Output of string ]
     | `Check_index
     | `Check_and_fix_index ] ->
@@ -77,6 +79,8 @@ module Make (Args : Args) : sig
     unit
 
   val test :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
     [ `Reconstruct_index of [ `In_place | `Output of string ]
     | `Check_index
     | `Check_and_fix_index ] ->
@@ -115,22 +119,26 @@ end = struct
         false
 
   module Index_reconstructor = struct
-    let create ~dest config =
+    let create ~fs ~dest config =
       let dest =
         match dest with
         | `Output path ->
+            let path = Eio.Path.(fs / path) in
             if Io.classify_path path <> `No_such_file_or_directory then
               Fmt.invalid_arg "Can't reconstruct index. File already exits.";
             path
         | `In_place ->
             if Conf.readonly config then raise Irmin_pack.RO_not_allowed;
-            Conf.root config
+            Eio.Path.(fs / Conf.root config)
       in
       let log_size = Conf.index_log_size config in
       [%log.app
         "Beginning index reconstruction with parameters: { log_size = %d }"
           log_size];
-      let index = Index.v_exn ~fresh:true ~readonly:false ~log_size dest in
+      let index =
+        Index.v_exn ~fresh:true ~readonly:false ~log_size
+          (Eio.Path.native_exn dest)
+      in
       index
 
     let iter_pack_entry ~always index key data =
@@ -364,7 +372,7 @@ end = struct
     refill_buffer ~from:Int63.zero;
     loop_entries ~buffer_off:0 Int63.zero None
 
-  let run_or_test ~initial_buffer_size mode config =
+  let run_or_test ~sw ~fs ~initial_buffer_size mode config =
     let always =
       Conf.indexing_strategy config
       |> Irmin_pack.Indexing_strategy.is_minimal
@@ -374,7 +382,7 @@ end = struct
       match mode with
       | `Reconstruct_index dest ->
           let open Index_reconstructor in
-          let v = create ~dest config in
+          let v = create ~fs ~dest config in
           (iter_pack_entry ~always v, finalise v, "Reconstructing index")
       | `Check_index ->
           let open Index_checker in
@@ -386,7 +394,7 @@ end = struct
           (iter_pack_entry ~always v, finalise v, "Checking and fixing index")
     in
     let run_duration = Io.Clock.counter () in
-    let fm = File_manager.open_ro config |> Errs.raise_if_error in
+    let fm = File_manager.open_ro ~sw ~fs config |> Errs.raise_if_error in
     let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
     let total = Dispatcher.end_offset dispatcher in
     let ingest_data progress =

--- a/src/irmin-pack/irmin_pack_intf.ml
+++ b/src/irmin-pack/irmin_pack_intf.ml
@@ -70,6 +70,8 @@ module type Sigs = sig
   module Conf = Conf
 
   val config :
+    sw:Eio.Switch.t ->
+    fs:_ Eio.Path.t ->
     ?fresh:bool ->
     ?readonly:bool ->
     ?lru_size:int ->
@@ -79,8 +81,8 @@ module type Sigs = sig
     ?indexing_strategy:Indexing_strategy.t ->
     ?use_fsync:bool ->
     ?no_migrate:bool ->
-    ?lower_root:string option ->
-    string ->
+    ?lower_root:Eio.Fs.dir_ty Eio.Path.t option ->
+    Eio.Fs.dir_ty Eio.Path.t ->
     Irmin.config
   (** Configuration options for stores. See {!Irmin_pack.Conf} for more details. *)
 

--- a/src/irmin-pack/layout.ml
+++ b/src/irmin-pack/layout.ml
@@ -14,7 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let toplevel name ~root = Filename.(concat root name)
+open Eio.Path
+
+let toplevel name ~root : Eio.Fs.dir_ty t = root / name
 
 module V1_and_v2 = struct
   let pack = toplevel "store.pack"
@@ -53,6 +55,7 @@ end
 module V4 = struct
   let branch = toplevel "store.branches"
   let dict = toplevel "store.dict"
+  let dict_tmp = toplevel "store.dict.tmp"
   let control = toplevel "store.control"
   let control_tmp = toplevel "store.control.tmp"
 
@@ -110,6 +113,7 @@ module Classification = struct
       | `Control
       | `Control_tmp
       | `Dict
+      | `Dict_tmp
       | `Gc_result of int
       | `Mapping of int
       | `Prefix of int
@@ -127,6 +131,7 @@ module Classification = struct
       | [ "store"; "control" ] -> `Control
       | [ "store"; "control"; "tmp" ] -> `Control_tmp
       | [ "store"; "dict" ] -> `Dict
+      | [ "store"; "dict"; "tmp" ] -> `Dict_tmp
       | [ "store"; g; "out" ] when is_number g -> `Gc_result (int_of_string g)
       | [ "store"; g; "reachable" ] when is_number g ->
           `Reachable (int_of_string g)

--- a/src/irmin-pack/unix/async.ml
+++ b/src/irmin-pack/unix/async.ml
@@ -17,108 +17,49 @@
 open! Irmin_pack_io.Import
 
 module Unix = struct
-  let kill_no_err pid =
-    try Unix.kill pid Sys.sigkill
-    with Unix.Unix_error (e, s1, s2) ->
-      [%log.warn
-        "Killing process with pid %d failed with error (%s, %s, %s)" pid
-          (Unix.error_message e) s1 s2]
-
-  (** [Exit] is a stack of PIDs that will be killed [at_exit]. *)
-  module Exit = struct
-    let proc_list = Atomic.make []
-
-    let rec add pid =
-      let pids = Atomic.get proc_list in
-      if not (Atomic.compare_and_set proc_list pids (pid :: pids)) then add pid
-
-    let rec remove pid =
-      let pids = Atomic.get proc_list in
-      let new_pids = List.filter (fun pid' -> pid <> pid') pids in
-      if not (Atomic.compare_and_set proc_list pids new_pids) then remove pid
-
-    let () =
-      at_exit @@ fun () ->
-      let pids = Atomic.exchange proc_list [] in
-      List.iter kill_no_err pids
-  end
-
   type outcome = [ `Success | `Cancelled | `Failure of string ]
   [@@deriving irmin]
 
   type status = [ `Running | `Success | `Cancelled | `Failure of string ]
   [@@deriving irmin]
 
-  type t = { pid : int; mutable status : status; lock : Eio.Mutex.t }
+  type t = Eio.Switch.t * outcome Eio.Promise.or_exn
 
-  module Exit_code = struct
-    let success = 0
-    let unhandled_exn = 42
-  end
-
-  let async f =
+  let async ~sw ~domain_mgr f =
+    let run f () =
+      Logs.set_level None;
+      match f () with
+      | () -> `Success
+      | exception _ -> `Failure "Unhandled exception"
+    in
     Stdlib.flush_all ();
-    match Unix.fork () with
-    | 0 ->
-        (* Lwt_main.Exit_hooks.remove_all ();
-           Lwt_main.abandon_yielded_and_paused (); *)
-        let exit_code =
-          match f () with
-          | () -> Exit_code.success
-          | exception e ->
-              [%log.err
-                "Unhandled exception in child process %s" (Printexc.to_string e)];
-              Exit_code.unhandled_exn
-        in
-        (* Use [Unix._exit] to avoid calling [at_exit] hooks. *)
-        Unix._exit exit_code
-    | pid ->
-        Exit.add pid;
-        { pid; status = `Running; lock = Eio.Mutex.create () }
+    let gc_sw_promise, gc_sw_resolver = Eio.Promise.create ~label:"gc_sw" () in
+    let promise =
+      Eio.Fiber.fork_promise ~sw (fun () ->
+          Eio.Switch.run @@ fun sw' ->
+          Eio.Promise.resolve gc_sw_resolver sw';
+          Eio.Domain_manager.run domain_mgr (run f))
+    in
+    let gc_sw = Eio.Promise.await gc_sw_promise in
+    (gc_sw, promise)
 
-  let status_of_process_outcome = function
-    | Unix.WEXITED n when n = Exit_code.success -> `Success
-    | Unix.WEXITED n when n = Exit_code.unhandled_exn ->
-        `Failure "Unhandled exception"
-    | Unix.WSIGNALED n -> `Failure (Fmt.str "Signaled %d" n)
-    | Unix.WEXITED n -> `Failure (Fmt.str "Exited %d" n)
-    | Unix.WSTOPPED n -> `Failure (Fmt.str "Stopped %d" n)
+  let await (_, p) : [> outcome ] =
+    match Eio.Promise.await p with
+    | Ok (#outcome as outcome) -> outcome
+    | Error _ -> `Failure "Unhandled exception"
 
-  let cancel t =
-    Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
-    match t.status with
-    | `Running ->
-        let pid, _ = Unix.waitpid [ Unix.WNOHANG ] t.pid in
-        if pid = 0 then (
-          (* Child process is still running. *)
-          kill_no_err t.pid;
-          Exit.remove t.pid;
-          t.status <- `Cancelled;
-          true)
-        else false
-    | _ -> false
+  let status (_, p) : [> status ] =
+    match Eio.Promise.peek p with
+    | Some (Ok (#outcome as outcome)) -> outcome
+    | Some (Error e) -> `Failure (Printexc.to_string e)
+    | None -> `Running
 
-  let status t =
-    Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
-    match t.status with
-    | `Running ->
-        let pid, status = Unix.waitpid [ Unix.WNOHANG ] t.pid in
-        if pid = 0 then `Running
-        else
-          let s = status_of_process_outcome status in
-          Exit.remove pid;
-          t.status <- s;
-          s
-    | #outcome as s -> s
+  exception Cancelled
 
-  let await t =
-    Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
-    match t.status with
-    | `Running ->
-        let pid, status = Unix.waitpid [] t.pid in
-        let s = status_of_process_outcome status in
-        Exit.remove pid;
-        t.status <- s;
-        s
-    | #outcome as s -> s
+  let cancel (sw, p) =
+    match Eio.Promise.peek p with
+    | None ->
+        Eio.Switch.fail sw Cancelled;
+        true
+    | Some _ -> false
 end

--- a/src/irmin/conf.ml
+++ b/src/irmin/conf.ml
@@ -93,6 +93,8 @@ module Spec = struct
         dest.keys src
     in
     { name = !name; keys }
+
+  let copy { name; keys } = { name; keys }
 end
 
 type t = Spec.t * Univ.t M.t

--- a/src/irmin/conf.mli
+++ b/src/irmin/conf.mli
@@ -47,6 +47,9 @@ module Spec : sig
 
       The name of the resulting spec will be the name of [a] and the names of
       the specs in [b] joined by hyphens. *)
+
+  val copy : t -> t
+  (** [copy t] returns a fresh spec with the same keys as [t]. *)
 end
 
 module Typ : sig

--- a/src/irmin/conf.mli
+++ b/src/irmin/conf.mli
@@ -36,12 +36,6 @@ module Spec : sig
   val name : t -> string
   (** [name spec] is the name associated with a config spec *)
 
-  val list : unit -> t Seq.t
-  (** [list ()] is a sequence containing all available config specs *)
-
-  val find : string -> t option
-  (** [find name] is the config spec associated with [name] if available *)
-
   val find_key : t -> string -> k option
   (** [find_key spec k] is the key associated with the name [k] in [spec] *)
 
@@ -55,11 +49,18 @@ module Spec : sig
       the specs in [b] joined by hyphens. *)
 end
 
+module Typ : sig
+  type 'a t
+
+  val create : unit -> 'a t
+end
+
 val key :
   ?docs:string ->
   ?docv:string ->
   ?doc:string ->
   ?allow_duplicate:bool ->
+  ?typ:'a Typ.t ->
   spec:Spec.t ->
   string ->
   'a Type.t ->
@@ -83,11 +84,36 @@ val key :
       if [allow_duplicate] is [false] (the default) and [name] has already been
       used to create a key *)
 
+val key' :
+  ?docs:string ->
+  ?docv:string ->
+  ?doc:string ->
+  ?allow_duplicate:bool ->
+  ?typ:'a Typ.t ->
+  spec:Spec.t ->
+  typename:string ->
+  to_string:('a -> string) ->
+  of_string:(string -> ('a, [ `Msg of string ]) result) ->
+  of_json_string:(string -> ('a, [ `Msg of string ]) result) ->
+  string ->
+  'a ->
+  'a key
+(** Same as {!key} for types that don't implement [Type.t] but can be serialized
+    with [to_string], and deserialized with either [of_string] or
+    [of_json_string]. The [typename] is the user-readable description of the
+    type, in case of dynamic type errors. *)
+
 val name : 'a key -> string
 (** The key name. *)
 
-val ty : 'a key -> 'a Type.t
-(** [tc k] is [k]'s converter. *)
+val typename : 'a key -> string
+(** [typename k] is the type name of [k]'s values. *)
+
+val of_string : 'a key -> string -> ('a, [ `Msg of string ]) result
+(** [of_string k] is the parser of [k]'s values. *)
+
+val of_json_string : 'a key -> string -> ('a, [ `Msg of string ]) result
+(** [of_json_string k] is the json parser of [k]'s values. *)
 
 val default : 'a key -> 'a
 (** [default k] is [k]'s default value. *)
@@ -154,6 +180,10 @@ val keys : t -> k Seq.t
 val with_spec : t -> Spec.t -> t
 (** [with_spec t s] is the config [t] with spec [s] *)
 
+val find_key : t -> string -> 'a Typ.t -> 'a
+(** [find_key t name typ] returns the value associated with [name] in the config
+    [t]. *)
+
 val verify : t -> t
 (** [verify t] is an identity function that ensures all keys match the spec
 
@@ -166,12 +196,3 @@ val uri : Uri.t Type.t
 
 val find_root : t -> string option
 (** [find_root c] is [root]'s mapping in [c], if any. *)
-
-module Env : sig
-  type _ Effect.t +=
-    | Fs : Eio.Fs.dir_ty Eio.Path.t Effect.t
-    | Net : _ Eio.Net.t Effect.t
-
-  val fs : unit -> Eio.Fs.dir_ty Eio.Path.t
-  val net : unit -> _ Eio.Net.t
-end

--- a/src/libirmin/config.ml
+++ b/src/libirmin/config.ml
@@ -40,10 +40,11 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_pack"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
+        run_env @@ fun env ->
         try
           let hash = Option.map Irmin_cli.Resolver.Hash.find hash in
           let c : config =
-            Irmin_cli.Resolver.load_config ~store:"pack" ?hash ?contents ()
+            Irmin_cli.Resolver.load_config ~env ~store:"pack" ?hash ?contents ()
           in
           Root.create_config c
         with _ -> null config)
@@ -52,8 +53,11 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_tezos"
       (void @-> returning config)
       (fun () ->
+        run_env @@ fun env ->
         try
-          let c : config = Irmin_cli.Resolver.load_config ~store:"tezos" () in
+          let c : config =
+            Irmin_cli.Resolver.load_config ~env ~store:"tezos" ()
+          in
           Root.create_config c
         with _ -> null config)
 
@@ -61,8 +65,11 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_git"
       (string_opt @-> returning config)
       (fun contents ->
+        run_env @@ fun env ->
         try
-          let c = Irmin_cli.Resolver.load_config ~store:"git" ?contents () in
+          let c =
+            Irmin_cli.Resolver.load_config ~env ~store:"git" ?contents ()
+          in
           Root.create_config c
         with _ -> null config)
 
@@ -70,9 +77,10 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_git_mem"
       (string_opt @-> returning config)
       (fun contents ->
+        run_env @@ fun env ->
         try
           let c =
-            Irmin_cli.Resolver.load_config ~store:"git-mem" ?contents ()
+            Irmin_cli.Resolver.load_config ~env ~store:"git-mem" ?contents ()
           in
           Root.create_config c
         with _ -> null config)
@@ -81,10 +89,11 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_fs"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
+        run_env @@ fun env ->
         try
           let hash = Option.map Irmin_cli.Resolver.Hash.find hash in
           let c =
-            Irmin_cli.Resolver.load_config ~store:"irf" ?hash ?contents ()
+            Irmin_cli.Resolver.load_config ~env ~store:"irf" ?hash ?contents ()
           in
           Root.create_config c
         with _ -> null config)
@@ -93,10 +102,11 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
     fn "config_mem"
       (string_opt @-> string_opt @-> returning config)
       (fun hash contents ->
+        run_env @@ fun env ->
         try
           let hash = Option.map Irmin_cli.Resolver.Hash.find hash in
           let c =
-            Irmin_cli.Resolver.load_config ~store:"mem" ?hash ?contents ()
+            Irmin_cli.Resolver.load_config ~env ~store:"mem" ?hash ?contents ()
           in
           Root.create_config c
         with _ -> null config)
@@ -116,7 +126,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             | None -> (false, config)
             | Some (Irmin.Backend.Conf.K k) ->
                 let t : a Irmin.Type.t = Root.get_ty ty in
-                if type_name t <> type_name (Irmin.Backend.Conf.ty k) then
+                if type_name t <> Irmin.Backend.Conf.typename k then
                   (false, config)
                 else
                   let value = Root.get_value value in
@@ -139,8 +149,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
             | None -> (false, config)
             | Some (Irmin.Backend.Conf.K k) ->
                 let path =
-                  Irmin.Type.of_string (Irmin.Backend.Conf.ty k) path
-                  |> Result.get_ok
+                  Irmin.Backend.Conf.of_string k path |> Result.get_ok
                 in
                 (true, Irmin.Backend.Conf.add config k path)
           in

--- a/src/libirmin/config.ml
+++ b/src/libirmin/config.ml
@@ -93,7 +93,7 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
         try
           let hash = Option.map Irmin_cli.Resolver.Hash.find hash in
           let c =
-            Irmin_cli.Resolver.load_config ~env ~store:"irf" ?hash ?contents ()
+            Irmin_cli.Resolver.load_config ~env ~store:"fs" ?hash ?contents ()
           in
           Root.create_config c
         with _ -> null config)

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -43,9 +43,12 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
 
   let fn name t f = I.internal ~runtime_lock:false ("irmin_" ^ name) t f
 
-  let run fn =
+  let run_env fn =
     Eio_main.run @@ fun env ->
-    Lwt_eio.with_event_loop ~clock:env#clock @@ fun _ -> fn ()
+    Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
+    fn (env :> Irmin_cli.eio)
+
+  let run fn = run_env (fun _ -> fn ())
 
   module Root = struct
     let to_voidp t x = Ctypes.coerce t (ptr void) x

--- a/src/libirmin/util.ml
+++ b/src/libirmin/util.ml
@@ -46,6 +46,14 @@ module Make (I : Cstubs_inverted.INTERNAL) = struct
   let run_env fn =
     Eio_main.run @@ fun env ->
     Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
+    Eio.Switch.run @@ fun sw ->
+    let env =
+      object
+        method cwd = Eio.Stdenv.cwd env
+        method clock = Eio.Stdenv.clock env
+        method sw = sw
+      end
+    in
     fn (env :> Irmin_cli.eio)
 
   let run fn = run_env (fun _ -> fn ())

--- a/test/irmin-bench/test.ml
+++ b/test/irmin-bench/test.ml
@@ -15,6 +15,8 @@
  *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  let fs = Eio.Stdenv.fs env in
   Alcotest.run "irmin-bench"
-    (Ema.test_cases @ Misc.test_cases @ Replay.test_cases)
+    (Ema.test_cases @ Misc.test_cases @ Replay.test_cases ~fs ~domain_mgr)

--- a/test/irmin-cli/test.ml
+++ b/test/irmin-cli/test.ml
@@ -40,5 +40,12 @@ end
 
 let () =
   Eio_main.run @@ fun env ->
-  let env = (env :> Irmin_cli.eio) in
+  Eio.Switch.run @@ fun sw ->
+  let env :> Irmin_cli.eio =
+    object
+      method cwd = Eio.Stdenv.cwd env
+      method clock = Eio.Stdenv.clock env
+      method sw = sw
+    end
+  in
   Alcotest.run "irmin-cli" [ ("conf", Conf.misc ~env) ]

--- a/test/irmin-cli/test.ml
+++ b/test/irmin-cli/test.ml
@@ -17,10 +17,10 @@
 include Irmin.Export_for_backends
 
 module Conf = struct
-  let test_config () =
+  let test_config ~env =
     let hash = Irmin_cli.Resolver.Hash.find "blake2b" in
     let _, cfg =
-      Irmin_cli.Resolver.load_config ~config_path:"test/irmin-cli/test.yml"
+      Irmin_cli.Resolver.load_config ~env ~config_path:"test/irmin-cli/test.yml"
         ~store:"pack" ~contents:"string" ~hash ()
     in
     let spec = Irmin.Backend.Conf.spec cfg in
@@ -34,8 +34,11 @@ module Conf = struct
     Alcotest.(check int) "index-log-size" 1234 index_log_size;
     Alcotest.(check bool) "fresh" true fresh
 
-  let misc : unit Alcotest.test_case list =
-    [ ("config", `Quick, fun () -> test_config ()) ]
+  let misc ~env : unit Alcotest.test_case list =
+    [ ("config", `Quick, fun () -> test_config ~env) ]
 end
 
-let () = Alcotest.run "irmin-cli" [ ("conf", Conf.misc) ]
+let () =
+  Eio_main.run @@ fun env ->
+  let env = (env :> Irmin_cli.eio) in
+  Alcotest.run "irmin-cli" [ ("conf", Conf.misc ~env) ]

--- a/test/irmin-cli/test_command_line.t
+++ b/test/irmin-cli/test_command_line.t
@@ -94,3 +94,33 @@ Clone a local repo
   irmin: [WARNING] Updating the control file to [Used_non_minimal_indexing_strategy]. It won't be possible to GC this irmin-pack store anymore.
   $ irmin get --root ./cloned a/b/c
   123
+
+Show documentation
+  $ irmin
+  usage: irmin [--version]
+               [--help]
+               <command> [<args>]
+  
+  The most commonly used subcommands are:
+      init        Initialize a store.
+      get         Read the value associated with a key.
+      set         Update the value associated with a key.
+      remove      Delete a key.
+      list        List subdirectories.
+      tree        List the store contents.
+      clone       Copy a remote respository to a local store
+      fetch       Download objects and refs from another repository.
+      merge       Merge branches.
+      pull        Fetch and merge with another repository.
+      push        Update remote references along with associated objects.
+      snapshot    Return a snapshot for the current state of the database.
+      revert      Revert the contents of the store to a previous state.
+      watch       Get notifications when values change.
+      dot         Dump the contents of the store as a Graphviz file.
+      graphql     Run a graphql server.
+      server      Run irmin-server.
+      options     Get information about backend specific configuration options.
+      branches    List branches
+      log         List commits
+  
+  See `irmin help <command>` for more information on a specific command.

--- a/test/irmin-fs/test.ml
+++ b/test/irmin-fs/test.ml
@@ -15,7 +15,6 @@
  *)
 
 let () =
-  Eio_main.run @@ fun env ->
-  Irmin_fs.run env#fs @@ fun () ->
+  Eio_main.run @@ fun _env ->
   Irmin_test.Store.run "irmin-fs" ~slow:true ~misc:[] ~sleep:Eio_unix.sleep
     [ (`Quick, Test_fs.suite) ]

--- a/test/irmin-fs/test_fs_unix.ml
+++ b/test/irmin-fs/test_fs_unix.ml
@@ -19,7 +19,6 @@ let stats () =
   (stats.Irmin_watcher.watchdogs, Irmin.Backend.Watch.workers ())
 
 let test_db = Test_fs.test_db
-let config = Test_fs.config
 let store = Irmin_test.store (module Irmin_fs_unix) (module Irmin.Metadata.None)
 
 let clean_dirs config =
@@ -39,5 +38,6 @@ let clean ~config =
   clean_dirs config;
   Irmin.Backend.Watch.(set_listen_dir_hook none)
 
-let suite =
+let suite ~path ~clock =
+  let config = Irmin_fs_unix.conf ~path ~clock in
   Irmin_test.Suite.create ~name:"FS.UNIX" ~init ~store ~config ~clean ~stats ()

--- a/test/irmin-fs/test_unix.ml
+++ b/test/irmin-fs/test_unix.ml
@@ -16,8 +16,9 @@
 
 let () =
   Eio_main.run @@ fun env ->
-  Irmin_fs.run env#fs @@ fun () ->
   Irmin_watcher.run @@ fun () ->
+  let path = Eio.Stdenv.cwd env in
+  let clock = Eio.Stdenv.clock env in
   Irmin_test.Store.run "irmin-fs.unix" ~slow:false ~sleep:Eio_unix.sleep
     ~misc:[]
-    [ (`Quick, Test_fs_unix.suite) ]
+    [ (`Quick, Test_fs_unix.suite ~path ~clock) ]

--- a/test/irmin-pack/bench_multicore/main.ml
+++ b/test/irmin-pack/bench_multicore/main.ml
@@ -120,11 +120,11 @@ let config =
 
 let bench_half config =
   Logs.set_level None;
-  Eio_main.run @@ fun env -> Bench.half ~d_mgr:env#domain_mgr ~config
+  Eio_main.run @@ fun env -> Bench.half ~fs:env#fs ~d_mgr:env#domain_mgr ~config
 
 let bench_full config =
   Logs.set_level None;
-  Eio_main.run @@ fun env -> Bench.full ~d_mgr:env#domain_mgr ~config
+  Eio_main.run @@ fun env -> Bench.full ~fs:env#fs ~d_mgr:env#domain_mgr ~config
 
 let cmd_half =
   let doc = "Half-diamond benchmark" in

--- a/test/irmin-pack/common.mli
+++ b/test/irmin-pack/common.mli
@@ -84,43 +84,72 @@ module Pack :
 
 (** Helper constructors for fresh pre-initialised dictionaries and packs *)
 module Make_context (Config : sig
-  val root : string
+  val root : fs:Eio.Fs.dir_ty Eio.Path.t -> Eio.Fs.dir_ty Eio.Path.t
 end) : sig
-  val fresh_name : string -> string
+  val fresh_name :
+    fs:Eio.Fs.dir_ty Eio.Path.t -> string -> Eio.Fs.dir_ty Eio.Path.t
   (** [fresh_name typ] is a clean directory for a resource of type [typ]. *)
 
-  type d = { name : string; fm : File_manager.t; dict : Dict.t }
+  type d = {
+    name : Eio.Fs.dir_ty Eio.Path.t;
+    fm : File_manager.t;
+    dict : Dict.t;
+  }
 
-  val get_dict : ?name:string -> readonly:bool -> fresh:bool -> unit -> d
+  val get_dict :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    ?name:Eio.Fs.dir_ty Eio.Path.t ->
+    readonly:bool ->
+    fresh:bool ->
+    unit ->
+    d
+
   val close_dict : d -> unit
 
   type t = {
-    name : string;
+    name : Eio.Fs.dir_ty Eio.Path.t;
     fm : File_manager.t;
     index : Index.t;
     pack : read Pack.t;
     dict : Dict.t;
   }
 
-  val get_rw_pack : unit -> t
-  val get_ro_pack : string -> t
-  val reopen_rw : string -> t
+  val get_rw_pack : sw:Eio.Switch.t -> fs:Eio.Fs.dir_ty Eio.Path.t -> t
+
+  val get_ro_pack :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    Eio.Fs.dir_ty Eio.Path.t ->
+    t
+
+  val reopen_rw :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    Eio.Fs.dir_ty Eio.Path.t ->
+    t
+
   val close_pack : t -> unit
 end
 
 val get : 'a option -> 'a
 val sha1 : string -> Schema.Hash.t
 val sha1_contents : string -> Schema.Hash.t
-val rm_dir : string -> unit
+val rm_dir : Eio.Fs.dir_ty Eio.Path.t -> unit
 val index_log_size : int option
 val random_string : int -> string
 val random_letters : int -> string
-val unlink_path : string -> unit
-val create_lower_root : ?mkdir:bool -> unit -> string
+val unlink_path : Eio.Fs.dir_ty Eio.Path.t -> unit
+
+val create_lower_root :
+  fs:Eio.Fs.dir_ty Eio.Path.t -> ?mkdir:bool -> unit -> Eio.Fs.dir_ty Eio.Path.t
 
 val exec_cmd : string -> (unit, int) result
 (** Exec a command, and return [Ok ()] or [Error n] if return code is n <> 0 *)
 
-val setup_test_env : root_archive:string -> root_local_build:string -> unit
+val setup_test_env :
+  root_archive:Eio.Fs.dir_ty Eio.Path.t ->
+  root_local_build:Eio.Fs.dir_ty Eio.Path.t ->
+  unit
 (** [setup_test_env ~root_archive ~root_local_build] copies an existing store to
     a temporary location, to be used by the test. *)

--- a/test/irmin-pack/dune
+++ b/test/irmin-pack/dune
@@ -48,12 +48,7 @@
  ;; Attached to `irmin-tezos` to avoid a cyclic dependency with `irmin-pack`
  (package irmin-tezos)
  (action
-  (run ./test.exe -q --color=always))
- ; TODO: Fix unix waitpid error in irmin-pack GC
- (enabled_if
-  (and
-   (<> %{system} macosx)
-   (<> %{system} freebsd))))
+  (run ./test.exe -q --color=always)))
 
 (library
  (name common)
@@ -67,7 +62,6 @@
   irmin-pack.unix
   irmin-tezos
   logs
-  lwt
   hex
   fpath)
  (preprocess

--- a/test/irmin-pack/test.ml
+++ b/test/irmin-pack/test.ml
@@ -16,7 +16,13 @@
 
 let () =
   Eio_main.run @@ fun env ->
+  let sr = Eio.Stdenv.secure_random env in
+  let fs = Eio.Stdenv.cwd env in
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  (* **/** *)
+  Eio.Switch.run @@ fun sw ->
+  let test_suite = Test_pack.suite ~sw ~fs in
   Irmin_test.Store.run "irmin-pack"
-    ~misc:(Test_pack.misc @@ Eio.Stdenv.domain_mgr env)
+    ~misc:(Test_pack.misc ~sr ~fs ~domain_mgr)
     ~sleep:Eio_unix.sleep
-    (List.map (fun s -> (`Quick, s)) Test_pack.suite)
+    (List.map (fun s -> (`Quick, s)) test_suite)

--- a/test/irmin-pack/test_async.ml
+++ b/test/irmin-pack/test_async.ml
@@ -20,20 +20,23 @@ module Async = Irmin_pack_unix.Async.Unix
 
 let check_outcome = Alcotest.check_repr Async.outcome_t
 
-let test_success () =
+let test_success ~domain_mgr () =
+  Eio.Switch.run @@ fun sw ->
   let f () = assert true in
-  let task = Async.async f in
+  let task = Async.async ~sw ~domain_mgr f in
   let result = Async.await task in
-  check_outcome "should succeed" result `Success
+  check_outcome "should succeed" `Success result
 
-let test_exception_in_task () =
+let test_exception_in_task ~domain_mgr () =
+  Eio.Switch.run @@ fun sw ->
   let f () = assert false in
-  let task = Async.async f in
+  let task = Async.async ~sw ~domain_mgr f in
   let result = Async.await task in
-  check_outcome "should fail" result (`Failure "Unhandled exception")
+  check_outcome "should fail" (`Failure "Unhandled exception") result
 
-let tests =
+let tests ~domain_mgr =
   [
-    Alcotest.test_case "Successful task" `Quick test_success;
-    Alcotest.test_case "Exception occurs in task" `Quick test_exception_in_task;
+    Alcotest.test_case "Successful task" `Quick (test_success ~domain_mgr);
+    Alcotest.test_case "Exception occurs in task" `Quick
+      (test_exception_in_task ~domain_mgr);
   ]

--- a/test/irmin-pack/test_async.mli
+++ b/test/irmin-pack/test_async.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : domain_mgr:_ Eio.Domain_manager.t -> unit Alcotest.test_case list

--- a/test/irmin-pack/test_corrupted.ml
+++ b/test/irmin-pack/test_corrupted.ml
@@ -17,7 +17,7 @@
 open! Import
 open Common
 
-let root = Filename.concat "_build" "test-corrupted"
+let root fs = Eio.Path.(fs / "_build" / "test-corrupted")
 
 module Conf = Irmin_tezos.Conf
 
@@ -26,12 +26,13 @@ module Store = struct
   include Maker.Make (Schema)
 end
 
-let config ?(readonly = false) ?(fresh = true) root =
-  Irmin_pack.config ~readonly ?index_log_size ~fresh root
+let config ~sw ~fs ?(readonly = false) ?(fresh = true) root =
+  Irmin_pack.config ~sw ~fs ~readonly ?index_log_size ~fresh root
 
 let info () = Store.Info.empty
 
 let read_file path =
+  let path = Eio.Path.native_exn path in
   let ch = open_in_bin path in
   Fun.protect
     (fun () ->
@@ -40,6 +41,7 @@ let read_file path =
     ~finally:(fun () -> close_in ch)
 
 let write_file path contents =
+  let path = Eio.Path.native_exn path in
   let ch = open_out_bin path in
   Fun.protect
     (fun () -> output_string ch contents)
@@ -47,10 +49,12 @@ let write_file path contents =
       flush ch;
       close_out ch)
 
-let test_corrupted_control_file () =
+let test_corrupted_control_file ~fs () =
+  Eio.Switch.run @@ fun sw ->
+  let root = root fs in
   rm_dir root;
-  let control_file_path = Filename.concat root "store.control" in
-  let repo = Store.Repo.v (config ~fresh:true root) in
+  let control_file_path = Eio.Path.(root / "store.control") in
+  let repo = Store.Repo.v (config ~sw ~fs ~fresh:true root) in
   let control_file_blob0 = read_file control_file_path in
   let store = Store.main repo in
   let () = Store.set_exn ~info store [ "a" ] "b" in
@@ -69,16 +73,17 @@ let test_corrupted_control_file () =
   assert (not (String.equal control_file_blob1 control_file_mix));
   write_file control_file_path control_file_mix;
   let error =
-    try Ok (Store.Repo.v (config ~fresh:false root)) with exn -> Error exn
+    try Ok (Store.Repo.v (config ~sw ~fs ~fresh:false root) : Store.Repo.t)
+    with exn -> Error exn
   in
   match error with
   | Error (Irmin_pack_unix.Errors.Pack_error (`Corrupted_control_file s)) ->
       Alcotest.(check string)
-        "path is corrupted" s "_build/test-corrupted/store.control"
+        "path is corrupted" s "./_build/test-corrupted/store.control"
   | _ -> Alcotest.fail "unexpected error"
 
-let tests =
+let tests ~fs =
   [
     Alcotest.test_case "Corrupted control file" `Quick
-      test_corrupted_control_file;
+      (test_corrupted_control_file ~fs);
   ]

--- a/test/irmin-pack/test_corrupted.mli
+++ b/test/irmin-pack/test_corrupted.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list

--- a/test/irmin-pack/test_dispatcher.ml
+++ b/test/irmin-pack/test_dispatcher.ml
@@ -19,21 +19,22 @@ open Common
 module S = Test_gc.Store
 module Dispatcher = Irmin_pack_unix.Dispatcher.Make (File_manager)
 
-let root = Filename.concat "_build" "test-dispatcher"
+let root ~fs = Eio.Path.(fs / "_build" / "test-dispatcher")
 let src = Logs.Src.create "tests.dispatcher" ~doc:"Test dispatcher"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let setup_store () =
+let setup_store ~sw ~fs domain_mgr () =
+  let root = root ~fs in
   rm_dir root;
-  let config = S.config root in
-  let t = S.init_with_config config in
+  let config = S.config ~sw ~fs root in
+  let t = S.init_with_config ~fs config in
   let _ = S.commit_1 t in
   let t, c2 = S.commit_2 t in
   let t = S.checkout_exn t c2 in
   let t, _c3 = S.commit_3 t in
   [%log.debug "Gc c1, keep c2, c3"];
-  let () = S.start_gc t c2 in
+  let () = S.start_gc ~fs ~domain_mgr t c2 in
   let () = S.finalise_gc t in
   let () = S.close t in
   config
@@ -75,9 +76,10 @@ let check_hex msg buf expected =
     msg expected
     (Bytes.to_string buf |> Hex.of_string |> Hex.show)
 
-let test_read () =
-  let config = setup_store () in
-  let fm = File_manager.open_ro config |> Errs.raise_if_error in
+let test_read ~fs ~domain_mgr () =
+  Eio.Switch.run @@ fun sw ->
+  let config = setup_store ~sw ~fs domain_mgr () in
+  let fm = File_manager.open_ro ~sw ~fs config |> Errs.raise_if_error in
   let dsp = Dispatcher.v fm |> Errs.raise_if_error in
   let _ =
     Alcotest.check_raises "cannot read node_1"
@@ -99,4 +101,5 @@ let test_read () =
 
   File_manager.close fm |> Errs.raise_if_error
 
-let tests = [ Alcotest.test_case "read" `Quick test_read ]
+let tests ~fs ~domain_mgr =
+  [ Alcotest.test_case "read" `Quick (test_read ~fs ~domain_mgr) ]

--- a/test/irmin-pack/test_dispatcher.mli
+++ b/test/irmin-pack/test_dispatcher.mli
@@ -14,4 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests :
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  domain_mgr:_ Eio.Domain_manager.t ->
+  unit Alcotest.test_case list

--- a/test/irmin-pack/test_existing_stores.mli
+++ b/test/irmin-pack/test_existing_stores.mli
@@ -14,4 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests :
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  domain_mgr:_ Eio.Domain_manager.t ->
+  unit Alcotest.test_case list

--- a/test/irmin-pack/test_gc.mli
+++ b/test/irmin-pack/test_gc.mli
@@ -15,23 +15,38 @@
  *)
 
 module Gc : sig
-  val tests : unit Alcotest.test_case list
+  val tests :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    unit Alcotest.test_case list
 end
 
 module Gc_archival : sig
-  val tests : unit Alcotest.test_case list
+  val tests :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    unit Alcotest.test_case list
 end
 
 module Concurrent_gc : sig
-  val tests : unit Alcotest.test_case list
+  val tests :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    unit Alcotest.test_case list
 end
 
 module Split : sig
-  val tests : unit Alcotest.test_case list
+  val tests :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    unit Alcotest.test_case list
 end
 
 module Snapshot : sig
-  val tests : unit Alcotest.test_case list
+  val tests :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    unit Alcotest.test_case list
 end
 
 module Store : sig
@@ -39,10 +54,23 @@ module Store : sig
 
   type t
 
-  val config : string -> Irmin.config
-  val init_with_config : Irmin.config -> t
+  val config :
+    sw:Eio.Switch.t ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    Eio.Fs.dir_ty Eio.Path.t ->
+    Irmin.config
+
+  val init_with_config : fs:Eio.Fs.dir_ty Eio.Path.t -> Irmin.config -> t
   val close : t -> unit
-  val start_gc : ?unlink:bool -> t -> S.commit -> unit
+
+  val start_gc :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    ?unlink:bool ->
+    t ->
+    S.commit ->
+    unit
+
   val finalise_gc : t -> unit
   val commit_1 : t -> t * S.commit
   val commit_2 : t -> t * S.commit

--- a/test/irmin-pack/test_hashes.ml
+++ b/test/irmin-pack/test_hashes.ml
@@ -17,10 +17,11 @@
 open! Import
 open Common
 
-let root = Filename.concat "_build" "test-irmin-tezos"
+let root fs = Eio.Path.(fs / "_build" / "test-irmin-tezos")
 
-let conf =
-  Irmin_pack.config ~readonly:false ~fresh:true ~index_log_size:1000 root
+let conf ~sw ~fs =
+  Irmin_pack.config ~sw ~fs ~readonly:false ~fresh:true ~index_log_size:1000
+    (root fs)
 
 let zero = Bytes.make 10 '0'
 
@@ -70,8 +71,8 @@ struct
     in
     tree
 
-  let persist_tree tree =
-    let repo = Repo.v conf in
+  let persist_tree ~sw ~fs tree =
+    let repo = Repo.v (conf ~sw ~fs) in
     let init_commit =
       Commit.v ~parents:[] ~info:Info.empty repo
         (Tree.singleton [ "singleton-step" ] (Bytes.of_string "singleton-val"))
@@ -144,9 +145,10 @@ module Test_tezos_conf = struct
     in
     ("len of values", nb_steps) :: checks
 
-  let inode_values_hash () =
+  let inode_values_hash ~fs () =
+    Eio.Switch.run @@ fun sw ->
     let tree = Store.build_tree some_steps in
-    let repo, tree, _ = Store.persist_tree tree in
+    let repo, tree, _ = Store.persist_tree ~sw ~fs tree in
     let root_node =
       match Store.Tree.destruct tree with
       | `Contents _ -> Alcotest.fail "Expected root to be node"
@@ -164,9 +166,10 @@ module Test_tezos_conf = struct
       "CoVeCU4o3dqmfdwqt2vh8LDz9X6qGbTUyLhgVvFReyzAvTf92AKx" h;
     Store.Repo.close repo
 
-  let commit_hash () =
+  let commit_hash ~fs () =
+    Eio.Switch.run @@ fun sw ->
     let tree = Store.build_tree some_steps in
-    let repo, _, commit = Store.persist_tree tree in
+    let repo, _, commit = Store.persist_tree ~sw ~fs tree in
     let commit_val = Store.to_backend_commit commit in
     let h = Commit.Hash.hash commit_val in
     let encode_bin_hash = Irmin.Type.(unstage (encode_bin Commit.Hash.t)) in
@@ -239,9 +242,10 @@ module Test_small_conf = struct
         "821707c86f7030b1102397feb88d454076ec64744dfd9811b8254bd61d396cfe" );
     ]
 
-  let inode_tree_hash () =
+  let inode_tree_hash ~fs () =
+    Eio.Switch.run @@ fun sw ->
     let tree = Store.build_tree many_steps in
-    let repo, tree, _ = Store.persist_tree tree in
+    let repo, tree, _ = Store.persist_tree ~sw ~fs tree in
     let root_node =
       match Store.Tree.destruct tree with
       | `Contents _ -> Alcotest.fail "Expected root to be node"
@@ -280,9 +284,10 @@ module Test_V1 = struct
 
   let many_steps = [ "00"; "01"; "02"; "03"; "04"; "05" ]
 
-  let commit_hash () =
+  let commit_hash ~fs () =
+    Eio.Switch.run @@ fun sw ->
     let tree = Store.build_tree many_steps in
-    let repo, _, commit = Store.persist_tree tree in
+    let repo, _, commit = Store.persist_tree ~sw ~fs tree in
     let commit_val = Store.to_backend_commit commit in
     let checks =
       [
@@ -305,12 +310,12 @@ module Test_V1 = struct
     Store.Repo.close repo
 end
 
-let tests =
+let tests ~fs =
   let tc name f = Alcotest.test_case name `Quick f in
   [
     tc "contents hash" Test_tezos_conf.contents_hash;
-    tc "inode_values hash" Test_tezos_conf.inode_values_hash;
-    tc "inode_tree hash" Test_small_conf.inode_tree_hash;
-    tc "commit hash" Test_tezos_conf.commit_hash;
-    tc "V1 commit hash" Test_V1.commit_hash;
+    tc "inode_values hash" (Test_tezos_conf.inode_values_hash ~fs);
+    tc "inode_tree hash" (Test_small_conf.inode_tree_hash ~fs);
+    tc "commit hash" (Test_tezos_conf.commit_hash ~fs);
+    tc "V1 commit hash" (Test_V1.commit_hash ~fs);
   ]

--- a/test/irmin-pack/test_hashes.mli
+++ b/test/irmin-pack/test_hashes.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list
 
 val check_iter :
   string ->

--- a/test/irmin-pack/test_indexing_strategy.ml
+++ b/test/irmin-pack/test_indexing_strategy.ml
@@ -17,6 +17,8 @@
 open! Import
 open Common
 
+let root fs = Eio.Path.(fs / "_build" / "test_indexing_strategy")
+
 let src =
   Logs.Src.create "tests.indexing_strategy" ~doc:"Test indexing strategy"
 
@@ -27,11 +29,12 @@ module Store = struct
   include Maker.Make (Schema)
 end
 
-let config ~indexing_strategy ?(readonly = false) ?(fresh = false) () =
-  let root = Filename.concat "_build" "test_indexing_strategy" in
+let config ~indexing_strategy ?(readonly = false) ?(fresh = false) root =
   Irmin_pack.config ~readonly ~indexing_strategy ~fresh root
 
-let test_unique_when_switched () =
+let test_unique_when_switched ~fs () =
+  let root = root fs in
+  rm_dir root;
   let value = "Welt" in
   let get_contents_key store path =
     let k = Store.key store path in
@@ -55,10 +58,11 @@ let test_unique_when_switched () =
   in
 
   (* 1. open store with always indexing, verify same offsets *)
+  Eio.Switch.run @@ fun sw ->
   let repo =
     Store.Repo.v
-    @@ config ~indexing_strategy:Irmin_pack.Indexing_strategy.always ~fresh:true
-         ()
+    @@ config ~sw ~fs ~indexing_strategy:Irmin_pack.Indexing_strategy.always
+         ~fresh:true root
   in
   let store = Store.main repo in
   let first_key =
@@ -85,8 +89,8 @@ let test_unique_when_switched () =
   (* 2. re-open store with minimal indexing, verify new offset *)
   let repo =
     Store.Repo.v
-    @@ config ~indexing_strategy:Irmin_pack.Indexing_strategy.minimal
-         ~fresh:false ()
+    @@ config ~sw ~fs ~indexing_strategy:Irmin_pack.Indexing_strategy.minimal
+         ~fresh:false root
   in
   let store = Store.main repo in
   let third_key =
@@ -107,8 +111,8 @@ let test_unique_when_switched () =
 
   Store.Repo.close repo
 
-let tests =
+let tests ~fs =
   [
     Alcotest.test_case "test unique when switching strategies" `Quick
-      test_unique_when_switched;
+      (test_unique_when_switched ~fs);
   ]

--- a/test/irmin-pack/test_indexing_strategy.mli
+++ b/test/irmin-pack/test_indexing_strategy.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list

--- a/test/irmin-pack/test_inode.ml
+++ b/test/irmin-pack/test_inode.ml
@@ -17,7 +17,7 @@
 open! Import
 open Common
 
-let root = Filename.concat "_build" "test-inode"
+let root ~fs = Eio.Path.(fs / "_build" / "test-inode")
 let src = Logs.Src.create "tests.instances" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -111,10 +111,11 @@ struct
       Irmin_pack.Conf.init ~fresh ~readonly ~indexing_strategy ~lru_size:0 name
 
     (* TODO : remove duplication with irmin_pack/ext.ml *)
-    let get_fm config =
+    let get_fm ~sw ~fs config =
       let readonly = Irmin_pack.Conf.readonly config in
 
-      if readonly then File_manager.open_ro config |> Errs.raise_if_error
+      if readonly then
+        File_manager.open_ro ~sw ~fs config |> Errs.raise_if_error
       else
         let fresh = Irmin_pack.Conf.fresh config in
         let root = Irmin_pack.Conf.root config in
@@ -124,21 +125,25 @@ struct
           | false -> Unix.mkdir (Filename.dirname root) 0o755
           | true -> ()
         in
-        match (Io.classify_path root, fresh) with
+        match (Io.classify_path Eio.Path.(fs / root), fresh) with
         | `No_such_file_or_directory, _ ->
-            File_manager.create_rw ~overwrite:false config
+            File_manager.create_rw ~sw ~fs ~overwrite:false config
             |> Errs.raise_if_error
         | `Directory, true ->
-            File_manager.create_rw ~overwrite:true config |> Errs.raise_if_error
+            File_manager.create_rw ~sw ~fs ~overwrite:true config
+            |> Errs.raise_if_error
         | `Directory, false ->
-            File_manager.open_rw config |> Errs.raise_if_error
+            File_manager.open_rw ~sw ~fs config |> Errs.raise_if_error
         | (`File | `Other), _ -> Errs.raise_error (`Not_a_directory root)
 
-    let get_store ~indexing_strategy () =
+    let get_store ~sw ~fs ~indexing_strategy () =
       [%log.app "Constructing a fresh context for use by the test"];
+      let root = root ~fs in
       rm_dir root;
-      let config = config ~indexing_strategy ~readonly:false ~fresh:true root in
-      let fm = get_fm config in
+      let config =
+        config ~sw ~fs ~indexing_strategy ~readonly:false ~fresh:true root
+      in
+      let fm = get_fm ~sw ~fs config in
       let dict = File_manager.dict fm in
       let dispatcher = Dispatcher.v fm |> Errs.raise_if_error in
       let lru = Irmin_pack_unix.Lru.create config in
@@ -342,9 +347,11 @@ let check_hardcoded_hash msg h v =
   | Ok hash -> check_hash msg hash (Inter.Val.hash_exn v)
 
 (** Test add values from an empty node. *)
-let test_add_values ~indexing_strategy =
+let test_add_values ~fs ~indexing_strategy =
+  let root = root ~fs in
   rm_dir root;
-  let t = Context.get_store ~indexing_strategy () in
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   check_node "hash empty node" (Inode.Val.empty ()) t;
   let v1 = Inode.Val.add (Inode.Val.empty ()) "x" (normal foo) in
@@ -355,9 +362,9 @@ let test_add_values ~indexing_strategy =
   check_values "add x+y vs v x+y" v2 v3;
   Context.close t
 
-let test_add_values () =
-  let () = test_add_values ~indexing_strategy:`always in
-  test_add_values ~indexing_strategy:`minimal
+let test_add_values ~fs () =
+  let () = test_add_values ~fs ~indexing_strategy:`always in
+  test_add_values ~fs ~indexing_strategy:`minimal
 
 let integrity_check ?(stable = true) v =
   Alcotest.(check bool) "check stable" (Inter.Val.stable v) stable;
@@ -367,9 +374,11 @@ let integrity_check ?(stable = true) v =
       v
 
 (** Test add to inodes. *)
-let test_add_inodes ~indexing_strategy =
+let test_add_inodes ~fs ~indexing_strategy =
+  let root = root ~fs in
   rm_dir root;
-  let t = Context.get_store ~indexing_strategy () in
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   let v1 = Inode.Val.of_list [ ("x", normal foo); ("y", normal bar) ] in
   let v2 = Inode.Val.add v1 "z" (normal foo) in
@@ -396,14 +405,16 @@ let test_add_inodes ~indexing_strategy =
   integrity_check v4 ~stable:false;
   Context.close t
 
-let test_add_inodes () =
-  let () = test_add_inodes ~indexing_strategy:`always in
-  test_add_inodes ~indexing_strategy:`minimal
+let test_add_inodes ~fs () =
+  let () = test_add_inodes ~fs ~indexing_strategy:`always in
+  test_add_inodes ~fs ~indexing_strategy:`minimal
 
 (** Test remove values on an empty node. *)
-let test_remove_values ~indexing_strategy =
+let test_remove_values ~fs ~indexing_strategy =
+  let root = root ~fs in
   rm_dir root;
-  let t = Context.get_store ~indexing_strategy () in
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   let v1 = Inode.Val.of_list [ ("x", normal foo); ("y", normal bar) ] in
   let v2 = Inode.Val.remove v1 "y" in
@@ -418,14 +429,16 @@ let test_remove_values ~indexing_strategy =
   Alcotest.(check bool) "v5 is empty" (Inode.Val.is_empty v5) true;
   Context.close t
 
-let test_remove_values () =
-  let () = test_remove_values ~indexing_strategy:`always in
-  test_remove_values ~indexing_strategy:`minimal
+let test_remove_values ~fs () =
+  let () = test_remove_values ~fs ~indexing_strategy:`always in
+  test_remove_values ~fs ~indexing_strategy:`minimal
 
 (** Test remove and add values to go from stable to unstable inodes. *)
-let test_remove_inodes ~indexing_strategy =
+let test_remove_inodes ~fs ~indexing_strategy =
+  let root = root ~fs in
   rm_dir root;
-  let t = Context.get_store ~indexing_strategy () in
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   let v1 =
     Inode.Val.of_list
@@ -451,9 +464,9 @@ let test_remove_inodes ~indexing_strategy =
   integrity_check v5;
   Context.close t
 
-let test_remove_inodes () =
-  let () = test_remove_inodes ~indexing_strategy:`always in
-  test_remove_inodes ~indexing_strategy:`minimal
+let test_remove_inodes ~fs () =
+  let () = test_remove_inodes ~fs ~indexing_strategy:`always in
+  test_remove_inodes ~fs ~indexing_strategy:`minimal
 
 (** For each of the 256 possible inode trees with [depth <= 3] and
     [width = Conf.entries = 2] built by [Inode.Val.v], assert that
@@ -503,8 +516,9 @@ let test_representation_uniqueness_maxdepth_3 () =
     (fun (ss, t) -> List.iter (fun s -> f ss t s) (P.steps p))
     (P.trees p)
 
-let test_truncated_inodes ~indexing_strategy =
-  let t = Context.get_store ~indexing_strategy () in
+let test_truncated_inodes ~fs ~indexing_strategy =
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   let to_truncated inode =
     let encode, decode =
@@ -566,12 +580,13 @@ let test_truncated_inodes ~indexing_strategy =
   (iter_steps_with_failure @@ fun step -> Inode.Val.remove v3 step);
   Context.close t
 
-let test_truncated_inodes () =
-  let () = test_truncated_inodes ~indexing_strategy:`always in
-  test_truncated_inodes ~indexing_strategy:`minimal
+let test_truncated_inodes ~fs () =
+  let () = test_truncated_inodes ~fs ~indexing_strategy:`always in
+  test_truncated_inodes ~fs ~indexing_strategy:`minimal
 
-let test_intermediate_inode_as_root ~indexing_strategy =
-  let t = Context.get_store ~indexing_strategy () in
+let test_intermediate_inode_as_root ~fs ~indexing_strategy =
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   let gen_step = Inode_permutations_generator.gen_step (module Inter) in
   let s000, s001, s010 =
@@ -623,8 +638,9 @@ let test_intermediate_inode_as_root ~indexing_strategy =
   with_exn (fun () -> Inode.Val.add v s000 (normal foo));
   Inode.batch t.store (fun store -> with_exn (fun () -> Inode.add store v))
 
-let test_invalid_depth_intermediate_inode ~indexing_strategy =
-  let t = Context_mock.get_store ~indexing_strategy () in
+let test_invalid_depth_intermediate_inode ~fs ~indexing_strategy =
+  Eio.Switch.run @@ fun sw ->
+  let t = Context_mock.get_store ~sw ~fs ~indexing_strategy () in
   let { Context_mock.foo; bar; _ } = t in
   let gen_step = Inode_permutations_generator.gen_step (module Inter_mock) in
   let s000, s001, s010 =
@@ -660,14 +676,19 @@ let test_invalid_depth_intermediate_inode ~indexing_strategy =
   in
   Context_mock.close t
 
-let test_intermediate_inode_as_root () =
-  let () = test_invalid_depth_intermediate_inode ~indexing_strategy:`always in
-  let () = test_invalid_depth_intermediate_inode ~indexing_strategy:`minimal in
-  let () = test_intermediate_inode_as_root ~indexing_strategy:`always in
-  test_intermediate_inode_as_root ~indexing_strategy:`minimal
+let test_intermediate_inode_as_root ~fs () =
+  let () =
+    test_invalid_depth_intermediate_inode ~fs ~indexing_strategy:`always
+  in
+  let () =
+    test_invalid_depth_intermediate_inode ~fs ~indexing_strategy:`minimal
+  in
+  let () = test_intermediate_inode_as_root ~fs ~indexing_strategy:`always in
+  test_intermediate_inode_as_root ~fs ~indexing_strategy:`minimal
 
-let test_concrete_inodes ~indexing_strategy =
-  let t = Context.get_store ~indexing_strategy () in
+let test_concrete_inodes ~fs ~indexing_strategy =
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
   let { Context.foo; bar; _ } = t in
   let pp_concrete = Irmin.Type.pp_json ~minify:false Inter.Val.Concrete.t in
   let result_t = Irmin.Type.result Inode.Val.t Inter.Val.Concrete.error_t in
@@ -701,9 +722,10 @@ let test_concrete_inodes ~indexing_strategy =
   check v;
   Context.close t
 
-let test_invalid_depth_concrete_inodes ~indexing_strategy =
+let test_invalid_depth_concrete_inodes ~fs ~indexing_strategy =
   let module C = Inter.Val.Concrete in
-  let t = Context.get_store ~indexing_strategy () in
+  Eio.Switch.run @@ fun sw ->
+  let t = Context.get_store ~sw ~fs ~indexing_strategy () in
 
   (* idea is to try and directly construct a Concrete that has a bad depth structure ie *)
   (* "Tree": { *)
@@ -738,11 +760,11 @@ let test_invalid_depth_concrete_inodes ~indexing_strategy =
 
   Context.close t
 
-let test_concrete_inodes () =
-  let () = test_invalid_depth_concrete_inodes ~indexing_strategy:`always in
-  let () = test_invalid_depth_concrete_inodes ~indexing_strategy:`minimal in
-  let () = test_concrete_inodes ~indexing_strategy:`always in
-  test_concrete_inodes ~indexing_strategy:`minimal
+let test_concrete_inodes ~fs () =
+  let () = test_invalid_depth_concrete_inodes ~fs ~indexing_strategy:`always in
+  let () = test_invalid_depth_concrete_inodes ~fs ~indexing_strategy:`minimal in
+  let () = test_concrete_inodes ~fs ~indexing_strategy:`always in
+  test_concrete_inodes ~fs ~indexing_strategy:`minimal
 
 module Inode_tezos = struct
   module S =
@@ -761,9 +783,11 @@ module Inode_tezos = struct
 
   let hex_encode s = Hex.of_string s |> Hex.show
 
-  let test_encode_bin_values ~indexing_strategy =
+  let test_encode_bin_values ~fs ~indexing_strategy =
+    let root = root ~fs in
     rm_dir root;
-    let t = S.Context.get_store ~indexing_strategy () in
+    Eio.Switch.run @@ fun sw ->
+    let t = S.Context.get_store ~sw ~fs ~indexing_strategy () in
     let { S.Context.foo; _ } = t in
     let v = S.Inode.Val.of_list [ ("x", normal foo); ("z", normal foo) ] in
     let h = S.Inter.Val.hash_exn v in
@@ -795,13 +819,15 @@ module Inode_tezos = struct
     check_iter "encode_bin" (encode_bin h) v checks;
     S.Context.close t
 
-  let test_encode_bin_values () =
-    let () = test_encode_bin_values ~indexing_strategy:`always in
-    test_encode_bin_values ~indexing_strategy:`minimal
+  let test_encode_bin_values ~fs () =
+    let () = test_encode_bin_values ~fs ~indexing_strategy:`always in
+    test_encode_bin_values ~fs ~indexing_strategy:`minimal
 
-  let test_encode_bin_tree ~indexing_strategy =
+  let test_encode_bin_tree ~fs ~indexing_strategy =
+    let root = root ~fs in
     rm_dir root;
-    let t = S.Context.get_store ~indexing_strategy () in
+    Eio.Switch.run @@ fun sw ->
+    let t = S.Context.get_store ~sw ~fs ~indexing_strategy () in
     let { S.Context.foo; bar; _ } = t in
     let v =
       S.Inode.Val.of_list
@@ -840,9 +866,9 @@ module Inode_tezos = struct
     check_iter "encode_bin" (encode_bin h) v checks;
     S.Context.close t
 
-  let test_encode_bin_tree () =
-    let () = test_encode_bin_tree ~indexing_strategy:`always in
-    test_encode_bin_tree ~indexing_strategy:`minimal
+  let test_encode_bin_tree ~fs () =
+    let () = test_encode_bin_tree ~fs ~indexing_strategy:`always in
+    test_encode_bin_tree ~fs ~indexing_strategy:`minimal
 end
 
 module Child_ordering = struct
@@ -988,23 +1014,25 @@ module Child_ordering = struct
     ()
 end
 
-let tests =
+let tests ~fs =
   let tc_sync name f = Alcotest.test_case name `Quick f in
   let tc name f = tc_sync name f in
   (* Test disabled because it relies on being able to serialise concrete inodes,
      which is not possible following the introduction of structured keys. *)
-  let _ = tc "test truncated inodes" test_truncated_inodes in
-  let _ = tc "test encode bin of trees" Inode_tezos.test_encode_bin_tree in
+  let _ = tc "test truncated inodes" (test_truncated_inodes ~fs) in
+  let _ =
+    tc "test encode bin of trees" (Inode_tezos.test_encode_bin_tree ~fs)
+  in
   [
-    tc "add values" test_add_values;
-    tc "add values to inodes" test_add_inodes;
-    tc "remove values" test_remove_values;
-    tc "remove inodes" test_remove_inodes;
-    tc "test concrete inodes" test_concrete_inodes;
+    tc "add values" (test_add_values ~fs);
+    tc "add values to inodes" (test_add_inodes ~fs);
+    tc "remove values" (test_remove_values ~fs);
+    tc "remove inodes" (test_remove_inodes ~fs);
+    tc "test concrete inodes" (test_concrete_inodes ~fs);
     tc "test representation uniqueness"
       test_representation_uniqueness_maxdepth_3;
-    tc "test encode bin of values" Inode_tezos.test_encode_bin_values;
-    tc "test intermediate inode as root" test_intermediate_inode_as_root;
+    tc "test encode bin of values" (Inode_tezos.test_encode_bin_values ~fs);
+    tc "test intermediate inode as root" (test_intermediate_inode_as_root ~fs);
     tc_sync "Child_ordering.seeded_hash" Child_ordering.test_seeded_hash;
     tc_sync "Child_ordering.hash_bits" Child_ordering.test_hash_bits;
     tc_sync "Child_ordering.custom" Child_ordering.test_custom;

--- a/test/irmin-pack/test_inode.mli
+++ b/test/irmin-pack/test_inode.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list

--- a/test/irmin-pack/test_lower.ml
+++ b/test/irmin-pack/test_lower.ml
@@ -30,27 +30,30 @@ module Direct_tc = struct
   module Lower = Irmin_pack_unix.Lower.Make (Io) (Errs)
   module Sparse = Irmin_pack_unix.Sparse_file.Make (Io)
 
-  let create_control volume_path payload =
+  let create_control ~sw volume_path payload =
     let path = Irmin_pack.Layout.V5.Volume.control ~root:volume_path in
-    Control.create_rw ~path ~tmp_path:None ~overwrite:true payload
+    Control.create_rw ~sw ~path ~tmp_path:None ~overwrite:true payload
 
-  let test_empty () =
-    let lower_root = create_lower_root () in
-    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let test_empty ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let$ lower = Lower.v ~sw ~readonly:false ~volume_num:0 lower_root in
     Alcotest.(check int) "0 volumes" 0 (Lower.volume_num lower);
     let _ = Lower.close lower in
     ()
 
-  let test_volume_num () =
-    let lower_root = create_lower_root () in
-    let result = Lower.v ~readonly:false ~volume_num:1 lower_root in
+  let test_volume_num ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let result = Lower.v ~sw ~readonly:false ~volume_num:1 lower_root in
     match result with
     | Error (`Volume_missing _) -> ()
     | _ -> Alcotest.fail "volume_num too high should return an error"
 
-  let test_add_volume () =
-    let lower_root = create_lower_root () in
-    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let test_add_volume ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let$ lower = Lower.v ~sw ~readonly:false ~volume_num:0 lower_root in
     let$ _ = Lower.add_volume lower in
     Alcotest.(check int) "1 volume" 1 (Lower.volume_num lower);
     let$ _ = Lower.reload ~volume_num:1 lower in
@@ -58,9 +61,10 @@ module Direct_tc = struct
     let _ = Lower.close lower in
     ()
 
-  let test_add_volume_ro () =
-    let lower_root = create_lower_root () in
-    let$ lower = Lower.v ~readonly:true ~volume_num:0 lower_root in
+  let test_add_volume_ro ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let$ lower = Lower.v ~sw ~readonly:true ~volume_num:0 lower_root in
     let result = Lower.add_volume lower in
     let () =
       match result with
@@ -70,9 +74,10 @@ module Direct_tc = struct
     let _ = Lower.close lower in
     ()
 
-  let test_add_multiple_empty () =
-    let lower_root = create_lower_root () in
-    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let test_add_multiple_empty ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let$ lower = Lower.v ~sw ~readonly:false ~volume_num:0 lower_root in
     let$ _ = Lower.add_volume lower in
     let result = Lower.add_volume lower |> Result.get_error in
     let () =
@@ -83,9 +88,10 @@ module Direct_tc = struct
     let _ = Lower.close lower in
     ()
 
-  let test_find_volume () =
-    let lower_root = create_lower_root () in
-    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let test_find_volume ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let$ lower = Lower.v ~sw ~readonly:false ~volume_num:0 lower_root in
     let$ volume = Lower.add_volume lower in
     let payload =
       Irmin_pack_unix.Control_file.Payload.Volume.Latest.
@@ -96,7 +102,7 @@ module Direct_tc = struct
           checksum = Int63.zero;
         }
     in
-    let _ = create_control (Lower.Volume.path volume) payload in
+    let _ = create_control ~sw (Lower.Volume.path volume) payload in
     let volume = Lower.find_volume ~off:(Int63.of_int 21) lower in
     Alcotest.(check bool)
       "volume not found before reload" false (Option.is_some volume);
@@ -106,9 +112,10 @@ module Direct_tc = struct
     let _ = Lower.close lower in
     ()
 
-  let test_read_exn () =
-    let lower_root = create_lower_root () in
-    let$ lower = Lower.v ~readonly:false ~volume_num:0 lower_root in
+  let test_read_exn ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let lower_root = create_lower_root ~fs () in
+    let$ lower = Lower.v ~sw ~readonly:false ~volume_num:0 lower_root in
     let$ volume = Lower.add_volume lower in
     (* Manually create mapping, data, and control file for volume.
 
@@ -119,7 +126,7 @@ module Direct_tc = struct
     let test_str = "hello" in
     let len = String.length test_str in
     let$ sparse =
-      Sparse.Ao.open_ao ~mapping_size:Int63.zero ~mapping:mapping_path
+      Sparse.Ao.open_ao ~sw ~mapping_size:Int63.zero ~mapping:mapping_path
         ~data:data_path
     in
     let seq = List.to_seq [ test_str ] in
@@ -137,7 +144,7 @@ module Direct_tc = struct
           checksum = Int63.zero;
         }
     in
-    let _ = create_control (Lower.Volume.path volume) payload in
+    let _ = create_control ~sw (Lower.Volume.path volume) payload in
     let$ _ = Lower.reload ~volume_num:1 lower in
     let buf = Bytes.create len in
     let _ = Lower.read_exn ~off:Int63.zero ~len lower buf in
@@ -156,16 +163,16 @@ module Store_tc = struct
 
   let test_dir = "_build"
 
-  let fresh_roots =
+  let fresh_roots ~fs =
     let c = ref 0 in
     fun ?(make_root = true) () ->
       incr c;
       let name =
-        Filename.concat test_dir ("test_lower_store_" ^ string_of_int !c)
+        Eio.Path.(fs / test_dir / ("test_lower_store_" ^ string_of_int !c))
       in
       Common.rm_dir name;
       let$ _ = if make_root then Io.mkdir name else Ok () in
-      let lower = Filename.concat name "lower" in
+      let lower = Eio.Path.(name / "lower") in
       Common.rm_dir lower;
       (name, lower)
 
@@ -174,10 +181,11 @@ module Store_tc = struct
       config ~readonly ~indexing_strategy:Indexing_strategy.minimal ~fresh
         ~lower_root root)
 
-  let init ?(readonly = false) ?(fresh = true) ?(include_lower = true) () =
-    let root, lower_root = fresh_roots () in
+  let init ~sw ~fs ?(readonly = false) ?(fresh = true) ?(include_lower = true)
+      () =
+    let root, lower_root = fresh_roots ~fs () in
     let lower_root = if include_lower then Some lower_root else None in
-    config ~readonly ~fresh ?lower_root root |> Store.Repo.v
+    Store.Repo.v (config ~sw ~fs ~readonly ~fresh ?lower_root root)
 
   let count_volumes repo =
     let open Store.Internal in
@@ -228,31 +236,35 @@ module Store_tc = struct
         | Some commit -> Store.Tree.fold (Store.Commit.tree commit) ())
       !commits
 
-  let test_create () =
-    let repo = init () in
+  let test_create ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let repo = init ~sw ~fs () in
     (* A newly created store with a lower should have an empty volume. *)
     let volume_num = count_volumes repo in
     Alcotest.(check int) "volume_num is 1" 1 volume_num;
     Store.Repo.close repo
 
-  let test_create_nested () =
-    let root, lower_root = fresh_roots ~make_root:false () in
-    let repo = config ~fresh:true ~lower_root root |> Store.Repo.v in
+  let test_create_nested ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs ~make_root:false () in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true ~lower_root root) in
     let volume_num = count_volumes repo in
     Alcotest.(check int) "volume_num is 1" 1 volume_num;
     Store.Repo.close repo
 
-  let test_open_rw_lower () =
-    let root, lower_root = fresh_roots ~make_root:false () in
-    let repo = config ~fresh:true root |> Store.Repo.v in
+  let test_open_rw_lower ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs ~make_root:false () in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true root) in
     let () = Store.Repo.close repo in
-    let repo = config ~fresh:false ~lower_root root |> Store.Repo.v in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:false ~lower_root root) in
     let volume_num = count_volumes repo in
     Alcotest.(check int) "volume_num is 1" 1 volume_num;
     Store.Repo.close repo
 
-  let test_add_volume_during_gc () =
-    let repo = init () in
+  let test_add_volume_during_gc ~fs ~domain_mgr () =
+    Eio.Switch.run @@ fun sw ->
+    let repo = init ~sw ~fs () in
     let main = Store.main repo in
     let () =
       Store.set_exn
@@ -260,7 +272,7 @@ module Store_tc = struct
         main [ "a" ] "a"
     in
     let c = Store.Head.get main in
-    let _ = Store.Gc.start_exn repo (Store.Commit.key c) in
+    let _ = Store.Gc.start_exn ~fs ~domain_mgr repo (Store.Commit.key c) in
     let () =
       Alcotest.check_raises "add volume during gc"
         (Irmin_pack_unix.Errors.Pack_error `Add_volume_forbidden_during_gc)
@@ -268,8 +280,9 @@ module Store_tc = struct
     in
     Store.Repo.close repo
 
-  let test_add_volume_wo_lower () =
-    let repo = init ~include_lower:false () in
+  let test_add_volume_wo_lower ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let repo = init ~sw ~fs ~include_lower:false () in
     let () =
       Alcotest.check_raises "add volume w/o lower"
         (Irmin_pack_unix.Errors.Pack_error `Add_volume_requires_lower)
@@ -277,33 +290,35 @@ module Store_tc = struct
     in
     Store.Repo.close repo
 
-  let test_add_volume_reopen () =
-    let root, lower_root = fresh_roots () in
-    let repo = Store.Repo.v (config ~fresh:true ~lower_root root) in
+  let test_add_volume_reopen ~fs ~domain_mgr () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs () in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true ~lower_root root) in
     let main = Store.main repo in
     let info () = Store.Info.v ~author:"test" Int64.zero in
     let () = Store.set_exn ~info main [ "a" ] "a" in
     let c1 = Store.Head.get main in
-    let _ = Store.Gc.start_exn repo (Store.Commit.key c1) in
+    let _ = Store.Gc.start_exn ~fs ~domain_mgr repo (Store.Commit.key c1) in
     let _ = Store.Gc.finalise_exn ~wait:true repo in
     let () = Store.add_volume repo in
     Alcotest.(check int) "two volumes" 2 (count_volumes repo);
     let _ = Store.Repo.close repo in
-    let repo = Store.Repo.v (config ~fresh:false ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:false ~lower_root root) in
     Alcotest.(check int) "two volumes after re-open" 2 (count_volumes repo);
     Store.Repo.close repo
 
-  let test_migrate () =
-    let root, lower_root = fresh_roots () in
+  let test_migrate ~fs () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs () in
     (* Create without a lower *)
-    let repo = Store.Repo.v (config ~fresh:true root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true root) in
     Alcotest.(check int) "volume_num is 0" 0 (count_volumes repo);
     let main = Store.main repo in
     let info () = Store.Info.v ~author:"test" Int64.zero in
     let () = Store.set_exn ~info main [ "a" ] "a" in
     let () = Store.Repo.close repo in
     (* Reopen with a lower to trigger the migration *)
-    let repo = Store.Repo.v (config ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~lower_root root) in
     Alcotest.(check int) "volume_num is 1" 1 (count_volumes repo);
     let main = Store.main repo in
     let a = Store.get main [ "a" ] in
@@ -314,7 +329,7 @@ module Store_tc = struct
     let () = Store.set_exn ~info main [ "a" ] "b" in
     let () = Store.Repo.close repo in
     (* Reopen with the same lower and check reads *)
-    let repo = Store.Repo.v (config ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~lower_root root) in
     Alcotest.(check int) "volume_num is 1" 1 (count_volumes repo);
     let main = Store.main repo in
     let b = Store.get main [ "a" ] in
@@ -329,53 +344,57 @@ module Store_tc = struct
     Store.Repo.close repo
 
   (* Tests that dead header is handled appropriately *)
-  let test_migrate_v2 () =
-    let ( / ) = Filename.concat in
+  let test_migrate_v2 ~fs () =
+    Eio.Switch.run @@ fun sw ->
     let root_archive =
-      "test" / "irmin-pack" / "data" / "version_2_to_3_always"
+      Eio.Path.(fs / "test" / "irmin-pack" / "data" / "version_2_to_3_always")
     in
-    let root = "_build" / "test_lower_migrate_v2" in
+    let root = Eio.Path.(fs / "_build" / "test_lower_migrate_v2") in
     setup_test_env ~root_archive ~root_local_build:root;
-    let lower_root = root / "lower" in
+    let lower_root = Eio.Path.(root / "lower") in
     (* Open store and trigger migration. This should succeed. *)
-    let repo = Store.Repo.v (config ~fresh:false ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:false ~lower_root root) in
     let _ = read_everything repo in
     Store.Repo.close repo
 
-  let test_migrate_v3 () =
+  let test_migrate_v3 ~fs () =
+    Eio.Switch.run @@ fun sw ->
     (* minimal indexing *)
-    let ( / ) = Filename.concat in
-    let root_archive = "test" / "irmin-pack" / "data" / "version_3_minimal" in
-    let root = "_build" / "test_lower_migrate_v3_minimal" in
+    let root_archive =
+      Eio.Path.(fs / "test" / "irmin-pack" / "data" / "version_3_minimal")
+    in
+    let root = Eio.Path.(fs / "_build" / "test_lower_migrate_v3_minimal") in
     setup_test_env ~root_archive ~root_local_build:root;
-    let lower_root = root / "lower" in
+    let lower_root = Eio.Path.(root / "lower") in
     (* Open store and trigger migration. This should succeed. *)
-    let repo = Store.Repo.v (config ~fresh:false ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:false ~lower_root root) in
     let _ = read_everything repo in
     let _ = Store.Repo.close repo in
 
     (* always indexing *)
-    let ( / ) = Filename.concat in
-    let root_archive = "test" / "irmin-pack" / "data" / "version_3_always" in
-    let root = "_build" / "test_lower_migrate_v3_always" in
+    let root_archive =
+      Eio.Path.(fs / "test" / "irmin-pack" / "data" / "version_3_always")
+    in
+    let root = Eio.Path.(fs / "_build" / "test_lower_migrate_v3_always") in
     setup_test_env ~root_archive ~root_local_build:root;
-    let lower_root = root / "lower" in
+    let lower_root = Eio.Path.(root / "lower") in
     (* Open store and trigger migration. This should succeed. *)
-    let repo = Store.Repo.v (config ~fresh:false ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:false ~lower_root root) in
     let _ = read_everything repo in
     Store.Repo.close repo
 
-  let test_migrate_then_gc () =
-    let root, lower_root = fresh_roots () in
+  let test_migrate_then_gc ~fs ~domain_mgr () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs () in
     (* Create without a lower *)
-    let repo = Store.Repo.v (config ~fresh:true root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true root) in
     Alcotest.(check int) "volume_num is 0" 0 (count_volumes repo);
     let main = Store.main repo in
     let info () = Store.Info.v ~author:"test" Int64.zero in
     let () = Store.set_exn ~info main [ "a" ] "a" in
     let () = Store.Repo.close repo in
     (* Reopen with a lower to trigger the migration *)
-    let repo = Store.Repo.v (config ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~lower_root root) in
     Alcotest.(check int) "volume_num is 1" 1 (count_volumes repo);
     (* Add two commits *)
     let main = Store.main repo in
@@ -384,15 +403,18 @@ module Store_tc = struct
     let b_commit = Store.Head.get main in
     let () = Store.set_exn ~info main [ "c" ] "c" in
     (* GC at [b] requires reading [a] data from the lower volume *)
-    let _ = Store.Gc.start_exn repo (Store.Commit.key b_commit) in
+    let _ =
+      Store.Gc.start_exn ~fs ~domain_mgr repo (Store.Commit.key b_commit)
+    in
     let _ = Store.Gc.finalise_exn ~wait:true repo in
     let _ = read_everything repo in
     Store.Repo.close repo
 
-  let test_migrate_then_gc_in_lower () =
-    let root, lower_root = fresh_roots () in
+  let test_migrate_then_gc_in_lower ~fs ~domain_mgr () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs () in
     (* Create without a lower *)
-    let repo = Store.Repo.v (config ~fresh:true root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true root) in
     Alcotest.(check int) "volume_num is 0" 0 (count_volumes repo);
     let main = Store.main repo in
     let info () = Store.Info.v ~author:"test" Int64.zero in
@@ -401,27 +423,30 @@ module Store_tc = struct
     let () = Store.set_exn ~info main [ "b" ] "b" in
     let () = Store.Repo.close repo in
     (* Reopen with a lower to trigger the migration *)
-    let repo = Store.Repo.v (config ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~lower_root root) in
     Alcotest.(check int) "volume_num is 1" 1 (count_volumes repo);
     (* [a] is now in the lower but GC should still succeed
 
        Important: we call GC on a commit that is not the latest in
        the lower (ie [b]) to ensure its offset is not equal to the start
        offset of the upper. *)
-    let _ = Store.Gc.start_exn repo (Store.Commit.key a_commit) in
+    let _ =
+      Store.Gc.start_exn ~fs repo ~domain_mgr (Store.Commit.key a_commit)
+    in
     let _ = Store.Gc.finalise_exn ~wait:true repo in
     Store.Repo.close repo
 
-  let test_volume_data_locality () =
-    let root, lower_root = fresh_roots () in
-    let repo = Store.Repo.v (config ~fresh:true ~lower_root root) in
+  let test_volume_data_locality ~fs ~domain_mgr () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs () in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true ~lower_root root) in
     let main = Store.main repo in
     let info () = Store.Info.v ~author:"test" Int64.zero in
     [%log.debug "add c1"];
     let () = Store.set_exn ~info main [ "c1" ] "a" in
     let c1 = Store.Head.get main in
     [%log.debug "GC c1"];
-    let _ = Store.Gc.start_exn repo (Store.Commit.key c1) in
+    let _ = Store.Gc.start_exn ~fs ~domain_mgr repo (Store.Commit.key c1) in
     let _ = Store.Gc.finalise_exn ~wait:true repo in
     let () = Store.add_volume repo in
     [%log.debug "add c2, c3, c4"];
@@ -432,7 +457,7 @@ module Store_tc = struct
     let () = Store.set_exn ~info main [ "c5" ] "e" in
     let c5 = Store.Head.get main in
     [%log.debug "GC c5"];
-    let _ = Store.Gc.start_exn repo (Store.Commit.key c5) in
+    let _ = Store.Gc.start_exn ~fs ~domain_mgr repo (Store.Commit.key c5) in
     let _ = Store.Gc.finalise_exn ~wait:true repo in
     let get_direct_key key =
       match Irmin_pack_unix.Pack_key.inspect key with
@@ -475,15 +500,16 @@ module Store_tc = struct
     in
     Store.Repo.close repo
 
-  let test_cleanup () =
-    let root, lower_root = fresh_roots () in
+  let test_cleanup ~fs ~domain_mgr () =
+    Eio.Switch.run @@ fun sw ->
+    let root, lower_root = fresh_roots ~fs () in
     [%log.debug "create store with data and run GC"];
-    let repo = Store.Repo.v (config ~fresh:true ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:true ~lower_root root) in
     let main = Store.main repo in
     let info () = Store.Info.v ~author:"test" Int64.zero in
     let () = Store.set_exn ~info main [ "a" ] "a" in
     let c1 = Store.Head.get main in
-    let _ = Store.Gc.start_exn repo (Store.Commit.key c1) in
+    let _ = Store.Gc.start_exn ~fs ~domain_mgr repo (Store.Commit.key c1) in
     let _ = Store.Gc.finalise_exn ~wait:true repo in
     let volume_root = volume_path repo Int63.zero in
     let generation = generation repo in
@@ -496,7 +522,7 @@ module Store_tc = struct
       Irmin_pack.Layout.V5.Volume.control ~root:volume_root
     in
     let$ () = Io.move_file ~src:volume_cf_path ~dst:volume_cf_gen_path in
-    let repo = Store.Repo.v (config ~fresh:false ~lower_root root) in
+    let repo = Store.Repo.v (config ~sw ~fs ~fresh:false ~lower_root root) in
     let () =
       match Io.classify_path volume_cf_path with
       | `File -> [%log.debug "control file exists"]
@@ -513,38 +539,43 @@ end
 module Store = struct
   include Store_tc
 
-  let tests =
+  let tests ~fs ~domain_mgr =
     Alcotest.
       [
-        quick_tc "create store" test_create;
-        quick_tc "create nested" test_create_nested;
-        quick_tc "open rw with lower" test_open_rw_lower;
-        quick_tc "add volume with no lower" test_add_volume_wo_lower;
-        quick_tc "add volume during gc" test_add_volume_during_gc;
-        quick_tc "control file updated after add" test_add_volume_reopen;
-        quick_tc "add volume and reopen" test_add_volume_reopen;
-        quick_tc "create without lower then migrate" test_migrate;
-        quick_tc "migrate v2" test_migrate_v2;
-        quick_tc "migrate v3" test_migrate_v3;
-        quick_tc "migrate then gc" test_migrate_then_gc;
-        quick_tc "migrate then gc in lower" test_migrate_then_gc_in_lower;
-        quick_tc "test data locality" test_volume_data_locality;
-        quick_tc "test cleanup" test_cleanup;
+        quick_tc "create store" (test_create ~fs);
+        quick_tc "create nested" (test_create_nested ~fs);
+        quick_tc "open rw with lower" (test_open_rw_lower ~fs);
+        quick_tc "add volume with no lower" (test_add_volume_wo_lower ~fs);
+        quick_tc "add volume during gc"
+          (test_add_volume_during_gc ~fs ~domain_mgr);
+        quick_tc "control file updated after add"
+          (test_add_volume_reopen ~fs ~domain_mgr);
+        quick_tc "add volume and reopen"
+          (test_add_volume_reopen ~fs ~domain_mgr);
+        quick_tc "create without lower then migrate" (test_migrate ~fs);
+        quick_tc "migrate v2" (test_migrate_v2 ~fs);
+        quick_tc "migrate v3" (test_migrate_v3 ~fs);
+        quick_tc "migrate then gc" (test_migrate_then_gc ~fs ~domain_mgr);
+        quick_tc "migrate then gc in lower"
+          (test_migrate_then_gc_in_lower ~fs ~domain_mgr);
+        quick_tc "test data locality"
+          (test_volume_data_locality ~fs ~domain_mgr);
+        quick_tc "test cleanup" (test_cleanup ~fs ~domain_mgr);
       ]
 end
 
 module Direct = struct
   include Direct_tc
 
-  let tests =
+  let tests ~fs =
     Alcotest.
       [
-        quick_tc "empty lower" test_empty;
-        quick_tc "volume_num too high" test_volume_num;
-        quick_tc "add volume" test_add_volume;
-        quick_tc "add volume ro" test_add_volume_ro;
-        quick_tc "add multiple empty" test_add_multiple_empty;
-        quick_tc "find volume" test_find_volume;
-        quick_tc "test read_exn" test_read_exn;
+        quick_tc "empty lower" (test_empty ~fs);
+        quick_tc "volume_num too high" (test_volume_num ~fs);
+        quick_tc "add volume" (test_add_volume ~fs);
+        quick_tc "add volume ro" (test_add_volume_ro ~fs);
+        quick_tc "add multiple empty" (test_add_multiple_empty ~fs);
+        quick_tc "find volume" (test_find_volume ~fs);
+        quick_tc "test read_exn" (test_read_exn ~fs);
       ]
 end

--- a/test/irmin-pack/test_lower.mli
+++ b/test/irmin-pack/test_lower.mli
@@ -15,9 +15,12 @@
  *)
 
 module Store : sig
-  val tests : unit Alcotest.test_case list
+  val tests :
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    domain_mgr:_ Eio.Domain_manager.t ->
+    unit Alcotest.test_case list
 end
 
 module Direct : sig
-  val tests : unit Alcotest.test_case list
+  val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list
 end

--- a/test/irmin-pack/test_mapping.mli
+++ b/test/irmin-pack/test_mapping.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list

--- a/test/irmin-pack/test_multicore.ml
+++ b/test/irmin-pack/test_multicore.ml
@@ -17,7 +17,7 @@
 open! Import
 open Common
 
-let root = Filename.concat "_build" "test-multicore"
+let root ~fs = Eio.Path.(fs / "_build" / "test-multicore")
 let src = Logs.Src.create "tests.multicore" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -106,19 +106,21 @@ let rec list_shape acc path : shape -> _ = function
 
 let list_shape shape = list_shape [] [] shape
 
-let make_store shape =
-  let repo = Store.Repo.v (Store.config ~fresh:true root) in
+let make_store ~fs shape =
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo = Store.Repo.v (Store.config ~sw ~fs ~fresh:true root) in
   let main = Store.main repo in
   let tree = make_tree shape in
   let () = Store.set_tree_exn ~info main [] tree in
   Store.Repo.close repo
 
-let domains_run d_mgr fns =
+let domains_run ~domain_mgr fns =
   let count = Atomic.make (List.length fns) in
   let fibers =
     List.map
       (fun fn () ->
-        Eio.Domain_manager.run d_mgr (fun () ->
+        Eio.Domain_manager.run domain_mgr (fun () ->
             Atomic.decr count;
             while Atomic.get count > 0 do
               Domain.cpu_relax ()
@@ -128,8 +130,8 @@ let domains_run d_mgr fns =
   in
   Eio.Fiber.all fibers
 
-let domains_spawn d_mgr ?(nb = 2) fn =
-  domains_run d_mgr @@ List.init nb (fun _ -> fn)
+let domains_spawn ~domain_mgr ?(nb = 2) fn =
+  domains_run ~domain_mgr @@ List.init nb (fun _ -> fn)
 
 let find_all tree paths =
   List.iter
@@ -139,13 +141,17 @@ let find_all tree paths =
       | Some value -> assert (expected = value))
     paths
 
-let test_find d_mgr =
+let test_find ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:true ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:true ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let paths = flatten_shape shape0 in
-  domains_spawn d_mgr (fun () -> find_all tree paths);
+  domains_spawn ~domain_mgr (fun () -> find_all tree paths);
   Store.Repo.close repo
 
 let rec expected_lengths acc path : shape -> _ = function
@@ -158,10 +164,14 @@ let rec expected_lengths acc path : shape -> _ = function
 
 let expected_lengths shape = expected_lengths [] [] shape
 
-let test_length d_mgr =
+let test_length ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:true ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:true ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let lengths = expected_lengths shape0 in
   let all_length () =
@@ -172,7 +182,7 @@ let test_length d_mgr =
         assert (expected = value))
       lengths
   in
-  domains_spawn ~nb:2 d_mgr all_length;
+  domains_spawn ~nb:2 ~domain_mgr all_length;
   Store.Repo.close repo
 
 let rec remove_all acc path : shape -> _ = function
@@ -210,10 +220,14 @@ let rec diff_shape acc path (old_shape : shape option) (new_shape : shape) =
 let diff_shape old_shape new_shape =
   List.rev @@ diff_shape [] [] (Some old_shape) new_shape
 
-let test_add_remove d_mgr =
+let test_add_remove ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:true ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:true ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let patch = diff_shape shape0 shape1 in
   let after_paths = flatten_shape shape1 in
@@ -232,7 +246,7 @@ let test_add_remove d_mgr =
         | `Remove name -> assert (not (Tree.mem tree name)))
       patch
   in
-  domains_spawn ~nb:2 d_mgr add_all;
+  domains_spawn ~nb:2 ~domain_mgr add_all;
   Store.Repo.close repo
 
 let apply_op tree = function
@@ -247,10 +261,14 @@ let check_patch_was_applied patch tree =
       | `Remove name -> assert (not (Store.Tree.mem tree name)))
     patch
 
-let test_commit d_mgr =
+let test_commit ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:false ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:false ~fresh:false root)
+  in
   let store = Store.main repo in
   let patch01 = diff_shape shape0 shape1 in
   let patch02 = diff_shape shape0 shape2 in
@@ -264,13 +282,17 @@ let test_commit d_mgr =
     let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
     check_patch_was_applied patch tree
   in
-  domains_run d_mgr [ do_commit patch01; do_commit patch02 ];
+  domains_run ~domain_mgr [ do_commit patch01; do_commit patch02 ];
   Store.Repo.close repo
 
-let test_merkle d_mgr =
+let test_merkle ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:false ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:false ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let hash = Store.Tree.key tree |> Option.get in
   let patch01 = diff_shape shape0 shape1 in
@@ -285,13 +307,17 @@ let test_merkle d_mgr =
     | Ok (new_tree, ()) -> check_patch_was_applied patch new_tree
     | Error _ -> assert false
   in
-  domains_run d_mgr [ do_proof patch01; do_proof patch02 ];
+  domains_run ~domain_mgr [ do_proof patch01; do_proof patch02 ];
   Store.Repo.close repo
 
-let test_hash d_mgr =
+let test_hash ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:false ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:false ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let patch01 = diff_shape shape0 shape1 in
   let patch12 = diff_shape shape1 shape2 in
@@ -309,7 +335,7 @@ let test_hash d_mgr =
   in
   let result1 = Atomic.make [] in
   let result2 = Atomic.make [] in
-  domains_run d_mgr [ do_hash result1; do_hash result2 ];
+  domains_run ~domain_mgr [ do_hash result1; do_hash result2 ];
   List.iter2
     (fun h1 h2 -> assert (h1 = h2))
     (Atomic.get result1) (Atomic.get result2);
@@ -328,30 +354,42 @@ let list_all cache tree paths =
         expected)
     paths
 
-let test_list_disk ~cache d_mgr =
+let test_list_disk ~fs ~cache ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:true ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:true ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let paths = list_shape shape0 in
-  domains_spawn d_mgr (fun () -> list_all cache tree paths);
+  domains_spawn ~domain_mgr (fun () -> list_all cache tree paths);
   Store.Repo.close repo
 
-let test_list_mem ~cache d_mgr =
+let test_list_mem ~fs ~cache ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:true ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:true ~fresh:false root)
+  in
   let tree = Store.main repo |> Store.Head.get |> Store.Commit.tree in
   let patch = diff_shape shape0 shape1 in
   let paths = list_shape shape1 in
   let tree = List.fold_left apply_op tree patch in
-  domains_spawn d_mgr (fun _ -> list_all cache tree paths);
+  domains_spawn ~domain_mgr (fun _ -> list_all cache tree paths);
   Store.Repo.close repo
 
-let test_commit_of_hash d_mgr =
+let test_commit_of_hash ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:false ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:false ~fresh:false root)
+  in
   let store = Store.main repo in
   let patch01 = diff_shape shape0 shape1 in
   let patch02 = diff_shape shape0 shape2 in
@@ -393,13 +431,17 @@ let test_commit_of_hash d_mgr =
     let diffs = Store.Tree.diff tree3 t3 in
     assert (diffs = [])
   in
-  domains_spawn d_mgr do_commit_of_hash;
+  domains_spawn ~domain_mgr do_commit_of_hash;
   Store.Repo.close repo
 
-let test_commit_parents d_mgr =
+let test_commit_parents ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:false ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:false ~fresh:false root)
+  in
   let store = Store.main repo in
   let patch01 = diff_shape shape0 shape1 in
   let commit = Store.Head.get store in
@@ -422,13 +464,17 @@ let test_commit_parents d_mgr =
            commit)
          commit commits)
   in
-  domains_spawn d_mgr do_commit_parents;
+  domains_spawn ~domain_mgr do_commit_parents;
   Store.Repo.close repo
 
-let test_commit_v d_mgr =
+let test_commit_v ~fs ~domain_mgr =
   Logs.set_level None;
-  make_store shape0;
-  let repo = Store.Repo.v (Store.config ~readonly:false ~fresh:false root) in
+  make_store ~fs shape0;
+  Eio.Switch.run @@ fun sw ->
+  let root = root ~fs in
+  let repo =
+    Store.Repo.v (Store.config ~sw ~fs ~readonly:false ~fresh:false root)
+  in
   let store = Store.main repo in
   let patch01 = diff_shape shape0 shape1 in
   let commit = Store.Head.get store in
@@ -441,23 +487,24 @@ let test_commit_v d_mgr =
     in
     ()
   in
-  domains_spawn d_mgr do_commit_v;
+  domains_spawn ~domain_mgr do_commit_v;
   Store.Repo.close repo
 
-let tests d_mgr =
-  let tc name fn = Alcotest.test_case name `Quick (fun () -> fn d_mgr) in
+(* TODO: Eio has to be fixed first to allow a switch to be used from different domains *)
+let tests ~fs ~domain_mgr =
+  let tc name fn = Alcotest.test_case name `Quick (fun () -> fn ~domain_mgr) in
   [
-    tc "find." test_find;
-    tc "length." test_length;
-    tc "add / remove." test_add_remove;
-    tc "commit." test_commit;
-    tc "merkle." test_merkle;
-    tc "hash." test_hash;
-    tc "list-disk-no-cache." (test_list_disk ~cache:false);
-    tc "list-disk-with-cache." (test_list_disk ~cache:true);
-    tc "list-mem-no-cache." (test_list_mem ~cache:false);
-    tc "list-mem-with-cache." (test_list_mem ~cache:true);
-    tc "commit-of-hash." test_commit_of_hash;
-    tc "commit-parents." test_commit_parents;
-    tc "commit-v." test_commit_v;
+    tc "find." (test_find ~fs);
+    tc "length." (test_length ~fs);
+    tc "add / remove." (test_add_remove ~fs);
+    tc "commit." (test_commit ~fs);
+    tc "merkle." (test_merkle ~fs);
+    tc "hash." (test_hash ~fs);
+    tc "list-disk-no-cache." (test_list_disk ~fs ~cache:false);
+    tc "list-disk-with-cache." (test_list_disk ~fs ~cache:true);
+    tc "list-mem-no-cache." (test_list_mem ~fs ~cache:false);
+    tc "list-mem-with-cache." (test_list_mem ~fs ~cache:true);
+    tc "commit-of-hash." (test_commit_of_hash ~fs);
+    tc "commit-parents." (test_commit_parents ~fs);
+    tc "commit-v." (test_commit_v ~fs);
   ]

--- a/test/irmin-pack/test_pack.mli
+++ b/test/irmin-pack/test_pack.mli
@@ -14,7 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val suite : Irmin_test.Suite.t list
+val suite :
+  sw:Eio.Switch.t -> fs:Eio.Fs.dir_ty Eio.Path.t -> Irmin_test.Suite.t list
 
 val misc :
-  _ Eio.Domain_manager.t -> (string * unit Alcotest.test_case list) list
+  sr:Eio__Flow.source_ty Eio.Std.r ->
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  domain_mgr:_ Eio.Domain_manager.t ->
+  (string * unit Alcotest.test_case list) list

--- a/test/irmin-pack/test_pack_version_bump.mli
+++ b/test/irmin-pack/test_pack_version_bump.mli
@@ -1,1 +1,4 @@
-val tests : unit Alcotest.test_case list
+val tests :
+  sr:Eio__Flow.source_ty Eio.Std.r ->
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  unit Alcotest.test_case list

--- a/test/irmin-pack/test_readonly.mli
+++ b/test/irmin-pack/test_readonly.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val tests : unit Alcotest.test_case list
+val tests : fs:Eio.Fs.dir_ty Eio.Path.t -> unit Alcotest.test_case list

--- a/test/irmin-pack/test_snapshot.ml
+++ b/test/irmin-pack/test_snapshot.ml
@@ -17,8 +17,8 @@
 open! Import
 open Common
 
-let root_export = Filename.concat "_build" "test-snapshot-export"
-let root_import = Filename.concat "_build" "test-snapshot-import"
+let root_export ~fs = Eio.Path.(fs / "_build" / "test-snapshot-export")
+let root_import ~fs = Eio.Path.(fs / "_build" / "test-snapshot-import")
 let src = Logs.Src.create "tests.snapshot" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -76,7 +76,9 @@ let decode_with_size rbuf =
   decode_bin_snapshot b (ref 0)
 
 let restore repo ?on_disk buf =
-  let on_disk = (on_disk :> [ `Path of string | `Reuse ] option) in
+  let on_disk =
+    (on_disk :> [ `Path of Eio.Fs.dir_ty Eio.Path.t | `Reuse ] option)
+  in
   let snapshot = S.Snapshot.Import.v ?on_disk repo in
   let total = String.length buf in
   let total_visited = ref 0 in
@@ -123,14 +125,19 @@ let tree2 () =
   let t = S.Tree.add t [ "c" ] "y" in
   S.Tree.add t [ "d" ] "y"
 
-let test_in_memory ~indexing_strategy () =
+let test_in_memory ~fs ~indexing_strategy () =
+  let root_export = root_export ~fs in
+  let root_import = root_import ~fs in
   rm_dir root_export;
   rm_dir root_import;
+  Eio.Switch.run @@ fun sw ->
   let repo_export =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_export)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_export)
   in
   let repo_import =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_import)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_import)
   in
   let test = test ~repo_export ~repo_import in
   let tree1 = S.Tree.singleton [ "a" ] "x" in
@@ -146,15 +153,20 @@ let test_in_memory_minimal =
 let test_in_memory_always =
   test_in_memory ~indexing_strategy:Irmin_pack.Indexing_strategy.always
 
-let test_on_disk ~indexing_strategy () =
+let test_on_disk ~fs ~indexing_strategy () =
+  let root_export = root_export ~fs in
+  let root_import = root_import ~fs in
   rm_dir root_export;
   rm_dir root_import;
-  let index_on_disk = Filename.concat root_import "index_on_disk" in
+  let index_on_disk = Eio.Path.(root_import / "index_on_disk") in
+  Eio.Switch.run @@ fun sw ->
   let repo_export =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_export)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_export)
   in
   let repo_import =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_import)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_import)
   in
   let test = test ~repo_export ~repo_import in
   let tree2 = tree2 () in
@@ -168,9 +180,9 @@ let test_on_disk_minimal =
 let test_on_disk_always =
   test_on_disk ~indexing_strategy:Irmin_pack.Indexing_strategy.always
 
-let start_gc repo commit =
+let start_gc ~fs ~domain_mgr repo commit =
   let commit_key = S.Commit.key commit in
-  let launched = S.Gc.start_exn ~unlink:false repo commit_key in
+  let launched = S.Gc.start_exn ~fs ~domain_mgr ~unlink:false repo commit_key in
   assert launched
 
 let finalise_gc repo =
@@ -179,7 +191,8 @@ let finalise_gc repo =
   | `Idle | `Running -> Alcotest.fail "expected finalised gc"
   | `Finalised _ -> ()
 
-let test_gc ~repo_export ~repo_import ?on_disk expected_visited =
+let test_gc ~fs ~domain_mgr ~repo_export ~repo_import ?on_disk expected_visited
+    =
   (* create the store *)
   let tree1 =
     let t = S.Tree.singleton [ "b"; "a" ] "x0" in
@@ -195,7 +208,7 @@ let test_gc ~repo_export ~repo_import ?on_disk expected_visited =
   in
   let c3 = S.Commit.v repo_export ~parents:[ k1 ] ~info tree3 in
   (* call gc on last commit *)
-  let () = start_gc repo_export c3 in
+  let () = start_gc ~fs ~domain_mgr repo_export c3 in
   let () = finalise_gc repo_export in
   let tree = S.Commit.tree c3 in
   let root_key = S.Tree.key tree |> Option.get in
@@ -217,39 +230,56 @@ let test_gc ~repo_export ~repo_import ?on_disk expected_visited =
 
 let indexing_strategy = Irmin_pack.Indexing_strategy.minimal
 
-let test_gced_store_in_memory () =
+let test_gced_store_in_memory ~fs ~domain_mgr () =
+  let root_export = root_export ~fs in
+  let root_import = root_import ~fs in
   rm_dir root_export;
   rm_dir root_import;
+  Eio.Switch.run @@ fun sw ->
   let repo_export =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_export)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_export)
   in
   let repo_import =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_import)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_import)
   in
-  let () = test_gc ~repo_export ~repo_import 5 in
+  let () = test_gc ~fs ~domain_mgr ~repo_export ~repo_import 5 in
   let () = S.Repo.close repo_export in
   S.Repo.close repo_import
 
-let test_gced_store_on_disk () =
+let test_gced_store_on_disk ~fs ~domain_mgr () =
+  let root_export = root_export ~fs in
+  let root_import = root_import ~fs in
   rm_dir root_export;
   rm_dir root_import;
-  let index_on_disk = Filename.concat root_import "index_on_disk" in
+  let index_on_disk = Eio.Path.(root_import / "index_on_disk") in
+  Eio.Switch.run @@ fun sw ->
   let repo_export =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_export)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_export)
   in
   let repo_import =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_import)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_import)
   in
-  let () = test_gc ~repo_export ~repo_import ~on_disk:(`Path index_on_disk) 5 in
+  let () =
+    test_gc ~fs ~domain_mgr ~repo_export ~repo_import
+      ~on_disk:(`Path index_on_disk) 5
+  in
   let () = S.Repo.close repo_export in
   S.Repo.close repo_import
 
-let test_export_import_reexport () =
+let test_export_import_reexport ~fs ~domain_mgr () =
+  let root_export = root_export ~fs in
+  let root_import = root_import ~fs in
   rm_dir root_export;
   rm_dir root_import;
+  Eio.Switch.run @@ fun sw ->
   (* export a snapshot. *)
   let repo_export =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_export)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_export)
   in
   let tree = S.Tree.singleton [ "a" ] "y" in
   let parent_commit = S.Commit.v repo_export ~parents:[] ~info tree in
@@ -266,7 +296,8 @@ let test_export_import_reexport () =
      a new store, with the key parent of type Indexed. *)
   rm_dir root_export;
   let repo_import =
-    S.Repo.v (config ~readonly:false ~fresh:true ~indexing_strategy root_import)
+    S.Repo.v
+      (config ~sw ~fs ~readonly:false ~fresh:true ~indexing_strategy root_import)
   in
   let _, key = Buffer.contents buf |> restore repo_import in
   let key = Option.get key in
@@ -276,12 +307,15 @@ let test_export_import_reexport () =
   let commit_key = S.Commit.key commit in
   let commit_hash = S.Commit.hash commit in
   (* export the gc-based snapshot in a clean root_export. *)
-  let () = S.create_one_commit_store repo_import commit_key root_export in
+  let () =
+    S.create_one_commit_store ~fs ~domain_mgr repo_import commit_key root_export
+  in
   let () = S.Repo.close repo_import in
   (* open the new store and check that everything is readable. *)
   let repo_export =
     S.Repo.v
-      (config ~readonly:false ~fresh:false ~indexing_strategy root_export)
+      (config ~sw ~fs ~readonly:false ~fresh:false ~indexing_strategy
+         root_export)
   in
   let commit = S.Commit.of_hash repo_export commit_hash in
   let commit = Option.get commit in
@@ -290,15 +324,15 @@ let test_export_import_reexport () =
   Alcotest.(check (option string)) "find blob" (Some "x") got;
   S.Repo.close repo_export
 
-let tests =
+let tests ~fs ~domain_mgr =
   let tc name f = Alcotest.test_case name `Quick f in
   [
-    tc "in memory minimal" test_in_memory_minimal;
-    tc "in memory always" test_in_memory_always;
-    tc "on disk minimal" test_on_disk_minimal;
-    tc "on disk always" test_on_disk_always;
-    tc "gced store, in memory" test_gced_store_in_memory;
-    tc "gced store, on disk" test_gced_store_on_disk;
+    tc "in memory minimal" (test_in_memory_minimal ~fs);
+    tc "in memory always" (test_in_memory_always ~fs);
+    tc "on disk minimal" (test_on_disk_minimal ~fs);
+    tc "on disk always" (test_on_disk_always ~fs);
+    tc "gced store, in memory" (test_gced_store_in_memory ~fs ~domain_mgr);
+    tc "gced store, on disk" (test_gced_store_on_disk ~fs ~domain_mgr);
     tc "import old snapshot, export gc based snapshot"
-      test_export_import_reexport;
+      (test_export_import_reexport ~fs ~domain_mgr);
   ]

--- a/test/irmin-tezos/irmin_fsck.ml
+++ b/test/irmin-tezos/irmin_fsck.ml
@@ -31,9 +31,10 @@ end
 module Store_tz = Irmin_pack_unix.Checks.Make (Maker_tz)
 
 let () =
-  Eio_main.run @@ fun _ ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
   try
     let store_type = Sys.getenv "STORE" in
-    if store_type = "PACK" then match Store.cli () with _ -> .
+    if store_type = "PACK" then match Store.cli ~fs () with _ -> .
     else raise Not_found
-  with Not_found -> ( match Store_tz.cli () with _ -> .)
+  with Not_found -> ( match Store_tz.cli ~fs () with _ -> .)

--- a/test/irmin/test_conf.ml
+++ b/test/irmin/test_conf.ml
@@ -28,12 +28,6 @@ let test_conf () =
       (Invalid_argument "invalid config key: x") (fun () ->
         ignore (add (empty spec_b) x 1))
   in
-  let specs =
-    Spec.list () |> Seq.map Spec.name |> List.of_seq |> List.sort String.compare
-  in
-  let () =
-    Alcotest.(check (list string)) "Spec list" [ "a"; "b"; "mem" ] specs
-  in
   let keys =
     Spec.keys spec_a
     |> Seq.map (fun (K k) -> name k)

--- a/test/libirmin/test.c
+++ b/test/libirmin/test.c
@@ -17,10 +17,7 @@ TEST test_irmin_value_json(void) {
   PASS();
 }
 
-TEST test_irmin_store(void) {
-  // Setup config
-  AUTO IrminConfig *config = irmin_config_git_mem(NULL);
-
+TEST test_irmin_store(IrminConfig *config) {
   // Initialize repo and store
   AUTO IrminRepo *repo = irmin_repo_new(config);
   AUTO Irmin *store = irmin_main(repo);
@@ -104,6 +101,16 @@ TEST test_irmin_store(void) {
   PASS();
 }
 
+TEST test_irmin_store_git(void) {
+  AUTO IrminConfig *config = irmin_config_git_mem(NULL);
+  return test_irmin_store(config);
+}
+
+TEST test_irmin_store_fs(void) {
+  AUTO IrminConfig *config = irmin_config_fs("sha1", "string");
+  return test_irmin_store(config);
+}
+
 TEST test_irmin_tree(void) {
   // Setup config
   AUTO IrminConfig *config = irmin_config_mem(NULL, NULL);
@@ -158,7 +165,9 @@ int main(int argc, char *argv[]) {
   GREATEST_MAIN_BEGIN();
   irmin_log_level("error");
   RUN_TEST(test_irmin_value_json);
-  RUN_TEST(test_irmin_store);
+  RUN_TEST(test_irmin_store_git);
+  RUN_TEST(test_irmin_store_fs);
   RUN_TEST(test_irmin_tree);
+  caml_shutdown();
   GREATEST_MAIN_END();
 }


### PR DESCRIPTION
(builds on top of the other Eio PRs, only the last commit https://github.com/mirage/irmin/commit/121309c2a25ab10d9de30acba63d5a16823b5268 is new)

The port to Eio of `libirmin` inherited a defect from the previous integration with the Lwt scheduler: Every calls from C into OCaml land would start a fresh scheduler, run the Irmin function, stop the scheduler and return the result to the C world. Not only is it inefficient to start/stop the scheduler so often, stopping Eio will also close any opened database files thanks to its strict resource management... which was not an issue before as Lwt allowed us to leak the open files across calls!

To address this, @talex5 recommended that we spawn a new domain to run the Eio scheduler on, with the C thread submitting request to it and blocking until the response comes back... but since `libirmin` doesn't expose any "async" operations to C, we would always have a single domain active at a time (either the C thread or the Eio one).
So it was slightly easier and more fun to flex some effect handlers to achieve the same outcome without a second domain:
- We start the Eio scheduler once on the first C call to an Irmin function, but we don't let Eio stop as we suspend it by performing an effect and save its continuation for later
- The next C call to Irmin will resume the suspended Eio scheduler, just long enough to run the Irmin function in its scope, then suspend the scheduler again, etc

cc @kayceesrk "Eio dawg, I heard you like schedulers"