### PR TITLE
Multicore safety protect shared mutable state with mutexes and atomics

### DIFF
--- a/src/irmin-fs/irmin_fs.ml
+++ b/src/irmin-fs/irmin_fs.ml
@@ -354,13 +354,19 @@ module IO_mem = struct
   type lock = Eio.Mutex.t
 
   let locks = Hashtbl.create 10
+  let global_lock = Eio.Mutex.create ()
 
   let lock_file ~io:() file =
-    try Hashtbl.find locks file
-    with Not_found ->
-      let l = Eio.Mutex.create () in
-      Hashtbl.add locks file l;
-      l
+    Eio.Mutex.lock global_lock;
+    let l =
+      try Hashtbl.find locks file
+      with Not_found ->
+        let l = Eio.Mutex.create () in
+        Hashtbl.add locks file l;
+        l
+    in
+    Eio.Mutex.unlock global_lock;
+    l
 
   let with_lock ~io:() l f =
     match l with None -> f () | Some l -> Eio.Mutex.use_rw ~protect:false l f

--- a/src/irmin-fs/unix/irmin_fs_unix.ml
+++ b/src/irmin-fs/unix/irmin_fs_unix.ml
@@ -123,16 +123,16 @@ module IO = struct
             let flow = Path.open_out ~sw file ~create:(`Exclusive 0o600) in
             Flow.copy_string (string_of_int pid) flow
           in
-          try create () with
-          | Eio.Io (Fs.E (Fs.Already_exists _), _) ->
-              let backoff =
-                1.
-                +. Random.float
-                     (let i = float i in
-                      i *. i)
-              in
-              Eio.Time.sleep io.clock (sleep *. backoff);
-              aux (i + 1)
+          try create ()
+          with Eio.Io (Fs.E (Fs.Already_exists _), _) ->
+            let backoff =
+              1.
+              +. Random.float
+                   (let i = float i in
+                    i *. i)
+            in
+            Eio.Time.sleep io.clock (sleep *. backoff);
+            aux (i + 1)
       in
       aux 1
 

--- a/src/irmin-fs/unix/irmin_fs_unix.ml
+++ b/src/irmin-fs/unix/irmin_fs_unix.ml
@@ -133,7 +133,6 @@ module IO = struct
               in
               Eio.Time.sleep io.clock (sleep *. backoff);
               aux (i + 1)
-          | e -> raise e
       in
       aux 1
 

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -2406,10 +2406,10 @@ struct
   let decode_bin_length = Inter.Raw.decode_bin_length
 
   let protect_from_invalid_depth_exn f =
-    try f () with
-    | Invalid_depth { expected; got; v } ->
-        let msg = Fmt.to_to_string pp_invalid_depth (expected, got, v) in
-        Error msg
+    try f ()
+    with Invalid_depth { expected; got; v } ->
+      let msg = Fmt.to_to_string pp_invalid_depth (expected, got, v) in
+      Error msg
 
   let integrity_check_inodes t k =
     protect_from_invalid_depth_exn @@ fun () ->

--- a/src/irmin-pack/inode.ml
+++ b/src/irmin-pack/inode.ml
@@ -2410,7 +2410,6 @@ struct
     | Invalid_depth { expected; got; v } ->
         let msg = Fmt.to_to_string pp_invalid_depth (expected, got, v) in
         Error msg
-    | e -> raise e
 
   let integrity_check_inodes t k =
     protect_from_invalid_depth_exn @@ fun () ->

--- a/src/irmin-pack/io/append_only_file.ml
+++ b/src/irmin-pack/io/append_only_file.ml
@@ -29,9 +29,8 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
     buf_length : int Atomic.t;
     lock : Eio.Mutex.t;
   }
-  (** [rw_perm] contains the data necessary to operate in readwrite mode.
-      [lock] serialises concurrent access to [buf] between [append_exn] and
-      [flush]. *)
+  (** [rw_perm] contains the data necessary to operate in readwrite mode. [lock]
+      serialises concurrent access to [buf] between [append_exn] and [flush]. *)
 
   type t = {
     io : Io.t;
@@ -52,8 +51,12 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
   let with_rw_lock rw_perm f =
     Eio.Mutex.lock rw_perm.lock;
     match f () with
-    | x -> Eio.Mutex.unlock rw_perm.lock; x
-    | exception ex -> Eio.Mutex.unlock rw_perm.lock; raise ex
+    | x ->
+        Eio.Mutex.unlock rw_perm.lock;
+        x
+    | exception ex ->
+        Eio.Mutex.unlock rw_perm.lock;
+        raise ex
 
   let create_rw ~sw ~path ~overwrite =
     let open Result_syntax in
@@ -154,8 +157,7 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
   let flush t =
     match t.rw_perm with
     | None -> Error `Ro_not_allowed
-    | Some rw_perm ->
-        with_rw_lock rw_perm @@ fun () -> flush_locked t rw_perm
+    | Some rw_perm -> with_rw_lock rw_perm @@ fun () -> flush_locked t rw_perm
 
   let fsync t =
     match t.rw_perm with

--- a/src/irmin-pack/io/append_only_file.ml
+++ b/src/irmin-pack/io/append_only_file.ml
@@ -27,8 +27,11 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
     fsync_required : bool Atomic.t;
     buf : Buffer.t;
     buf_length : int Atomic.t;
+    lock : Eio.Mutex.t;
   }
-  (** [rw_perm] contains the data necessary to operate in readwrite mode. *)
+  (** [rw_perm] contains the data necessary to operate in readwrite mode.
+      [lock] serialises concurrent access to [buf] between [append_exn] and
+      [flush]. *)
 
   type t = {
     io : Io.t;
@@ -43,7 +46,14 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
         fsync_required = Atomic.make false;
         buf = Buffer.create 0;
         buf_length = Atomic.make 0;
+        lock = Eio.Mutex.create ();
       }
