### PR TITLE
irmin-client: do not duplicate connections on clone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+### Added
+
+### Fixed
+
+- **irmin-client**
+  - Fix a fd lead when using `clone` (#2322, @samoht)
+
+### Removed
+
 ## 3.9.0 (2023-10-05)
 
 ### Added

--- a/src/irmin-client/client.ml
+++ b/src/irmin-client/client.ml
@@ -527,7 +527,6 @@ struct
 
   let clone ~src ~dst =
     let repo = repo src in
-    let* repo = dup repo in
     let* () =
       Head.find src >>= function
       | None -> Branch.remove repo dst


### PR DESCRIPTION
This is (1) not needed to work properly as clone doesn't need to hold any special state in the connection; and (2) this is opening another file descriptor that is usually never closed.