### PR TITLE
irmin-git: use closeable functors from irmin core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+## Unreleased
+
+### Added
+
+- **irmin**
+  - Add `Content_addressable.Check_closed_store`, the canonical closeable-store
+    functor, with `make_closeable`, `make_closeable_with` and
+    `get_if_open_exn` (#1937, @kgkoutis)
+
+### Changed
+
+- **irmin-git**
+  - Use the closeable-store functors from irmin instead of local copies:
+    removed `Atomic_write.Check_closed` and `Content_addressable.Check_closed`
+    (#1937, @kgkoutis)
+
 ## 3.11.0 (2025-06-19)
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
   - Use the closeable-store functors from irmin instead of local copies:
     removed `Atomic_write.Check_closed` and `Content_addressable.Check_closed`
     (#1937, @kgkoutis)
+  - **Breaking**: `Backend.Make` no longer exposes the concrete store types for
+    `Contents.t`, `Node.t` and `Commit.t`; use the new `contents_t`, `node_t`
+    and `commit_t` accessors instead (#1937, @kgkoutis)
 
 ## 3.11.0 (2025-06-19)
 

--- a/src/irmin-git/atomic_write.ml
+++ b/src/irmin-git/atomic_write.ml
@@ -17,64 +17,6 @@
 open Import
 include Atomic_write_intf
 
-module Check_closed (S : Irmin.Atomic_write.S) = struct
-  type t = { closed : bool ref; t : S.t }
-  type key = S.key
-  type value = S.value
-
-  let check_not_closed t = if !(t.closed) then raise Irmin.Closed
-
-  let mem t k =
-    check_not_closed t;
-    S.mem t.t k
-
-  let find t k =
-    check_not_closed t;
-    S.find t.t k
-
-  let set t k v =
-    check_not_closed t;
-    S.set t.t k v
-
-  let test_and_set t k ~test ~set =
-    check_not_closed t;
-    S.test_and_set t.t k ~test ~set
-
-  let remove t k =
-    check_not_closed t;
-    S.remove t.t k
-
-  let list t =
-    check_not_closed t;
-    S.list t.t
-
-  type watch = S.watch
-
-  let watch t ?init f =
-    check_not_closed t;
-    S.watch t.t ?init f
-
-  let watch_key t k ?init f =
-    check_not_closed t;
-    S.watch_key t.t k ?init f
-
-  let unwatch t w =
-    check_not_closed t;
-    S.unwatch t.t w
-
-  let v t = { closed = ref false; t }
-
-  let close t =
-    if !(t.closed) then Lwt.return_unit
-    else (
-      t.closed := true;
-      S.close t.t)
-
-  let clear t =
-    check_not_closed t;
-    S.clear t.t
-end
-
 module Make (K : Key) (G : Git.S) = struct
   module Key = K
   module Val = Irmin.Hash.Make (G.Hash)

--- a/src/irmin-git/atomic_write_intf.ml
+++ b/src/irmin-git/atomic_write_intf.ml
@@ -34,10 +34,4 @@ module type Sigs = sig
       G.t ->
       t Lwt.t
   end
-
-  module Check_closed (S : Irmin.Atomic_write.S) : sig
-    include Irmin.Atomic_write.S with type key = S.key and type value = S.value
-
-    val v : S.t -> t
-  end
 end

--- a/src/irmin-git/backend.ml
+++ b/src/irmin-git/backend.ml
@@ -37,33 +37,37 @@ struct
   module Node_key = Key
 
   module Contents = struct
-    module S = Contents.Make (G) (Schema.Contents)
-    include Irmin.Contents.Store (S) (S.Hash) (S.Val)
+    module Raw = Contents.Make (G) (Schema.Contents)
+    module S = Irmin.Content_addressable.Check_closed_store (Raw)
+    include Irmin.Contents.Store (S) (Raw.Hash) (Raw.Val)
   end
 
   module Node = struct
-    module S = Node.Store (G) (Schema.Path)
+    module Raw = Node.Store (G) (Schema.Path)
+    module S = Irmin.Content_addressable.Check_closed_store (Raw)
 
     include
-      Irmin.Node.Store (Contents) (S) (S.Key) (S.Val) (Metadata) (Schema.Path)
+      Irmin.Node.Store (Contents) (S) (Raw.Key) (Raw.Val) (Metadata)
+        (Schema.Path)
   end
 
   module Node_portable = Irmin.Node.Portable.Of_node (Node.Val)
 
   module Commit = struct
-    module S = Commit.Store (G)
-    include Irmin.Commit.Store (Schema.Info) (Node) (S) (S.Hash) (S.Val)
+    module Raw = Commit.Store (G)
+    module S = Irmin.Content_addressable.Check_closed_store (Raw)
+    include Irmin.Commit.Store (Schema.Info) (Node) (S) (Raw.Hash) (Raw.Val)
   end
 
-  module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.S.Val)
+  module Commit_portable = Irmin.Commit.Portable.Of_commit (Commit.Raw.Val)
 
   module Branch = struct
     module Key = Schema.Branch
     module Val = Commit_key
     module S = Atomic_write.Make (Schema.Branch) (G)
-    include Atomic_write.Check_closed (S)
+    include Irmin.Atomic_write.Check_closed_store (S)
 
-    let v ?lock ~head ~bare t = S.v ?lock ~head ~bare t >|= v
+    let v ?lock ~head ~bare t = S.v ?lock ~head ~bare t >|= make_closeable
   end
 
   module Slice = Irmin.Backend.Slice.Make (Contents) (Node) (Commit)
@@ -76,9 +80,16 @@ struct
     type t = { config : Irmin.config; closed : bool ref; g : G.t; b : Branch.t }
 
     let branch_t t = t.b
-    let contents_t t : 'a Contents.t = (t.closed, t.g)
-    let node_t t : 'a Node.t = (contents_t t, (t.closed, t.g))
-    let commit_t t : 'a Commit.t = (node_t t, (t.closed, t.g))
+
+    let contents_t t : 'a Contents.t =
+      Contents.S.make_closeable_with t.closed t.g
+
+    let node_t t : 'a Node.t =
+      (contents_t t, Node.S.make_closeable_with t.closed t.g)
+
+    let commit_t t : 'a Commit.t =
+      (node_t t, Commit.S.make_closeable_with t.closed t.g)
+
     let batch t f = f (contents_t t) (node_t t) (commit_t t)
 
     type config = {
@@ -121,6 +132,9 @@ struct
   end
 
   let git_of_repo r = r.Repo.g
+  let contents_t = Repo.contents_t
+  let node_t = Repo.node_t
+  let commit_t = Repo.commit_t
 
   let repo_of_git ?head ?(bare = true) ?lock g =
     let+ b = Branch.v ?lock ~head ~bare g in

--- a/src/irmin-git/backend.mli
+++ b/src/irmin-git/backend.mli
@@ -27,19 +27,20 @@ module Make
                 with type Hash.t = G.hash
                  and type Node.t = G.Value.Tree.t
                  and type Commit.t = G.Value.Commit.t) : sig
-  type t := bool ref * G.t
-
   include
     Irmin.Backend.S
       with module Schema = Schema
-      with type 'a Contents.t = t
-       and type 'a Node.t = t * t
-       and type 'a Commit.t = (t * t) * t
-       and type Contents.key = G.hash
+      with type Contents.key = G.hash
        and type Node.key = G.hash
        and type Commit.key = G.hash
        and type Remote.endpoint = Mimic.ctx * Smart_git.Endpoint.t
 
+  val contents_t : Repo.t -> 'a Contents.t
+  (** Like [Repo.contents_t] but returning a store handle usable for reads and
+      writes. *)
+
+  val node_t : Repo.t -> 'a Node.t
+  val commit_t : Repo.t -> 'a Commit.t
   val git_of_repo : Repo.t -> G.t
 
   val repo_of_git :

--- a/src/irmin-git/commit.ml
+++ b/src/irmin-git/commit.ml
@@ -122,5 +122,5 @@ module Store (G : Git.S) = struct
     let to_git c = G.Value.commit c
   end
 
-  include Content_addressable.Check_closed (Content_addressable.Make (G) (V))
+  include Content_addressable.Make (G) (V)
 end

--- a/src/irmin-git/commit.mli
+++ b/src/irmin-git/commit.mli
@@ -25,7 +25,7 @@ module Make (G : Git.S) :
 module Store (G : Git.S) : sig
   include
     Irmin.Content_addressable.S
-      with type _ t = bool ref * G.t
+      with type _ t = G.t
        and type key = G.Hash.t
        and type value = G.Value.Commit.t
 

--- a/src/irmin-git/content_addressable.ml
+++ b/src/irmin-git/content_addressable.ml
@@ -62,35 +62,3 @@ module Make (G : Git.S) (V : Value.S with type value := G.Value.t) = struct
   let batch t f = f t
   let close _ = Lwt.return ()
 end
-
-module Check_closed (S : Irmin.Content_addressable.S) = struct
-  type 'a t = bool ref * 'a S.t
-  type key = S.key
-  type value = S.value
-
-  let check_not_closed t = if !(fst t) then raise Irmin.Closed
-
-  let mem t k =
-    check_not_closed t;
-    S.mem (snd t) k
-
-  let find t k =
-    check_not_closed t;
-    S.find (snd t) k
-
-  let add t v =
-    check_not_closed t;
-    S.add (snd t) v
-
-  let unsafe_add t k v =
-    check_not_closed t;
-    S.unsafe_add (snd t) k v
-
-  let batch t f =
-    check_not_closed t;
-    S.batch (snd t) (fun x -> f (fst t, x))
-
-  let close (c, _) =
-    c := true;
-    Lwt.return ()
-end

--- a/src/irmin-git/content_addressable_intf.ml
+++ b/src/irmin-git/content_addressable_intf.ml
@@ -20,12 +20,4 @@ module type Sigs = sig
       with type _ t = G.t
        and type key = G.Hash.t
        and type value = V.t
-
-  module Check_closed (S : Irmin.Content_addressable.S) : sig
-    include
-      Irmin.Content_addressable.S
-        with type 'a t = bool ref * 'a S.t
-         and type key = S.key
-         and type value = S.value
-  end
 end

--- a/src/irmin-git/contents.ml
+++ b/src/irmin-git/contents.ml
@@ -38,7 +38,7 @@ module Make (G : Git.S) (C : Irmin.Contents.S) = struct
       G.Value.blob (G.Value.Blob.of_string str)
   end
 
-  include Content_addressable.Check_closed (Content_addressable.Make (G) (V))
+  include Content_addressable.Make (G) (V)
 
   module Val = struct
     include C

--- a/src/irmin-git/contents.mli
+++ b/src/irmin-git/contents.mli
@@ -19,7 +19,7 @@
 module Make (G : Git.S) (C : Irmin.Contents.S) : sig
   include
     Irmin.Content_addressable.S
-      with type _ t = bool ref * G.t
+      with type _ t = G.t
        and type key = G.Hash.t
        and type value = C.t
 

--- a/src/irmin-git/irmin_git.ml
+++ b/src/irmin-git/irmin_git.ml
@@ -123,14 +123,14 @@ module Content_addressable (G : Git.S) = struct
     end
 
     module Schema = Schema.Make (G) (V) (Reference)
-    module M = Maker.Make (Schema)
-    module X = M.Backend.Contents
+    module B = Backend.Make (G) (No_sync) (Schema)
+    module X = B.Contents
 
     type 'a t = G.t
 
-    let state t =
-      let+ r = M.repo_of_git t in
-      M.Backend.Repo.contents_t r
+    let state t : 'a X.t Lwt.t =
+      let+ r = B.repo_of_git t in
+      B.contents_t r
 
     type key = X.key
     type value = X.value
@@ -176,7 +176,7 @@ module Atomic_write (G : Git.S) = struct
     end
 
     module AW = Atomic_write.Make (Branch.Make (K)) (G)
-    include Atomic_write.Check_closed (AW)
+    include Irmin.Atomic_write.Check_closed_store (AW)
   end
 end
 

--- a/src/irmin-git/node.ml
+++ b/src/irmin-git/node.ml
@@ -200,5 +200,5 @@ module Store (G : Git.S) (P : Irmin.Path.S) = struct
     let of_git = function Git.Value.Tree t -> Some t | _ -> None
   end
 
-  include Content_addressable.Check_closed (Content_addressable.Make (G) (V))
+  include Content_addressable.Make (G) (V)
 end

--- a/src/irmin-git/node.mli
+++ b/src/irmin-git/node.mli
@@ -26,7 +26,7 @@ module Make (G : Git.S) (P : Irmin.Path.S) :
 module Store (G : Git.S) (P : Irmin.Path.S) : sig
   include
     Irmin.Content_addressable.S
-      with type _ t = bool ref * G.t
+      with type _ t = G.t
        and type key = G.Hash.t
        and type value = G.Value.Tree.t
 

--- a/src/irmin/content_addressable.ml
+++ b/src/irmin/content_addressable.ml
@@ -43,42 +43,37 @@ module Make (AO : Append_only.Maker) (K : Hash.S) (V : Type.S) = struct
     add t k v >|= fun () -> k
 end
 
-module Check_closed (CA : Maker) (K : Hash.S) (V : Type.S) = struct
-  module S = CA (K) (V)
+module Check_closed_store (CA : S) = struct
+  type 'a t = { closed : bool ref; t : 'a CA.t }
+  type value = CA.value
+  type key = CA.key
 
-  type 'a t = { closed : bool ref; t : 'a S.t }
-  type key = S.key
-  type value = S.value
+  let make_closeable t = { closed = ref false; t }
+  let make_closeable_with closed t = { closed; t }
 
-  let check_not_closed t = if !(t.closed) then raise Store_properties.Closed
+  let get_if_open_exn t =
+    if !(t.closed) then raise Store_properties.Closed else t.t
 
-  let mem t k =
-    check_not_closed t;
-    S.mem t.t k
-
-  let find t k =
-    check_not_closed t;
-    S.find t.t k
-
-  let add t v =
-    check_not_closed t;
-    S.add t.t v
-
-  let unsafe_add t k v =
-    check_not_closed t;
-    S.unsafe_add t.t k v
+  let mem t k = (get_if_open_exn t |> CA.mem) k
+  let find t k = (get_if_open_exn t |> CA.find) k
+  let add t v = (get_if_open_exn t |> CA.add) v
+  let unsafe_add t k v = (get_if_open_exn t |> CA.unsafe_add) k v
 
   let batch t f =
-    check_not_closed t;
-    S.batch t.t (fun w -> f { t = w; closed = t.closed })
-
-  let v conf =
-    let+ t = S.v conf in
-    { closed = ref false; t }
+    (get_if_open_exn t |> CA.batch) (fun w -> f { t = w; closed = t.closed })
 
   let close t =
     if !(t.closed) then Lwt.return_unit
     else (
       t.closed := true;
-      S.close t.t)
+      CA.close t.t)
+end
+
+module Check_closed (CA : Maker) (K : Hash.S) (V : Type.S) = struct
+  module S = CA (K) (V)
+  include Check_closed_store (S)
+
+  let v conf =
+    let+ t = S.v conf in
+    make_closeable t
 end

