### PR TITLE
improve irmin-fs path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _opam
 .#*
 .*.swp
 **/.DS_Store
+examples/irmin_example
+irmin-pack-example

--- a/examples/dune
+++ b/examples/dune
@@ -1,5 +1,6 @@
 (executables
  (names
+  fs_branches
   readme
   trees
   sync
@@ -19,6 +20,7 @@
   irmin.unix
   irmin-client.unix
   irmin-git.unix
+  irmin-fs.unix
   irmin-graphql.unix
   irmin-pack.unix
   irmin-watcher
@@ -35,6 +37,7 @@
 (alias
  (name examples)
  (deps
+  fs_branches.exe
   readme.exe
   trees.exe
   sync.exe
@@ -51,6 +54,7 @@
  (name runtest)
  (package irmin-cli)
  (deps
+  fs_branches.exe
   readme.exe
   trees.exe
   sync.exe

--- a/examples/fs_branches.ml
+++ b/examples/fs_branches.ml
@@ -1,0 +1,21 @@
+module Store = Irmin_fs_unix.KV.Make (Irmin.Contents.String)
+
+let info () = Irmin.Info.Default.v ~message:"Commit" (Mtime_clock.now_ns ())
+
+let main env =
+  let conf =
+    Irmin_fs_unix.config
+      ~root:Eio.Path.(env#cwd / "irmin_example")
+      ~clock:env#clock
+  in
+  let repo = Store.Repo.v conf in
+  let main = Store.main repo in
+  Store.set_exn ~info main [ "a" ] "hello";
+  let b1 = Store.of_branch repo "exp1" in
+  Store.set_exn ~info b1 [ "a" ] "world";
+  let branches = Store.Branch.list repo in
+  Eio.traceln "Branches: [%a]\n%!"
+    Fmt.(list ~sep:(Fmt.any ", ") string)
+    branches
+
+let () = Eio_main.run main

--- a/irmin-test.opam
+++ b/irmin-test.opam
@@ -25,7 +25,6 @@ depends: [
   "eio"          {>= "1.0"}
   "eio_main"     {>= "0.15"}
   "alcotest"     {>= "1.8.0"}
-  "qcheck-alcotest" {with-test & >= "0.21.1"}
   "metrics"      {>= "0.4.1"}
   "metrics-unix" {>= "0.4.1"}
   "ocaml-syntax-shims"

--- a/src/irmin-fs/unix/irmin_fs_unix.ml
+++ b/src/irmin-fs/unix/irmin_fs_unix.ml
@@ -35,10 +35,10 @@ let spec ~path:fs ~clock =
   let fs = (fs :> fs) in
   let _fs_key =
     let to_string fs = Eio.Path.native_exn fs in
-    let of_string str = Ok Eio.Path.(fs / str) in
+    let of_string _str = Ok fs in
     let of_json_string str =
       match Irmin.Type.(of_json_string string) str with
-      | Ok str -> Ok Eio.Path.(fs / str)
+      | Ok _str -> Ok fs
       | Error e -> Error e
     in
     Conf.serialized_key ~typ:fs_typ ~spec ~typename:"_ Eio.Path.t" ~to_string
@@ -54,7 +54,7 @@ let spec ~path:fs ~clock =
   in
   spec
 
-let conf ~path ~clock = Conf.empty (spec ~path ~clock)
+let config ~root ~clock = Conf.empty (spec ~path:root ~clock)
 
 module IO = struct
   type nonrec io = io
@@ -236,6 +236,14 @@ module IO = struct
           in
           true)
 
+  let string_chop_prefix ~prefix str =
+    let open Astring in
+    let len = String.length prefix in
+    if String.length str <= len then str
+    else
+      let s = String.with_range ~len str in
+      if String.equal s prefix then String.with_range str ~first:len else str
+
   let rec_files ~io:{ fs; _ } dir : path list =
     let dir = Path.(fs / dir) in
     let rec aux accu dir =
@@ -243,7 +251,9 @@ module IO = struct
       let fs = files dir in
       List.fold_left aux (fs @ accu) ds
     in
-    aux [] dir |> List.map snd
+    aux [] dir
+    |> List.map (fun x ->
+           string_chop_prefix ~prefix:(Filename.concat (snd dir) "") @@ snd x)
 
   let mkdir ~io:{ fs; _ } dirname = mkdir Path.(fs / dirname)
 end

--- a/src/irmin-fs/unix/irmin_fs_unix.ml
+++ b/src/irmin-fs/unix/irmin_fs_unix.ml
@@ -35,10 +35,15 @@ let spec ~path:fs ~clock =
   let fs = (fs :> fs) in
   let _fs_key =
     let to_string fs = Eio.Path.native_exn fs in
-    let of_string _str = Ok fs in
+    let of_string str =
+      assert (str = Eio.Path.native_exn fs);
+      Ok fs
+    in
     let of_json_string str =
       match Irmin.Type.(of_json_string string) str with
-      | Ok _str -> Ok fs
+      | Ok str ->
+          assert (str = Eio.Path.native_exn fs);
+          Ok fs
       | Error e -> Error e
     in
     Conf.serialized_key ~typ:fs_typ ~spec ~typename:"_ Eio.Path.t" ~to_string

--- a/src/irmin-fs/unix/irmin_fs_unix.mli
+++ b/src/irmin-fs/unix/irmin_fs_unix.mli
@@ -34,4 +34,4 @@ include module type of Irmin_unix
 val spec :
   path:_ Eio.Path.t -> clock:_ Eio.Time.clock -> Irmin.Backend.Conf.Spec.t
 
-val conf : path:_ Eio.Path.t -> clock:_ Eio.Time.clock -> Irmin.Backend.Conf.t
+val config : root:_ Eio.Path.t -> clock:_ Eio.Time.clock -> Irmin.Backend.Conf.t

--- a/test/irmin-fs/test_fs_unix.ml
+++ b/test/irmin-fs/test_fs_unix.ml
@@ -39,5 +39,5 @@ let clean ~config =
   Irmin.Backend.Watch.(set_listen_dir_hook none)
 
 let suite ~path ~clock =
-  let config = Irmin_fs_unix.conf ~path ~clock in
+  let config = Irmin_fs_unix.config ~root:path ~clock in
   Irmin_test.Suite.create ~name:"FS.UNIX" ~init ~store ~config ~clean ~stats ()

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -44,8 +44,8 @@ type action = Add of key * int | Clear
 let add k v = Add (k, v)
 let clear = Clear
 
-let gen_action =
-  QCheck.Gen.(oneof_weighted [ (5, map2 add nat_small nat); (1, pure clear) ])
+let[@alert "-deprecated"] gen_action =
+  QCheck.Gen.(frequency [ (5, map2 add int_small nat); (1, pure clear) ])
 
 let print_action = function
   | Add (k, v) -> Fmt.str "add %d %d" k v

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -45,7 +45,7 @@ let add k v = Add (k, v)
 let clear = Clear
 
 let[@alert "-deprecated"] gen_action =
-  QCheck.Gen.(frequency [ (5, map2 add int_small nat); (1, pure clear) ])
+  QCheck.Gen.(frequency [ (5, map2 add small_int nat); (1, pure clear) ])
 
 let print_action = function
   | Add (k, v) -> Fmt.str "add %d %d" k v


### PR DESCRIPTION
Fixes #2375

The way configuration is currently done is a little confusing because it separates the Eio fs path from the path to the store. This PR is an attempt to combine the `path` and `root` into a single `root` parameter. This now looks like:

```ocaml
  let conf =
    Irmin_fs_unix.config
      ~root:Eio.Path.(env#cwd / "irmin_example")
      ~clock:env#clock
  in
```

One trade-off is in the way this handles encoding/decoding. Since there is not a good way (that I know of) to build an absolute path from another absolute path in Eio, this PR just validates that the `fs` path matches the encoded path. Open to suggestions, but I'm not sure how much it really matters.