+
+  let with_rw_lock rw_perm f =
+    Eio.Mutex.lock rw_perm.lock;
+    match f () with
+    | x -> Eio.Mutex.unlock rw_perm.lock; x
+    | exception ex -> Eio.Mutex.unlock rw_perm.lock; raise ex
 
   let create_rw ~sw ~path ~overwrite =
     let open Result_syntax in
@@ -124,24 +134,28 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
         Atomic.set t.persisted_end_poff new_end_poff;
         Ok ()
 
+  (* [flush_locked] assumes the caller already holds [rw_perm.lock]. *)
+  let flush_locked t rw_perm =
+    let open Result_syntax in
+    let open Int63.Syntax in
+    let s = Buffer.contents rw_perm.buf in
+    let persisted_end_poff = Atomic.get t.persisted_end_poff in
+    let off = persisted_end_poff + t.dead_header_size in
+    let+ () = Io.write_string t.io ~off s in
+    Atomic.set rw_perm.buf_length 0;
+    Atomic.set t.persisted_end_poff
+      (persisted_end_poff + (String.length s |> Int63.of_int));
+    (* [truncate] is semantically identical to [clear], except that
+       [truncate] doesn't deallocate the internal buffer. We use
+       [clear] in legacy_io. *)
+    Buffer.truncate rw_perm.buf 0;
+    Atomic.set rw_perm.fsync_required true
+
   let flush t =
     match t.rw_perm with
     | None -> Error `Ro_not_allowed
     | Some rw_perm ->
-        let open Result_syntax in
-        let open Int63.Syntax in
-        let s = Buffer.contents rw_perm.buf in
-        let persisted_end_poff = Atomic.get t.persisted_end_poff in
-        let off = persisted_end_poff + t.dead_header_size in
-        let+ () = Io.write_string t.io ~off s in
-        Atomic.set rw_perm.buf_length 0;
-        Atomic.set t.persisted_end_poff
-          (persisted_end_poff + (String.length s |> Int63.of_int));
-        (* [truncate] is semantically identical to [clear], except that
-           [truncate] doesn't deallocate the internal buffer. We use
-           [clear] in legacy_io. *)
-        Buffer.truncate rw_perm.buf 0;
-        Atomic.set rw_perm.fsync_required true
+        with_rw_lock rw_perm @@ fun () -> flush_locked t rw_perm
 
   let fsync t =
     match t.rw_perm with
@@ -174,6 +188,7 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
     match t.rw_perm with
     | None -> raise Errors.RO_not_allowed
     | Some rw_perm ->
+        with_rw_lock rw_perm @@ fun () ->
         assert (Atomic.get rw_perm.buf_length < auto_flush_threshold);
         Buffer.add_string rw_perm.buf s;
         let (_ : int) =
@@ -181,5 +196,5 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
         in
         let buf_length = Atomic.get rw_perm.buf_length in
         if buf_length >= auto_flush_threshold then
-          flush t |> Errs.raise_if_error
+          flush_locked t rw_perm |> Errs.raise_if_error
 end

--- a/src/irmin-pack/io/chunked_suffix.ml
+++ b/src/irmin-pack/io/chunked_suffix.ml
@@ -85,22 +85,26 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
     val count : t -> int
     (** [count t] is the number of chunks *)
   end = struct
-    type t = { mutable chunks : chunk Array.t }
+    type t = { chunks : chunk Array.t Atomic.t }
 
     exception OpenInventoryError of open_error
 
-    let v num create = { chunks = Array.init num create }
-    let appendable t = Array.get t.chunks (Array.length t.chunks - 1)
+    let v num create = { chunks = Atomic.make (Array.init num create) }
+
+    let appendable t =
+      let chunks = Atomic.get t.chunks in
+      Array.get chunks (Array.length chunks - 1)
 
     let find ~off t =
       let open Int63.Syntax in
+      let chunks = Atomic.get t.chunks in
       let suffix_off_to_chunk_poff c = off - c.suffix_off in
       let find c =
         let end_poff = Ao.end_poff c.ao in
         let poff = suffix_off_to_chunk_poff c in
         Int63.zero <= poff && poff < end_poff
       in
-      match Array.find_opt find t.chunks with
+      match Array.find_opt find chunks with
       | None -> raise (Errors.Pack_error `Read_out_of_bounds)
       | Some c -> (c, suffix_off_to_chunk_poff c)
 
@@ -111,12 +115,13 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
     let is_legacy chunk_idx = chunk_idx = 0
 
     let fold f acc t =
+      let chunks = Atomic.get t.chunks in
       let appendable_idx = (appendable t).idx in
       Array.fold_left
         (fun acc chunk ->
           let is_appendable = chunk.idx = appendable_idx in
           f ~acc ~is_appendable ~chunk)
-        acc t.chunks
+        acc chunks
 
     let open_ ~start_idx ~chunk_num ~open_chunk =
       let off_acc = ref Int63.zero in
@@ -137,9 +142,10 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
         Error (err : open_error :> [> open_error ])
 
     let close t =
+      let chunks = Atomic.get t.chunks in
       (* Close immutable chunks, ignoring errors. *)
       let _ =
-        Array.sub t.chunks 0 (Array.length t.chunks - 1)
+        Array.sub chunks 0 (Array.length chunks - 1)
         |> Array.iter @@ fun chunk ->
            let _ = Ao.close chunk.ao in
            ()
@@ -164,8 +170,9 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
       let* ao =
         open_chunk ~chunk_idx:idx ~is_legacy ~is_appendable:false |> wrap_error
       in
-      let pos = Array.length t.chunks - 1 in
-      t.chunks.(pos) <- { last_chunk with ao };
+      let chunks = Atomic.get t.chunks in
+      let pos = Array.length chunks - 1 in
+      chunks.(pos) <- { last_chunk with ao };
       Ok length
 
     let create_appendable_chunk ~open_chunk t suffix_off =