--- a/src/irmin/content_addressable_intf.ml
+++ b/src/irmin/content_addressable_intf.ml
@@ -65,5 +65,21 @@ module type Sigs = sig
     (** @inline *)
   end
 
+  module Check_closed_store (CA : S) : sig
+    include S with type key = CA.key and type value = CA.value
+
+    val make_closeable : 'a CA.t -> 'a t
+    (** [make_closeable t] returns a version of [t] that raises {!Irmin.Closed}
+        if an operation is performed when it is already closed. *)
+
+    val make_closeable_with : bool ref -> 'a CA.t -> 'a t
+    (** [make_closeable_with closed t] is like {!make_closeable} but reuses
+        [closed] to keep track of the state of the store. *)
+
+    val get_if_open_exn : 'a t -> 'a CA.t
+    (** [get_if_open_exn t] returns the store (without close checks) if it is
+        open; otherwise raises {!Irmin.Closed} *)
+  end
+
   module Check_closed (M : Maker) : Maker
 end


### PR DESCRIPTION
The closeable-store wrappers (a store handle that raises `Irmin.Closed` after `close`) were duplicated between `irmin` and `irmin-git`. `irmin-pack` already used the core `Atomic_write.Check_closed_store` / `Indexable.Check_closed_store`, but `irmin-git` carried its own copies.

