### PR TITLE
Add TSan stress suite (PR B for TSan CI)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Irmin TSan development",
+  "image": "ghcr.io/tarides/ocaml-devcontainer-tsan:latest",
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+  },
+  "postStartCommand": "bash /home/vscode/.fix-tsan-aslr.sh || true",
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=dune-cache,target=/home/vscode/.cache/dune,type=volume"
+  ],
+  "remoteEnv": {
+    "DUNE_CACHE_ROOT": "/home/vscode/.cache/dune",
+    "EIO_BACKEND": "posix"
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  }
+}

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,96 @@
+name: TSan
+
+# ThreadSanitizer nightly race-hunting workflow.
+# Requires bare ubuntu-latest runners (for writable /proc/sys); cannot run
+# inside a container: job, Codespaces, or ocaml-ci.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: tsan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tsan:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'tsan')
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      EIO_BACKEND: posix
+      TSAN_OPTIONS: "halt_on_error=0 history_size=7 second_deadlock_stack=1 exitcode=66 log_path=tsan-report suppressions=${{ github.workspace }}/test/irmin-pack/tsan_suppressions.txt"
+      IRMIN_STM_ITER: "5000"
+      IRMIN_STM_PACK_ITER: "2000"
+      IRMIN_MULTICORE_DOMAINS: "8"
+      IRMIN_MULTICORE_ITER: "50"
+      IRMIN_TSAN_STRESS_ITER: "500"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reduce ASLR entropy for TSan shadow memory
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
+      - name: Install libunwind
+        run: sudo apt-get update -y && sudo apt-get install -y libunwind-dev
+
+      - name: Cache opam root
+        uses: actions/cache@v4
+        with:
+          path: ~/.opam
+          key: tsan-opam-${{ runner.os }}-5.3.0-${{ hashFiles('*.opam') }}
+          restore-keys: |
+            tsan-opam-${{ runner.os }}-5.3.0-
+
+      - name: Set up OCaml with TSan
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "ocaml-variants.5.3.0+options,ocaml-option-tsan"
+          dune-cache: true
+
+      - name: Install dune
+        run: opam install -y dune
+
+      - name: Install dependencies
+        run: opam install -y --deps-only --with-test .
+
+      - name: Build
+        run: opam exec -- dune build @install
+
+      - name: Run tests and stress suite under TSan
+        run: |
+          set -o pipefail
+          opam exec -- dune build @runtest @tsan-stress --force --no-buffer 2>&1 | tee tsan-run.log
+
+      - name: Summarize findings
+        if: always()
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(tsan-report.*)
+          n=0
+          if [ ${#files[@]} -gt 0 ] || [ -f tsan-run.log ]; then
+            n=$(grep -ch "WARNING: ThreadSanitizer" "${files[@]}" tsan-run.log 2>/dev/null | awk '{s+=$1} END {print s+0}')
+          fi
+          {
+            echo "### TSan findings: $n"
+            if [ "$n" = "0" ]; then
+              echo "No races detected."
+            else
+              echo "See artifact \`tsan-reports-${{ github.run_id }}\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload TSan reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tsan-reports-${{ github.run_id }}
+          path: |
+            tsan-report.*
+            tsan-run.log
+          if-no-files-found: ignore

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -71,16 +71,24 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob
-          files=(tsan-report.*)
-          n=0
+          files=(tsan-report.* _build/default/test/irmin-pack/test_tsan_stress/tsan-report.*)
+          warnings=0
+          errors=0
           if [ ${#files[@]} -gt 0 ] || [ -f tsan-run.log ]; then
-            n=$(grep -ch "WARNING: ThreadSanitizer" "${files[@]}" tsan-run.log 2>/dev/null | awk '{s+=$1} END {print s+0}')
+            warnings=$(grep -ch "WARNING: ThreadSanitizer" "${files[@]}" tsan-run.log 2>/dev/null | awk -F: '{s+=$NF} END {print s+0}')
+            errors=$(grep -ch "ERROR: ThreadSanitizer" "${files[@]}" tsan-run.log 2>/dev/null | awk -F: '{s+=$NF} END {print s+0}')
           fi
+          total=$((warnings + errors))
           {
-            echo "### TSan findings: $n"
-            if [ "$n" = "0" ]; then
+            echo "### TSan findings: $total"
+            echo ""
+            echo "- data-race warnings: $warnings"
+            echo "- signal/SEGV-on-race errors: $errors"
+            if [ "$total" = "0" ]; then
+              echo ""
               echo "No races detected."
             else
+              echo ""
               echo "See artifact \`tsan-reports-${{ github.run_id }}\`."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -92,5 +100,6 @@ jobs:
           name: tsan-reports-${{ github.run_id }}
           path: |
             tsan-report.*
+            _build/default/test/irmin-pack/test_tsan_stress/tsan-report.*
             tsan-run.log
           if-no-files-found: ignore

--- a/test/irmin-pack/test_multicore.ml
+++ b/test/irmin-pack/test_multicore.ml
@@ -23,9 +23,7 @@ let src = Logs.Src.create "tests.multicore" ~doc:"Tests"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let int_env name default =
-  match Sys.getenv_opt name with
-  | Some s -> int_of_string s
-  | None -> default
+  match Sys.getenv_opt name with Some s -> int_of_string s | None -> default
 
 let default_domains = int_env "IRMIN_MULTICORE_DOMAINS" 2
 let test_iter = int_env "IRMIN_MULTICORE_ITER" 1

--- a/test/irmin-pack/test_multicore.ml
+++ b/test/irmin-pack/test_multicore.ml
@@ -22,6 +22,14 @@ let src = Logs.Src.create "tests.multicore" ~doc:"Tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+let int_env name default =
+  match Sys.getenv_opt name with
+  | Some s -> int_of_string s
+  | None -> default
+
+let default_domains = int_env "IRMIN_MULTICORE_DOMAINS" 2
+let test_iter = int_env "IRMIN_MULTICORE_ITER" 1
+
 module Store = struct
   module Maker = Irmin_pack_unix.Maker (Conf)
   include Maker.Make (Schema)
@@ -130,7 +138,7 @@ let domains_run ~domain_mgr fns =
   in
   Eio.Fiber.all fibers
 
-let domains_spawn ~domain_mgr ?(nb = 2) fn =
+let domains_spawn ~domain_mgr ?(nb = default_domains) fn =
   domains_run ~domain_mgr @@ List.init nb (fun _ -> fn)
 
 let find_all tree paths =
@@ -499,18 +507,26 @@ let test_commit_v ~fs ~domain_mgr =
 
 let tests ~fs ~domain_mgr =
   let tc name fn = Alcotest.test_case name `Quick (fun () -> fn ~domain_mgr) in
-  [
-    tc "find." (test_find ~fs);
-    tc "length." (test_length ~fs);
-    tc "add / remove." (test_add_remove ~fs);
-    tc "commit." (test_commit ~fs);
-    tc "merkle." (test_merkle ~fs);
-    tc "hash." (test_hash ~fs);
-    tc "list-disk-no-cache." (test_list_disk ~fs ~cache:false);
-    tc "list-disk-with-cache." (test_list_disk ~fs ~cache:true);
-    tc "list-mem-no-cache." (test_list_mem ~fs ~cache:false);
-    tc "list-mem-with-cache." (test_list_mem ~fs ~cache:true);
-    tc "commit-of-hash." (test_commit_of_hash ~fs);
-    tc "commit-parents." (test_commit_parents ~fs);
-    tc "commit-v." (test_commit_v ~fs);
-  ]
+  let cases =
+    [
+      ("find.", test_find ~fs);
+      ("length.", test_length ~fs);
+      ("add / remove.", test_add_remove ~fs);
+      ("commit.", test_commit ~fs);
+      ("merkle.", test_merkle ~fs);
+      ("hash.", test_hash ~fs);
+      ("list-disk-no-cache.", test_list_disk ~fs ~cache:false);
+      ("list-disk-with-cache.", test_list_disk ~fs ~cache:true);
+      ("list-mem-no-cache.", test_list_mem ~fs ~cache:false);
+      ("list-mem-with-cache.", test_list_mem ~fs ~cache:true);
+      ("commit-of-hash.", test_commit_of_hash ~fs);
+      ("commit-parents.", test_commit_parents ~fs);
+      ("commit-v.", test_commit_v ~fs);
+    ]
+  in
+  if test_iter <= 1 then List.map (fun (name, fn) -> tc name fn) cases
+  else
+    List.concat_map
+      (fun (name, fn) ->
+        List.init test_iter (fun i -> tc (Printf.sprintf "%s%d" name i) fn))
+      cases

--- a/test/irmin-pack/test_stm/test_stm.ml
+++ b/test/irmin-pack/test_stm/test_stm.ml
@@ -70,7 +70,11 @@ let agree_test_eio ~count ~domain_mgr =
   TT.agree_test_par ~domain_mgr ~count ~name:"Irmin test parallel"
 
 let () =
-  let count = 500 in
+  let count =
+    match Sys.getenv_opt "IRMIN_STM_ITER" with
+    | Some s -> int_of_string s
+    | None -> 500
+  in
   Eio_main.run @@ fun env ->
   let domain_mgr = Eio.Stdenv.domain_mgr env in
   QCheck_base_runner.run_tests_main [ agree_test_eio ~count ~domain_mgr ]

--- a/test/irmin-pack/test_stm/test_stm_irmin_pack.ml
+++ b/test/irmin-pack/test_stm/test_stm_irmin_pack.ml
@@ -117,7 +117,11 @@ let agree_test_eio ~count ~domain_mgr ~fs ~sw =
   TT.agree_test_par ~domain_mgr ~count ~name:"Irmin test parallel"
 
 let () =
-  let count = 100 in
+  let count =
+    match Sys.getenv_opt "IRMIN_STM_PACK_ITER" with
+    | Some s -> int_of_string s
+    | None -> 100
+  in
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let domain_mgr = Eio.Stdenv.domain_mgr env in

--- a/test/irmin-pack/test_tsan_stress/dune
+++ b/test/irmin-pack/test_tsan_stress/dune
@@ -1,9 +1,29 @@
 (executable
  (name main)
- (modules main)
- (libraries eio_main))
+ (modules
+  main
+  stress_common
+  stress_ao_buf
+  stress_dict
+  stress_mem_cache
+  stress_watch
+  stress_fs_pool)
+ (libraries
+  eio_main
+  irmin
+  irmin.mem
+  irmin-pack.io
+  irmin-pack.unix
+  irmin-fs.unix))
+
+; Run each scenario in a fresh process so a race that corrupts memory
+; and triggers a SEGV in one scenario does not prevent the others from
+; running. Each scenario writes TSan reports to tsan-report.<pid>, and
+; the outer workflow aggregates all of them.
 
 (rule
  (alias tsan-stress)
+ (deps main.exe)
  (action
-  (run ./main.exe)))
+  (bash
+   "./main.exe mem || true; ./main.exe watch || true; ./main.exe ao || true; ./main.exe dict || true; ./main.exe fs || true")))

--- a/test/irmin-pack/test_tsan_stress/dune
+++ b/test/irmin-pack/test_tsan_stress/dune
@@ -1,0 +1,9 @@
+(executable
+ (name main)
+ (modules main)
+ (libraries eio_main))
+
+(rule
+ (alias tsan-stress)
+ (action
+  (run ./main.exe)))

--- a/test/irmin-pack/test_tsan_stress/main.ml
+++ b/test/irmin-pack/test_tsan_stress/main.ml
@@ -1,32 +1,68 @@
-(* TSan stress suite.
+(* TSan stress suite — dispatcher.
 
-   Dispatcher for race-hunting scenarios. Each scenario targets a mutable
-   state hotspot that the standard test suite does not exercise across
-   domains. Scenarios are added incrementally.
+   Each scenario targets a mutable-state hotspot that the standard test
+   suite does not exercise across domains. Iteration count is driven by
+   [IRMIN_TSAN_STRESS_ITER] (default 100).
 
-   Iteration count: [IRMIN_TSAN_STRESS_ITER] env var (default 100). *)
+   Scenarios and expected outcomes under TSan:
+
+   - mem:   clean data-race warning at irmin_mem.ml:51 (Hashtbl.add in
+            the global cache) and on the shared KMap mutable.
+   - watch: clean data-race warning at watch.ml:33 (listen_dir_hook
+            ref assignment).
+   - ao:    SEGV — concurrent Buffer.add_string corrupts the buffer
+            fast enough that TSan's signal handler fires before the
+            race warning is written. The SEGV itself is evidence of
+            the race; a clean warning would need finer-grained access.
+   - dict:  SEGV — same pattern as ao, via the two unguarded Hashtbl.t
+            caches plus the append path through Ao.
+   - fs:    TSan "nested bug, aborting" — the race interacts with Eio
+            scheduler/pool internals in a way the sanitizer can't
+            unwind. Surfaces the problem but not a specific site.
+
+   Because ao/dict/fs crash, each scenario is run in its own process by
+   the @tsan-stress dune alias so one crash does not hide the others.
+
+   Usage:
+     main.exe                 run all scenarios
+     main.exe all             same
+     main.exe <name>          run one scenario (ao|dict|mem|watch|fs) *)
 
 let iter_count =
   match Sys.getenv_opt "IRMIN_TSAN_STRESS_ITER" with
   | Some s -> int_of_string s
   | None -> 100
 
-let scenarios : (string * (iter:int -> unit)) list = []
+type env = Eio_unix.Stdenv.base
 
-let run_all () =
-  List.iter
-    (fun (name, fn) ->
-      Printf.printf "tsan-stress: %s (iter=%d)\n%!" name iter_count;
-      fn ~iter:iter_count)
-    scenarios
+let scenarios : (string * (env:env -> iter:int -> unit)) list =
+  [
+    ("ao", Stress_ao_buf.run);
+    ("dict", Stress_dict.run);
+    ("mem", Stress_mem_cache.run);
+    ("watch", Stress_watch.run);
+    ("fs", Stress_fs_pool.run);
+  ]
+
+let run_one ~env (name, fn) =
+  Printf.printf "tsan-stress: %s (iter=%d)\n%!" name iter_count;
+  fn ~env ~iter:iter_count
 
 let () =
-  let which = if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all" in
+  let which =
+    match Sys.argv with
+    | [| _ |] | [| _; "all" |] -> `All
+    | [| _; name |] -> `One name
+    | _ ->
+        prerr_endline "usage: main.exe [all|ao|dict|mem|watch|fs]";
+        exit 2
+  in
+  Eio_main.run @@ fun env ->
   match which with
-  | "all" -> run_all ()
-  | name -> (
+  | `All -> List.iter (run_one ~env) scenarios
+  | `One name -> (
       match List.assoc_opt name scenarios with
-      | Some fn -> fn ~iter:iter_count
+      | Some fn -> run_one ~env (name, fn)
       | None ->
           Printf.eprintf "tsan-stress: unknown scenario %S\n%!" name;
           exit 2)

--- a/test/irmin-pack/test_tsan_stress/main.ml
+++ b/test/irmin-pack/test_tsan_stress/main.ml
@@ -21,9 +21,7 @@ let run_all () =
     scenarios
 
 let () =
-  let which =
-    if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all"
-  in
+  let which = if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all" in
   match which with
   | "all" -> run_all ()
   | name -> (

--- a/test/irmin-pack/test_tsan_stress/main.ml
+++ b/test/irmin-pack/test_tsan_stress/main.ml
@@ -1,0 +1,34 @@
+(* TSan stress suite.
+
+   Dispatcher for race-hunting scenarios. Each scenario targets a mutable
+   state hotspot that the standard test suite does not exercise across
+   domains. Scenarios are added incrementally.
+
+   Iteration count: [IRMIN_TSAN_STRESS_ITER] env var (default 100). *)
+
+let iter_count =
+  match Sys.getenv_opt "IRMIN_TSAN_STRESS_ITER" with
+  | Some s -> int_of_string s
+  | None -> 100
+
+let scenarios : (string * (iter:int -> unit)) list = []
+
+let run_all () =
+  List.iter
+    (fun (name, fn) ->
+      Printf.printf "tsan-stress: %s (iter=%d)\n%!" name iter_count;
+      fn ~iter:iter_count)
+    scenarios
+
+let () =
+  let which =
+    if Array.length Sys.argv >= 2 then Sys.argv.(1) else "all"
+  in
+  match which with
+  | "all" -> run_all ()
+  | name -> (
+      match List.assoc_opt name scenarios with
+      | Some fn -> fn ~iter:iter_count
+      | None ->
+          Printf.eprintf "tsan-stress: unknown scenario %S\n%!" name;
+          exit 2)

--- a/test/irmin-pack/test_tsan_stress/stress_ao_buf.ml
+++ b/test/irmin-pack/test_tsan_stress/stress_ao_buf.ml
@@ -1,0 +1,29 @@
+(* Races the unguarded [Buffer.t] and atomic counter in
+   [Append_only_file.rw_perm] (src/irmin-pack/io/append_only_file.ml).
+
+   N domains call [Ao.append_exn] concurrently on the same [Ao.t].
+   The function does [Buffer.add_string] without synchronisation, then
+   an [Atomic.fetch_and_add] on [buf_length] — the TOCTOU and the
+   Buffer mutation both surface to TSan. *)
+
+module Io = Irmin_pack_unix.Io.Unix
+module Errs = Irmin_pack_io.Io_errors.Make (Io)
+module Ao = Irmin_pack_io.Append_only_file.Make (Io) (Errs)
+
+let run ~env ~iter =
+  Eio.Switch.run @@ fun sw ->
+  let dmgr = Eio.Stdenv.domain_mgr env in
+  let path = Stress_common.scratch_file ~env "stress_ao_buf.data" in
+  let ao =
+    match Ao.create_rw ~sw ~path ~overwrite:true with
+    | Ok ao -> ao
+    | Error _ -> failwith "stress_ao_buf: create_rw failed"
+  in
+  let worker () =
+    for _ = 1 to iter do
+      Ao.append_exn ao "xxxxxxxx"
+    done
+  in
+  Stress_common.domains_spawn ~dmgr ~nb:2 worker;
+  ignore (Ao.flush ao);
+  ignore (Ao.close ao)

--- a/test/irmin-pack/test_tsan_stress/stress_common.ml
+++ b/test/irmin-pack/test_tsan_stress/stress_common.ml
@@ -1,0 +1,43 @@
+(* Barrier-synchronised domain spawning, mirroring the idiom in
+   test/irmin-pack/test_multicore.ml so the workers start roughly
+   together and the scheduler has to interleave them. *)
+
+(* Clean scratch directory for scenarios that need on-disk state.
+   Rooted at [/tmp/irmin-tsan-stress/<name>] to avoid clashing with
+   a possibly missing or read-only [_build] under the process cwd. *)
+let scratch_path ~env name =
+  let fs = Eio.Stdenv.fs env in
+  let base = Eio.Path.(fs / "tmp" / "irmin-tsan-stress") in
+  let p = Eio.Path.(base / name) in
+  (try Eio.Path.rmtree p with _ -> ());
+  (try Eio.Path.mkdirs ~perm:0o755 base with _ -> ());
+  (try Eio.Path.mkdir ~perm:0o755 p with _ -> ());
+  p
+
+(* Like [scratch_path] but returns a path to a file (non-existing)
+   whose parent directory has been freshly created. *)
+let scratch_file ~env name =
+  let fs = Eio.Stdenv.fs env in
+  let base = Eio.Path.(fs / "tmp" / "irmin-tsan-stress") in
+  (try Eio.Path.mkdirs ~perm:0o755 base with _ -> ());
+  let p = Eio.Path.(base / name) in
+  (try Eio.Path.unlink p with _ -> ());
+  p
+
+let domains_run ~dmgr fns =
+  let count = Atomic.make (List.length fns) in
+  let fibers =
+    List.map
+      (fun fn () ->
+        Eio.Domain_manager.run dmgr (fun () ->
+            Atomic.decr count;
+            while Atomic.get count > 0 do
+              Domain.cpu_relax ()
+            done;
+            fn ()))
+      fns
+  in
+  Eio.Fiber.all fibers
+
+let domains_spawn ~dmgr ?(nb = 4) fn =
+  domains_run ~dmgr (List.init nb (fun _ -> fn))

--- a/test/irmin-pack/test_tsan_stress/stress_dict.ml
+++ b/test/irmin-pack/test_tsan_stress/stress_dict.ml
@@ -1,0 +1,32 @@
+(* Races the two unguarded [Hashtbl.t]s and [mutable last_refill_offset]
+   in src/irmin-pack/io/dict.ml.
+
+   One writer domain loops [Dict.index] (which appends and mutates both
+   tables via [Hashtbl.add]); readers concurrently loop [Dict.find]. *)
+
+module Io = Irmin_pack_unix.Io.Unix
+module Dict = Irmin_pack_io.Dict.Make (Io)
+
+let run ~env ~iter =
+  Eio.Switch.run @@ fun sw ->
+  let dmgr = Eio.Stdenv.domain_mgr env in
+  let path = Stress_common.scratch_file ~env "stress_dict.data" in
+  let dict =
+    match Dict.create_rw ~sw ~overwrite:true ~path with
+    | Ok d -> d
+    | Error _ -> failwith "stress_dict: create_rw failed"
+  in
+  let writer () =
+    for i = 1 to iter do
+      let _ = Dict.index dict (Printf.sprintf "str-%d" i) in
+      ()
+    done
+  in
+  let reader () =
+    for i = 1 to iter do
+      let _ = Dict.find dict i in
+      ()
+    done
+  in
+  Stress_common.domains_run ~dmgr [ writer; reader ];
+  ignore (Dict.close dict)

--- a/test/irmin-pack/test_tsan_stress/stress_fs_pool.ml
+++ b/test/irmin-pack/test_tsan_stress/stress_fs_pool.ml
@@ -1,0 +1,27 @@
+(* Races the shared [Eio_pool.t] instances ([mkdir_pool], [openfile_pool])
+   in src/irmin-fs/unix/irmin_fs_unix.ml:75,87.
+
+   A single FS-backed store is shared across N domains; each writes a
+   distinct key. Store.set_exn goes through [with_write_file] which uses
+   [openfile_pool]; creating the root directory uses [mkdir_pool]. The
+   pool's internal state (queue, counter) is shared across domains. *)
+
+module Store = Irmin_fs_unix.KV.Make (Irmin.Contents.String)
+
+let run ~env ~iter =
+  Eio.Switch.run @@ fun _sw ->
+  let clock = Eio.Stdenv.clock env in
+  let dmgr = Eio.Stdenv.domain_mgr env in
+  let root = Stress_common.scratch_path ~env "stress_fs_pool" in
+  let cfg = Irmin_fs_unix.config ~root ~clock in
+  let repo = Store.Repo.v cfg in
+  let main = Store.main repo in
+  let info () = Store.Info.v 0L in
+  let worker id () =
+    for i = 1 to iter do
+      Store.set_exn ~info main [ Printf.sprintf "k-%d-%d" id i ] "v"
+    done
+  in
+  let fns = List.init 2 (fun id -> worker id) in
+  Stress_common.domains_run ~dmgr fns;
+  Store.Repo.close repo

--- a/test/irmin-pack/test_tsan_stress/stress_mem_cache.ml
+++ b/test/irmin-pack/test_tsan_stress/stress_mem_cache.ml
@@ -1,0 +1,23 @@
+(* Races the global [cache : (string, _) Hashtbl.t] captured by
+   [Irmin_mem.Read_only.v] in src/irmin/mem/irmin_mem.ml:44.
+
+   N domains barrier-start, then each opens and closes a Repo.v
+   repeatedly. On cold cache they all race on Hashtbl.find_opt/add;
+   after that, set_exn on the shared repo races the mutable KMap field
+   of the underlying Read_only instance. *)
+
+module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
+
+let run ~env ~iter =
+  let dmgr = Eio.Stdenv.domain_mgr env in
+  let info () = Store.Info.v 0L in
+  let worker id () =
+    for i = 1 to iter do
+      let repo = Store.Repo.v (Irmin_mem.config ()) in
+      let main = Store.main repo in
+      Store.set_exn ~info main [ Printf.sprintf "k-%d-%d" id i ] "v";
+      Store.Repo.close repo
+    done
+  in
+  let fns = List.init 4 (fun id -> worker id) in
+  Stress_common.domains_run ~dmgr fns

--- a/test/irmin-pack/test_tsan_stress/stress_watch.ml
+++ b/test/irmin-pack/test_tsan_stress/stress_watch.ml
@@ -1,0 +1,15 @@
+(* Races the global [listen_dir_hook] / [watch_switch] refs in
+   src/irmin/watch.ml:28-29. N domains concurrently overwrite the
+   shared hook with [set_listen_dir_hook]; the assignment to the
+   [ref] is unsynchronised. *)
+
+let dummy_hook _ _ _ _ = ()
+
+let run ~env ~iter =
+  let dmgr = Eio.Stdenv.domain_mgr env in
+  let worker () =
+    for _ = 1 to iter do
+      Irmin.Backend.Watch.set_listen_dir_hook dummy_hook
+    done
+  in
+  Stress_common.domains_spawn ~dmgr ~nb:4 worker

--- a/test/irmin-pack/tsan_suppressions.txt
+++ b/test/irmin-pack/tsan_suppressions.txt
@@ -1,0 +1,11 @@
+# ThreadSanitizer suppressions for Irmin nightly CI.
+#
+# Rule: suppress runtime/FFI noise only. Every finding in an Irmin module is
+# a real race — do NOT add entries for src/ here.
+
+# OCaml runtime internals (minor heap / major heap bookkeeping).
+race:caml_modify
+race:caml_alloc_shr
+
+# index uses mmap + its own atomics that TSan doesn't instrument.
+called_from_lib:index


### PR DESCRIPTION
## Summary

Fills in the `@tsan-stress` alias shipped empty by #2402 (PR A). Five per-hotspot race-hunting scenarios land under `test/irmin-pack/test_tsan_stress/`, each targeting mutable state that the existing multicore + QCheck-STM suites do not exercise across domains.

**Stacked on #2402.** Target is `eio`; please merge #2402 first. This branch contains #2402's commit plus two more.

### Scenarios and what they produce under TSan

| Scenario | Hotspot | Expected TSan output |
|---|---|---|
| `stress_mem_cache` | `src/irmin/mem/irmin_mem.ml:44,51` | Clean data-race warning (`WARNING: ThreadSanitizer`) pointing at `Hashtbl.add` in the global cache |
| `stress_watch` | `src/irmin/watch.ml:33` | Clean data-race warning pointing at the `listen_dir_hook :=` assignment |
| `stress_ao_buf` | `src/irmin-pack/io/append_only_file.ml` (`Buffer.t` in `rw_perm`) | SEGV (TSan signal handler) — the Buffer corruption is fast enough that TSan aborts before the race warning lands. The crash itself is evidence of the race. |
| `stress_dict` | `src/irmin-pack/io/dict.ml:25-31` | SEGV on the same pattern (two unguarded Hashtbl.t + append path). |
| `stress_fs_pool` | `src/irmin-fs/unix/irmin_fs_unix.ml:75,87` (`Eio_pool`) | "Nested bug, aborting" — TSan unable to unwind through the Eio scheduler/pool interaction. Demonstrates the problem without pinpointing it. |

The `@tsan-stress` alias runs each in its own process (`main.exe <name> || true` chained), so one scenario's crash does not suppress the others.

### Correspondence with #2397

After locally merging #2397 on top of `eio` + this PR, re-running the suite gave the following result (reported with `IRMIN_TSAN_STRESS_ITER` up to 500):

| Scenario | #2397 fix commit | Outcome with #2397 applied |
|---|---|---|
| `stress_watch` | `d050ed73e0 Replace global refs with Atomic.t in watch.ml` | **Fixed** — zero TSan findings. |
| `stress_mem_cache` | `289e6272ff Protect in-memory store cache with a mutex in irmin_mem` | **Partially fixed.** The `Eio.Mutex` around the global cache Hashtbl eliminates races at `irmin_mem.ml:51`, but the per-instance `mutable t : KMap.t` field is still unsynchronised. Warnings now appear at `irmin_mem.ml:72` (`Read_only.find`), `:86` (`Append_only.add`), `:136`–`:142` (`Atomic_write.test_and_set`). Downstream symptom: concurrent `Store.set_exn` still produces `Irmin.Tree.find_tree.findv: encountered dangling hash` and `set_exn: Failure after 13 attempts to retry`. |
| `stress_ao_buf` | `b690c5b2b1 Protect append-only file buffer with a mutex` | **Inconclusive.** The mutex is in place and the hot path is serialised, but TSan still exits via SEGV on every run. Could be (a) a residual race outside the lock's scope, or (b) a TSan-on-OCaml-5 shadow-memory issue. Needs a narrower reproducer to distinguish. |
| `stress_dict` | `788ad16a7b Protect dict hashtables with a mutex` | **Inconclusive** for the same reason as `stress_ao_buf`. |
| `stress_fs_pool` | `ec0c10e619` protects `Irmin_fs.IO_mem` but not `Irmin_fs_unix`'s `mkdir_pool` / `openfile_pool` | **Unchanged** — "nested bug, aborting" still fires. #2397's scope does not include `irmin_fs_unix`. |

Takeaway: #2397 is necessary but not sufficient. Two concrete gaps remain (`irmin_mem` KMap, `irmin_fs_unix` pools) plus two cases where the fix is applied but TSan output remains unclear. Tracking the remainder in a follow-up issue (**#2404**).

### Workflow counts SEGV-on-race as a finding

`.github/workflows/tsan.yml` summary step now tallies both `WARNING: ThreadSanitizer` and `ERROR: ThreadSanitizer` occurrences. Reports from both `cwd/tsan-report.*` and the dune build dir (`_build/default/test/irmin-pack/test_tsan_stress/tsan-report.*`) are uploaded to the workflow artifact.

### Development recipe

Reproducible locally via the `.devcontainer/devcontainer.json` added in the first commit:

```bash
docker run --privileged --rm -v $PWD:/workspace -w /workspace \
  ghcr.io/tarides/ocaml-devcontainer-tsan:latest bash
# inside:
opam switch ocaml+tsan && eval $(opam env)
opam install -y --deps-only --no-depexts irmin irmin-pack irmin-fs
opam install -y eio_main
dune build test/irmin-pack/test_tsan_stress/main.exe
EIO_BACKEND=posix TSAN_OPTIONS='halt_on_error=0 history_size=7 log_path=tsan-report' \
  dune build @test/irmin-pack/test_tsan_stress/tsan-stress --force
```

Or VS Code → "Reopen in Container" with the committed devcontainer config.

### What this does *not* do

- Fix any of the races. This is still detection only.
- Replace PR A's workflow — it extends it.
- Ship dscheck tests (still on the #2401 roadmap as a separate Phase 6 follow-up).

Context: #2401 Phase 6.

## Test plan

- [ ] Add `tsan` label to this PR → workflow runs → five scenarios each produce a `tsan-report.<pid>` artifact.
- [ ] Verify the step summary reports `data-race warnings: N` (≥2 — `mem` and `watch`) and `signal/SEGV-on-race errors: M` (≥2 — `ao`, `dict`).
- [ ] Open the `tsan-reports-<run>` artifact; confirm `mem` and `watch` reports cite `irmin_mem.ml:51` and `watch.ml:33` respectively in the stack trace.
- [ ] Merge #2402 first, then this, then confirm the next nightly run still green-path succeeds (builds and uploads, regardless of finding count).
- [ ] After #2397 merges: confirm `watch` disappears from the nightly report, and follow-up issue tracks the remaining gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
