### PR TITLE
Fix test_stm by using posix Eio backend

### DIFF
--- a/test/irmin-pack/test_stm/dune
+++ b/test/irmin-pack/test_stm/dune
@@ -1,6 +1,6 @@
-(test
+; Use posix backend to avoid io_uring resource exhaustion on Linux
+(executable
  (name test_stm)
- (package irmin-test)
  (modules test_stm tree_model common_model)
  (libraries
   common
@@ -16,6 +16,11 @@
   irmin-pack.mem
   irmin.mem
   irmin-tezos))
+
+(rule
+ (alias runtest)
+ (package irmin-test)
+ (action (setenv EIO_BACKEND posix (run ./test_stm.exe))))
 
 (test
  (name test_stm_irmin_pack)

--- a/test/irmin-pack/test_stm/dune
+++ b/test/irmin-pack/test_stm/dune
@@ -1,4 +1,5 @@
 ; Use posix backend to avoid io_uring resource exhaustion on Linux
+
 (executable
  (name test_stm)
  (modules test_stm tree_model common_model)
@@ -20,7 +21,11 @@
 (rule
  (alias runtest)
  (package irmin-test)
- (action (setenv EIO_BACKEND posix (run ./test_stm.exe))))
+ (action
+  (setenv
+   EIO_BACKEND
+   posix
+   (run ./test_stm.exe))))
 
 (test
  (name test_stm_irmin_pack)


### PR DESCRIPTION
## Summary
- Fix `test_stm` which was failing on Linux due to io_uring resource exhaustion (`ENOMEM` on `io_uring_queue_init`)
- Use the posix backend via `EIO_BACKEND=posix` environment variable instead of io_uring
- Convert the test stanza to executable + rule pattern to enable setting the environment variable

## Details
The `test_stm` test spawns multiple Eio domains for parallel state machine testing. On machines with fewer cores, this exhausts io_uring resources causing `ENOMEM` errors. The posix backend doesn't have this limitation.

Note: The posix backend still uses multiple cores in parallel. `EIO_BACKEND` only affects how I/O operations are implemented (io_uring vs epoll), not the parallelism model which comes from OCaml 5 domains.

## Test plan
- [x] Verified test passes locally with `EIO_BACKEND=posix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)