### PR TITLE
Fix repo initialization with opam

### DIFF
--- a/dune
+++ b/dune
@@ -6,6 +6,7 @@
 
 (mdx
  (files README.md)
+ (package irmin-cli)
  (deps %{bin:irmin})
  (libraries
   irmin

--- a/examples/dune
+++ b/examples/dune
@@ -64,6 +64,7 @@
 (mdx
  (files merkle_proofs.md)
  (deps %{bin:irmin})
+ (package irmin-cli)
  (libraries
   irmin
   irmin-cli

--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -45,7 +45,7 @@ let add k v = Add (k, v)
 let clear = Clear
 
 let gen_action =
-  QCheck.Gen.(frequency [ (5, map2 add small_int nat); (1, pure clear) ])
+  QCheck.Gen.(oneof_weighted [ (5, map2 add nat_small nat); (1, pure clear) ])
 
 let print_action = function
   | Add (k, v) -> Fmt.str "add %d %d" k v


### PR DESCRIPTION
This PR fixes issues when installing/initializing a new opam switch using something like 

```sh
$ opam switch install . --with-test --with-dev
```