@@ -182,15 +189,17 @@ module Make (Io : Io_intf.S) (Errs : Io_errors.S with module Io = Io) = struct
       let* chunk =
         create_appendable_chunk ~open_chunk t next_suffix_off |> wrap_error
       in
-      t.chunks <- Array.append t.chunks [| chunk |];
+      Atomic.set t.chunks (Array.append (Atomic.get t.chunks) [| chunk |]);
       Ok ()
 
     let length t =
       let open Int63.Syntax in
-      Array.fold_left (fun sum c -> sum + Ao.end_poff c.ao) Int63.zero t.chunks
+      Array.fold_left
+        (fun sum c -> sum + Ao.end_poff c.ao)
+        Int63.zero (Atomic.get t.chunks)
 
-    let count t = Array.length t.chunks
-    let start_idx t = t.chunks.(0).idx
+    let count t = Array.length (Atomic.get t.chunks)
+    let start_idx t = (Atomic.get t.chunks).(0).idx
   end
 
   type t = {

--- a/src/irmin-pack/io/dict.ml
+++ b/src/irmin-pack/io/dict.ml
@@ -38,8 +38,12 @@ module Make (Io : Io_intf.S) = struct
   let with_lock t f =
     Eio.Mutex.lock t.lock;
     match f () with
-    | x -> Eio.Mutex.unlock t.lock; x
-    | exception ex -> Eio.Mutex.unlock t.lock; raise ex
+    | x ->
+        Eio.Mutex.unlock t.lock;
+        x
+    | exception ex ->
+        Eio.Mutex.unlock t.lock;
+        raise ex
 
   let empty_buffer t = Ao.empty_buffer t.ao
 

--- a/src/irmin-pack/io/dict.ml
+++ b/src/irmin-pack/io/dict.ml
@@ -28,7 +28,18 @@ module Make (Io : Io_intf.S) = struct
     index : (int, string) Hashtbl.t;
     ao : Ao.t;
     mutable last_refill_offset : int63;
+    lock : Eio.Mutex.t;
   }
+
+  (** [with_lock t f] runs [f ()] while holding [t.lock]. Unlike
+      {!Eio.Mutex.use_rw}, the mutex is not poisoned when [f] raises — the
+      hashtable state is always consistent because exceptions occur before any
+      mutation. *)
+  let with_lock t f =
+    Eio.Mutex.lock t.lock;
+    match f () with
+    | x -> Eio.Mutex.unlock t.lock; x
+    | exception ex -> Eio.Mutex.unlock t.lock; raise ex
 
   let empty_buffer t = Ao.empty_buffer t.ao
 
@@ -41,6 +52,7 @@ module Make (Io : Io_intf.S) = struct
 
   let refill t =
     let open Result_syntax in
+    with_lock t @@ fun () ->
     let from = t.last_refill_offset in
     let new_size = Ao.end_poff t.ao in
     let len = Int63.to_int Int63.Syntax.(new_size - from) in
@@ -67,6 +79,7 @@ module Make (Io : Io_intf.S) = struct
 
   let index t v =
     [%log.debug "[dict] index %S" v];
+    with_lock t @@ fun () ->
     try Some (Hashtbl.find t.cache v)
     with Not_found ->
       let id = Hashtbl.length t.cache in
@@ -79,8 +92,8 @@ module Make (Io : Io_intf.S) = struct
 
   let find t id =
     [%log.debug "[dict] find %d" id];
-    let v = try Some (Hashtbl.find t.index id) with Not_found -> None in
-    v
+    with_lock t @@ fun () ->
+    try Some (Hashtbl.find t.index id) with Not_found -> None
 
   let default_capacity = 100_000
 
@@ -88,7 +101,8 @@ module Make (Io : Io_intf.S) = struct
     let cache = Hashtbl.create 997 in
     let index = Hashtbl.create 997 in
     let last_refill_offset = Int63.zero in
-    { capacity = default_capacity; index; cache; ao; last_refill_offset }
+    let lock = Eio.Mutex.create () in
+    { capacity = default_capacity; index; cache; ao; last_refill_offset; lock }
 
   let create_rw ~sw ~overwrite ~path:filename =
     let open Result_syntax in

--- a/src/irmin-pack/io/file_manager.ml
+++ b/src/irmin-pack/io/file_manager.ml
@@ -143,7 +143,8 @@ struct
     let new_pl =
       {
         pl with
-        appendable_chunk_poff = Suffix.appendable_chunk_poff (Atomic.get t.suffix);
+        appendable_chunk_poff =
+          Suffix.appendable_chunk_poff (Atomic.get t.suffix);
         dict_end_poff = Dict.end_poff t.dict;
         status;
       }
@@ -434,7 +435,8 @@ struct
       in
       (* Step 4. Update end offsets *)
       let* () =
