### PR TITLE
Upgrade to `mirage-crypto-rng` and relay on `use_default`

### DIFF
--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -16,7 +16,7 @@
 
 open Lwt.Syntax
 
-let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
+let () = Mirage_crypto_rng_unix.use_default ()
 let info = Irmin_git_unix.info
 
 let path =

--- a/irmin-client.opam
+++ b/irmin-client.opam
@@ -24,7 +24,7 @@ depends: [
   "irmin-test" {= version & with-test}
   "alcotest-lwt" {with-test & >= "1.8.0"}
   "irmin-watcher" {with-test & >= "0.5.0"}
-  "mirage-crypto-rng-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/test/irmin-client/dune
+++ b/test/irmin-client/dune
@@ -8,7 +8,7 @@
   websocket-lwt-unix
   conduit-lwt-unix
   alcotest-lwt
-  mirage-crypto-rng-lwt
+  mirage-crypto-rng.unix
   irmin-test
   irmin-watcher)
  (enabled_if

--- a/test/irmin-client/util.ml
+++ b/test/irmin-client/util.ml
@@ -16,7 +16,7 @@
 
 open Lwt.Infix
 
-let () = Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna)
+let () = Mirage_crypto_rng_unix.use_default ()
 
 module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
 module Client = Irmin_client_unix.Make (Store)


### PR DESCRIPTION
cf: https://github.com/mirage/mirage-crypto/pull/256

Installing Irmin, currently, leads to a depreciation alert on `rng` initialization.