### PR TITLE
Add CI job building irmin with dune package management

### DIFF
--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -1,0 +1,18 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Use dune
+        uses: ocaml-dune/setup-dune@fd640f52b2a84d68cd4867cb5972247b70630d1a
+        with:
+          workspace: dune-workspace.for-ci

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _opam
 **/.DS_Store
 examples/irmin_example
 irmin-pack-example
+dune.lock/

--- a/dune-workspace.for-ci
+++ b/dune-workspace.for-ci
@@ -1,0 +1,3 @@
+(lang dune 3.22)
+
+(pkg enabled)

--- a/irmin-cli.opam
+++ b/irmin-cli.opam
@@ -59,7 +59,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d" ]
+  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#675125d9e95cd09ef0c18ab1d9d6d69a26856b9f" ]
 ]
 
 synopsis: "CLI for Irmin"

--- a/irmin-client.opam
+++ b/irmin-client.opam
@@ -27,7 +27,7 @@ depends: [
   "lwt-dllist" {>= "1.0.1"}
 ]
 pin-depends: [
-  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d" ]
+  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#675125d9e95cd09ef0c18ab1d9d6d69a26856b9f" ]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/irmin-fs.opam
+++ b/irmin-fs.opam
@@ -26,7 +26,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d" ]
+  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#675125d9e95cd09ef0c18ab1d9d6d69a26856b9f" ]
 ]
 
 synopsis: "Generic file-system backend for Irmin"

--- a/irmin-git.opam
+++ b/irmin-git.opam
@@ -39,7 +39,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d" ]
+  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#675125d9e95cd09ef0c18ab1d9d6d69a26856b9f" ]
 ]
 
 synopsis: "Git backend for Irmin"

--- a/irmin-server.opam
+++ b/irmin-server.opam
@@ -31,7 +31,7 @@ depends: [
 ]
 
 pin-depends: [
-  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d" ]
+  [ "irmin-watcher.dev" "git+https://github.com/patricoferris/irmin-watcher#675125d9e95cd09ef0c18ab1d9d6d69a26856b9f" ]
 ]
 
 build: [

--- a/test/irmin-pack/test_stm/tree_model.ml
+++ b/test/irmin-pack/test_stm/tree_model.ml
@@ -61,10 +61,10 @@ module TreeModel = struct
                 if name <> p then (name, subtree) else (name, aux subtree ps))
               subtrees
             |> List.filter (fun (_, subtree) ->
-                   match subtree with
-                   | Contents _ -> true
-                   | Node [] -> false
-                   | Node _ -> true)
+                match subtree with
+                | Contents _ -> true
+                | Node [] -> false
+                | Node _ -> true)
           in
           Node nsubtrees
     in


### PR DESCRIPTION
Hello irmin folks!
We've been wanting to make sure that irmin can be built using dune package management, and this PR introduces a CI job that can make that check automatically.
If you were to try building irmin with 'stock' dune (3.20.2) with pkg enabled, you'd hit a error related to `irmin-watcher`.
Since ocaml/dune#13232, this is now fixed, and dune (on its `main` branch) can be used by irmin devs as a daily driver!

Note that this PR is built on top of #2387