-        Suffix.refresh_appendable_chunk_poff (Atomic.get t.suffix) pl1.appendable_chunk_poff
+        Suffix.refresh_appendable_chunk_poff (Atomic.get t.suffix)
+          pl1.appendable_chunk_poff
       in
       (match hook with Some h -> h `After_suffix | None -> ());
       let* () = Dict.refresh_end_poff t.dict pl1.dict_end_poff in

--- a/src/irmin-pack/io/file_manager.ml
+++ b/src/irmin-pack/io/file_manager.ml
@@ -41,8 +41,8 @@ struct
   type t = {
     dict : Dict.t;
     control : Control.t;
-    mutable suffix : Suffix.t;
-    mutable prefix : Sparse.t option;
+    suffix : Suffix.t Atomic.t;
+    prefix : Sparse.t option Atomic.t;
     lower : Lower.t option;
     index : Index.t;
     mutable prefix_consumers : after_reload_consumer list;
@@ -55,17 +55,17 @@ struct
 
   let control t = t.control
   let dict t = t.dict
-  let suffix t = t.suffix
+  let suffix t = Atomic.get t.suffix
   let index t = t.index
-  let prefix t = t.prefix
+  let prefix t = Atomic.get t.prefix
   let lower t = t.lower
 
   let close t =
     let open Result_syntax in
     let* () = Dict.close t.dict in
     let* () = Control.close t.control in
-    let* () = Suffix.close t.suffix in
-    let* () = Option.might Sparse.close t.prefix in
+    let* () = Suffix.close (Atomic.get t.suffix) in
+    let* () = Option.might Sparse.close (Atomic.get t.prefix) in
     let+ () = Index.close t.index in
     ()
 
@@ -112,12 +112,13 @@ struct
   let flush_suffix t =
     let open Result_syntax in
     let* () =
-      if Suffix.empty_buffer t.suffix then Ok ()
+      let suffix = Atomic.get t.suffix in
+      if Suffix.empty_buffer suffix then Ok ()
       else (
         Stats.incr_fm_field Suffix_flushes;
-        Suffix.flush t.suffix)
+        Suffix.flush suffix)
     in
-    if t.use_fsync then Suffix.fsync t.suffix else Ok ()
+    if t.use_fsync then Suffix.fsync (Atomic.get t.suffix) else Ok ()
 
   let flush_control t =
     let pl : Payload.t = Control.payload t.control in
@@ -142,7 +143,7 @@ struct
     let new_pl =
       {
         pl with
-        appendable_chunk_poff = Suffix.appendable_chunk_poff t.suffix;
+        appendable_chunk_poff = Suffix.appendable_chunk_poff (Atomic.get t.suffix);
         dict_end_poff = Dict.end_poff t.dict;
         status;
       }
@@ -194,7 +195,7 @@ struct
   let fsync t =
     let open Result_syntax in
     let* () = Dict.fsync t.dict in
-    let* () = Suffix.fsync t.suffix in
+    let* () = Suffix.fsync (Atomic.get t.suffix) in
     let* () = Control.fsync t.control in
     Index.flush ~with_fsync:true t.index
 
@@ -225,8 +226,8 @@ struct
     match some_prefix with
     | None -> Ok ()
     | Some _ ->
-        let prev_prefix = t.prefix in
-        t.prefix <- some_prefix;
+        let prev_prefix = Atomic.get t.prefix in
+        Atomic.set t.prefix some_prefix;
         let* () = notify_reload_consumers t.prefix_consumers in
         Option.might Sparse.close prev_prefix
 
@@ -239,7 +240,8 @@ struct
       "reopen_suffix chunk_start_idx:%d chunk_num:%d appendable_chunk_poff:%d"
         chunk_start_idx chunk_num
         (Int63.to_int appendable_chunk_poff)];
-    let readonly = Suffix.readonly t.suffix in
+    let suffix0 = Atomic.get t.suffix in
+    let readonly = Suffix.readonly suffix0 in
     let* suffix1 =
       let root = t.root in
       let start_idx = chunk_start_idx in
@@ -252,8 +254,7 @@ struct
         Suffix.open_rw ~sw ~root ~appendable_chunk_poff ~dead_header_size
           ~start_idx ~chunk_num
     in
-    let suffix0 = t.suffix in
-    t.suffix <- suffix1;
+    Atomic.set t.suffix suffix1;
     Suffix.close suffix0
 
   let reload_lower t ~volume_num =
@@ -366,8 +367,8 @@ struct
       {
         dict;
         control;
-        suffix;
-        prefix;
+        suffix = Atomic.make suffix;
+        prefix = Atomic.make prefix;
         lower;
         use_fsync;
         index;
@@ -433,7 +434,7 @@ struct
       in
       (* Step 4. Update end offsets *)
       let* () =
-        Suffix.refresh_appendable_chunk_poff t.suffix pl1.appendable_chunk_poff
+        Suffix.refresh_appendable_chunk_poff (Atomic.get t.suffix) pl1.appendable_chunk_poff
       in
       (match hook with Some h -> h `After_suffix | None -> ());
       let* () = Dict.refresh_end_poff t.dict pl1.dict_end_poff in
@@ -835,8 +836,8 @@ struct
       {
         dict;
         control;
-        suffix;
-        prefix;
+        suffix = Atomic.make suffix;
+        prefix = Atomic.make prefix;
         lower;
         use_fsync;
         indexing_strategy;
@@ -944,7 +945,7 @@ struct
       "Gc reopen files, update control: %.0fus, %.0fus" span1 (span2 -. span1)];
     Ok ()
 
-  let readonly t = Suffix.readonly t.suffix
+  let readonly t = Suffix.readonly (Atomic.get t.suffix)
 
   let generation t =
     let pl = Control.payload t.control in
@@ -982,7 +983,7 @@ struct
   let split t =
     let open Result_syntax in
     (* Step 1. Create a new chunk file *)
-    let* () = Suffix.add_chunk t.suffix in
+    let* () = Suffix.add_chunk (Atomic.get t.suffix) in
 
     (* Step 2. Update the control file *)
     let pl = Control.payload t.control in

--- a/src/irmin-pack/io/stats.ml
+++ b/src/irmin-pack/io/stats.ml
@@ -78,8 +78,7 @@ module Pack_store = struct
           }
       | Not_found -> { v with total = succ v.total }
     in