This moves the canonical implementation to irmin core:

- add `Irmin.Content_addressable.Check_closed_store`, in the same style as the existing `Irmin.Indexable.Check_closed_store` and `Irmin.Atomic_write.Check_closed_store`, with `make_closeable`, `make_closeable_with` (to share a repo-level `closed` flag between the repo and the store handles it returns) and `get_if_open_exn`;
- re-express `Irmin.Content_addressable.Check_closed` on top of it (same public interface);
- remove the duplicated `Check_closed` functors from `Irmin_git.Atomic_write` and `Irmin_git.Content_addressable`, and wrap the raw git stores in `Irmin_git.Backend` instead.

The repo-level sharing of the `closed` flag is preserved, and no `Check_closed` implementation lives outside `src/irmin/` after this.

**Breaking change**: `Irmin_git.Backend.Make` no longer exposes the concrete store types for `Contents.t`, `Node.t` and `Commit.t` (previously leaked as `bool ref * G.t` and tuples thereof). New `contents_t`, `node_t` and `commit_t` accessors take a `Repo.t` and return a usable store handle.

Net -59 lines. Built and tested locally in a Docker OCaml 4.14 environment: `dune build` for irmin/irmin-git/irmin-pack/irmin-test plus `dune runtest` for test/irmin (91 tests), test/irmin-git (99 tests) and test/irmin-pack (242 tests) all pass, as does `dune build @fmt`.

Fixes #1937
