### PR TITLE
Rename Irmin.Node.S.effect type to read_effect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@
 - **irmin-git**
   - Expose `Content_addressable` type (#2329, @art-w)
 
+### Changed
+
+- **irmin**
+  - Rename `Node.S.effect` to `read_effect` for OCaml 5.3 compatibility (#2347, @art-w)
+
 ### Fixed
 
 - **irmin-client**

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -124,10 +124,10 @@ module type Core = sig
       purpose (so [Tree.hash] and [Tree.equal] are not in the Lwt monad as
       well). *)
 
-  type effect := expected_depth:int -> node_key -> t option
+  type read_effect := expected_depth:int -> node_key -> t option
   (** The type for read effects. *)
 
-  val with_handler : (effect -> effect) -> t -> t
+  val with_handler : (read_effect -> read_effect) -> t -> t
   (** [with_handler f] replace the current effect handler [h] by [f h]. [f h]
       will be called for all the recursive read effects that are required by
       recursive operations on nodes. .*)


### PR DESCRIPTION
`effect` is a keyword in OCaml 5.3 https://github.com/mirage/irmin/issues/2346