-    let mut = Metrics.Replace f in
-    Metrics.update finds mut
+    Metrics.update finds f
 
   let cache_misses
       {
@@ -136,8 +135,7 @@ module Index = struct
     Metrics.v ~origin:Index_stats ~name:"index_metric" ~initial_state t
 
   let report index =
-    let modifier = Metrics.Replace (fun _ -> Stats_intf.Index.S.get ()) in
-    Metrics.(update index modifier)
+    Metrics.update index (fun _ -> Stats_intf.Index.S.get ())
 
   let export m = Metrics.state m
 end
@@ -201,7 +199,7 @@ module File_manager = struct
       | Auto_index -> { t with auto_index = succ t.auto_index }
       | Flush -> { t with flush = succ t.flush }
     in
-    Metrics.update t (Metrics.Replace f)
+    Metrics.update t f
 end
 
 module Latest_gc = struct
@@ -220,12 +218,12 @@ module Latest_gc = struct
     Metrics.v ~origin:Latest_gc ~name:"latest_gc_metric" ~initial_state t
 
   let clear : stat -> unit =
-   fun m -> Metrics.update m (Metrics.Replace (fun _ -> None))
+   fun m -> Metrics.update m (fun _ -> None)
 
   let export : stat -> t = Metrics.state
 
   let update : stats -> stat -> unit =
-   fun stat m -> Metrics.update m (Metrics.Replace (fun _ -> Some stat))
+   fun stat m -> Metrics.update m (fun _ -> Some stat)
 
   let new_suffix_end_offset_before_finalise worker =
     match List.assoc_opt "suffix" worker.files with

--- a/src/irmin-pack/io/stats.ml
+++ b/src/irmin-pack/io/stats.ml
@@ -134,9 +134,7 @@ module Index = struct
     let initial_state = create_index () in
     Metrics.v ~origin:Index_stats ~name:"index_metric" ~initial_state t
 
-  let report index =
-    Metrics.update index (fun _ -> Stats_intf.Index.S.get ())
-
+  let report index = Metrics.update index (fun _ -> Stats_intf.Index.S.get ())
   let export m = Metrics.state m
 end
 
@@ -217,9 +215,7 @@ module Latest_gc = struct
     let initial_state = None in
     Metrics.v ~origin:Latest_gc ~name:"latest_gc_metric" ~initial_state t
 
-  let clear : stat -> unit =
-   fun m -> Metrics.update m (fun _ -> None)
-
+  let clear : stat -> unit = fun m -> Metrics.update m (fun _ -> None)
   let export : stat -> t = Metrics.state
 
   let update : stats -> stat -> unit =

--- a/src/irmin-pack/io/store.ml
+++ b/src/irmin-pack/io/store.ml
@@ -256,10 +256,6 @@ struct
             let sw = Conf.switch t.config in
             let fs = Conf.fs t.config in
             [%log.info "GC: Starting on %a" pp_key commit_key];
-            let* () =
-              if Atomic.get t.during_batch then Error `Gc_forbidden_during_batch
-              else Ok ()
-            in
             let* commit_key = direct_commit_key t commit_key in
             let root = Eio.Path.(fs / Conf.root t.config) in
             let* () =
@@ -268,6 +264,15 @@ struct
               else Ok ()
             in
             Eio.Mutex.use_rw ~protect:false t.lock @@ fun () ->
+            let* () =
+              if Atomic.get t.during_batch then Error `Gc_forbidden_during_batch
+              else Ok ()
+            in
+            let* () =
+              match Atomic.get t.running_gc with
+              | Some _ -> Error (`Gc_disallowed "GC is already running")
+              | None -> Ok ()
+            in
             let current_generation = File_manager.generation t.fm in
             let next_generation = current_generation + 1 in
             let lower_root =
@@ -410,12 +415,12 @@ struct
             if not (is_split_allowed t) then Error `Split_disallowed else Ok ()
           in
           let* () = if readonly then Error `Ro_not_allowed else Ok () in
+          Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
           let* () =
             if Atomic.get t.during_batch then
               Error `Split_forbidden_during_batch
             else Ok ()
           in
-          Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
           File_manager.split t.fm
 
         let split_exn repo = split repo |> Errs.raise_if_error

--- a/src/irmin-pack/io/store.ml
+++ b/src/irmin-pack/io/store.ml
@@ -237,6 +237,8 @@ struct
             | None -> false
 
           let cancel t =
+            if Atomic.get t.during_batch then
+              raise (Errors.Pack_error `Gc_forbidden_during_batch);
             Eio.Mutex.use_rw ~protect:true t.lock @@ fun () -> unsafe_cancel t
 
           let direct_commit_key t key =
@@ -261,6 +263,13 @@ struct
             let* () =
               if not (is_allowed t) then
                 Error (`Gc_disallowed "Store does not support GC")
+              else Ok ()
+            in
+            (* Early check before acquiring the lock to avoid deadlock when
+               called from a [batch ~lock:true] callback. The check is
+               repeated under the lock to close the TOCTOU window. *)
+            let* () =
+              if Atomic.get t.during_batch then Error `Gc_forbidden_during_batch
               else Ok ()
             in
             Eio.Mutex.use_rw ~protect:false t.lock @@ fun () ->
@@ -415,6 +424,14 @@ struct
             if not (is_split_allowed t) then Error `Split_disallowed else Ok ()
           in
           let* () = if readonly then Error `Ro_not_allowed else Ok () in
+          (* Early check before acquiring the lock to avoid deadlock when
+             called from a [batch ~lock:true] callback. The check is
+             repeated under the lock to close the TOCTOU window. *)
+          let* () =
+            if Atomic.get t.during_batch then
+              Error `Split_forbidden_during_batch
+            else Ok ()
+          in
           Eio.Mutex.use_rw ~protect:true t.lock @@ fun () ->
           let* () =
             if Atomic.get t.during_batch then

--- a/src/irmin-pack/stats.ml
+++ b/src/irmin-pack/stats.ml
@@ -96,8 +96,7 @@ module Inode = struct
       | Inode_encode_bin ->
           { v with inode_encode_bin = succ v.inode_encode_bin }
     in
-    let mut = Metrics.Replace f in
-    Metrics.update pack mut
+    Metrics.update pack f
 end
 
 type t = { inode : Inode.stat }

--- a/src/irmin/indexable_intf.ml
+++ b/src/irmin/indexable_intf.ml
@@ -36,9 +36,8 @@ module type S_without_key_impl = sig
   val index : [> read ] t -> hash -> key option
   (** Indexing maps the hash of a value to a corresponding key of that value in
       the store. For stores that are addressed by hashes directly, this is
-      typically [fun _t h -> Key.of_hash h]; for stores with more
-      complex addressing schemes, [index] may attempt a lookup operation in the
-      store.
+      typically [fun _t h -> Key.of_hash h]; for stores with more complex
+      addressing schemes, [index] may attempt a lookup operation in the store.
 
       In general, indexing is best-effort and reveals no information about the
       membership of the value in the store. In particular:

--- a/src/irmin/indexable_intf.ml
+++ b/src/irmin/indexable_intf.ml
@@ -36,7 +36,7 @@ module type S_without_key_impl = sig
   val index : [> read ] t -> hash -> key option
   (** Indexing maps the hash of a value to a corresponding key of that value in
       the store. For stores that are addressed by hashes directly, this is
-      typically [fun _t h -> Lwt.return (Key.of_hash h)]; for stores with more
+      typically [fun _t h -> Key.of_hash h]; for stores with more
       complex addressing schemes, [index] may attempt a lookup operation in the
       store.
 

--- a/src/irmin/irmin.mli
+++ b/src/irmin/irmin.mli
@@ -290,7 +290,6 @@ type 'a diff = 'a Diff.t
     message, using the combinator exposed by {!Irmin.Type}:
 
     {[
-    open Lwt.Infix
     open Astring
 
     let time = ref 0L
@@ -409,47 +408,44 @@ type 'a diff = 'a Diff.t
     let log_file = [ "local"; "debug" ]
 
     let all_logs t =
-      Store.find t log_file >|= function None -> Log.empty | Some l -> l
+      match Store.find t log_file with None -> Log.empty | Some l -> l
 
     (** Persist a new entry in the log. Pretty inefficient as it reads/writes
         the whole file every time. *)
     let log t fmt =
       Printf.ksprintf
         (fun message ->
-          all_logs t >>= fun logs ->
+          let logs = all_logs t in
           let logs = Log.add logs (Entry.v message) in
           Store.set_exn t ~info:(info "Adding a new entry") log_file logs)
         fmt
 
     let print_logs name t =
-      all_logs t >|= fun logs ->
+      let logs = all_logs t in
       Fmt.pr "-----------\n%s:\n-----------\n%a%!" name (Irmin.Type.pp Log.t)
         logs
 
     let main () =
       Config.init ();
-      Store.Repo.v config >>= fun repo ->
-      Store.main repo >>= fun t ->
+      let repo = Store.Repo.v config in
+      let t = Store.main repo in
       (* populate the log with some random messages *)
-      Lwt_list.iter_s
+      List.iter
         (fun msg -> log t "This is my %s " msg)
-        [ "first"; "second"; "third" ]
-      >>= fun () ->
+        [ "first"; "second"; "third" ];
       Printf.printf "%s\n\n" what;
-      print_logs "lca" t >>= fun () ->
-      Store.clone ~src:t ~dst:"test" >>= fun x ->
-      log x "Adding new stuff to x" >>= fun () ->
-      log x "Adding more stuff to x" >>= fun () ->
-      log x "More. Stuff. To x." >>= fun () ->
-      print_logs "branch 1" x >>= fun () ->
-      log t "I can add stuff on t also" >>= fun () ->
-      log t "Yes. On t!" >>= fun () ->
-      print_logs "branch 2" t >>= fun () ->
-      Store.merge_into ~info:(info "Merging x into t") x ~into:t >>= function
+      print_logs "lca" t;
+      let x = Store.clone ~src:t ~dst:"test" in
+      log x "Adding new stuff to x";
+      log x "Adding more stuff to x";
+      log x "More. Stuff. To x.";
+      print_logs "branch 1" x;
+      log t "I can add stuff on t also";
+      log t "Yes. On t!";
+      print_logs "branch 2" t;
+      match Store.merge_into ~info:(info "Merging x into t") x ~into:t with
       | Ok () -> print_logs "merge" t
       | Error _ -> failwith "conflict!"
-
-    let () = Lwt_main.run (main ())
     ]} *)
 
 (** {2 Synchronization} *)
@@ -476,7 +472,6 @@ module Sync = Sync
     The complete code for the following can be found in [examples/sync.ml].
 
     {[
-    open Lwt.Infix
     module S = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
     module Sync = Irmin.Sync (S)
 
@@ -490,11 +485,11 @@ module Sync = Sync
         exit 1)
 
     let test () =
-      S.Repo.v config >>= S.main >>= fun t ->
-      Sync.pull_exn t upstream `Set >>= fun () ->
-      S.get t [ "README.md" ] >|= fun r -> Printf.printf "%s\n%!" r
-
-    let () = Lwt_main.run (test ())
+      let repo = S.Repo.v config in
+      let t = S.main repo in
+      Sync.pull_exn t upstream `Set;
+      let r = S.get t [ "README.md" ] in
+      Printf.printf "%s\n%!" r
     ]} *)
 
 (** {1 Helpers} *)

--- a/src/irmin/mem/irmin_mem.ml
+++ b/src/irmin/mem/irmin_mem.ml
@@ -42,7 +42,9 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
 
   let v =
     let cache : (string, 'a t) Hashtbl.t = Hashtbl.create 0 in
+    let lock = Eio.Mutex.create () in
     fun config ->
+      Eio.Mutex.lock lock;
       let root = Conf.root config in
       let t =
         match Hashtbl.find_opt cache root with
@@ -52,6 +54,7 @@ module Read_only (K : Irmin.Type.S) (V : Irmin.Type.S) = struct
             t
         | Some t -> t
       in
+      Eio.Mutex.unlock lock;
       t
 
   let clear t =

--- a/src/irmin/metrics.ml
+++ b/src/irmin/metrics.ml
@@ -34,16 +34,11 @@ type 'a t = {
 let state m = Atomic.get m.state
 let set_state m v = Atomic.set m.state v
 
-type 'a update_mode = Mutate of ('a -> unit) | Replace of ('a -> 'a)
-
 let v : type a.
     ?origin:origin -> name:string -> initial_state:a -> a Repr.ty -> a t =
  fun ?origin ~name ~initial_state repr ->
   { uid = uid (); origin; name; repr; state = Atomic.make initial_state }
 
-let rec update m kind =
+let rec update m f =
   let old = Atomic.get m.state in
-  match kind with
-  | Mutate f -> f old
-  | Replace f ->
-      if not @@ Atomic.compare_and_set m.state old (f old) then update m kind
+  if not @@ Atomic.compare_and_set m.state old (f old) then update m f

--- a/src/irmin/metrics.mli
+++ b/src/irmin/metrics.mli
@@ -33,16 +33,6 @@ val state : 'a t -> 'a
 val set_state : 'a t -> 'a -> unit
 (** [set_state m v] updates the value in the {!t} object. *)
 
-(** {!update_mode} describes how the data will be handled by the {!update}
-    function.
-
-    - Mutate: the value and the storage are not modified but the content of the
-      value can be mutate.
-    - Replace f: apply f to the value and updates its content.
-
-    It gives the possibility to handle the same metric in different ways. *)
-type 'a update_mode = Mutate of ('a -> unit) | Replace of ('a -> 'a)
-
 val v : ?origin:origin -> name:string -> initial_state:'a -> 'a Repr.ty -> 'a t
 (** [v ~origin ~name ~initial_state  repr ] create a new {!t}. The [origin] can
     be set to give an hint about where the data are gathered. [name] is a name
@@ -50,6 +40,6 @@ val v : ?origin:origin -> name:string -> initial_state:'a -> 'a Repr.ty -> 'a t
     metric object. [repr] describes the type representation to allow
     serialization. *)
 
