### PR TITLE
Format bullet list

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,6 +9,5 @@ This project follows the OCaml Code of Conduct [enforcement policy](https://gith
 To report any violations, please contact:
 - Thomas Gazagnaire <thomas [at] tarides [dot] com>
 - Arthur Wendling <arthur [at] tarides [dot] com>
-- Kevin Smith <kevin [at] tarides [dot] com>
 - Gwenaëlle Lecat <gwenaelle [at] tarides [dot] com>
 - Vincent Balat <vincent.balat [at] tarides [dot] com>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,8 +7,8 @@ This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/co
 This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
 
 To report any violations, please contact:
-Thomas Gazagnaire <thomas [at] tarides [dot] com>
-Arthur Wendling <arthur [at] tarides [dot] com>
-Kevin Smith <kevin [at] tarides [dot] com>
-Gwenaëlle Lecat <gwenaelle [at] tarides [dot] com>
-Vincent Balat <vincent.balat [at] tarides [dot] com>
+- Thomas Gazagnaire <thomas [at] tarides [dot] com>
+- Arthur Wendling <arthur [at] tarides [dot] com>
+- Kevin Smith <kevin [at] tarides [dot] com>
+- Gwenaëlle Lecat <gwenaelle [at] tarides [dot] com>
+- Vincent Balat <vincent.balat [at] tarides [dot] com>


### PR DESCRIPTION
Small change to format the contact list, as they were all appearing one after the other instead of in a bullet list.