### PR TITLE
irmin-git: expose Content_addressable type

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.0
+version = 0.26.2
 profile = conventional
 
 ocaml-version = 4.08.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Added
+
+- **irmin-git**
+  - Expose `Content_addressable` type (#2329, @art-w)
+
 ### Fixed
 
 - **irmin-client**

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -110,7 +110,8 @@ module Content_addressable (G : Git.S) = struct
     let v ?dotgit:_ _root = assert false
   end
 
-  module type S = Irmin.Content_addressable.S with type _ t = G.t and type key = G.Hash.t
+  module type S =
+    Irmin.Content_addressable.S with type _ t = G.t and type key = G.Hash.t
 
   module Maker = Maker_ext (G) (No_sync)
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -110,7 +110,7 @@ module Content_addressable (G : Git.S) = struct
     let v ?dotgit:_ _root = assert false
   end
 
-  module type S = Irmin.Content_addressable.S with type key = G.Hash.t
+  module type S = Irmin.Content_addressable.S with type _ t = G.t and type key = G.Hash.t
 
   module Maker = Maker_ext (G) (No_sync)
 
@@ -125,11 +125,12 @@ module Content_addressable (G : Git.S) = struct
     module M = Maker.Make (Schema)
     module X = M.Backend.Contents
 
+    type 'a t = G.t
+
     let state t =
-      let+ r = M.repo_of_git (snd t) in
+      let+ r = M.repo_of_git t in
       M.Backend.Repo.contents_t r
 
-    type 'a t = bool ref * G.t
     type key = X.key
     type value = X.value
 

--- a/src/irmin-git/irmin_git_intf.ml
+++ b/src/irmin-git/irmin_git_intf.ml
@@ -116,7 +116,8 @@ module type Sigs = sig
     (** Use Git as a content-addressable store. Values will be stored into
         [.git/objects].*)
 
-    module type S = Irmin.Content_addressable.S with type _ t = G.t and type key = G.Hash.t
+    module type S =
+      Irmin.Content_addressable.S with type _ t = G.t and type key = G.Hash.t
 
     module Make (V : Irmin.Type.S) : S with type value = V.t
   end

--- a/src/irmin-git/irmin_git_intf.ml
+++ b/src/irmin-git/irmin_git_intf.ml
@@ -116,7 +116,7 @@ module type Sigs = sig
     (** Use Git as a content-addressable store. Values will be stored into
         [.git/objects].*)
 
-    module type S = Irmin.Content_addressable.S with type key = G.Hash.t
+    module type S = Irmin.Content_addressable.S with type _ t = G.t and type key = G.Hash.t
 
     module Make (V : Irmin.Type.S) : S with type value = V.t
   end


### PR DESCRIPTION
As reported in #2328 the Irmin_git `Content_addressable` functor is unusable since its type `t` is private. An alternative to this PR would be to hide the CA module, since it's unused, and its presence encourages users to write code that doesn't work with git remote sync...