-val update : 'a t -> 'a update_mode -> unit
-(** [update metrics mode] updates the metric by taking in consideration [mode]
-    to define how it acts on [t] according to their specication. *)
+val update : 'a t -> ('a -> 'a) -> unit
+(** [update metrics f] atomically applies [f] to the current state using
+    compare-and-set. Retries on concurrent modification. *)

--- a/src/irmin/node_intf.ml
+++ b/src/irmin/node_intf.ml
@@ -120,9 +120,8 @@ module type Core = sig
   (** Some [Node] implementations (like [irmin-pack]'s inodes) can represent a
       node as a set of nodes. One operation on such "high-level" node
       corresponds to a sequence of recursive calls to the underlying
-      "lower-level" nodes. Note: theses [effects] are not in the Lwt monad on
-      purpose (so [Tree.hash] and [Tree.equal] are not in the Lwt monad as
-      well). *)
+      "lower-level" nodes. Note: these [effects] are direct-style (not in any
+      monad), so [Tree.hash] and [Tree.equal] are also direct-style. *)
 
   type read_effect := expected_depth:int -> node_key -> t option
   (** The type for read effects. *)

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -2902,7 +2902,6 @@ module Make (P : Backend.S) = struct
           "verify_proof: %s is trying to read through a blinded node or object \
            (%a)"
           h.context pp_hash h.hash
