### PR TITLE
Add TSan nightly CI workflow

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,96 @@
+name: TSan
+
+# ThreadSanitizer nightly race-hunting workflow.
+# Requires bare ubuntu-latest runners (for writable /proc/sys); cannot run
+# inside a container: job, Codespaces, or ocaml-ci.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: tsan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tsan:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'tsan')
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      EIO_BACKEND: posix
+      TSAN_OPTIONS: "halt_on_error=0 history_size=7 second_deadlock_stack=1 exitcode=66 log_path=tsan-report suppressions=${{ github.workspace }}/test/irmin-pack/tsan_suppressions.txt"
+      IRMIN_STM_ITER: "5000"
+      IRMIN_STM_PACK_ITER: "2000"
+      IRMIN_MULTICORE_DOMAINS: "8"
+      IRMIN_MULTICORE_ITER: "50"
+      IRMIN_TSAN_STRESS_ITER: "500"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reduce ASLR entropy for TSan shadow memory
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
+      - name: Install libunwind
+        run: sudo apt-get update -y && sudo apt-get install -y libunwind-dev
+
+      - name: Cache opam root
+        uses: actions/cache@v4
+        with:
+          path: ~/.opam
+          key: tsan-opam-${{ runner.os }}-5.3.0-${{ hashFiles('*.opam') }}
+          restore-keys: |
+            tsan-opam-${{ runner.os }}-5.3.0-
+
+      - name: Set up OCaml with TSan
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "ocaml-variants.5.3.0+options,ocaml-option-tsan"
+          dune-cache: true
+
+      - name: Install dune
+        run: opam install -y dune
+
+      - name: Install dependencies
+        run: opam install -y --deps-only --with-test .
+
+      - name: Build
+        run: opam exec -- dune build @install
+
+      - name: Run tests and stress suite under TSan
+        run: |
+          set -o pipefail
+          opam exec -- dune build @runtest @tsan-stress --force --no-buffer 2>&1 | tee tsan-run.log
+
+      - name: Summarize findings
+        if: always()
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(tsan-report.*)
+          n=0
+          if [ ${#files[@]} -gt 0 ] || [ -f tsan-run.log ]; then
+            n=$(grep -ch "WARNING: ThreadSanitizer" "${files[@]}" tsan-run.log 2>/dev/null | awk '{s+=$1} END {print s+0}')
+          fi
+          {
+            echo "### TSan findings: $n"
+            if [ "$n" = "0" ]; then
+              echo "No races detected."
+            else
+              echo "See artifact \`tsan-reports-${{ github.run_id }}\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload TSan reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tsan-reports-${{ github.run_id }}
+          path: |
+            tsan-report.*
+            tsan-run.log
+          if-no-files-found: ignore

--- a/test/irmin-pack/test_multicore.ml
+++ b/test/irmin-pack/test_multicore.ml
@@ -23,9 +23,7 @@ let src = Logs.Src.create "tests.multicore" ~doc:"Tests"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let int_env name default =
-  match Sys.getenv_opt name with
-  | Some s -> int_of_string s
-  | None -> default
+  match Sys.getenv_opt name with Some s -> int_of_string s | None -> default
 
 let default_domains = int_env "IRMIN_MULTICORE_DOMAINS" 2
 let test_iter = int_env "IRMIN_MULTICORE_ITER" 1

--- a/test/irmin-pack/test_multicore.ml
+++ b/test/irmin-pack/test_multicore.ml
@@ -22,6 +22,14 @@ let src = Logs.Src.create "tests.multicore" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+let int_env name default =
+  match Sys.getenv_opt name with
+  | Some s -> int_of_string s
+  | None -> default
+
+let default_domains = int_env "IRMIN_MULTICORE_DOMAINS" 2
+let test_iter = int_env "IRMIN_MULTICORE_ITER" 1
+
 module Store = struct
   module Maker = Irmin_pack_unix.Maker (Conf)
   include Maker.Make (Schema)
@@ -130,7 +138,7 @@ let domains_run ~domain_mgr fns =
   in
   Eio.Fiber.all fibers
 
-let domains_spawn ~domain_mgr ?(nb = 2) fn =
+let domains_spawn ~domain_mgr ?(nb = default_domains) fn =
   domains_run ~domain_mgr @@ List.init nb (fun _ -> fn)
 
 let find_all tree paths =
@@ -499,18 +507,26 @@ let test_commit_v ~fs ~domain_mgr =
 
 let tests ~fs ~domain_mgr =
   let tc name fn = Alcotest.test_case name `Quick (fun () -> fn ~domain_mgr) in
-  [
-    tc "find." (test_find ~fs);
-    tc "length." (test_length ~fs);
-    tc "add / remove." (test_add_remove ~fs);
-    tc "commit." (test_commit ~fs);
-    tc "merkle." (test_merkle ~fs);
-    tc "hash." (test_hash ~fs);
-    tc "list-disk-no-cache." (test_list_disk ~fs ~cache:false);
-    tc "list-disk-with-cache." (test_list_disk ~fs ~cache:true);
-    tc "list-mem-no-cache." (test_list_mem ~fs ~cache:false);
-    tc "list-mem-with-cache." (test_list_mem ~fs ~cache:true);
-    tc "commit-of-hash." (test_commit_of_hash ~fs);
-    tc "commit-parents." (test_commit_parents ~fs);
-    tc "commit-v." (test_commit_v ~fs);
-  ]
+  let cases =
+    [
+      ("find.", test_find ~fs);
+      ("length.", test_length ~fs);
+      ("add / remove.", test_add_remove ~fs);
+      ("commit.", test_commit ~fs);
+      ("merkle.", test_merkle ~fs);
+      ("hash.", test_hash ~fs);
+      ("list-disk-no-cache.", test_list_disk ~fs ~cache:false);
+      ("list-disk-with-cache.", test_list_disk ~fs ~cache:true);
+      ("list-mem-no-cache.", test_list_mem ~fs ~cache:false);
+      ("list-mem-with-cache.", test_list_mem ~fs ~cache:true);
+      ("commit-of-hash.", test_commit_of_hash ~fs);
+      ("commit-parents.", test_commit_parents ~fs);
+      ("commit-v.", test_commit_v ~fs);
+    ]
+  in
+  if test_iter <= 1 then List.map (fun (name, fn) -> tc name fn) cases
+  else
+    List.concat_map
+      (fun (name, fn) ->
+        List.init test_iter (fun i -> tc (Printf.sprintf "%s%d" name i) fn))
+      cases

--- a/test/irmin-pack/test_stm/test_stm.ml
+++ b/test/irmin-pack/test_stm/test_stm.ml
@@ -70,7 +70,11 @@ let agree_test_eio ~count ~domain_mgr =
   TT.agree_test_par ~domain_mgr ~count ~name:"Irmin test parallel"
 
 let () =
-  let count = 500 in
+  let count =
+    match Sys.getenv_opt "IRMIN_STM_ITER" with
+    | Some s -> int_of_string s
+    | None -> 500
+  in
   Eio_main.run @@ fun env ->
   let domain_mgr = Eio.Stdenv.domain_mgr env in
   QCheck_base_runner.run_tests_main [ agree_test_eio ~count ~domain_mgr ]

--- a/test/irmin-pack/test_stm/test_stm_irmin_pack.ml
+++ b/test/irmin-pack/test_stm/test_stm_irmin_pack.ml
@@ -117,7 +117,11 @@ let agree_test_eio ~count ~domain_mgr ~fs ~sw =
   TT.agree_test_par ~domain_mgr ~count ~name:"Irmin test parallel"
 
 let () =
-  let count = 100 in
+  let count =
+    match Sys.getenv_opt "IRMIN_STM_PACK_ITER" with
+    | Some s -> int_of_string s
+    | None -> 100
+  in
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let domain_mgr = Eio.Stdenv.domain_mgr env in

--- a/test/irmin-pack/test_tsan_stress/dune
+++ b/test/irmin-pack/test_tsan_stress/dune
@@ -1,0 +1,9 @@
+(executable
+ (name main)
+ (modules main)
+ (libraries eio_main))
+
+(rule
+ (alias tsan-stress)
+ (action
+  (run ./main.exe)))

--- a/test/irmin-pack/test_tsan_stress/main.ml
+++ b/test/irmin-pack/test_tsan_stress/main.ml
@@ -21,9 +21,7 @@ let run_all () =
     scenarios
 
 let () =
-  let which =
-    if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all"
-  in
+  let which = if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all" in
   match which with
   | "all" -> run_all ()
   | name -> (

--- a/test/irmin-pack/test_tsan_stress/main.ml
+++ b/test/irmin-pack/test_tsan_stress/main.ml
@@ -1,0 +1,34 @@
+(* TSan stress suite.
+
+   Dispatcher for race-hunting scenarios. Each scenario targets a mutable
+   state hotspot that the standard test suite does not exercise across
+   domains. Scenarios are added incrementally.
+
+   Iteration count: [IRMIN_TSAN_STRESS_ITER] env var (default 100). *)
+
+let iter_count =
+  match Sys.getenv_opt "IRMIN_TSAN_STRESS_ITER" with
+  | Some s -> int_of_string s
+  | None -> 100
+
+let scenarios : (string * (iter:int -> unit)) list = []
+
+let run_all () =
+  List.iter
+    (fun (name, fn) ->
+      Printf.printf "tsan-stress: %s (iter=%d)\n%!" name iter_count;
+      fn ~iter:iter_count)
+    scenarios
+
+let () =
+  let which =
+    if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all"
+  in
+  match which with
+  | "all" -> run_all ()
+  | name -> (
+      match List.assoc_opt name scenarios with
+      | Some fn -> fn ~iter:iter_count
+      | None ->
+          Printf.eprintf "tsan-stress: unknown scenario %S\n%!" name;
+          exit 2)

--- a/test/irmin-pack/tsan_suppressions.txt
+++ b/test/irmin-pack/tsan_suppressions.txt
@@ -1,0 +1,11 @@
+# ThreadSanitizer suppressions for Irmin nightly CI.
+#
+# Rule: suppress runtime/FFI noise only. Every finding in an Irmin module is
+# a real race — do NOT add entries for src/ here.
+
+# OCaml runtime internals (minor heap / major heap bookkeeping).
+race:caml_modify
+race:caml_alloc_shr
+
+# index uses mmap + its own atomics that TSan doesn't instrument.
+called_from_lib:index


### PR DESCRIPTION
## Summary

Adds a nightly GitHub Actions workflow that runs the Irmin test suite under ThreadSanitizer (TSan) to hunt for data races on the eio branch.

- `.github/workflows/tsan.yml` — nightly cron (`0 3 * * *`) + `workflow_dispatch` + opt-in PR `tsan` label. Ubuntu-latest bare runner, 75-min timeout, opam cache keyed on the TSan compiler spec. Runs `dune build @runtest @tsan-stress` under TSan with `halt_on_error=0 exitcode=66` so a single run surfaces every race. Uploads `tsan-report.*` + `tsan-run.log` as artifact; writes a finding count to the job summary.
- `test/irmin-pack/tsan_suppressions.txt` — minimal runtime/FFI noise filter (`caml_modify`, `caml_alloc_shr`, `called_from_lib:index`). No Irmin-module entries by design.
- Existing tests become env-var scalable: `IRMIN_STM_ITER` (default 500), `IRMIN_STM_PACK_ITER` (default 100), `IRMIN_MULTICORE_DOMAINS` (default 2), `IRMIN_MULTICORE_ITER` (default 1). All backward-compatible; `dune runtest` in regular CI is unchanged.
- `test/irmin-pack/test_tsan_stress/` ships as an **empty dispatcher** on a separate `@tsan-stress` alias so the workflow has a stable target. The five per-hotspot stress scenarios (dict refill, `irmin_mem` cache, `watch` globals, `Irmin_fs_unix` pool, `append_only_file` buffer) land in a follow-up PR.

Setup recipe is the one validated by the [TSan PoC](https://github.com/cuihtlauac/tsan-poc/actions/runs/24236635971): `sudo sysctl vm.mmap_rnd_bits=28`, `libunwind-dev`, `ocaml-variants.5.3.0+options,ocaml-option-tsan`, `opam install dune` explicitly. All four Irmin pin-depends build cleanly under TSan (validated [here](https://github.com/cuihtlauac/tsan-poc/actions/runs/24237262152)).

No `src/` changes — this adds **detection only**. Expected first-run outcome: a nonzero number of races reported, matching the race patterns fixed in #2397. That output is the baseline for follow-up fix PRs.

Context: part of the Irmin 4.0.0 release roadmap, #2401 Phase 6.

## Test plan

- [ ] Add `tsan` label to this PR → workflow fires → setup + switch build + cache + `dune build` steps all succeed.
- [ ] Artifact `tsan-reports-<run_id>` uploaded on completion, step summary shows `### TSan findings: <N>`.
- [ ] Merge → first scheduled nightly run produces a baseline report.
- [ ] Verify default `dune runtest` behavior on non-TSan CI jobs is unchanged (env vars absent → existing defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)