### PR TITLE
Fix deprecated QCheck functions in test_lru.ml

### DIFF
--- a/test/irmin/test_lru.ml
+++ b/test/irmin/test_lru.ml
@@ -45,7 +45,7 @@ let add k v = Add (k, v)
 let clear = Clear
 
 let gen_action =
-  QCheck.Gen.(frequency [ (5, map2 add small_int nat); (1, pure clear) ])
+  QCheck.Gen.(oneof_weighted [ (5, map2 add nat_small nat); (1, pure clear) ])
 
 let print_action = function
   | Add (k, v) -> Fmt.str "add %d %d" k v


### PR DESCRIPTION
## Summary
- Update test_lru.ml to use non-deprecated QCheck.Gen functions

## Changes
- `frequency` → `oneof_weighted`
- `small_int` → `nat_small`

## Problem
Build fails with recent qcheck-alcotest due to deprecated function alerts being treated as errors.

## Test plan
- [x] `dune build` succeeds
- [x] `dune runtest test/irmin` passes

🤖 Generated with [Claude Code](https://claude.ai/code)