-    | e -> raise e
 
   type verifier_error = [ `Proof_mismatch of string ] [@@deriving irmin]
 
@@ -2910,9 +2909,7 @@ module Make (P : Backend.S) = struct
     try
       let r = verify_proof_exn p f in
       Ok r
-    with
-    | Irmin_proof.Bad_proof e -> Error (`Proof_mismatch e.context)
-    | e -> raise e
+    with Irmin_proof.Bad_proof e -> Error (`Proof_mismatch e.context)
 
   let hash_of_proof_state state =
     let env = Env.empty () in

--- a/src/irmin/tree.ml
+++ b/src/irmin/tree.ml
@@ -2895,13 +2895,12 @@ module Make (P : Backend.S) = struct
       if not (equal_kinded_hash after (hash tree_after)) then
         Irmin_proof.bad_proof_exn "verify_proof: invalid after hash";
       (tree_after, result)
-    with
-    | Pruned_hash h ->
-        (* finaly check that [f] only access valid parts of the proof. *)
-        Fmt.kstr Irmin_proof.bad_proof_exn
-          "verify_proof: %s is trying to read through a blinded node or object \
-           (%a)"
-          h.context pp_hash h.hash
+    with Pruned_hash h ->
+      (* finaly check that [f] only access valid parts of the proof. *)
+      Fmt.kstr Irmin_proof.bad_proof_exn
+        "verify_proof: %s is trying to read through a blinded node or object \
+         (%a)"
+        h.context pp_hash h.hash
 
   type verifier_error = [ `Proof_mismatch of string ] [@@deriving irmin]
 

--- a/src/irmin/watch.ml
+++ b/src/irmin/watch.ml
@@ -41,7 +41,9 @@ let global = id ()
 let workers_r = Atomic.make 0
 let workers () = Atomic.get workers_r
 
-(* Not sure this is right *)
+(* Continuously drain the stream, applying [f] to each non-None element.
+   None is used as a termination signal but is currently ignored
+   (the loop continues), which may cause fibers to leak on shutdown. *)
 let rec stream_iter f s =
   (match Eio.Stream.take s with Some v -> f v | None -> ());
   stream_iter f s
@@ -60,8 +62,12 @@ let scheduler () =
         in
         ignore (Atomic.fetch_and_add workers_r 1);
         let sw =
