### PR TITLE
irmin_git: `fetch_all` for fetching all refs of a remote repo

### DIFF
--- a/src/irmin/remote.ml
+++ b/src/irmin/remote.ml
@@ -28,6 +28,9 @@ module None (H : Type.S) (R : Type.S) = struct
   let fetch () ?depth:_ _ _br =
     Lwt.return (Error (`Msg "fetch operation is not available"))
 
+  let fetch_all () ?depth:_ _ =
+    Lwt.return [ Error (`Msg "fetch_all operation is not available") ]
+
   let push () ?depth:_ _ _br =
     Lwt.return (Error (`Msg "push operation is not available"))
 end

--- a/src/irmin/remote_intf.ml
+++ b/src/irmin/remote_intf.ml
@@ -42,6 +42,15 @@ module type S = sig
       same name, which is now in the local store. [No_head] means no such branch
       exists. *)
 
+  val fetch_all :
+    t ->
+    ?depth:int ->
+    endpoint ->
+    (commit option, [> `Msg of string ]) result list Lwt.t
+  (** [fetch_all t] is like [fetch] but fetches every remote reference, not just
+      the one associated with a particular branch. It returns list of all
+      reference heads, which are all now in the local store. *)
+
   val push :
     t ->
     ?depth:int ->


### PR DESCRIPTION
This PR adds a function very similar to `fetch` but that fetches and stores every remote Ref instead of just the one associated with a branch. It returns the list of all Ref heads.

---

I use this function (available from a vendored version of `irmin`) to get [all of the branch names in a remote repo](https://github.com/zazedd/radiocarbon-website/blob/2e4ba20fdb93700aed2d908128361895e769bca6/lib/files_db.ml#L101) and to [prepare to merge a branch into main](https://github.com/zazedd/radiocarbon-website/blob/2e4ba20fdb93700aed2d908128361895e769bca6/src/handlers/contributions.ml#L89).
