### PR TITLE
irmin-git: fix sync example, initialize mirage-crypto-rng

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,12 @@
 ### Fixed
 
 - **irmin-client**
-  - Fix a fd lead when using `clone` (#2322, @samoht)
+  - Fix a fd leak when using `clone` (#2322, @samoht)
+- **irmin-git**
+  - Fix git sync example (#2327, @art-w)
 - **irmin**
   - Fix CI, update dependencies (#2321, @smorimoto)
+  - Update documentation (#2323, #2324, #2325, @christinerose)
 
 ### Removed
 

--- a/examples/dune
+++ b/examples/dune
@@ -20,6 +20,7 @@
   irmin-graphql.unix
   irmin-pack.unix
   irmin-watcher
+  mirage-crypto-rng.unix
   websocket-lwt-unix
   conduit-lwt-unix
   lwt

--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -16,6 +16,7 @@
 
 open Lwt.Syntax
 
+let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
 let info = Irmin_git_unix.info
 
 let path =


### PR DESCRIPTION
As reported by @kentookura and @jonsterling in https://github.com/mirage/irmin/issues/2319 , on some platforms it is necessary to initialize the mirage crypto rng before using irmin-git Sync.