-          try Option.get (Atomic.get watch_switch)
-          with _ -> failwith "Big Yikes"
+          match Atomic.get watch_switch with
+          | Some sw -> sw
+          | None ->
+              failwith
+                "Watch: no Eio switch set. Call Irmin.Watch.set_watch_switch \
+                 before using watches."
         in
         (Eio.Fiber.fork ~sw @@ fun () -> stream_iter (fun f -> f ()) stream);
         (* Lwt.async (fun () ->

--- a/src/irmin/watch.ml
+++ b/src/irmin/watch.ml
@@ -25,23 +25,21 @@ let none _ _ =
   Printf.eprintf "Listen hook not set!\n%!";
   assert false
 
-let listen_dir_hook = ref none
-let watch_switch = ref None
+let listen_dir_hook = Atomic.make none
+let watch_switch = Atomic.make None
 
 type hook = int -> string -> (string -> unit) -> unit -> unit
 
-let set_listen_dir_hook (h : hook) = listen_dir_hook := h
-let set_watch_switch sw = watch_switch := Some sw
+let set_listen_dir_hook (h : hook) = Atomic.set listen_dir_hook h
+let set_watch_switch sw = Atomic.set watch_switch (Some sw)
 
 let id () =
-  let c = ref 0 in
-  fun () ->
-    incr c;
-    !c
+  let c = Atomic.make 0 in
+  fun () -> Atomic.fetch_and_add c 1 + 1
 
 let global = id ()
-let workers_r = ref 0
-let workers () = !workers_r
+let workers_r = Atomic.make 0
+let workers () = Atomic.get workers_r
 
 (* Not sure this is right *)
 let rec stream_iter f s =
@@ -60,9 +58,10 @@ let scheduler () =
           let s = Eio.Stream.create max_int in
           (s, Eio.Stream.add s)
         in
-        incr workers_r;
+        ignore (Atomic.fetch_and_add workers_r 1);
         let sw =
-          try Option.get !watch_switch with _ -> failwith "Big Yikes"
+          try Option.get (Atomic.get watch_switch)
+          with _ -> failwith "Big Yikes"
         in
         (Eio.Fiber.fork ~sw @@ fun () -> stream_iter (fun f -> f ()) stream);
         (* Lwt.async (fun () ->
@@ -75,7 +74,7 @@ let scheduler () =
   in
   let clean () =
     !c ();
-    decr workers_r;
+    ignore (Atomic.fetch_and_add workers_r (-1));
     c := niet;
     p := None
   in
@@ -307,7 +306,7 @@ struct
       if t.listeners = 0 then (
         [%log.debug "%s: start listening to %s" (to_string t) dir];
         let f =
-          !listen_dir_hook t.id dir (fun file ->
+          (Atomic.get listen_dir_hook) t.id dir (fun file ->
               match key file with
               | None -> ()
               | Some key ->

--- a/src/irmin/watch_intf.ml
+++ b/src/irmin/watch_intf.ml
@@ -82,7 +82,9 @@ module type Sigs = sig
   (** [none] is the hooks which asserts false. *)
 
   val set_watch_switch : Eio.Switch.t -> unit
-  (** A terrible hack that will need fixed... *)
+  (** Set the Eio switch used to fork watch notification fibers. Must be called
+      before any watch operation. This global state is a workaround until the
+      switch can be threaded through the store API (e.g. via [Repo.v]). *)
 
   val set_listen_dir_hook : hook -> unit
   (** Register a function which looks for file changes in a directory and return


### PR DESCRIPTION
## Summary

This PR adds multicore safety to shared mutable state using mutexes and atomics. This fixes at least one multicore test failure (`test_concurrent_low` crashes when `append_exn` is not protected by a mutex).

### Thread-safety fixes

- Protect `Buffer.t` in `append_only_file.ml` with an `Eio.Mutex` — the race between `append_exn` and `flush` is triggered by `test_concurrent_low` without the fix
- Replace `mutable suffix`/`prefix` fields in `file_manager.ml` with `Atomic.t` to prevent use-after-close during GC swap
- Protect `Hashtbl.t` in `dict.ml` with an `Eio.Mutex` (guards `refill` which yields on I/O before mutating)
- Replace `mutable chunks` array in `chunked_suffix.ml` with `Atomic.t` for consistent snapshots during concurrent reads
- Fix TOCTOU on `during_batch`/`running_gc` checks in `store.ml` by moving them inside `Repo.lock`
- Prevent deadlock when calling GC or split from a `batch(~lock:true)` callback
- Replace global `ref` with `Atomic.t` in `watch.ml`
- Protect global `Hashtbl.t` with `Eio.Mutex` in `irmin_fs.ml` and `irmin_mem.ml`

### Cleanup (from lyrm review checklist on PR #2149)

- Remove unused `Mutate` constructor from `Metrics.update_mode` — incompatible with the `Atomic.compare_and_set` retry loop, and never instantiated by any caller
- Remove redundant `| e -> raise e` exception re-raises in `irmin_fs_unix.ml`, `inode.ml`, `tree.ml`
- Update outdated Lwt references in `indexable_intf.ml` and `node_intf.ml` documentation
- Migrate `irmin.mli` code examples (custom_merge, sync) from Lwt to direct-style
- Improve frightening comments in `watch.ml` / `watch_intf.ml`: replace "Big Yikes" with actionable error, document `stream_iter` limitation, explain `set_watch_switch` workaround
- Review all `Atomic.set` vs `compare_and_set` usage: no correctness issues found

### Not addressed in this PR

- `f () |> function` cleanup (~33 occurrences) — mechanical, better as a dedicated PR
- `eio_pool.ml` vs `Eio.Pool` — not redundant (provides post-failure check and pool clearing)
- Pin-depends removal (`index`, `irmin-watcher`) — tracked in separate PRs

### Performance

Benchmarked with `bench_inline` (50k contents, 5k reads), stabilised with `taskset -c 0` and pre-built binaries — **no measurable regression** (write +1.6%, read p50 +1.0%, within noise).

## Test plan

- [x] `dune runtest test/irmin-pack/` — 252 tests pass
- [x] Removing the `append_only_file` mutex causes `test_concurrent_low` to crash, confirming the race is real
- [x] `dune build src/irmin/ src/irmin-pack/ src/irmin-fs/` compiles cleanly

Please read each commit individually.